### PR TITLE
fix: release ci versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,9 @@ jobs:
         run: |
           # Get the latest release tag
           LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          
+          # Extract version number from tag (remove 'v' prefix if present)
+          VERSION=${LATEST_TAG#v}
 
           # Force clean the working directory and reset any changes
           echo "Cleaning working directory and resetting any changes"
@@ -59,7 +62,11 @@ jobs:
           echo "Checking out latest tag: $LATEST_TAG"
           git checkout -b temp-publish-branch $LATEST_TAG
 
-          echo "Publishing version: $LATEST_TAG"
-          npx lerna publish from-package --yes --dist-tag latest
+          echo "Setting version to: $VERSION"
+          # Update lerna.json and all package.json files to the release version
+          npx lerna version $VERSION --exact --no-git-tag-version --no-push --yes --force-publish
+
+          echo "Publishing version: $VERSION"
+          npx lerna publish from-package --yes --dist-tag latest --no-private --force-publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Summary of the Fix:
The main issue was that the CI workflow was trying to publish packages without first updating their versions to match the release tag. Here's what I changed:

Extract version from tag: Remove the 'v' prefix from the git tag to get the actual version number
Run lerna version: Update all [package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) files to the release version using lerna version $VERSION --exact --no-git-tag-version --no-push --yes --force-publish
Add missing flags: Added --no-private --force-publish flags to match the local command behavior
Key Differences Explained:
Local command: Runs lerna version first to bump versions, then publishes
Original CI: Only tried to publish without version bumping, causing "No changed packages to publish"
Fixed CI: Now mimics the local behavior by setting versions first, then publishing
The --force-publish flag ensures all packages get published even if lerna thinks they haven't changed, and --no-private excludes private packages from publishing (like the client package which has "private": true).