### PR TITLE
Update vite.config.ts

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -181,7 +181,7 @@ export default defineConfig(({ mode }): CustomUserConfig => {
       cssMinify: true,
       sourcemap: true,
       rollupOptions: {
-        external: ['cloudflare:sockets'],
+        external: ['cloudflare:sockets', 'langchain/text_splitter'],
         output: {
           manualChunks: {
             vendor: ['react', 'react-dom', 'react-router-dom'],


### PR DESCRIPTION
fixes this

```
✗ Build failed in 1.51s
@elizaos/client:build: error during build:
@elizaos/client:build: [vite]: Rollup failed to resolve import "langchain/text_splitter" from "/Users/studio/Documents/GitHub/eliza/packages/core/src/utils.ts".
@elizaos/client:build: This is most likely unintended because it can break your application at runtime.
@elizaos/client:build: If you do want to externalize this module explicitly add it to
@elizaos/client:build: `build.rollupOptions.external`
@elizaos/client:build:     at viteLog (file:///Users/studio/Documents/GitHub/eliza/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46345:15)
@elizaos/client:build:     at file:///Users/studio/Documents/GitHub/eliza/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46403:18
@elizaos/client:build:     at Object.onwarn (file:///Users/studio/Documents/GitHub/eliza/node_modules/.vite-temp/vite.config.ts.timestamp-1749805877643-ed141450f117f.mjs:175:11)
@elizaos/client:build:     at Object.onwarn (file:///Users/studio/Documents/GitHub/eliza/node_modules/@vitejs/plugin-react-swc/index.mjs:107:40)
@elizaos/client:build:     at file:///Users/studio/Documents/GitHub/eliza/node_modules/vite-plugin-node-polyfills/dist/index.js:70:48
@elizaos/client:build:     at handleCircularDependancyWarning (/Users/studio/Documents/GitHub/eliza/node_modules/node-stdlib-browser/helpers/rollup/plugin.js:29:3)
@elizaos/client:build:     at onwarn (file:///Users/studio/Documents/GitHub/eliza/node_modules/vite-plugin-node-polyfills/dist/index.js:68:15)
@elizaos/client:build:     at file:///Users/studio/Documents/GitHub/eliza/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46401:7
@elizaos/client:build:     at onRollupLog (file:///Users/studio/Documents/GitHub/eliza/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46393:5)
@elizaos/client:build:     at onLog (file:///Users/studio/Documents/GitHub/eliza/node_modules/vite/dist/node/chunks/dep-DBxKXgDP.js:46043:7)
@elizaos/client:build: error: script "build" exited with code 1
@elizaos/client:build: ERROR: command finished with error: command (/Users/studio/Documents/GitHub/eliza/packages/client) /Users/studio/Documents/GitHub/eliza/node_modules/.bin/bun run build exited (1)
@elizaos/client#build: command (/Users/studio/Documents/GitHub/eliza/packages/client) /Users/studio/Documents/GitHub/eliza/node_modules/.bin/bun run build exited (1)

```