### PR TITLE
Fix: Ensure correct .elizadb, .eliza placement for projects + plugins across monorepo contexts

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -161,12 +161,12 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
         message: 'No local .env file found. Create one?',
         initialValue: true,
       });
-      
+
       if (clack.isCancel(respCreateLocal)) {
         clack.cancel('Operation cancelled.');
         process.exit(0);
       }
-      
+
       createLocal = respCreateLocal;
     }
     if (!createLocal) {
@@ -189,12 +189,12 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
         message: 'Would you like to add a new environment variable?',
         initialValue: true,
       });
-      
+
       if (clack.isCancel(respAddNew)) {
         clack.cancel('Operation cancelled.');
         process.exit(0);
       }
-      
+
       addNew = respAddNew;
     }
 
@@ -232,12 +232,12 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
     // Prompt user to select a variable or action
     const selection = await clack.select({
       message: 'Select a variable to edit or an action:',
-      options: choices.map(choice => ({
+      options: choices.map((choice) => ({
         value: choice.value,
-        label: choice.title
+        label: choice.title,
       })),
     });
-    
+
     if (clack.isCancel(selection)) {
       clack.cancel('Operation cancelled.');
       process.exit(0);
@@ -273,7 +273,7 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
       clack.cancel('Operation cancelled.');
       process.exit(0);
     }
-    
+
     if (!action || action === 'back') {
       continue;
     }
@@ -283,7 +283,7 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
         message: `Enter the new value for ${selection}:`,
         defaultValue: envVars[selection],
       });
-      
+
       if (clack.isCancel(value)) {
         clack.cancel('Operation cancelled.');
         process.exit(0);
@@ -301,12 +301,12 @@ async function editEnvVars(scope: 'local', fromMainMenu = false, yes = false): P
           message: `Are you sure you want to delete ${selection}?`,
           initialValue: false,
         });
-        
+
         if (clack.isCancel(resp)) {
           clack.cancel('Operation cancelled.');
           process.exit(0);
         }
