### PR TITLE
fix: payload sent to event handler

### DIFF
--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -522,7 +522,9 @@ export class MessageManager {
       // Emit both generic and platform-specific message sent events
       this.runtime.emitEvent(EventType.MESSAGE_SENT, {
         runtime: this.runtime,
-        message: content,
+        message: {
+          content: content,
+        },
         roomId,
         source: 'telegram',
       });


### PR DESCRIPTION
This PR fixes small bug with the incorrect payload passed to the event handler for `MESSAGE_SENT`. 

![image](https://github.com/user-attachments/assets/aae5ba6c-672b-4ba6-ae6a-2b1af82090b4)
