### PR TITLE
fix: preserve avatar when updating secrets from SecretPanel

### DIFF
--- a/packages/client/src/hooks/use-partial-update.ts
+++ b/packages/client/src/hooks/use-partial-update.ts
@@ -241,15 +241,15 @@ export function usePartialUpdate<T extends object>(initialValue: T) {
         // Extract settings but remove 'secrets' key to avoid duplication
         const { secrets, avatar, ...otherSettings } = settings;
 
-        // Only include avatar if it's a valid string; otherwise, omit it from the update
-        const safeAvatar = typeof avatar === 'string' ? avatar : '';
-
         // Create the updated settings object
         const updatedSettings = {
           ...(prevValue as any).settings, // Start with existing settings
           ...otherSettings, // Add other settings (not secrets)
-          avatar: safeAvatar,
         };
+
+        if (typeof avatar === 'string') {
+          updatedSettings.avatar = avatar;
+        }
 
         // Only add secrets if it was included in the update
         if (secrets) {


### PR DESCRIPTION
Fixes an issue where updating secrets via SecretPanel unintentionally reset agent.settings.avatar to an empty string.

Updates updateSettings logic in usePartialUpdate to:

Preserve existing avatar unless explicitly provided.

Update secrets safely while retaining all other settings fields.

Filter out null values from secrets to handle deletions cleanly.

Ensures SecretPanel, AvatarPanel, and other panels can coexist without wiping each other’s state during partial updates.


issue:

https://github.com/user-attachments/assets/c27e37ed-43d6-49a0-89a8-dfebc0f6ea74


