### PR TITLE
fix(docs): update documentation version from 1.0.10 to 1.0.17

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -256,7 +256,7 @@ const config = {
           lastVersion: 'current',
           versions: {
             current: {
-              label: '1.0.10',
+              label: '1.0.17',
               path: '',
               banner: 'none',
             },


### PR DESCRIPTION
## Summary
- Updated the current version label in docusaurus.config.ts from 1.0.10 to 1.0.17
- This fixes the incorrect version display that was showing as 1.10.0 instead of 1.0.17

## Changes
- Modified `packages/docs/docusaurus.config.ts` line 259 to update the version label

## Test plan
- [ ] Verify the documentation builds successfully with `bun run build:docs`
- [ ] Check that the version displays correctly as 1.0.17 when deployed

🤖 Generated with Claude Code