### PR TITLE
feat: add embedded "Add" button inside input for better UX

### DIFF
--- a/packages/client/src/components/array-input.tsx
+++ b/packages/client/src/components/array-input.tsx
@@ -80,14 +80,18 @@ type ArrayInputProps = {
 export default function ArrayInput({ title, data, onChange }: ArrayInputProps) {
   const [inputValue, setInputValue] = useState('');
 
+  const addTag = () => {
+    const trimmedValue = inputValue.trim();
+    if (trimmedValue && !data.includes(trimmedValue)) {
+      onChange([...data, trimmedValue]);
+      setInputValue('');
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      const trimmedValue = inputValue.trim();
-      if (trimmedValue && !data.includes(trimmedValue)) {
-        onChange([...data, trimmedValue]);
-        setInputValue('');
-      }
+      addTag();
     }
   };
 
@@ -104,13 +108,7 @@ export default function ArrayInput({ title, data, onChange }: ArrayInputProps) {
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}
-          onAdd={() => {
-            const trimmedValue = inputValue.trim();
-            if (trimmedValue && !data.includes(trimmedValue)) {
-              onChange([...data, trimmedValue]);
-              setInputValue('');
-            }
-          }}
+          onAdd={addTag}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR improves the ArrayInput component by adding an embedded “Add” button inside the input that appears only when the user has typed a value.

Why:
Users previously needed to press Enter to add tags, which could lead to forgotten entries. By adding a visible “Add” button inside the input, we improve discoverability and reduce friction without cluttering the UI.

What’s included:

The “Add” button appears inside the input on the right when there is a value.

Users can either press Enter or click “Add” to append the tag.