-        
+
         confirm = resp;
       }
       if (confirm) {
@@ -347,13 +347,13 @@ async function addNewVariable(
     clack.cancel('Operation cancelled.');
     process.exit(0);
   }
-  
+
   if (!key) return;
 
   const value = await clack.text({
     message: `Enter the value for ${key}:`,
   });
-  
+
   if (clack.isCancel(value)) {
     clack.cancel('Operation cancelled.');
     process.exit(0);
@@ -450,7 +450,7 @@ async function resetEnv(yes = false): Promise<void> {
   const cacheDir = path.join(elizaDir, 'cache');
 
   const localEnvPath = (await getLocalEnvPath()) ?? path.join(process.cwd(), '.env');
-  const localDbDir = await resolvePgliteDir();
+  const localDbDir = await resolvePgliteDir(undefined, undefined, true); // Respect env vars in env management
 
   // Check if external Postgres is in use
   let usingExternalPostgres = false;
@@ -525,7 +525,7 @@ async function resetEnv(yes = false): Promise<void> {
     // Prompt user to select items with styling matching interactive mode
     const selections = await clack.multiselect({
       message: colors.cyan(colors.bold('Select items to reset:')),
-      options: resetItems.map(item => ({ value: item.value, label: item.title })),
+      options: resetItems.map((item) => ({ value: item.value, label: item.title })),
       required: true,
     });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -247,7 +247,9 @@ async function startAgents(options: {
 }) {
   const postgresUrl = await configureDatabaseSettings(options.configure);
   if (postgresUrl) process.env.POSTGRES_URL = postgresUrl;
-  const pgliteDataDir = postgresUrl ? undefined : await resolvePgliteDir();
+  const pgliteDataDir = postgresUrl
+    ? undefined
+    : await resolvePgliteDir(undefined, undefined, true); // Respect env vars for CLI start
 
   const server = new AgentServer();
   await server.initialize({ dataDir: pgliteDataDir, postgresUrl });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -31,7 +31,7 @@ import { Command } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { detectDirectoryType } from '@/src/utils/directory-detection';
+import { detectDirectoryType, handleDirectoryContextErrors } from '@/src/utils/directory-detection';
 import { validatePort } from '@/src/utils/port-validation';
 import { plugin as sqlPlugin } from '@elizaos/plugin-sql';
 import dotenv from 'dotenv';
@@ -270,6 +270,12 @@ async function startAgents(options: {
       await startAgent(character, server);
     }
   } else {
+    // Check directory type and handle appropriately
+    const cwd = process.cwd();
+    const directoryInfo = detectDirectoryType(cwd);
+
+    handleDirectoryContextErrors(directoryInfo, 'start');
+
     const elizaCharacter = getElizaCharacter();
     await startAgent(elizaCharacter, server);
   }

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -27,7 +27,11 @@ import type {
   CentralRootMessage,
   MessageServiceStructure,
 } from './types';
-import { createDatabaseAdapter, DatabaseMigrationService, plugin as sqlPlugin } from '@elizaos/plugin-sql';
+import {
+  createDatabaseAdapter,
+  DatabaseMigrationService,
+  plugin as sqlPlugin,
+} from '@elizaos/plugin-sql';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -111,7 +115,7 @@ export class AgentServer {
     try {
       logger.debug('Initializing AgentServer (async operations)...');
 
-      const agentDataDir = await resolvePgliteDir(options?.dataDir);
+      const agentDataDir = await resolvePgliteDir(options?.dataDir, undefined, true); // Respect env vars for server flexibility
       logger.info(`[INIT] Database Dir for SQL plugin: ${agentDataDir}`);
       this.database = createDatabaseAdapter(
         {
@@ -127,21 +131,23 @@ export class AgentServer {
       logger.info('[INIT] Running database migrations for messaging tables...');
       try {
         const migrationService = new DatabaseMigrationService();
-        
+
         // Get the underlying database instance
         const db = (this.database as any).getDatabase();
         await migrationService.initializeWithDatabase(db);
-        
+
         // Register the SQL plugin schema
         migrationService.discoverAndRegisterPluginSchemas([sqlPlugin]);
-        
+
         // Run the migrations
         await migrationService.runAllPluginMigrations();
-        
+
         logger.success('[INIT] Database migrations completed successfully');
       } catch (migrationError) {
         logger.error('[INIT] Failed to run database migrations:', migrationError);
-        throw new Error(`Database migration failed: ${migrationError instanceof Error ? migrationError.message : String(migrationError)}`);
+        throw new Error(
+          `Database migration failed: ${migrationError instanceof Error ? migrationError.message : String(migrationError)}`
+        );
       }
 
       // Add a small delay to ensure database is fully ready
@@ -243,14 +249,14 @@ export class AgentServer {
   private async ensureDefaultAgent(): Promise<void> {
     try {
       const DEFAULT_AGENT_ID = '00000000-0000-0000-0000-000000000002';
-      
+
       // Check if the default agent exists
       logger.info('[AgentServer] Checking for default agent...');
       const agent = await this.database.getAgent(DEFAULT_AGENT_ID as UUID);
-      
+
       if (!agent) {
         logger.info('[AgentServer] Creating default agent...');
-        
+
         // Create default agent
         const defaultAgent = {
           id: DEFAULT_AGENT_ID as UUID,
@@ -261,11 +267,11 @@ export class AgentServer {
           settings: {},
           modelProvider: 'none',
           modelName: 'none',
-          createdAt: new Date()
+          createdAt: new Date(),
         };
-        
+
         const created = await this.database.createAgent(defaultAgent as any);
-        
+
         if (created) {
           logger.success('[AgentServer] Default agent created successfully');
         } else {

--- a/packages/cli/src/server/services/message.ts
+++ b/packages/cli/src/server/services/message.ts
@@ -108,6 +108,13 @@ export class MessageBusService extends Service {
           logger.info(
             `[${this.runtime.character.name}] MessageBusService: Agent is subscribed to ${this.subscribedServers.size} servers`
           );
+
+          // Check if we need to show monorepo warning after agent initialization
+          if (global._elizaShowMonorepoWarning) {
+            const { showMonorepoWarning } = await import('../../utils/directory-detection.js');
+            showMonorepoWarning(global._elizaShowMonorepoWarning);
+            delete global._elizaShowMonorepoWarning;
+          }
         }
       }
     } catch (error) {

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -216,7 +216,9 @@ export async function getElizaDirectories(targetProjectDir?: string) {
   const userEnv = UserEnvironment.getInstance();
   const paths = await userEnv.getPathInfo();
 
-  const projectRoot = targetProjectDir || paths.monorepoRoot || process.cwd();
+  // Use targetProjectDir if provided, otherwise use the same directory logic as getPathInfo()
+  // This ensures consistency between config and database paths
+  const projectRoot = targetProjectDir || process.cwd();
   const elizaDir = targetProjectDir ? path.resolve(targetProjectDir, '.eliza') : paths.elizaDir;
   const envFilePath = targetProjectDir ? path.resolve(targetProjectDir, '.env') : paths.envFilePath;
 

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -229,7 +229,7 @@ export async function getElizaDirectories(targetProjectDir?: string) {
   });
 
   const defaultElizaDbDir = path.resolve(projectRoot, '.elizadb');
-  const elizaDbDir = await resolvePgliteDir(undefined, defaultElizaDbDir);
+  const elizaDbDir = await resolvePgliteDir(undefined, defaultElizaDbDir, false); // Use false for monorepo consistency
 
   return { elizaDir, elizaDbDir, envFilePath };
 }
@@ -439,7 +439,7 @@ export async function storePgliteDataDir(dataDir: string, envFilePath: string): 
  */
 export async function promptAndStorePostgresUrl(envFilePath: string): Promise<string | null> {
   clack.intro('🗄️  PostgreSQL Configuration');
-  
+
   const response = await clack.text({
     message: 'Enter your Postgres URL:',
     placeholder: 'postgresql://user:password@host:port/dbname',
@@ -453,7 +453,7 @@ export async function promptAndStorePostgresUrl(envFilePath: string): Promise<st
       return undefined;
     },
   });
-  
+
   if (clack.isCancel(response)) {
     clack.cancel('Operation cancelled.');
     return null;
@@ -462,7 +462,7 @@ export async function promptAndStorePostgresUrl(envFilePath: string): Promise<st
   // Store the URL in the .env file
   const spinner = clack.spinner();
   spinner.start('Saving PostgreSQL configuration...');
-  
+
   try {
     await storePostgresUrl(response, envFilePath);
     spinner.stop('PostgreSQL configuration saved successfully!');
@@ -564,9 +564,9 @@ export async function storeAnthropicKey(key: string, envFilePath: string): Promi
  */
 export async function promptAndStoreOpenAIKey(envFilePath: string): Promise<string | null> {
   clack.intro('🤖 OpenAI API Configuration');
-  
+
   clack.note('Get your API key from: https://platform.openai.com/api-keys', 'API Key Information');
-  
+
   const response = await clack.password({
     message: 'Enter your OpenAI API key:',
     validate: (value) => {
@@ -590,7 +590,7 @@ export async function promptAndStoreOpenAIKey(envFilePath: string): Promise<stri
   // Store the key in the .env file (even if invalid)
   const spinner = clack.spinner();
   spinner.start('Saving OpenAI API key...');
-  
+
   try {
     await storeOpenAIKey(response, envFilePath);
     spinner.stop('OpenAI API key saved successfully!');
@@ -610,9 +610,12 @@ export async function promptAndStoreOpenAIKey(envFilePath: string): Promise<stri
  */
 export async function promptAndStoreAnthropicKey(envFilePath: string): Promise<string | null> {
   clack.intro('🤖 Anthropic Claude Configuration');
-  
-  clack.note('Get your API key from: https://console.anthropic.com/settings/keys', 'API Key Information');
-  
+
+  clack.note(
+    'Get your API key from: https://console.anthropic.com/settings/keys',
+    'API Key Information'
+  );
+
   const response = await clack.password({
     message: 'Enter your Anthropic API key:',
     validate: (value) => {
@@ -636,7 +639,7 @@ export async function promptAndStoreAnthropicKey(envFilePath: string): Promise<s
   // Store the key in the .env file (even if invalid)
   const spinner = clack.spinner();
   spinner.start('Saving Anthropic API key...');
-  
+
   try {
     await storeAnthropicKey(response, envFilePath);
     spinner.stop('Anthropic API key saved successfully!');
@@ -662,7 +665,7 @@ export async function configureDatabaseSettings(reconfigure = false): Promise<st
 
   // Check if we already have database configuration in env
   let postgresUrl = process.env.POSTGRES_URL;
-  const pgliteDataDir = await resolvePgliteDir(undefined, elizaDbDir);
+  const pgliteDataDir = await resolvePgliteDir(undefined, elizaDbDir, true); // Respect env vars when checking existing config
 
   // Add debug logging
   logger.debug(`Configuration check - POSTGRES_URL: ${postgresUrl ? 'SET' : 'NOT SET'}`);

--- a/packages/cli/test/setup.ts
+++ b/packages/cli/test/setup.ts
@@ -84,7 +84,7 @@ vi.mock('../src/utils/user-environment', () => ({
 vi.mock('../src/utils/resolve-utils', () => ({
   expandTildePath: vi.fn((p) => p),
   resolveEnvFile: vi.fn().mockReturnValue('/mock/globalDefault.env'), // Consistent global default
-  resolvePgliteDir: vi.fn().mockResolvedValue('/mock/.globalDefault-elizadb'),
+  resolvePgliteDir: vi.fn().mockResolvedValue('/mock/.globalDefault-elizadb'), // Mocks handle any signature
 }));
 
 // Mock for prompts, often used in commands
@@ -132,5 +132,6 @@ vi.mock('../src/utils', async (importOriginal) => {
   return {
     ...actual,
     resolveEnvFile: vi.fn().mockReturnValue('/mock/globalDefault.env'),
+    resolvePgliteDir: vi.fn().mockResolvedValue('/mock/.globalDefault-elizadb'), // Add resolvePgliteDir mock here too
   };
 });

--- a/packages/plugin-sql/src/index.ts
+++ b/packages/plugin-sql/src/index.ts
@@ -54,7 +54,7 @@ export function createDatabaseAdapter(
   },
   agentId: UUID
 ): IDatabaseAdapter {
-  const dataDir = resolvePgliteDir(config.dataDir);
+  const dataDir = resolvePgliteDir(config.dataDir, undefined, true); // Respect env vars for plugin flexibility
 
   if (config.postgresUrl) {
     if (!globalSingletons.postgresConnectionManager) {


### PR DESCRIPTION
# Fix CLI Database and Config File Creation in Wrong Directories

## Problem

The ElizaOS CLI commands (`elizaos start` and `elizaos dev`) were creating database (`.elizadb`) and configuration (`.eliza`) files in incorrect locations, causing several issues:

1. **Monorepo Root Pollution**: When running from projects/plugins inside the monorepo, files were created in the monorepo root instead of the current working directory
2. **Subdirectory Execution Issues**: Running commands from subdirectories (e.g., `packages/cli`) would create files in the monorepo root, not the intended location
3. **Poor User Experience**: No clear guidance when users ran commands from inappropriate directories
4. **Inconsistent Behavior**: Different directory contexts resulted in unpredictable file placement

## Solution

Implemented comprehensive directory validation and centralized error handling:

### 1. **Centralized Directory Validation**

- Added `handleDirectoryContextErrors()` function for consistent validation across commands
- Integrated directory type detection into both `start` and `dev` commands
- Ensured database and config files are always created in the current working directory

### 2. **Enhanced User Guidance**

- **Fatal Errors**: Clear error messages for invalid directory contexts (e.g., running from subdirectories)
- **Warnings**: Styled warnings for monorepo usage with guidance toward best practices
- **Styled Messaging**: Consistent, color-coded error and warning displays matching existing UI patterns

### 3. **Improved Plugin Detection**

- Refined heuristics to reduce false positives in plugin detection
- Fixed issue where `project-tee-starter` was incorrectly flagged as a plugin

### 4. **Deferred Warning Display**

- Monorepo warnings now appear after agent initialization to avoid interrupting startup
- Uses global flag mechanism to schedule warnings for appropriate timing

## Examples

### Before (Problematic Behavior)

```bash
# Running from monorepo root
cd /path/to/eliza
elizaos start
# ❌ Creates .elizadb and .eliza in /path/to/eliza

# Running from plugin inside monorepo
cd /path/to/eliza/packages/plugin-bootstrap
elizaos start
# ❌ Creates .elizadb and .eliza in /path/to/eliza (monorepo root)

# Running from subdirectory
cd /path/to/eliza/packages/cli
elizaos start
# ❌ Creates .elizadb and .eliza in /path/to/eliza (monorepo root)
```

### After (Fixed Behavior)

```bash
# Running from monorepo root
cd /path/to/eliza
elizaos start
# ✅ Creates .elizadb and .eliza in /path/to/eliza
# ⚠️  Shows warning: "Running from monorepo root is not best practice"

# Running from plugin inside monorepo
cd /path/to/eliza/packages/plugin-bootstrap
elizaos start
# ✅ Creates .elizadb and .eliza in /path/to/eliza/packages/plugin-bootstrap
# ⚠️  Shows warning: "Running from monorepo root is not best practice"

# Running from subdirectory
cd /path/to/eliza/packages/cli
elizaos start
# ❌ Shows error: "Must run elizaos start from project or plugin directory"
# 🛑 Exits with helpful guidance to run "elizaos create"
```

### Validation Matrix

All directory types now behave correctly:

| Directory Type                     | START | DEV  | Database/Config Location |
| ---------------------------------- | ----- | ---- | ------------------------ |
| elizaos-project (outside monorepo) | ✅    | ✅   | Current directory        |
| elizaos-plugin (outside monorepo)  | ✅    | ✅   | Current directory        |
| elizaos-project (inside monorepo)  | ✅⚠️  | ✅⚠️ | Current directory        |
| elizaos-plugin (inside monorepo)   | ✅⚠️  | ✅⚠️ | Current directory        |
| elizaos-monorepo                   | ✅⚠️  | ✅⚠️ | Current directory        |
| elizaos-subdir                     | ❌    | ❌   | N/A (exits with error)   |

Legend: ✅ = Works, ⚠️ = Warning shown, ❌ = Error shown and exits

## Files Changed

- `packages/cli/src/commands/dev.ts` - Integrated centralized directory validation
- `packages/cli/src/commands/start.ts` - Added directory validation to start command
- `packages/cli/src/server/services/message.ts` - Deferred monorepo warning display
- `packages/cli/src/utils/directory-detection.ts` - Added comprehensive validation and styling functions

## Benefits

1. **Predictable File Placement**: Database and config files always created in current working directory
2. **Better Developer Experience**: Clear guidance when commands are run from inappropriate locations
3. **Monorepo Best Practices**: Gentle warnings guide users toward creating projects outside monorepo
4. **Consistent UX**: Styled error/warning messages match existing CLI design patterns
5. **Reduced Support Issues**: Self-explanatory error messages with actionable guidance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error and warning messages when running CLI commands from unsupported directories, providing clearer guidance and styled console output.
  - Centralized directory validation and messaging for CLI commands to enhance user feedback and enforce best practices.

- **Bug Fixes**
  - Fixed directory detection logic to ensure configuration and database paths are consistently resolved relative to the correct project directory.

- **Enhancements**
  - Reduced repeated logging of directory paths and types during startup for a cleaner console experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->