### PR TITLE
Fix/core build missing entry points

### DIFF
--- a/packages/core/src/specs/v1/index.ts
+++ b/packages/core/src/specs/v1/index.ts
@@ -17,26 +17,27 @@ export * from './types';
 
 // Adapters created for v1 -> v2 compatibility
 // Export only the adapter functions and V1 types to avoid conflicts
-export { fromV2State, toV2State, State } from './state';
+export { fromV2State, toV2State } from './state';
+export type { State } from './state';
 
 export { asUUID, generateUuidFromString } from './uuid';
 
 export {
   fromV2ActionExample,
   toV2ActionExample,
-  ActionExample,
   convertContentToV1,
   convertContentToV2,
 } from './actionExample';
 
-export { fromV2Provider, toV2Provider, Provider } from './provider';
+export type { ActionExample } from './actionExample';
 
-export {
-  createTemplateFunction,
-  processTemplate,
-  getTemplateValues,
-  TemplateType,
-} from './templates';
+export { fromV2Provider, toV2Provider } from './provider';
+
+export type { Provider } from './provider';
+
+export { createTemplateFunction, processTemplate, getTemplateValues } from './templates';
+
+export type { TemplateType } from './templates';
 
 // Existing exports
 export * from './messages';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/specs/v1/index.ts', 'src/specs/v2/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/specs/v1/index.ts',
+    'src/specs/v1/state.ts',
+    'src/specs/v1/actionExample.ts',
+    'src/specs/v1/templates.ts',
+    'src/specs/v1/uuid.ts',
+    'src/specs/v1/provider.ts',
+    'src/specs/v1/messages.ts',
+    'src/specs/v1/posts.ts',
+    'src/specs/v1/runtime.ts',
+    'src/specs/v1/types.ts',
+    'src/specs/v2/index.ts',
+  ],
   outDir: 'dist',
   clean: true,
   format: ['esm'],

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,20 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: [
-    'src/index.ts',
-    'src/specs/v1/index.ts',
-    'src/specs/v1/state.ts',
-    'src/specs/v1/actionExample.ts',
-    'src/specs/v1/templates.ts',
-    'src/specs/v1/uuid.ts',
-    'src/specs/v1/provider.ts',
-    'src/specs/v1/messages.ts',
-    'src/specs/v1/posts.ts',
-    'src/specs/v1/runtime.ts',
-    'src/specs/v1/types.ts',
-    'src/specs/v2/index.ts',
-  ],
+  entry: ['src/index.ts', 'src/specs/v1/*.ts', 'src/specs/v2/index.ts'],
   outDir: 'dist',
   clean: true,
   format: ['esm'],


### PR DESCRIPTION
**Problem**

CLI plugin loading was failing with errors like export 'State' not found in './state' and export 'ActionExample' not found in './actionExample'. This prevented @elizaos/plugin-sql and other plugins from loading, causing the CLI to fail with "Database adapter not initialized" errors. This was causing basic stuff like elizaos start/dev to fail with default char. 

**Root Cause**

The @elizaos/core package build configuration had two issues:
- Missing entry points: tsup.config.ts only included 3 entry points, but the v1 specs used relative imports like import { State } from './state'. Since state.ts wasn't an entry point, no state.js file was built, causing runtime module resolution failures.
- Type vs runtime exports: TypeScript types like State were being exported as runtime values (export { State }), but they only exist at compile-time, causing build errors when tsup tried to create JavaScript exports for non-existent runtime values.

**Solution**

Added all v1 spec files as entry points in tsup.config.ts so they get built into importable .js modules
Changed type exports to use export type { } syntax to keep types in the type-only namespace while preserving function exports as runtime exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal structure by distinguishing between type-only and value exports, enhancing module clarity without affecting the user-facing API.

- **Chores**
  - Updated build configuration to include additional entry points for better modularization. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->