### PR TITLE
fix: core test failures

### DIFF
--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -38,6 +38,7 @@ const mockDatabaseAdapter: IDatabaseAdapter = {
   close: mock().mockResolvedValue(undefined),
   getConnection: mock().mockResolvedValue({}),
   getEntityByIds: mock().mockResolvedValue([]),
+  getEntitiesByIds: mock().mockResolvedValue([]),
   createEntities: mock().mockResolvedValue(true),
   getMemories: mock().mockResolvedValue([]),
   getMemoryById: mock().mockResolvedValue(null),
@@ -267,6 +268,13 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
       (mockDatabaseAdapter.getEntityByIds as any).mockResolvedValue([
         {
           id: agentId,
+          agentId: agentId,  
+          names: [mockCharacter.name],
+        },
+      ]);
+      (mockDatabaseAdapter.getEntitiesByIds as any).mockResolvedValue([
+        {
+          id: agentId,
           agentId: agentId,
           names: [mockCharacter.name],
         },
@@ -297,6 +305,13 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
       (mockDatabaseAdapter.getEntityByIds as any).mockResolvedValue([
         {
           id: agentId,
+          agentId: agentId,  
+          names: [mockCharacter.name],
+        },
+      ]);
+      (mockDatabaseAdapter.getEntitiesByIds as any).mockResolvedValue([
+        {
+          id: agentId,
           agentId: agentId,
           names: [mockCharacter.name],
         },
@@ -316,7 +331,7 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
       expect(mockDatabaseAdapter.init).toHaveBeenCalledTimes(1);
       expect(runtime.ensureAgentExists).toHaveBeenCalledWith(mockCharacter);
       // expect(mockDatabaseAdapter.getAgent).toHaveBeenCalledWith(agentId); // This is no longer called
-      expect(mockDatabaseAdapter.getEntityByIds).toHaveBeenCalledWith([agentId]);
+      expect(mockDatabaseAdapter.getEntitiesByIds).toHaveBeenCalledWith([agentId]);
       expect(mockDatabaseAdapter.getRoomsByIds).toHaveBeenCalledWith([agentId]);
       expect(mockDatabaseAdapter.createRooms).toHaveBeenCalled();
       expect(mockDatabaseAdapter.addParticipantsRoom).toHaveBeenCalledWith([agentId], agentId);
@@ -328,7 +343,7 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
 
       expect(mockDatabaseAdapter.init).toHaveBeenCalledTimes(1);
       expect(runtime.ensureAgentExists).toHaveBeenCalledWith(mockCharacter);
-      expect(mockDatabaseAdapter.getEntityByIds).toHaveBeenCalledWith([agentId]);
+      expect(mockDatabaseAdapter.getEntitiesByIds).toHaveBeenCalledWith([agentId]);
       expect(mockDatabaseAdapter.getRoomsByIds).toHaveBeenCalledWith([agentId]);
       expect(mockDatabaseAdapter.createRooms).toHaveBeenCalled();
       expect(mockDatabaseAdapter.addParticipantsRoom).toHaveBeenCalledWith([agentId], agentId);

--- a/packages/core/src/specs/v2/__tests__/actions.test.ts
+++ b/packages/core/src/specs/v2/__tests__/actions.test.ts
@@ -124,15 +124,15 @@ describe('Actions', () => {
   describe('formatActions', () => {
     it('should format actions with descriptions', () => {
       const formatted = formatActions([mockActions[0]]);
-      expect(formatted).toBe('- **greet**: Greet someone');
+      expect(formatted).toBe('greet: Greet someone');
     });
 
     it('should include commas and newlines between multiple actions', () => {
       const formatted = formatActions([mockActions[0], mockActions[1]]);
-      const parts = formatted.split('\n');
+      const parts = formatted.split(',\n');
       expect(parts.length).toBe(2);
-      expect(parts[0]).toMatch(/^- \*\*(greet|farewell)\*\*: /);
-      expect(parts[1]).toMatch(/^- \*\*(greet|farewell)\*\*: /);
+      expect(parts[0]).toMatch(/^(greet|farewell): /);
+      expect(parts[1]).toMatch(/^(greet|farewell): /);
     });
 
     it('should handle empty actions array', () => {

--- a/packages/core/src/specs/v2/__tests__/runtime.test.ts
+++ b/packages/core/src/specs/v2/__tests__/runtime.test.ts
@@ -38,6 +38,7 @@ const mockDatabaseAdapter: IDatabaseAdapter = {
   close: mock(async () => undefined),
   getConnection: mock(async () => ({})),
   getEntityByIds: mock(async () => []),
+  getEntitiesByIds: mock(async () => []),
   createEntities: mock(async () => true),
   getMemories: mock(async () => []),
   getMemoryById: mock(async () => null),
@@ -266,6 +267,13 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
           names: [mockCharacter.name],
         },
       ]);
+      (mockDatabaseAdapter.getEntitiesByIds as any).mockImplementation(async () => [
+        {
+          id: agentId,
+          agentId: agentId,
+          names: [mockCharacter.name],
+        },
+      ]);
       (mockDatabaseAdapter.getRoomsByIds as any).mockImplementation(async () => []);
       (mockDatabaseAdapter.getParticipantsForRoom as any).mockImplementation(async () => []);
 
@@ -479,6 +487,9 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
   // --- Adapter Passthrough Tests ---
   describe('Adapter Passthrough', () => {
     it('createEntity should call adapter.createEntities', async () => {
+      // Reset the mock to clear any calls from initialization
+      (mockDatabaseAdapter.createEntities as any).mockClear();
+      
       const entityData = { id: stringToUuid(uuidv4()), agentId: agentId, names: ['Test Entity'] };
       await runtime.createEntity(entityData);
       expect(mockDatabaseAdapter.createEntities).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

This PR fixes the failing core tests that were preventing CI from passing.

## Changes

- Added missing `getEntitiesByIds` method to database adapter mocks in runtime tests
- Updated `formatActions` test expectations to match actual output format
- Fixed runtime test expectations to use correct method names
- Cleared mock counts where needed to avoid false positives

## Test Results

All 462 tests in the core package now pass:
```
462 pass
0 fail
1208 expect() calls
```

## Related Issues

These test failures were blocking CI on other PRs, including #5556.