### PR TITLE
Filter out ignored Farcaster mentioned

### DIFF
--- a/packages/plugin-farcaster/src/common/callbacks.ts
+++ b/packages/plugin-farcaster/src/common/callbacks.ts
@@ -19,7 +19,7 @@ export function standardCastHandlerCallback({
   config: FarcasterConfig;
   roomId: UUID;
   onCompletion?: (casts: CastWithInteractions[], memories: Memory[]) => Promise<void>;
-  onError?: (error: Error) => Promise<void>;
+  onError?: (error: unknown) => Promise<void>;
 }): HandlerCallback {
   const callback: HandlerCallback = async (content: Content, _files?: any) => {
     try {
@@ -48,7 +48,7 @@ export function standardCastHandlerCallback({
         });
 
         if (i === 0) {
-          // sendCast lost response action, so we need to add it back here
+          // sendCast removes the response action, so we need to add it back here
           memory.content.actions = content.actions;
         }
 
@@ -65,7 +65,7 @@ export function standardCastHandlerCallback({
       logger.error('[Farcaster] Error posting cast:', error);
 
       if (onError) {
-        await onError(error as Error);
+        await onError(error);
       }
 
       return [];

--- a/packages/plugin-farcaster/src/managers/interactions.ts
+++ b/packages/plugin-farcaster/src/managers/interactions.ts
@@ -286,10 +286,16 @@ export class FarcasterInteractionManager {
     });
 
     const responseActions = (response.match(/(?:RESPOND|IGNORE|STOP)/g) || ['IGNORE'])[0];
-    // if (responseActions !== 'RESPOND') {
-    //   logger.info(`Not responding to cast based on shouldRespond decision: ${responseActions}`);
-    //   return;
-    // }
+    if (responseActions !== 'RESPOND') {
+      logger.info(`Not responding to cast based on shouldRespond decision: ${responseActions}`);
+      try {
+        // save the memory so we don't process it again in mentions
+        await this.runtime.createMemory(memory, 'messages');
+      } catch (error) {
+        logger.error('Error creating ignoredmemory', error);
+      }
+      return;
+    }
 
     // setup callback for the response
     const callback = standardCastHandlerCallback({


### PR DESCRIPTION
# Risks
Low. This PR fixes a bug in the Farcaster integration where non-responding decisions weren't being properly recorded.

# Background

## What does this PR do?
Fixes a bug in the Farcaster interaction manager where mentions that the agent chose to ignore weren't being saved to memory. This was causing the system to potentially reprocess the same mentions repeatedly.

The fix properly implements the previously commented-out code for `responseActions !== 'RESPOND'` scenarios, adding memory recording for non-responses with appropriate error handling.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review the implementation in packages/plugin-farcaster/src/managers/interactions.ts around line 286-298

## Detailed testing steps
- Test Farcaster integration with a mention that the agent decides to ignore
- Verify that the mention is properly recorded in memory and not reprocessed if encountered again
- Check logs for confirmation messages: "Not responding to cast based on shouldRespond decision"