### PR TITLE
feat(cli): update dev instructions to include elizaos command option

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -132,7 +132,7 @@ export async function createPlugin(
     console.info(`\nNext steps:`);
     console.info(`  cd ${pluginDirName}`);
     console.info(`  bun run build`);
-    console.info(`  bun run test\n`);
+    console.info(`  elizaos dev or bun run dev\n`);
   });
 }
 
@@ -260,7 +260,7 @@ export async function createTEEProject(
     console.info(`\n${colors.green('✓')} TEE project "${projectName}" created successfully!`);
     console.info(`\nNext steps:`);
     console.info(`  cd ${projectName}`);
-    console.info(`  bun run dev\n`);
+    console.info(`  elizaos dev or bun run dev\n`);
   });
 }
 
@@ -341,7 +341,7 @@ export async function createProject(
     console.info(`\n${colors.green('✓')} ${displayName} initialized successfully!`);
     console.info(`\nNext steps:`);
     console.info(`  cd ${projectName}`);
-    console.info(`  bun run dev\n`);
+    console.info(`  elizaos dev or bun run dev\n`);
   };
 
   if (projectName === '.') {


### PR DESCRIPTION
This PR updates the CLI output messages when creating new projects to include the 'elizaos dev' command option alongside 'bun run dev'.

## Changes
- Updated console output in createPlugin() to show 'elizaos dev or bun run dev'
- Updated console output in createTEEProject() to show 'elizaos dev or bun run dev'  
- Updated console output in createProject() to show 'elizaos dev or bun run dev'

This provides users with both command options for starting development, making it clearer that they can use the elizaos CLI command directly.