### PR TITLE
feat: plugins add env var prompting

### DIFF
--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -209,11 +209,11 @@ const promptForPluginEnvVars = async (packageName: string, cwd: string): Promise
   
   if (Object.keys(envRequirements).length === 0) {
     logger.debug(`No environment variables required for ${packageName}`);
-    console.log(`✅ No environment variables required for ${packageName}`);
+    logger.info(`✅ No environment variables required for ${packageName}`);
     return;
   }
 
-  console.log(`\n${emoji.rocket(`Plugin ${packageName} requires environment variables:`)}`);
+  logger.info(`\n${emoji.rocket(`Plugin ${packageName} requires environment variables:`)}`);
   
   // Read current .env file to check for existing values
   const envContent = readEnvFile(cwd);


### PR DESCRIPTION
<img width="718" alt="Screenshot 2025-06-05 at 9 43 30 AM" src="https://github.com/user-attachments/assets/991b4b60-dda7-469c-a60d-07bcf5b2f4a7" />

This pull request enhances the plugin installation process in the CLI by adding support for environment variable configuration, improving package name handling, and refining user prompts. The most significant changes include introducing functions to manage `.env` files and prompt users for environment variables, updating plugin installation workflows to include these prompts, and improving package name resolution.

### Environment Variable Management:
* Added utility functions to read, write, and update `.env` files (`readEnvFile`, `writeEnvFile`, `updateEnvFile`) and to prompt users for environment variable values (`promptForEnvVar`). These functions streamline the process of configuring plugins that require specific environment variables.

* Introduced `promptForPluginEnvVars`, a function that extracts environment variable requirements from a plugin's `package.json` and prompts the user to provide values, updating the `.env` file accordingly.

### Plugin Installation Workflow:
* Updated the plugin installation action to include optional prompts for environment variables after a plugin is installed. Users can skip these prompts using the `--skip-env-prompt` flag. [[1]](diffhunk://#diff-319a6b9f06a3b46dbbba6af360def478c6e9fa16f280659419ca9fc33bc3352cL186-R368) [[2]](diffhunk://#diff-319a6b9f06a3b46dbbba6af360def478c6e9fa16f280659419ca9fc33bc3352cL248-R444) [[3]](diffhunk://#diff-319a6b9f06a3b46dbbba6af360def478c6e9fa16f280659419ca9fc33bc3352cR469-R486)

### Package Name Handling:
* Added `extractPackageName` to handle various input formats (e.g., GitHub URLs, shorthand notations) and resolve them into valid npm package names. This ensures accurate package identification during installation.

* Adjusted `findPluginPackageName` to prioritize certain naming conventions (e.g., `@elizaos/` over `@elizaos-plugins/`) for better package resolution.

### Command-Line Interface:
* Changed the `--no-env-prompt` flag to `--skip-env-prompt` for better clarity and consistency in the CLI options.