### PR TITLE
fix: improve maxConnectionAttempts calculation in test-utils

### DIFF
--- a/packages/cli/tests/commands/test-utils.ts
+++ b/packages/cli/tests/commands/test-utils.ts
@@ -295,7 +295,8 @@ export async function waitForServerReady(
 
   // First, check if anything is listening on the port using a simple connection test
   let connectionAttempts = 0;
-  const maxConnectionAttempts = maxWaitTime / 1000;
+  // Base max attempts on actual polling intervals rather than arbitrary time division
+  const maxConnectionAttempts = Math.max(5, Math.floor(maxWaitTime / (pollInterval * 2)));
 
   while (Date.now() - startTime < maxWaitTime) {
     try {


### PR DESCRIPTION
## Problem

The current `maxConnectionAttempts` calculation in `waitForServerReady` function uses an arbitrary time division (`maxWaitTime / 1000`) that assumes each connection attempt takes exactly 1 second. This leads to:

- Inconsistent behavior across platforms (especially macOS CI with 3000ms polling intervals)
- Potential premature timeouts in slower environments
- Time-based vs attempt-based logic mismatch

## Solution

Replace the arbitrary calculation with a more robust approach that:
- Uses actual polling intervals (`pollInterval * 2`) for calculation
- Ensures minimum 5 connection attempts regardless of timing
- Provides consistent behavior across all platforms
- Scales attempts based on actual environmental conditions

## Changes

- Updated `maxConnectionAttempts` calculation to use `Math.max(5, Math.floor(maxWaitTime / (pollInterval * 2)))`
- Added explanatory comment for the logic
- Maintains backward compatibility while improving reliability

## Testing

This change improves test stability, especially on macOS CI where polling intervals are longer (3000ms vs 1000ms on other platforms).

## Impact

- Better test reliability across different environments
- More predictable connection attempt behavior
- Reduced false negatives in CI environments