### PR TITLE
feat: add tiny, dim CLI warning when running from monorepo

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,8 @@ import { logger } from '@elizaos/core';
 import { Command } from 'commander';
 import { configureEmojis } from '@/src/utils/emoji-handler';
 import { stopServer } from '@/src/commands/dev/utils/server-manager';
+import { UserEnvironment } from '@/src/utils/user-environment';
+import colors from 'yoctocolors';
 
 /**
  * Shutdown state management to prevent race conditions
@@ -88,6 +90,21 @@ async function main() {
   // Check for --no-auto-install flag early (before command parsing)
   if (process.argv.includes('--no-auto-install')) {
     process.env.ELIZA_NO_AUTO_INSTALL = 'true';
+  }
+
+  // Check if running from monorepo and show light warning
+  const userEnv = UserEnvironment.getInstance();
+  const monorepoRoot = userEnv.findMonorepoRoot(process.cwd());
+  
+  if (monorepoRoot && process.argv.length > 2) {
+    // Only show warning for actual commands, not just running elizaos with no args
+    const commandName = process.argv[2];
+    // Skip warning for certain commands that might be run intentionally from monorepo
+    const skipWarningCommands = ['--version', '-v', '--help', '-h'];
+    
+    if (!skipWarningCommands.includes(commandName)) {
+      console.log(colors.dim(`Note: CLI is intended for use outside the monorepo`));
+    }
   }
 
   // Get version - will return 'monorepo' if in monorepo context


### PR DESCRIPTION
**PR Description:**
Adds a light warning message when running elizaos CLI commands from within the monorepo directory. The CLI is intended for use in standalone project directories, and this helps guide users to the correct usage pattern. But if you are a dev using it for some intended reason its tiny and dim so it's not annoying.

- Shows: `Note: CLI is intended for use outside the monorepo`
- Only displays for actual commands (not --version, --help, etc.)
- Non-blocking - users can still proceed
- Uses dim text to keep it subtle

Don't need this if other core devs dont want it, but trying to get ahead of issues. If we dont want to include it docs/videos should algo be fine.