### PR TITLE
fix: Windows plugin test timeout and hanging issues

### DIFF
--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -195,7 +195,7 @@ describe('ElizaOS Dev Commands', () => {
   };
 
   it('dev --help shows usage', () => {
-    const result = execSync(`${elizaosCmd} dev --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} dev --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('Usage: elizaos dev');
     expect(result).toContain('development mode');
     expect(result).toContain('auto-rebuild');
@@ -520,12 +520,14 @@ describe('ElizaOS Dev Commands', () => {
   it('dev command validates port parameter', () => {
     // Test that invalid port is rejected
     try {
-      execSync(`${elizaosCmd} dev --port abc`, {
-        encoding: 'utf8',
-        stdio: 'pipe',
-        timeout: TEST_TIMEOUTS.QUICK_COMMAND,
-        cwd: projectDir,
-      });
+      execSync(`${elizaosCmd} dev --port abc`, 
+        getPlatformOptions({
+          encoding: 'utf8',
+          stdio: 'pipe',
+          timeout: TEST_TIMEOUTS.QUICK_COMMAND,
+          cwd: projectDir,
+        })
+      );
       expect(false).toBe(true); // Should not reach here
     } catch (error: any) {
       // Expect command to fail with non-zero exit code

--- a/packages/cli/tests/commands/env.test.ts
+++ b/packages/cli/tests/commands/env.test.ts
@@ -61,11 +61,15 @@ describe('ElizaOS Env Commands', () => {
       return;
     }
 
-    // Use printf to simulate user input on Unix systems
-    const result = execSync(`printf "y\\n" | ${context.elizaosCmd} env edit-local`, {
+    // Use platform-appropriate command to simulate user input
+    const inputCommand = process.platform === 'win32' 
+      ? `echo y | ${context.elizaosCmd} env edit-local`
+      : `printf "y\\n" | ${context.elizaosCmd} env edit-local`;
+    
+    const result = execSync(inputCommand, getPlatformOptions({
       encoding: 'utf8',
-      shell: '/bin/bash',
-    });
+      shell: process.platform === 'win32' ? 'cmd.exe' : '/bin/bash',
+    }));
 
     // The command should complete successfully
     expect(result).toBeTruthy();

--- a/packages/cli/tests/commands/plugins.test.ts
+++ b/packages/cli/tests/commands/plugins.test.ts
@@ -218,7 +218,7 @@ describe('ElizaOS Plugin Commands', () => {
   it(
     'plugins installed-plugins shows installed plugins',
     async () => {
-      const result = execSync(`${elizaosCmd} plugins installed-plugins`, { encoding: 'utf8' });
+      const result = execSync(`${elizaosCmd} plugins installed-plugins`, getPlatformOptions({ encoding: 'utf8' }));
       // Should show previously installed plugins from other tests
       expect(result).toMatch(/@elizaos\/plugin-|github:/);
     },
@@ -242,11 +242,13 @@ describe('ElizaOS Plugin Commands', () => {
         let packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).toContain('@elizaos/plugin-elevenlabs');
 
-        execSync(`${elizaosCmd} plugins remove @elizaos/plugin-elevenlabs`, {
-          stdio: 'pipe',
-          timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
-          cwd: projectDir,
-        });
+        execSync(`${elizaosCmd} plugins remove @elizaos/plugin-elevenlabs`, 
+          getPlatformOptions({
+            stdio: 'pipe',
+            timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
+            cwd: projectDir,
+          })
+        );
 
         packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).not.toContain('@elizaos/plugin-elevenlabs');
@@ -272,11 +274,13 @@ describe('ElizaOS Plugin Commands', () => {
 
         // Add all plugins first
         for (const plugin of plugins) {
-          execSync(`${elizaosCmd} plugins add ${plugin} --skip-env-prompt --skip-verification`, {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
-            cwd: projectDir,
-          });
+          execSync(`${elizaosCmd} plugins add ${plugin} --skip-env-prompt --skip-verification`, 
+            getPlatformOptions({
+              stdio: 'pipe',
+              timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
+              cwd: projectDir,
+            })
+          );
         }
 
         // Test different remove aliases
@@ -287,11 +291,13 @@ describe('ElizaOS Plugin Commands', () => {
         ];
 
         for (const [command, plugin] of removeCommands) {
-          execSync(`${elizaosCmd} plugins ${command} ${plugin}`, {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
-            cwd: projectDir,
-          });
+          execSync(`${elizaosCmd} plugins ${command} ${plugin}`, 
+            getPlatformOptions({
+              stdio: 'pipe',
+              timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
+              cwd: projectDir,
+            })
+          );
         }
       } catch (error: any) {
         console.error('[ERROR] Plugin remove aliases failed:', error.message);
@@ -308,11 +314,13 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins add fails for missing plugin',
     async () => {
       try {
-        execSync(`${elizaosCmd} plugins add missing --skip-env-prompt`, {
-          stdio: 'pipe',
-          timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
-          cwd: projectDir,
-        });
+        execSync(`${elizaosCmd} plugins add missing --skip-env-prompt`, 
+          getPlatformOptions({
+            stdio: 'pipe',
+            timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
+            cwd: projectDir,
+          })
+        );
         expect(false).toBe(true); // Should not reach here
       } catch (e: any) {
         expect(e.status).not.toBe(0);

--- a/packages/cli/tests/commands/publish.test.ts
+++ b/packages/cli/tests/commands/publish.test.ts
@@ -361,7 +361,7 @@ esac`;
 
   // publish --help (safe test that never prompts)
   it('publish --help shows usage', () => {
-    const result = execSync(`${elizaosCmd} publish --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} publish --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('Usage: elizaos publish');
     expect(result).toContain('Publish a plugin to npm, GitHub, and the registry');
     expect(result).toContain('--npm');
@@ -373,18 +373,18 @@ esac`;
   // CLI integration (safe test)
   it('publish command integrates with CLI properly', () => {
     // Test that publish command is properly integrated into main CLI
-    const helpResult = execSync(`${elizaosCmd} --help`, { encoding: 'utf8' });
+    const helpResult = execSync(`${elizaosCmd} --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(helpResult).toContain('publish');
 
     // Test that publish command can be invoked
-    const publishHelpResult = execSync(`${elizaosCmd} publish --help`, { encoding: 'utf8' });
+    const publishHelpResult = execSync(`${elizaosCmd} publish --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(publishHelpResult).toContain('Options:');
   });
 
   // Test mode functionality (should not prompt with proper mocking)
   it('publish command validates basic directory structure', () => {
     // Test that publish command works with help
-    const result = execSync(`${elizaosCmd} publish --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} publish --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('publish');
   });
 
@@ -400,14 +400,14 @@ esac`;
       })
     );
 
-    const result = execSync(`${elizaosCmd} publish --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} publish --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('publish');
   });
 
   // Dry run functionality (should not prompt)
   it('publish dry-run flag works', () => {
     // Test that --dry-run flag is recognized
-    const result = execSync(`${elizaosCmd} publish --dry-run --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} publish --dry-run --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('dry-run');
   });
 });

--- a/packages/cli/tests/commands/test-utils.ts
+++ b/packages/cli/tests/commands/test-utils.ts
@@ -541,6 +541,11 @@ export function getPlatformOptions(baseOptions: any = {}): any {
     }
     platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
     platformOptions.windowsHide = true;
+    
+    // Use safer stdio handling on Windows to prevent hanging
+    if (platformOptions.stdio === 'pipe') {
+      platformOptions.stdio = ['ignore', 'pipe', 'pipe'];
+    }
   } else if (process.platform === 'darwin') {
     // macOS specific options
     // Only scale the timeout if one was explicitly provided

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -47,7 +47,7 @@ describe('ElizaOS Update Commands', () => {
 
   // --help
   it('update --help shows usage and options', () => {
-    const result = execSync(`${elizaosCmd} update --help`, { encoding: 'utf8' });
+    const result = execSync(`${elizaosCmd} update --help`, getPlatformOptions({ encoding: 'utf8' }));
     expect(result).toContain('Usage: elizaos update');
     expect(result).toContain('--cli');
     expect(result).toContain('--packages');

--- a/packages/cli/tests/test-timeouts.ts
+++ b/packages/cli/tests/test-timeouts.ts
@@ -19,7 +19,9 @@ export const TEST_TIMEOUTS = {
         ? 6 * 60 * 1000
         : 5 * 60 * 1000, // Platform-specific locally
   INDIVIDUAL_TEST: isCI
-    ? 60 * 1000 // 60 seconds in CI for all platforms - matches bunfig.toml
+    ? isWindows
+      ? 90 * 1000  // 90 seconds for Windows CI (some tests need more time)
+      : 60 * 1000  // 60 seconds for other platforms in CI
     : isWindows
       ? 5 * 60 * 1000
       : isMacOS
@@ -46,7 +48,9 @@ export const TEST_TIMEOUTS = {
         ? 75 * 1000
         : 60 * 1000, // Platform-specific locally
   PLUGIN_INSTALLATION: isCI
-    ? 90 * 1000 // 90 seconds in CI (increased to handle slow postinstall scripts)
+    ? isWindows
+      ? 120 * 1000 // 2 minutes for Windows CI (plugins can be slow)
+      : 90 * 1000  // 90 seconds for other platforms in CI
     : process.platform === 'win32'
       ? 3 * 60 * 1000
       : 2 * 60 * 1000, // 3/2 minutes locally


### PR DESCRIPTION
## Summary
- Fix Windows plugin test timeouts by using getPlatformOptions for all execSync calls
- Improve stdio handling on Windows to prevent process hanging
- Increase timeouts for Windows CI environment

## Root Cause
The "plugins remove aliases" test was failing on Windows CI because:
1. Test framework timeout (60s) was less than command timeout (90s)
2. Windows processes were hanging due to improper stdio handling with `'pipe'`
3. Tests weren't using platform-specific options for Windows

## Changes
1. **Fixed execSync calls**: Updated all execSync calls in `plugins.test.ts` to use `getPlatformOptions()` 
2. **Improved stdio handling**: Modified `getPlatformOptions()` to use `['ignore', 'pipe', 'pipe']` instead of `'pipe'` on Windows
3. **Updated timeouts**: 
   - `INDIVIDUAL_TEST`: 90 seconds for Windows CI (up from 60s)
   - `PLUGIN_INSTALLATION`: 120 seconds for Windows CI (up from 90s)

## Test Plan
- [x] Verify all execSync calls in plugins.test.ts use getPlatformOptions
- [x] Confirm timeout increases for Windows CI
- [x] Test stdio handling improvements

This should resolve the Windows CI failures for plugin tests that were timing out.

🤖 Generated with [Claude Code](https://claude.ai/code)