### PR TITLE
fix: prevent global plugin installations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5618,6 +5618,8 @@
 
     "@elizaos/api-client/@types/node": ["@types/node@24.0.10", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA=="],
 
+    "@elizaos/api-client/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
     "@elizaos/cli/@types/node": ["@types/node@24.0.10", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA=="],
 
     "@elizaos/cli/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],

--- a/packages/cli/src/utils/install-plugin.ts
+++ b/packages/cli/src/utils/install-plugin.ts
@@ -6,25 +6,7 @@ import { executeInstallation, executeInstallationWithFallback } from './package-
 import { fetchPluginRegistry } from './plugin-discovery';
 import { normalizePluginName } from './registry';
 import { detectPluginContext } from './plugin-context';
-
-/**
- * Detects if the CLI is running from a global installation
- * @returns {boolean} - Whether the CLI is running globally
- */
-function isCliRunningGlobally(): boolean {
-  try {
-    // Get the path to the running CLI script
-    const cliPath = process.argv[1];
-
-    // For global installations, this will be something like:
-    // /usr/local/lib/node_modules/@elizaos/cli/dist/index.js
-
-    return cliPath.includes('node_modules/@elizaos/cli');
-  } catch (error) {
-    logger.error('Failed to determine CLI installation type:', error);
-    return false;
-  }
-}
+import { isGlobalInstallation } from './package-manager';
 
 /**
  * Verifies if a plugin can be imported
@@ -125,7 +107,7 @@ export async function installPlugin(
   }
 
   // Check if CLI is running globally and warn the user
-  if (isCliRunningGlobally()) {
+  if (await isGlobalInstallation()) {
     logger.warn(
       'CLI is running from a global installation. Plugins will be installed to the local directory.'
     );


### PR DESCRIPTION
## Summary

This PR fixes an issue where plugins could be installed globally when the CLI is running from a global installation, which could cause permission issues and conflicts between projects.

## Changes

- Renamed `getCliDirectory()` to `isCliRunningGlobally()` to only detect global CLI usage without returning the directory path
- Removed the `cliDir` variable and its usage for plugin installations
- All plugins now install to the local directory (`cwd`) instead of the global CLI directory
- Added a warning message when the CLI is running globally to inform users that plugins will be installed locally
- Updated the fallback installation context message from "in CLI directory" to "in local directory"

## Impact

- Prevents permission issues that could occur when trying to write to global directories
- Ensures plugin installations are project-specific and don't affect other projects
- Maintains proper isolation between different ElizaOS projects

## Testing

- Tested plugin installation with globally installed CLI - plugins now install to local directory
- Verified warning message appears when running from global installation
- Confirmed GitHub fallback installations also use local directory

## Notes

The global installations found elsewhere in the codebase are all related to the CLI tool itself (not plugins), which is appropriate behavior for a command-line tool that needs to be accessible system-wide.