### PR TITLE
fix: starter avatar

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -1,5 +1,5 @@
 import { getElizaCharacter } from '@/src/characters/eliza';
-import { copyTemplate as copyTemplateUtil } from '@/src/utils';
+import { copyTemplate as copyTemplateUtil, copyElizaAvatarToProject } from '@/src/utils';
 import { join } from 'path';
 import fs from 'node:fs/promises';
 import * as clack from '@clack/prompts';
@@ -329,6 +329,9 @@ export async function createProject(
     await runTasks([
       createTask('Copying project template', () =>
         copyTemplateUtil('project-starter', projectTargetDir)
+      ),
+      createTask('Copying Eliza avatar image', () =>
+        copyElizaAvatarToProject(projectTargetDir)
       ),
       createTask('Setting up project environment', () =>
         setupProjectEnvironment(projectTargetDir, database, aiModel, embeddingModel, true)

--- a/packages/cli/src/utils/copy-avatar.ts
+++ b/packages/cli/src/utils/copy-avatar.ts
@@ -6,12 +6,22 @@ import { existsSync } from 'node:fs';
  * Copies elizaos-avatar.png from CLI dist into the project's frontend folder.
  */
 export async function copyElizaAvatarToProject(projectTargetDir: string) {
-  const avatarSourcePath = resolve(__dirname, '../dist/elizaos-avatar.png');
-  const frontendTargetDir = join(projectTargetDir, 'src/frontend/avatars');
-  const avatarTargetPath = join(frontendTargetDir, 'elizaos-avatar.png');
-
-  if (!existsSync(frontendTargetDir)) {
-    await mkdir(frontendTargetDir, { recursive: true });
+    try {
+      const avatarSourcePath = resolve(__dirname, './elizaos-avatar.png');
+      
+      if (!existsSync(avatarSourcePath)) {
+        throw new Error(`Avatar source not found at ${avatarSourcePath}`);
+      }
+      
+      const frontendTargetDir = join(projectTargetDir, 'src/frontend/avatars');
+      const avatarTargetPath = join(frontendTargetDir, 'elizaos-avatar.png');
+  
+      if (!existsSync(frontendTargetDir)) {
+        await mkdir(frontendTargetDir, { recursive: true });
+      }
+      await copyFile(avatarSourcePath, avatarTargetPath);
+    } catch (error) {
+      console.error('Failed to copy avatar:', error);
+      throw error;
+    }
   }
-  await copyFile(avatarSourcePath, avatarTargetPath);
-}

--- a/packages/cli/src/utils/copy-avatar.ts
+++ b/packages/cli/src/utils/copy-avatar.ts
@@ -1,0 +1,17 @@
+import { join, resolve } from 'node:path';
+import { mkdir, copyFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+/**
+ * Copies elizaos-avatar.png from CLI dist into the project's frontend folder.
+ */
+export async function copyElizaAvatarToProject(projectTargetDir: string) {
+  const avatarSourcePath = resolve(__dirname, '../dist/elizaos-avatar.png');
+  const frontendTargetDir = join(projectTargetDir, 'src/frontend/avatars');
+  const avatarTargetPath = join(frontendTargetDir, 'elizaos-avatar.png');
+
+  if (!existsSync(frontendTargetDir)) {
+    await mkdir(frontendTargetDir, { recursive: true });
+  }
+  await copyFile(avatarSourcePath, avatarTargetPath);
+}

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -23,3 +23,4 @@ export * from './spinner-utils';
 export * from './run-bun';
 export * from './test-runner';
 export * from './user-environment';
+export * from './copy-avatar';

--- a/packages/project-starter/src/character.ts
+++ b/packages/project-starter/src/character.ts
@@ -1,5 +1,15 @@
 import { type Character } from '@elizaos/core';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const imagePath = resolve(__dirname, './frontend/assets/avatars/elizaos-avatar.png');
+const avatar = existsSync(imagePath)
+  ? `data:image/png;base64,${readFileSync(imagePath).toString('base64')}`
+  : '';
 /**
  * Represents the default character (Eliza) with her specific attributes and behaviors.
  * Eliza responds to a wide range of messages, is helpful and conversational.
@@ -41,6 +51,7 @@ export const character: Character = {
   ],
   settings: {
     secrets: {},
+    avatar
   },
   system:
     'Respond to all messages in a helpful, conversational manner. Provide assistance on a wide range of topics, using knowledge when needed. Be concise but thorough, friendly but professional. Use humor when appropriate and be empathetic to user needs. Provide valuable information and insights when questions are asked.',

--- a/packages/project-starter/src/character.ts
+++ b/packages/project-starter/src/character.ts
@@ -6,7 +6,7 @@ import { dirname, resolve } from 'node:path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const imagePath = resolve(__dirname, './frontend/assets/avatars/elizaos-avatar.png');
+const imagePath = resolve(__dirname, '../dist/frontend/assets/avatars/elizaos-avatar.png');
 const avatar = existsSync(imagePath)
   ? `data:image/png;base64,${readFileSync(imagePath).toString('base64')}`
   : '';

--- a/packages/project-starter/tsup.config.ts
+++ b/packages/project-starter/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: 'dist',
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   sourcemap: true,
-  clean: true,
+  clean: false,
   format: ['esm'], // Ensure you're targeting CommonJS
   dts: false, // Skip DTS generation to avoid external import issues // Ensure you're targeting CommonJS
   external: [

--- a/packages/project-starter/vite.config.ts
+++ b/packages/project-starter/vite.config.ts
@@ -2,12 +2,43 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { mkdirSync, copyFileSync, existsSync } from 'node:fs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+function copyAvatarPlugin() {
+  return {
+    name: "copy-eliza-avatar",
+    apply: "build" as const,
+    closeBundle() {
+      const src = path.resolve(
+        __dirname,
+        "src/frontend/avatars/elizaos-avatar.png"
+      );
+      const destDir = path.resolve(__dirname, "dist/frontend/assets/avatars");
+      const dest = path.resolve(destDir, "elizaos-avatar.png");
+
+      if (!existsSync(src)) {
+        console.warn(
+          `elizaos-avatar.png not found at ${src}, skipping copy.`
+        );
+        return;
+      }
+
+      if (!existsSync(destDir)) {
+        mkdirSync(destDir, { recursive: true });
+      }
+
+      copyFileSync(src, dest);
+      console.info(`Copied elizaos-avatar.png to ${dest} during build.`);
+    },
+  };
+}
+
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), copyAvatarPlugin()],
   root: 'src/frontend',
   build: {
     outDir: '../../dist/frontend',


### PR DESCRIPTION
Currently, the starter project does not include the default Eliza avatar like the monorepo does. This PR fixes that by:

✅ Copying elizaos-avatar.png into the project's src/frontend/avatars folder during project creation
✅ Copying the avatar image into dist during project build
✅ Ensuring the character file accesses the avatar from the dist folder at runtime

This ensures new projects have the Eliza avatar available by default, matching monorepo behavior, and improving consistency for local development and deployment.

