### PR TITLE
fix: onboarding user settings error

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -24,6 +24,7 @@ import {
   type Plugin,
   PluginEvents,
   postCreationTemplate,
+  Role,
   type Room,
   shouldRespondTemplate,
   truncateToCompleteSentence,
@@ -977,6 +978,19 @@ const syncSingleUser = async (
     const roomId = createUniqueUuid(runtime, channelId);
     const worldId = createUniqueUuid(runtime, serverId);
 
+    // Create world with ownership metadata for DM connections (onboarding)
+    const worldMetadata = type === ChannelType.DM ? {
+      ownership: {
+        ownerId: entityId,
+      },
+      roles: {
+        [entityId]: Role.OWNER,
+      },
+      settings: {}, // Initialize empty settings for onboarding
+    } : undefined;
+
+    logger.info(`[Bootstrap] syncSingleUser - type: ${type}, isDM: ${type === ChannelType.DM}, worldMetadata: ${JSON.stringify(worldMetadata)}`);
+
     await runtime.ensureConnection({
       entityId,
       roomId,
@@ -988,7 +1002,16 @@ const syncSingleUser = async (
       serverId,
       type,
       worldId,
+      metadata: worldMetadata,
     });
+
+    // Verify the world was created with proper metadata
+    try {
+      const createdWorld = await runtime.getWorld(worldId);
+      logger.info(`[Bootstrap] Created world check - ID: ${worldId}, metadata: ${JSON.stringify(createdWorld?.metadata)}`);
+    } catch (error) {
+      logger.error(`[Bootstrap] Failed to verify created world: ${error}`);
+    }
 
     logger.success(`[Bootstrap] Successfully synced user: ${entity?.id}`);
   } catch (error) {
@@ -1152,8 +1175,10 @@ const events = {
 
   [EventType.ENTITY_JOINED]: [
     async (payload: EntityPayload) => {
+      logger.debug(`[Bootstrap] ENTITY_JOINED event received for entity ${payload.entityId}`);
+      
       if (!payload.worldId) {
-        logger.error('[Bootstrap] No callback provided for entity joined');
+        logger.error('[Bootstrap] No worldId provided for entity joined');
         return;
       }
       if (!payload.roomId) {

--- a/packages/plugin-bootstrap/src/providers/settings.ts
+++ b/packages/plugin-bootstrap/src/providers/settings.ts
@@ -174,7 +174,19 @@ export const settingsProvider: Provider = {
 
       if (isOnboarding) {
         // In onboarding mode, use the user's world directly
-        world = userWorlds?.find((world) => world.metadata?.settings);
+        // Look for worlds with settings metadata, or create one if none exists
+        world = userWorlds?.find((world) => world.metadata?.settings !== undefined);
+
+        if (!world && userWorlds && userWorlds.length > 0) {
+          // If user has worlds but none have settings, use the first one and initialize settings
+          world = userWorlds[0];
+          if (!world.metadata) {
+            world.metadata = {};
+          }
+          world.metadata.settings = {};
+          await runtime.updateWorld(world);
+          logger.info(`Initialized settings for user's world ${world.id}`);
+        }
 
         if (!world) {
           logger.error('No world found for user during onboarding');


### PR DESCRIPTION
```
[2025-06-10 10:32:52] ERROR: No world found for user during onboarding
[2025-06-10 10:32:52] ERROR: Critical error in settings provider: Error: No server ownership found for onboarding
```

This pull request introduces enhancements to the Socket.IO server and the bootstrap plugin to improve event handling, metadata management, and onboarding processes. Key changes include adding support for `ENTITY_JOINED` events, creating worlds with ownership metadata for DM channels, and initializing settings for user worlds during onboarding.

### Enhancements to Socket.IO server:

* [`packages/cli/src/server/socketio/index.ts`](diffhunk://#diff-dccfb381a823a17c3843573fce899161dd411f5cb46617c657b040d7a0dc0d92L118-R168): Added handling for `ENTITY_JOINED` events when a channel is joined, including emitting events with metadata for world/entity creation. Improved logging for debugging and monitoring event emissions. [[1]](diffhunk://#diff-dccfb381a823a17c3843573fce899161dd411f5cb46617c657b040d7a0dc0d92L118-R168) [[2]](diffhunk://#diff-dccfb381a823a17c3843573fce899161dd411f5cb46617c657b040d7a0dc0d92R205-R228)

### Improvements to bootstrap plugin:

* [`packages/plugin-bootstrap/src/index.ts`](diffhunk://#diff-ade2059be3b14bcc6b85b1f1bd73a46a0e7e1c170a3c4ac96e55853f77429b7fR981-R993): Enhanced `syncSingleUser` to create worlds with ownership metadata for DM channels, including roles and settings initialization. Added verification of created worlds to ensure proper metadata. [[1]](diffhunk://#diff-ade2059be3b14bcc6b85b1f1bd73a46a0e7e1c170a3c4ac96e55853f77429b7fR981-R993) [[2]](diffhunk://#diff-ade2059be3b14bcc6b85b1f1bd73a46a0e7e1c170a3c4ac96e55853f77429b7fR1005-R1015)
* [`packages/plugin-bootstrap/src/index.ts`](diffhunk://#diff-ade2059be3b14bcc6b85b1f1bd73a46a0e7e1c170a3c4ac96e55853f77429b7fR1178-R1181): Improved handling of `ENTITY_JOINED` events by adding detailed logging and verifying the presence of `worldId` and `roomId`.

### Onboarding enhancements:

* [`packages/plugin-bootstrap/src/providers/settings.ts`](diffhunk://#diff-887a51c9adb1e6cd9a0aeb962a7b8e69f5603558187992376cd13a30612c0a62L177-R189): Updated onboarding mode to initialize settings metadata for user worlds if none exists, ensuring proper setup during world creation.