### PR TITLE
chore: remove model caching since its slower

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -85,14 +85,6 @@ jobs:
           echo "OPENAI_API_KEY=$OPENAI_API_KEY" > .env
           echo "LOG_LEVEL=info" >> .env
 
-      - name: Cache models
-        uses: actions/cache@v4
-        with:
-          path: ~/.eliza/models
-          key: ${{ runner.os }}-models-${{ hashFiles('.github/workflows/cli-tests.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-models-
-
       - name: Download models
         shell: bash
         run: |


### PR DESCRIPTION
its faster do download models than caching / un-compressing