### PR TITLE
fix: Refactor agents in rooms API to participants, fix missing world/serverId GET API.

### DIFF
--- a/packages/client/src/components/app-sidebar.tsx
+++ b/packages/client/src/components/app-sidebar.tsx
@@ -48,8 +48,8 @@ const getRoomAgentIds = (
   const agentIds: UUID[] = [];
 
   rooms.forEach((room) => {
-    if ((room as any).participants) {
-      (room as any).participants.forEach((participant: any) => {
+    if (room.participants) {
+      room.participants.forEach((participant) => {
         if (participant.agentId) {
           agentIds.push(participant.agentId);
         }
@@ -318,8 +318,8 @@ export function AppSidebar() {
       const validRooms: { agentId: UUID; name: string }[] = [];
 
       roomArray.forEach((room) => {
-        if ((room as any).participants) {
-          (room as any).participants.forEach((participant: any) => {
+        if (room.participants) {
+          room.participants.forEach((participant) => {
             if (participant.agentId) {
               validRooms.push({
                 agentId: participant.agentId,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -559,5 +559,12 @@ export abstract class DatabaseAdapter<DB = unknown> implements IDatabaseAdapter 
     tableName?: string;
   }): Promise<Memory[]>;
 
+  abstract getMemoriesByServerId(params: {
+    worldId: UUID;
+    serverId: UUID;
+    count?: number;
+    tableName?: string;
+  }): Promise<Memory[]>;
+
   abstract deleteRoomsByWorldId(worldId: UUID): Promise<void>;
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1182,7 +1182,6 @@ export class AgentRuntime implements IAgentRuntime {
       await this.createRoom({
         id,
         name,
-        agentId: this.agentId,
         source,
         type,
         channelId,
@@ -2143,5 +2142,14 @@ export class AgentRuntime implements IAgentRuntime {
     tableName?: string;
   }): Promise<Memory[]> {
     return await this.adapter.getMemoriesByWorldId(params);
+  }
+
+  async getMemoriesByServerId(params: {
+    worldId: UUID;
+    serverId: UUID;
+    count?: number;
+    tableName?: string;
+  }): Promise<Memory[]> {
+    return await this.adapter.getMemoriesByServerId(params);
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -574,13 +574,16 @@ export type RoomMetadata = Record<string, unknown>;
 export type Room = {
   id: UUID;
   name?: string;
-  agentId?: UUID;
   source: string;
   type: ChannelType;
   channelId?: string;
   serverId?: string;
   worldId?: UUID;
   metadata?: RoomMetadata;
+  participants?: {
+    agentId: UUID;
+    character: Character;
+  }[];
 };
 
 /**
@@ -1073,6 +1076,13 @@ export interface IDatabaseAdapter {
 
   getMemoriesByWorldId(params: {
     worldId: UUID;
+    count?: number;
+    tableName?: string;
+  }): Promise<Memory[]>;
+
+  getMemoriesByServerId(params: {
+    worldId: UUID;
+    serverId: UUID;
     count?: number;
     tableName?: string;
   }): Promise<Memory[]>;

--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -2774,13 +2774,7 @@ export abstract class BaseDrizzleAdapter<
       const rooms = await this.db
         .select({ id: roomTable.id })
         .from(roomTable)
-        .where(
-          and(
-            eq(roomTable.worldId, params.worldId),
-            eq(roomTable.serverId, params.serverId),
-            eq(roomTable.agentId, this.agentId)
-          )
-        );
+        .where(and(eq(roomTable.worldId, params.worldId), eq(roomTable.serverId, params.serverId)));
 
       if (rooms.length === 0) {
         return [];
@@ -2788,6 +2782,7 @@ export abstract class BaseDrizzleAdapter<
 
       const roomIds = rooms.map((room) => room.id as UUID);
 
+      // Filter memories by agentId in the getMemoriesByRoomIds call
       const memories = await this.getMemoriesByRoomIds({
         roomIds,
         tableName: params.tableName || 'messages',


### PR DESCRIPTION
This pull request introduces significant updates to the handling of participants in rooms, memory retrieval by server ID, and related data structures and APIs. These changes aim to improve the flexibility of the system by supporting multiple participants per room and enabling memory queries scoped by server and world. Below is a categorized summary of the most important changes:

### Room Participant Management
* Replaced the single `agentId` field in the `Room` type with a `participants` array, allowing each room to track multiple agents and their associated characters. (`packages/core/src/types.ts`, [packages/core/src/types.tsL577-R586](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479L577-R586))
* Updated the `getRoomAgentIds` function and `AppSidebar` component logic to handle the new `participants` structure, ensuring proper extraction and display of agent IDs and names. (`packages/client/src/components/app-sidebar.tsx`, [[1]](diffhunk://#diff-033854ee14ba4ed376c007175c16b3eecd687c496616f024611bd5dec6967b01L44-R61) [[2]](diffhunk://#diff-033854ee14ba4ed376c007175c16b3eecd687c496616f024611bd5dec6967b01L300-R331)
* Enhanced the `RoomListSection` component to display unique participant counts and names, reflecting the new room structure. (`packages/client/src/components/app-sidebar.tsx`, [[1]](diffhunk://#diff-033854ee14ba4ed376c007175c16b3eecd687c496616f024611bd5dec6967b01L166-R194) [[2]](diffhunk://#diff-033854ee14ba4ed376c007175c16b3eecd687c496616f024611bd5dec6967b01L185-R203)

### Memory Retrieval by Server ID
* Added a new `getMemoriesByServerId` method to the `IDatabaseAdapter` interface and implemented it in the `BaseDrizzleAdapter` class. This method retrieves memories for a specific server within a world. (`packages/core/src/types.ts`, [[1]](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479R1082-R1088); `packages/plugin-sql/src/base.ts`, [[2]](diffhunk://#diff-c0212488c0446f46225384f931dd7dfe141e77896ddeaf45373b859f8121d129R2766-R2800)
* Introduced a new API endpoint to fetch memories by server ID, enabling external clients to query this data. (`packages/cli/src/server/api/world.ts`, [packages/cli/src/server/api/world.tsR95-R128](diffhunk://#diff-f0039e9c4c3da8b55f87e38277f5ec21fb212f1df9cf2d575090a577d6330e8aR95-R128))

### Database and Runtime Adjustments
* Updated database logic to include `worldId` in memory records, ensuring proper scoping for queries involving worlds and servers. (`packages/plugin-sql/src/base.ts`, [[1]](diffhunk://#diff-c0212488c0446f46225384f931dd7dfe141e77896ddeaf45373b859f8121d129R1126) [[2]](diffhunk://#diff-c0212488c0446f46225384f931dd7dfe141e77896ddeaf45373b859f8121d129R1143) [[3]](diffhunk://#diff-c0212488c0446f46225384f931dd7dfe141e77896ddeaf45373b859f8121d129R1180) [[4]](diffhunk://#diff-c0212488c0446f46225384f931dd7dfe141e77896ddeaf45373b859f8121d129R1225)
* Added a `getMemoriesByServerId` method to the `AgentRuntime` class, delegating calls to the database adapter. (`packages/core/src/runtime.ts`, [packages/core/src/runtime.tsR2146-R2154](diffhunk://#diff-731eeb09ecd79fd1c3157ce640aa046c8c798d2fdf133837b696e4e1bfa8c0c4R2146-R2154))

### Removal of Legacy Fields
* Removed the `agentId` field from the `Room` type and related logic, as it is now replaced by the `participants` array. (`packages/core/src/types.ts`, [[1]](diffhunk://#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479L577-R586); `packages/core/src/runtime.ts`, [[2]](diffhunk://#diff-731eeb09ecd79fd1c3157ce640aa046c8c798d2fdf133837b696e4e1bfa8c0c4L1185)

These updates collectively enhance the system's scalability and flexibility by supporting multi-participant rooms and enabling more granular memory queries.