### PR TITLE
fix: Database isolation for template testing + standardize ignore files

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -163,7 +163,15 @@ const runE2eTests = async (
 
     // Set up standard paths and load .env
     const elizaDir = path.join(process.cwd(), '.eliza');
-    const elizaDbDir = await resolvePgliteDir();
+
+    // Handle edge case: when testing template directories directly (e.g., project-starter, plugin-starter)
+    // Use project-specific path to avoid database contamination in monorepo root
+    const isTemplateDirectory =
+      process.cwd().includes('/project-starter') || process.cwd().includes('/plugin-starter');
+    const elizaDbDir = isTemplateDirectory
+      ? path.join(process.cwd(), '.elizadb') // Project-specific for templates
+      : await resolvePgliteDir(); // Normal resolution for created projects
+
     const envInfo = await UserEnvironment.getInstanceInfo();
     const envFilePath = envInfo.paths.envFilePath;
 

--- a/packages/plugin-starter/.dockerignore
+++ b/packages/plugin-starter/.dockerignore
@@ -1,0 +1,75 @@
+# Build outputs (Docker will build these)
+dist/
+node_modules/
+
+# Environment files (use Docker env instead)
+.env*
+*.env
+
+# OS files
+.DS_Store
+Thumbs.db
+.AppleDouble
+.LSOverride
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory
+coverage/
+
+# Cache directories
+.npm/
+.cache/
+.eslintcache
+.turbo/
+
+# Temporary folders
+tmp/
+temp/
+
+# ElizaOS runtime directories
+.eliza/
+.elizadb/
+elizadb/
+pglite/
+cache/
+data/
+
+# Git files
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+docs/
+*.md
+
+# CI/CD files
+.github/
+.gitlab-ci.yml
+.travis.yml
+.circleci/
+
+# Package manager lock files (let Docker handle dependencies)
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb 

--- a/packages/plugin-starter/.gitignore
+++ b/packages/plugin-starter/.gitignore
@@ -52,6 +52,7 @@ temp/
 
 # ElizaOS specific
 .eliza/
+.elizadb/
 elizadb/
 pglite/
 cache/

--- a/packages/plugin-starter/.npmignore
+++ b/packages/plugin-starter/.npmignore
@@ -1,6 +1,63 @@
-.turbo
-dist
-node_modules
-.env
+# Source files (published package uses dist/)
+src/
+__tests__/
+e2e/
+
+# Development files
+*.test.ts
+*.test.js
+*.spec.ts
+*.spec.js
+vitest.config.*
+tsconfig.json
+tsconfig.build.json
+tsup.config.*
+.turbo/
+
+# Environment files
+.env*
 *.env
-.env.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage
+coverage/
+
+# Cache directories
+.cache/
+.npm/
+.eslintcache
+
+# Temporary folders
+tmp/
+temp/
+
+# ElizaOS runtime directories
+.eliza/
+.elizadb/
+elizadb/
+pglite/
+cache/
+data/
+
+# Git files
+.git/
+.gitignore
+
+# Documentation that shouldn't be in package
+README.md
+docs/

--- a/packages/project-starter/.dockerignore
+++ b/packages/project-starter/.dockerignore
@@ -1,0 +1,75 @@
+# Build outputs (Docker will build these)
+dist/
+node_modules/
+
+# Environment files (use Docker env instead)
+.env*
+*.env
+
+# OS files
+.DS_Store
+Thumbs.db
+.AppleDouble
+.LSOverride
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory
+coverage/
+
+# Cache directories
+.npm/
+.cache/
+.eslintcache
+.turbo/
+
+# Temporary folders
+tmp/
+temp/
+
+# ElizaOS runtime directories
+.eliza/
+.elizadb/
+elizadb/
+pglite/
+cache/
+data/
+
+# Git files
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+docs/
+*.md
+
+# CI/CD files
+.github/
+.gitlab-ci.yml
+.travis.yml
+.circleci/
+
+# Package manager lock files (let Docker handle dependencies)
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb 

--- a/packages/project-starter/.gitignore
+++ b/packages/project-starter/.gitignore
@@ -1,6 +1,58 @@
+# Build outputs
 dist/
 node_modules/
+
+# Environment files
 .env
 .env.local
+.env.production
+.env.staging
+.env.development
+.env.bak
+*.env
+
+# OS files
 .DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
 *.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# Cache directories
+.cache/
+.npm/
+.eslintcache
+
+# Temporary folders
+tmp/
+temp/
+
+# Database files
+*.db
+*.pglite
+*.pglite3
+
+# ElizaOS specific
+.eliza/
+.elizadb/
+elizadb/
+pglite/
+cache/

--- a/packages/project-starter/.npmignore
+++ b/packages/project-starter/.npmignore
@@ -1,6 +1,63 @@
-.turbo
-dist
-node_modules
-.env
+# Source files (published package uses dist/)
+src/
+__tests__/
+e2e/
+
+# Development files
+*.test.ts
+*.test.js
+*.spec.ts
+*.spec.js
+vitest.config.*
+tsconfig.json
+tsconfig.build.json
+tsup.config.*
+.turbo/
+
+# Environment files
+.env*
 *.env
-.env.local
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Coverage
+coverage/
+
+# Cache directories
+.cache/
+.npm/
+.eslintcache
+
+# Temporary folders
+tmp/
+temp/
+
+# ElizaOS runtime directories
+.eliza/
+.elizadb/
+elizadb/
+pglite/
+cache/
+data/
+
+# Git files
+.git/
+.gitignore
+
+# Documentation that shouldn't be in package
+README.md
+docs/


### PR DESCRIPTION
## 🐛 **Database Isolation Fix**

Fixes critical database path resolution bug in `elizaos test` command that caused database contamination when testing template directories directly. kind of an edge case but still not great for the developer if they do decide to test project-starter or plugin-starter. 

### **Problem**
- Running `elizaos test` in `packages/project-starter/` created database in monorepo root (`/.elizadb`)
- Caused WASM initialization errors and test contamination
- Only affected template development, not end-user projects created via `elizaos create`

### **Solution**
- Added edge case detection for template directories (`project-starter`, `plugin-starter`)
- Use project-specific database paths (`./elizadb`) for templates
- Maintains normal behavior for user-created projects

## 🗂️ **Template Ignore Files Standardization**

Comprehensive standardization of ignore files across `project-starter` and `plugin-starter` templates.

### **Changes**
- **`.gitignore`**: Expanded from 6 to 58 lines with proper categorization
- **`.npmignore`**: Expanded from 6 to 63 lines optimized for npm publishing  
- **`.dockerignore`**: Added new comprehensive Docker build context exclusions
- **Consistency**: All ignore files now identical between both templates

### **Coverage**
- Build outputs (`dist/`, `node_modules/`)
- Environment files (`.env*`, `*.env`)
- OS files (`.DS_Store`, `Thumbs.db`)
- IDE files (`.vscode/`, `.idea/`)
- ElizaOS runtime directories (`.eliza/`, `.elizadb/`, `cache/`)
- Development artifacts, logs, coverage, etc.

## 🧪 **Testing**

- [x] Template testing now uses isolated databases
- [x] Component tests pass in both templates
- [x] Ignore files prevent unnecessary file tracking/publishing

## 📦 **Impact**

- **Template developers**: No more database contamination when testing templates
- **End users**: Better ignore file coverage in created projects
- **Publishing**: Cleaner package contents with proper `.npmignore`
- **Docker**: Optimized build contexts with `.dockerignore`

Fixes the core database isolation issue identified in template testing workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added comprehensive `.dockerignore` files to both project and plugin starter packages to optimize Docker builds by excluding unnecessary files.
  - Expanded `.gitignore` and `.npmignore` files in project and plugin starter packages to better exclude development, environment, and runtime files from version control and published packages.
- **Refactor**
  - Improved handling of database directory paths during end-to-end tests to prevent database contamination in template projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->