### PR TITLE
chore: limit starter create UX to three simple choices

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -36,7 +36,7 @@ export async function createPlugin(
 
   if (!isNonInteractive) {
     const confirmCreate = await clack.confirm({
-      message: `Create plugin "${pluginDirName}" in ${pluginTargetDir}?`,
+      message: `Create plugin "${colors.cyan(pluginDirName)}" with template in new dir ${colors.dim(pluginTargetDir)}?`,
     });
 
     if (clack.isCancel(confirmCreate) || !confirmCreate) {
@@ -53,62 +53,11 @@ export async function createPlugin(
 
   console.info(`\n${colors.green('✓')} Plugin "${pluginDirName}" created successfully!`);
   console.info(`\nNext steps:`);
-  console.info(`  cd ${pluginDirName}`);
+  console.info(`  cd ${pluginTargetDir}`);
   console.info(`  bun run build`);
-  console.info(`  bun run test\n`);
+  console.info(`  elizaos start\n`);
 }
 
-/**
- * Creates a new agent character file with the specified name.
- */
-export async function createAgent(
-  agentName: string,
-  targetDir: string,
-  isNonInteractive = false
-): Promise<void> {
-  const agentFilePath = join(targetDir, `${agentName}.json`);
-
-  // Check if agent file already exists
-  try {
-    await fs.access(agentFilePath);
-    throw new Error(`Agent file ${agentFilePath} already exists`);
-  } catch (error: any) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-    // File doesn't exist, which is what we want
-  }
-
-  if (!isNonInteractive) {
-    const confirmCreate = await clack.confirm({
-      message: `Create agent "${agentName}" at ${agentFilePath}?`,
-    });
-
-    if (clack.isCancel(confirmCreate) || !confirmCreate) {
-      clack.cancel('Agent creation cancelled.');
-      process.exit(0);
-    }
-  }
-
-  // Create agent character based on Eliza template
-  const agentCharacter = {
-    ...elizaCharacter,
-    name: agentName,
-    bio: [
-      `${agentName} is a helpful AI assistant created to provide assistance and engage in meaningful conversations.`,
-      `${agentName} is knowledgeable, creative, and always eager to help users with their questions and tasks.`,
-    ],
-  };
-
-  await fs.writeFile(agentFilePath, JSON.stringify(agentCharacter, null, 2));
-
-  if (!isNonInteractive) {
-    console.info(`\n${colors.green('✓')} Agent "${agentName}" created successfully!`);
-  }
-  console.info(`Agent character created successfully at: ${agentFilePath}`);
-  console.info(`\nTo use this agent:`);
-  console.info(`  elizaos agent start --path ${agentFilePath}\n`);
-}
 
 /**
  * Creates a new TEE project with the specified name and configuration.
@@ -130,7 +79,7 @@ export async function createTEEProject(
 
   if (!isNonInteractive) {
     const confirmCreate = await clack.confirm({
-      message: `Create TEE project "${projectName}" in ${teeTargetDir}?`,
+      message: `Create TEE project "${colors.cyan(projectName)}" with ${database} + ${aiModel} in new dir ${colors.dim(teeTargetDir)}?`,
     });
 
     if (clack.isCancel(confirmCreate) || !confirmCreate) {
@@ -153,8 +102,9 @@ export async function createTEEProject(
 
   console.info(`\n${colors.green('✓')} TEE project "${projectName}" created successfully!`);
   console.info(`\nNext steps:`);
-  console.info(`  cd ${projectName}`);
-  console.info(`  bun run dev\n`);
+  console.info(`  cd ${teeTargetDir}`);
+  console.info(`  bun run build`);
+  console.info(`  elizaos start\n`);
 }
 
 /**
@@ -178,7 +128,7 @@ export async function createProject(
 
   if (!isNonInteractive) {
     const confirmCreate = await clack.confirm({
-      message: `Create project "${projectName}" in ${projectTargetDir}?`,
+      message: `Create project "${colors.cyan(projectName === '.' ? 'in current directory' : projectName)}" with ${database} + ${aiModel} in new dir ${colors.dim(projectTargetDir)}?`,
     });
 
     if (clack.isCancel(confirmCreate) || !confirmCreate) {
@@ -203,8 +153,9 @@ export async function createProject(
   await buildProject(projectTargetDir);
 
   const displayName = projectName === '.' ? 'Project' : `Project "${projectName}"`;
-  console.info(`\n${colors.green('✓')} ${displayName} initialized successfully!`);
+  console.info(`\n${colors.green('✓')} ${displayName} created successfully!`);
   console.info(`\nNext steps:`);
-  console.info(`  cd ${projectName}`);
-  console.info(`  bun run dev\n`);
+  console.info(`  cd ${projectTargetDir}`);
+  console.info(`  bun run build`);
+  console.info(`  elizaos start\n`);
 }

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -7,12 +7,12 @@ import { logger } from '@elizaos/core';
 
 import { validateCreateOptions, validateProjectName } from './utils';
 import { selectDatabase, selectAIModel } from './utils';
-import { createProject, createPlugin, createAgent, createTEEProject } from './actions';
+import { createProject, createPlugin, createTEEProject } from './actions';
 import type { CreateOptions } from './types';
 
 export const create = new Command('create')
-  .description('Create a new ElizaOS project, plugin, agent, or TEE project')
-  .argument('[name]', 'name of the project/plugin/agent to create')
+  .description('Create a new ElizaOS project, custom plugin, or TEE project')
+  .argument('[name]', 'name of the project/plugin to create')
   .option('--dir <dir>', 'directory to create the project in', '.')
   .option('--yes, -y', 'skip prompts and use defaults')
   .option('--type <type>', 'type of project to create (project, plugin, agent, tee)', 'project')
@@ -53,17 +53,12 @@ export const create = new Command('create')
               {
                 label: 'Project - Full ElizaOS application',
                 value: 'project',
-                hint: 'Complete project with runtime, agents, and all features',
+                hint: 'Complete project with starter agent, plugin and all features',
               },
               {
-                label: 'Plugin - Custom ElizaOS plugin',
+                label: 'Plugin - New ElizaOS plugin',
                 value: 'plugin',
-                hint: 'Extend ElizaOS functionality with custom plugins',
-              },
-              {
-                label: 'Agent - Character definition file',
-                value: 'agent',
-                hint: 'Create a new agent character file',
+                hint: 'Extend ElizaOS functionality with custom plugins, develop with default eliza character',
               },
               {
                 label: 'TEE Project - Trusted Execution Environment project',
@@ -79,7 +74,7 @@ export const create = new Command('create')
             process.exit(0);
           }
 
-          projectType = selectedType as 'project' | 'plugin' | 'agent' | 'tee';
+          projectType = selectedType as 'project' | 'plugin' | 'tee';
         }
 
         // Prompt for name

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -122,10 +122,6 @@ export const create = new Command('create')
           await createPlugin(projectName!, targetDir, isNonInteractive);
           break;
 
-        case 'agent':
-          await createAgent(projectName!, targetDir, isNonInteractive);
-          break;
-
         case 'tee': {
           // TEE projects need database and AI model selection
           let database = 'pglite';


### PR DESCRIPTION
## Summary
- Simplified the create command UX by limiting options to three choices: project, plugin, and TEE project
- Removed the agent creation option to streamline the user experience
- Updated confirmation messages with better formatting using colors and clearer directory paths
- Improved next steps instructions to use consistent commands (`elizaos start` instead of `bun run dev`)
- Enhanced hint text for better user understanding of each option

## Changes
- Removed `createAgent` function from creators.ts
- Updated create command description and options
- Improved confirmation messages with colored text and clearer paths
- Standardized next steps across all creation types

## Test plan
- [ ] Test project creation flow
- [ ] Test plugin creation flow  
- [ ] Test TEE project creation flow
- [ ] Verify all confirmation messages display correctly
- [ ] Confirm next steps commands work as expected