### PR TITLE
fix: action examples bug

### DIFF
--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -15,8 +15,20 @@ export const composeActionExamples = (actionsData: Action[], count: number): str
     return '';
   }
 
+  // Filter out actions without examples
+  const actionsWithExamples = actionsData.filter(
+    (action) => action.examples && Array.isArray(action.examples) && action.examples.length > 0
+  );
+
+  // If no actions have examples, return empty string
+  if (!actionsWithExamples.length) {
+    return '';
+  }
+
   // Create a working copy of the examples
-  const examplesCopy: ActionExample[][][] = actionsData.map((action) => [...action.examples]);
+  const examplesCopy: ActionExample[][][] = actionsWithExamples.map((action) => [
+    ...action.examples,
+  ]);
 
   const selectedExamples: ActionExample[][] = [];
 


### PR DESCRIPTION
## Description
Fixed a bug in action example processing where the system was incorrectly requiring examples for actions even when examples are optional.

## Problem
Actions in Eliza have an `examples` field that should be optional, but the current implementation was not properly handling cases where actions don't provide examples, causing validation or processing issues.

## Solution
Updated the logic to properly skip example validation/processing when actions don't have examples defined, since examples are not a required field for actions.

## Changes
- Modified action processing logic to handle optional examples correctly
- Added proper checks to skip example validation when examples array is empty or undefined

## Testing
- Verified that actions without examples now work correctly
- Confirmed that actions with examples continue to function as expected

## Impact
This fix allows developers to create actions without being forced to provide examples, making the framework more flexible and easier to use for simple action implementations.