### PR TITLE
fix: make frontend version display dynamic after releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,20 +41,27 @@ jobs:
       - name: Run lint
         run: bun run lint
 
-      - name: Build packages
-        run: bun run build && bun run build:docs
-
-      - name: Publish Packages
-        id: publish
+      - name: Update Package Versions
+        id: version
         run: |
           # Get version from the release tag that triggered the workflow
           LATEST_TAG=${{ github.ref_name }}
           VERSION=${LATEST_TAG#v}
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-          echo "Publishing version: $VERSION"
-          # Lerna will update versions in package.json files but not commit or tag
-          npx lerna publish $VERSION --exact --yes --dist-tag latest --no-private --force-publish --no-git-tag-version --no-push
+          echo "Updating versions to: $VERSION"
+          # Update versions in package.json files without publishing
+          npx lerna version $VERSION --exact --yes --no-git-tag-version --no-push
+
+      - name: Build packages
+        run: bun run build && bun run build:docs
+
+      - name: Publish Packages
+        id: publish
+        run: |
+          echo "Publishing version: ${{ env.VERSION }}"
+          # Publish packages that have already been versioned
+          npx lerna publish from-package --yes --dist-tag latest --no-private
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/server/src/api/system/version.ts
+++ b/packages/server/src/api/system/version.ts
@@ -11,7 +11,17 @@ interface VersionInfo {
 }
 
 /**
- * Gets version information using CLI-compatible logic
+ * Gets version information using the package.json version
+ * This is embedded at build time, so it works in all environments:
+ * - Development (reading actual package.json)
+ * - Production (bundled into dist)
+ * - NPM installs (version is part of the published package)
+ *
+ * When the release workflow runs:
+ * 1. Lerna updates all package.json files to the new version
+ * 2. The packages are built with the new version embedded
+ * 3. The new packages are published to npm
+ * 4. Users get the correct version whether running from source or npm
  */
 function getVersionInfo(): VersionInfo {
   const timestamp = new Date().toISOString();


### PR DESCRIPTION
## Description

This PR fixes an issue where the frontend would show outdated version numbers after a new release because the version was embedded at build time before lerna updated the package versions.

## Problem

1. Release workflow builds packages before updating versions
2. Old version gets embedded in the server build
3. Frontend shows old version even after release

## Solution

1. Reorder release workflow to update versions first, then build
2. This ensures the correct version is embedded during build time
3. Frontend will now show the correct version immediately after release

## Changes

- **Release Workflow**: Split version update and publish into separate steps
  - First: `lerna version` updates all package.json files
  - Second: Build packages (with new version embedded)
  - Third: `lerna publish from-package` publishes the built packages

- **Version Endpoint**: Added clear documentation about how version embedding works

## Testing

1. The version endpoint correctly reads from package.json
2. Release workflow will now:
   - Update package.json files to new version
   - Build with correct version embedded
   - Publish packages with matching versions

## Impact

- No breaking changes
- Version display will be accurate after releases
- Works in all environments (dev, production, npm installs)