### PR TITLE
fix: load actual default character

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -1,4 +1,4 @@
-import { character as elizaCharacter } from '@/src/characters/eliza';
+import { getElizaCharacter } from '@/src/characters/eliza';
 import { copyTemplate as copyTemplateUtil, buildProject } from '@/src/utils';
 import { join } from 'path';
 import fs from 'node:fs/promises';
@@ -92,7 +92,7 @@ export async function createAgent(
 
   // Create agent character based on Eliza template
   const agentCharacter = {
-    ...elizaCharacter,
+    ...getElizaCharacter(),
     name: agentName,
     bio: [
       `${agentName} is a helpful AI assistant created to provide assistance and engage in meaningful conversations.`,

--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -10,7 +10,7 @@ import { logger, stringToUuid } from '@elizaos/core';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
-import { character as elizaCharacter } from '@/src/characters/eliza';
+import { getElizaCharacter } from '@/src/characters/eliza';
 
 /**
  * Interface for a project module that can be loaded.
@@ -142,6 +142,7 @@ export async function loadProject(dir: string): Promise<Project> {
       // Create a fallback project with the default Eliza character
       // Use deterministic UUID based on character name to match runtime behavior
       const defaultCharacterName = 'Eliza (Default)';
+      const elizaCharacter = getElizaCharacter(); // Get the filtered character based on env vars
       const defaultAgent: ProjectAgent = {
         character: {
           ...elizaCharacter,
@@ -230,6 +231,7 @@ export async function loadProject(dir: string): Promise<Project> {
         // Use the Eliza character as our test agent
         // Use deterministic UUID based on character name to match runtime behavior
         const characterName = 'Eliza (Test Mode)';
+        const elizaCharacter = getElizaCharacter(); // Get the filtered character based on env vars
         const testCharacter: Character = {
           ...elizaCharacter,
           id: stringToUuid(characterName) as UUID,

--- a/packages/cli/src/server/loader.ts
+++ b/packages/cli/src/server/loader.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type Character, logger } from '@elizaos/core';
 import multer from 'multer';
-import { character as defaultCharacter } from '../characters/eliza';
+import { getElizaCharacter } from '../characters/eliza';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -301,7 +301,7 @@ export async function loadCharacters(charactersArg: string): Promise<Character[]
 
   if (loadedCharacters.length === 0) {
     logger.info('No characters found, using default character');
-    loadedCharacters.push(defaultCharacter);
+    loadedCharacters.push(getElizaCharacter());
   }
 
   return loadedCharacters;


### PR DESCRIPTION
This is a follow on to my previous PR, default char ENVs were never being loaded, this also exposed wrong function import, now default eliza is truly being loaded in CLI monorepo.