### PR TITLE
fix: ids should be uuid not text

### DIFF
--- a/packages/plugin-sql/src/__tests__/integration/messaging.test.ts
+++ b/packages/plugin-sql/src/__tests__/integration/messaging.test.ts
@@ -95,6 +95,21 @@ describe('Messaging Integration Tests', () => {
     it('should add and retrieve agents for a server', async () => {
       const agent1 = uuidv4() as UUID;
       const agent2 = uuidv4() as UUID;
+      
+      // Create the agents first before adding them to server
+      await adapter.createAgent({
+        id: agent1,
+        name: 'Test Agent 1',
+        bio: 'Test agent bio',
+        configurationId: uuidv4() as UUID,
+      });
+      await adapter.createAgent({
+        id: agent2,
+        name: 'Test Agent 2',
+        bio: 'Test agent bio',
+        configurationId: uuidv4() as UUID,
+      });
+      
       await adapter.addAgentToServer(serverId, agent1);
       await adapter.addAgentToServer(serverId, agent2);
 

--- a/packages/plugin-sql/src/schema/serverAgent.ts
+++ b/packages/plugin-sql/src/schema/serverAgent.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, primaryKey } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, primaryKey } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { messageServerTable } from './messageServer';
 import { agentTable } from './agent';
@@ -6,10 +6,10 @@ import { agentTable } from './agent';
 export const serverAgentsTable = pgTable(
   'server_agents',
   {
-    serverId: text('server_id')
+    serverId: uuid('server_id')
       .notNull()
       .references(() => messageServerTable.id, { onDelete: 'cascade' }),
-    agentId: text('agent_id')
+    agentId: uuid('agent_id')
       .notNull()
       .references(() => agentTable.id, { onDelete: 'cascade' }),
   },


### PR DESCRIPTION
## What does this PR do?

Fixes database schema by changing ID columns from `text` type to proper `uuid` type for better type safety and consistency.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Testing

Database migration tested to ensure proper UUID handling.