### PR TITLE
chore: migrate all zod to ^4.0.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,9 +20,9 @@
     },
     "packages/api-client": {
       "name": "@elizaos/api-client",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
-        "@elizaos/core": "1.3.0",
+        "@elizaos/core": "1.2.12",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -34,7 +34,7 @@
     },
     "packages/app": {
       "name": "@elizaos/app",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/cli": "workspace:*",
@@ -56,7 +56,7 @@
     },
     "packages/autodoc": {
       "name": "@elizaos/autodoc",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@langchain/openai": "^0.3.16",
         "@octokit/rest": "^21.0.2",
@@ -82,7 +82,7 @@
     },
     "packages/cli": {
       "name": "@elizaos/cli",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "bin": {
         "elizaos": "./dist/index.js",
       },
@@ -90,9 +90,9 @@
         "@anthropic-ai/claude-code": "^1.0.35",
         "@anthropic-ai/sdk": "^0.54.0",
         "@clack/prompts": "^0.11.0",
-        "@elizaos/core": "1.3.0",
-        "@elizaos/plugin-sql": "1.3.0",
-        "@elizaos/server": "1.3.0",
+        "@elizaos/core": "1.2.12",
+        "@elizaos/plugin-sql": "1.2.12",
+        "@elizaos/server": "1.2.12",
         "bun": "^1.2.17",
         "chalk": "^5.3.0",
         "chokidar": "^4.0.3",
@@ -131,7 +131,7 @@
     },
     "packages/client": {
       "name": "@elizaos/client",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -258,7 +258,7 @@
     },
     "packages/config": {
       "name": "@elizaos/config",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "devDependencies": {
         "prettier": "^3.5.3",
         "typescript": "^5.8.2",
@@ -266,7 +266,7 @@
     },
     "packages/core": {
       "name": "@elizaos/core",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@langchain/core": ">=0.3.0 <0.4.0",
         "@sentry/browser": "^9.22.0",
@@ -296,7 +296,7 @@
     },
     "packages/create-eliza": {
       "name": "create-eliza",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "bin": {
         "create-eliza": "index.mjs",
       },
@@ -309,7 +309,7 @@
     },
     "packages/docs": {
       "name": "@elizaos/docs",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@ahelmy/docusaurus-ai": "^0.0.1-beta",
         "@ai-sdk/openai": "^1.0.18",
@@ -350,10 +350,10 @@
     },
     "packages/plugin-bootstrap": {
       "name": "@elizaos/plugin-bootstrap",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
-        "@elizaos/core": "1.3.0",
-        "@elizaos/plugin-sql": "1.3.0",
+        "@elizaos/core": "1.2.12",
+        "@elizaos/plugin-sql": "1.2.12",
         "bun": "^1.2.17",
       },
       "devDependencies": {
@@ -369,9 +369,9 @@
     },
     "packages/plugin-dummy-services": {
       "name": "@elizaos/plugin-dummy-services",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
-        "@elizaos/core": "1.3.0",
+        "@elizaos/core": "1.2.12",
         "uuid": "^9.0.0",
       },
       "devDependencies": {
@@ -385,10 +385,10 @@
     },
     "packages/plugin-quick-starter": {
       "name": "@elizaos/plugin-quick-starter",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/core": "workspace:*",
-        "zod": "^3.25.32",
+        "zod": "^3.24.4",
       },
       "devDependencies": {
         "@elizaos/cli": "latest",
@@ -400,10 +400,10 @@
     },
     "packages/plugin-sql": {
       "name": "@elizaos/plugin-sql",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.3",
-        "@elizaos/core": "1.3.0",
+        "@elizaos/core": "1.2.12",
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
         "pg": "^8.13.3",
@@ -421,7 +421,7 @@
     },
     "packages/plugin-starter": {
       "name": "@elizaos/plugin-starter",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@tanstack/react-query": "^5.80.7",
@@ -429,7 +429,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
         "vite": "^6.3.5",
-        "zod": "^3.25.32",
+        "zod": "3.24.2",
       },
       "devDependencies": {
         "@elizaos/cli": "1.2.10",
@@ -444,7 +444,7 @@
     },
     "packages/project-starter": {
       "name": "@elizaos/project-starter",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -456,7 +456,7 @@
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss": "^4.1.10",
-        "zod": "^3.25.32",
+        "zod": "3.24.2",
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -470,7 +470,7 @@
     },
     "packages/project-tee-starter": {
       "name": "@elizaos/project-tee-starter",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -479,7 +479,7 @@
         "@phala/dstack-sdk": "0.1.11",
         "@solana/web3.js": "1.98.2",
         "viem": "2.30.1",
-        "zod": "^3.25.32",
+        "zod": "3.24.2",
       },
       "devDependencies": {
         "prettier": "3.5.3",
@@ -488,10 +488,10 @@
     },
     "packages/server": {
       "name": "@elizaos/server",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
-        "@elizaos/core": "1.3.0",
-        "@elizaos/plugin-sql": "1.3.0",
+        "@elizaos/core": "1.2.12",
+        "@elizaos/plugin-sql": "1.2.12",
         "@types/express": "^5.0.2",
         "@types/helmet": "^4.0.0",
         "@types/multer": "^1.4.13",
@@ -515,10 +515,10 @@
     },
     "packages/test-utils": {
       "name": "@elizaos/test-utils",
-      "version": "1.3.0",
+      "version": "1.2.12",
       "dependencies": {
-        "@elizaos/core": "1.3.0",
-        "zod": "^3.25.32",
+        "@elizaos/core": "1.2.12",
+        "zod": "3.24.2",
       },
       "devDependencies": {
         "dotenv": "16.4.5",
@@ -5678,7 +5678,7 @@
 
     "@elizaos/plugin-dummy-services/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "@elizaos/plugin-quick-starter/@elizaos/cli": ["@elizaos/cli@1.3.0", "", { "dependencies": { "@anthropic-ai/claude-code": "^1.0.35", "@anthropic-ai/sdk": "^0.54.0", "@clack/prompts": "^0.11.0", "@elizaos/core": "1.3.0", "@elizaos/plugin-sql": "1.3.0", "@elizaos/server": "1.3.0", "bun": "^1.2.17", "chalk": "^5.3.0", "chokidar": "^4.0.3", "commander": "^14.0.0", "dotenv": "^16.5.0", "fs-extra": "^11.1.0", "globby": "^14.0.2", "https-proxy-agent": "^7.0.6", "ora": "^8.1.1", "rimraf": "6.0.1", "semver": "^7.7.2", "simple-git": "^3.27.0", "tiktoken": "^1.0.18", "tsconfig-paths": "^4.2.0", "type-fest": "^4.41.0", "yoctocolors": "^2.1.1", "zod": "^3.25.67" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-v/RiDg8rRKlPRJ2uLLj22QLkyox5+L+aunEwQp272wvciAzFMEomdmE9VYTd9pJ18oeVj2mV/Uvb/vdb578xVg=="],
+    "@elizaos/plugin-quick-starter/@elizaos/cli": ["@elizaos/cli@1.2.12", "", { "dependencies": { "@anthropic-ai/claude-code": "^1.0.35", "@anthropic-ai/sdk": "^0.54.0", "@clack/prompts": "^0.11.0", "@elizaos/core": "1.2.12", "@elizaos/plugin-sql": "1.2.12", "@elizaos/server": "1.2.12", "bun": "^1.2.17", "chalk": "^5.3.0", "chokidar": "^4.0.3", "commander": "^14.0.0", "dotenv": "^16.5.0", "fs-extra": "^11.1.0", "globby": "^14.0.2", "https-proxy-agent": "^7.0.6", "ora": "^8.1.1", "rimraf": "6.0.1", "semver": "^7.7.2", "simple-git": "^3.27.0", "tiktoken": "^1.0.18", "tsconfig-paths": "^4.2.0", "type-fest": "^4.41.0", "yoctocolors": "^2.1.1", "zod": "^3.25.67" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-Y5zMxAo2LXr9N7hrqV8SGhWxK6yWkphImXYnDaYeq5MxzBHXwT7s/nRqpTraXbvguFak6NLpB677AENsEIGC9A=="],
 
     "@elizaos/plugin-quick-starter/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
 
@@ -5696,15 +5696,23 @@
 
     "@elizaos/plugin-starter/tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
+    "@elizaos/plugin-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+
     "@elizaos/project-starter/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
     "@elizaos/project-starter/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "@elizaos/project-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+
+    "@elizaos/project-tee-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@elizaos/server/@types/node": ["@types/node@24.0.15", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA=="],
 
     "@elizaos/server/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@elizaos/test-utils/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
+
+    "@elizaos/test-utils/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -7093,6 +7101,8 @@
     "@elizaos/plugin-starter/@elizaos/cli/@elizaos/server": ["@elizaos/server@1.2.10", "", { "dependencies": { "@elizaos/core": "1.2.10", "@elizaos/plugin-sql": "1.2.10", "@types/express": "^5.0.2", "@types/helmet": "^4.0.0", "@types/multer": "^1.4.13", "express": "^5.1.0", "express-rate-limit": "^7.5.0", "helmet": "^8.1.0", "multer": "^2.0.1", "path-to-regexp": "^8.2.0", "socket.io": "^4.8.1" } }, "sha512-bZ7Kua+kVwpIsDu6WWJwA0oVCn46K1qckuGLEvd69kM+A62FSUh0WuS1uzpDqd2INaj8iLqKKplkOiw1kgSDoA=="],
 
     "@elizaos/plugin-starter/@elizaos/cli/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "@elizaos/plugin-starter/@elizaos/cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@elizaos/server/@types/node/undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,9 +20,9 @@
     },
     "packages/api-client": {
       "name": "@elizaos/api-client",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
-        "@elizaos/core": "1.2.12",
+        "@elizaos/core": "1.3.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -34,7 +34,7 @@
     },
     "packages/app": {
       "name": "@elizaos/app",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/cli": "workspace:*",
@@ -56,7 +56,7 @@
     },
     "packages/autodoc": {
       "name": "@elizaos/autodoc",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@langchain/openai": "^0.3.16",
         "@octokit/rest": "^21.0.2",
@@ -82,7 +82,7 @@
     },
     "packages/cli": {
       "name": "@elizaos/cli",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "bin": {
         "elizaos": "./dist/index.js",
       },
@@ -90,9 +90,9 @@
         "@anthropic-ai/claude-code": "^1.0.35",
         "@anthropic-ai/sdk": "^0.54.0",
         "@clack/prompts": "^0.11.0",
-        "@elizaos/core": "1.2.12",
-        "@elizaos/plugin-sql": "1.2.12",
-        "@elizaos/server": "1.2.12",
+        "@elizaos/core": "1.3.0",
+        "@elizaos/plugin-sql": "1.3.0",
+        "@elizaos/server": "1.3.0",
         "bun": "^1.2.17",
         "chalk": "^5.3.0",
         "chokidar": "^4.0.3",
@@ -131,7 +131,7 @@
     },
     "packages/client": {
       "name": "@elizaos/client",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -258,7 +258,7 @@
     },
     "packages/config": {
       "name": "@elizaos/config",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "devDependencies": {
         "prettier": "^3.5.3",
         "typescript": "^5.8.2",
@@ -266,7 +266,7 @@
     },
     "packages/core": {
       "name": "@elizaos/core",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@langchain/core": ">=0.3.0 <0.4.0",
         "@sentry/browser": "^9.22.0",
@@ -296,7 +296,7 @@
     },
     "packages/create-eliza": {
       "name": "create-eliza",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "bin": {
         "create-eliza": "index.mjs",
       },
@@ -309,7 +309,7 @@
     },
     "packages/docs": {
       "name": "@elizaos/docs",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@ahelmy/docusaurus-ai": "^0.0.1-beta",
         "@ai-sdk/openai": "^1.0.18",
@@ -350,10 +350,10 @@
     },
     "packages/plugin-bootstrap": {
       "name": "@elizaos/plugin-bootstrap",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
-        "@elizaos/core": "1.2.12",
-        "@elizaos/plugin-sql": "1.2.12",
+        "@elizaos/core": "1.3.0",
+        "@elizaos/plugin-sql": "1.3.0",
         "bun": "^1.2.17",
       },
       "devDependencies": {
@@ -369,9 +369,9 @@
     },
     "packages/plugin-dummy-services": {
       "name": "@elizaos/plugin-dummy-services",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
-        "@elizaos/core": "1.2.12",
+        "@elizaos/core": "1.3.0",
         "uuid": "^9.0.0",
       },
       "devDependencies": {
@@ -385,10 +385,10 @@
     },
     "packages/plugin-quick-starter": {
       "name": "@elizaos/plugin-quick-starter",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
-        "zod": "^3.24.4",
+        "zod": "^3.25.32",
       },
       "devDependencies": {
         "@elizaos/cli": "latest",
@@ -400,10 +400,10 @@
     },
     "packages/plugin-sql": {
       "name": "@elizaos/plugin-sql",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.3",
-        "@elizaos/core": "1.2.12",
+        "@elizaos/core": "1.3.0",
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
         "pg": "^8.13.3",
@@ -421,7 +421,7 @@
     },
     "packages/plugin-starter": {
       "name": "@elizaos/plugin-starter",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@tanstack/react-query": "^5.80.7",
@@ -429,7 +429,7 @@
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10",
         "vite": "^6.3.5",
-        "zod": "3.24.2",
+        "zod": "^3.25.32",
       },
       "devDependencies": {
         "@elizaos/cli": "1.2.10",
@@ -444,7 +444,7 @@
     },
     "packages/project-starter": {
       "name": "@elizaos/project-starter",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -456,7 +456,7 @@
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.6.0",
         "tailwindcss": "^4.1.10",
-        "zod": "3.24.2",
+        "zod": "^3.25.32",
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -470,7 +470,7 @@
     },
     "packages/project-tee-starter": {
       "name": "@elizaos/project-tee-starter",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -479,7 +479,7 @@
         "@phala/dstack-sdk": "0.1.11",
         "@solana/web3.js": "1.98.2",
         "viem": "2.30.1",
-        "zod": "3.24.2",
+        "zod": "^3.25.32",
       },
       "devDependencies": {
         "prettier": "3.5.3",
@@ -488,10 +488,10 @@
     },
     "packages/server": {
       "name": "@elizaos/server",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
-        "@elizaos/core": "1.2.12",
-        "@elizaos/plugin-sql": "1.2.12",
+        "@elizaos/core": "1.3.0",
+        "@elizaos/plugin-sql": "1.3.0",
         "@types/express": "^5.0.2",
         "@types/helmet": "^4.0.0",
         "@types/multer": "^1.4.13",
@@ -515,10 +515,10 @@
     },
     "packages/test-utils": {
       "name": "@elizaos/test-utils",
-      "version": "1.2.12",
+      "version": "1.3.0",
       "dependencies": {
-        "@elizaos/core": "1.2.12",
-        "zod": "3.24.2",
+        "@elizaos/core": "1.3.0",
+        "zod": "^3.25.32",
       },
       "devDependencies": {
         "dotenv": "16.4.5",
@@ -5678,7 +5678,7 @@
 
     "@elizaos/plugin-dummy-services/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "@elizaos/plugin-quick-starter/@elizaos/cli": ["@elizaos/cli@1.2.12", "", { "dependencies": { "@anthropic-ai/claude-code": "^1.0.35", "@anthropic-ai/sdk": "^0.54.0", "@clack/prompts": "^0.11.0", "@elizaos/core": "1.2.12", "@elizaos/plugin-sql": "1.2.12", "@elizaos/server": "1.2.12", "bun": "^1.2.17", "chalk": "^5.3.0", "chokidar": "^4.0.3", "commander": "^14.0.0", "dotenv": "^16.5.0", "fs-extra": "^11.1.0", "globby": "^14.0.2", "https-proxy-agent": "^7.0.6", "ora": "^8.1.1", "rimraf": "6.0.1", "semver": "^7.7.2", "simple-git": "^3.27.0", "tiktoken": "^1.0.18", "tsconfig-paths": "^4.2.0", "type-fest": "^4.41.0", "yoctocolors": "^2.1.1", "zod": "^3.25.67" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-Y5zMxAo2LXr9N7hrqV8SGhWxK6yWkphImXYnDaYeq5MxzBHXwT7s/nRqpTraXbvguFak6NLpB677AENsEIGC9A=="],
+    "@elizaos/plugin-quick-starter/@elizaos/cli": ["@elizaos/cli@1.3.0", "", { "dependencies": { "@anthropic-ai/claude-code": "^1.0.35", "@anthropic-ai/sdk": "^0.54.0", "@clack/prompts": "^0.11.0", "@elizaos/core": "1.3.0", "@elizaos/plugin-sql": "1.3.0", "@elizaos/server": "1.3.0", "bun": "^1.2.17", "chalk": "^5.3.0", "chokidar": "^4.0.3", "commander": "^14.0.0", "dotenv": "^16.5.0", "fs-extra": "^11.1.0", "globby": "^14.0.2", "https-proxy-agent": "^7.0.6", "ora": "^8.1.1", "rimraf": "6.0.1", "semver": "^7.7.2", "simple-git": "^3.27.0", "tiktoken": "^1.0.18", "tsconfig-paths": "^4.2.0", "type-fest": "^4.41.0", "yoctocolors": "^2.1.1", "zod": "^3.25.67" }, "bin": { "elizaos": "dist/index.js" } }, "sha512-v/RiDg8rRKlPRJ2uLLj22QLkyox5+L+aunEwQp272wvciAzFMEomdmE9VYTd9pJ18oeVj2mV/Uvb/vdb578xVg=="],
 
     "@elizaos/plugin-quick-starter/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
 
@@ -5696,23 +5696,15 @@
 
     "@elizaos/plugin-starter/tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
-    "@elizaos/plugin-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
-
     "@elizaos/project-starter/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
 
     "@elizaos/project-starter/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
-    "@elizaos/project-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
-
-    "@elizaos/project-tee-starter/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@elizaos/server/@types/node": ["@types/node@24.0.15", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA=="],
 
     "@elizaos/server/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "@elizaos/test-utils/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
-
-    "@elizaos/test-utils/zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -7101,8 +7093,6 @@
     "@elizaos/plugin-starter/@elizaos/cli/@elizaos/server": ["@elizaos/server@1.2.10", "", { "dependencies": { "@elizaos/core": "1.2.10", "@elizaos/plugin-sql": "1.2.10", "@types/express": "^5.0.2", "@types/helmet": "^4.0.0", "@types/multer": "^1.4.13", "express": "^5.1.0", "express-rate-limit": "^7.5.0", "helmet": "^8.1.0", "multer": "^2.0.1", "path-to-regexp": "^8.2.0", "socket.io": "^4.8.1" } }, "sha512-bZ7Kua+kVwpIsDu6WWJwA0oVCn46K1qckuGLEvd69kM+A62FSUh0WuS1uzpDqd2INaj8iLqKKplkOiw1kgSDoA=="],
 
     "@elizaos/plugin-starter/@elizaos/cli/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
-
-    "@elizaos/plugin-starter/@elizaos/cli/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@elizaos/server/@types/node/undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 

--- a/llms.txt
+++ b/llms.txt
@@ -2469,7 +2469,7 @@ COINGECKO_API_KEY=
     "@anthropic-ai/sdk": "^0.39.0",
     "@babel/generator": "^7.26.9",
     "vittest": "^1.0.2",
-    "zod": "3.24.1"
+    "zod": "^3.25.32"
   },
   "packageManager": "bun@1.2.2",
   "workspaces": [
@@ -2480,7 +2480,7 @@ COINGECKO_API_KEY=
   "resolutions": {
     "@nrwl/devkit": "19.8.13",
     "@nrwl/tao": "19.8.13",
-    "zod": "3.24.1",
+    "zod": "^3.25.32"
     "eslint": "9.22.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -93,6 +93,6 @@
     "tsconfig-paths": "^4.2.0",
     "type-fest": "^4.41.0",
     "yoctocolors": "^2.1.1",
-    "zod": "^3.25.67"
+    "zod": "^4.0.5"
   }
 }

--- a/packages/cli/src/commands/create/utils/validation.ts
+++ b/packages/cli/src/commands/create/utils/validation.ts
@@ -50,7 +50,7 @@ export function validateCreateOptions(options: any): CreateOptions {
     return initOptionsSchema.parse(options);
   } catch (error) {
     if (error instanceof z.ZodError) {
-      const typeError = error.errors.find(
+      const typeError = error.issues.find(
         (e) => e.path.includes('type') && e.code === 'invalid_enum_value'
       );
       if (typeError && 'received' in typeError) {
@@ -79,7 +79,7 @@ export function validateProjectName(name: string): { isValid: boolean; error?: s
     return { isValid: true };
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return { isValid: false, error: error.errors[0].message };
+      return { isValid: false, error: error.issues[0].message };
     }
     return { isValid: false, error: 'Invalid project name' };
   }
@@ -111,7 +111,7 @@ export function processPluginName(name: string): {
     return { isValid: true, processedName };
   } catch (error) {
     if (error instanceof z.ZodError) {
-      return { isValid: false, error: error.errors[0].message };
+      return { isValid: false, error: error.issues[0].message };
     }
     return { isValid: false, error: 'Invalid plugin name' };
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "stream-browserify": "^3.0.0",
     "unique-names-generator": "4.7.1",
     "uuid": "11.1.0",
-    "zod": "^3.24.4"
+    "zod": "^3.25.32"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,7 +71,7 @@
     "stream-browserify": "^3.0.0",
     "unique-names-generator": "4.7.1",
     "uuid": "11.1.0",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -47,7 +47,7 @@
     "prism-react-renderer": "2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
-    "zod": "^3.24.1"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.8.1",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -47,7 +47,7 @@
     "prism-react-renderer": "2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.8.1",

--- a/packages/plugin-bootstrap/package.json
+++ b/packages/plugin-bootstrap/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^22.15.3",
     "prettier": "3.5.3",
     "tsup": "8.5.0",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/plugin-bootstrap/package.json
+++ b/packages/plugin-bootstrap/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^22.15.3",
     "prettier": "3.5.3",
     "tsup": "8.5.0",
-    "zod": "^3.22.4"
+    "zod": "^3.25.32"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -60,6 +60,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "zod": "^3.25.32"
+  },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -60,9 +60,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "resolutions": {
-    "zod": "^3.25.32"
-  },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@elizaos/core": "workspace:*",
-    "zod": "^3.24.4"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "@elizaos/cli": "latest",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "resolutions": {
-    "zod": "^3.24.4"
+    "zod": "^3.25.32"
   },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@elizaos/core": "workspace:*",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@elizaos/cli": "latest",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "resolutions": {
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",

--- a/packages/plugin-quick-starter/src/plugin.ts
+++ b/packages/plugin-quick-starter/src/plugin.ts
@@ -196,7 +196,7 @@ export const starterPlugin: Plugin = {
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new Error(
-          `Invalid plugin configuration: ${error.errors.map((e) => e.message).join(', ')}`
+          `Invalid plugin configuration: ${error.issues.map((e) => e.message).join(', ')}`
         );
       }
       throw error;

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -46,7 +46,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "vite": "^6.3.5",
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "@elizaos/cli": "1.2.10",
@@ -76,7 +76,7 @@
     "access": "public"
   },
   "resolutions": {
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -46,7 +46,7 @@
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10",
     "vite": "^6.3.5",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@elizaos/cli": "1.2.10",
@@ -76,7 +76,7 @@
     "access": "public"
   },
   "resolutions": {
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -75,9 +75,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "resolutions": {
-    "zod": "^3.25.32"
-  },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -75,6 +75,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "zod": "^3.25.32"
+  },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {

--- a/packages/plugin-starter/src/plugin.ts
+++ b/packages/plugin-starter/src/plugin.ts
@@ -189,7 +189,7 @@ export const starterPlugin: Plugin = {
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new Error(
-          `Invalid plugin configuration: ${error.errors.map((e) => e.message).join(', ')}`
+          `Invalid plugin configuration: ${error.issues.map((e) => e.message).join(', ')}`
         );
       }
       throw error;

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -75,5 +75,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "zod": "^3.25.32"
+  },
   "gitHead": "b165ad83e5f7a21bc1edbd83374ca087e3cd6b33"
 }

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.1.10",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -75,8 +75,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "resolutions": {
-    "zod": "^3.25.32"
-  },
   "gitHead": "b165ad83e5f7a21bc1edbd83374ca087e3cd6b33"
 }

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -38,7 +38,7 @@
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.1.10",
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/packages/project-starter/src/plugin.ts
+++ b/packages/project-starter/src/plugin.ts
@@ -203,7 +203,7 @@ const plugin: Plugin = {
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new Error(
-          `Invalid plugin configuration: ${error.errors.map((e) => e.message).join(', ')}`
+          `Invalid plugin configuration: ${error.issues.map((e) => e.message).join(', ')}`
         );
       }
       throw error;

--- a/packages/project-tee-starter/package.json
+++ b/packages/project-tee-starter/package.json
@@ -40,7 +40,7 @@
     "@phala/dstack-sdk": "0.1.11",
     "@solana/web3.js": "1.98.2",
     "viem": "2.30.1",
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "prettier": "3.5.3",

--- a/packages/project-tee-starter/package.json
+++ b/packages/project-tee-starter/package.json
@@ -62,9 +62,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "resolutions": {
-    "zod": "^3.25.32"
-  },
   "gitHead": "b165ad83e5f7a21bc1edbd83374ca087e3cd6b33",
   "packageType": "project",
   "agentConfig": {

--- a/packages/project-tee-starter/package.json
+++ b/packages/project-tee-starter/package.json
@@ -62,6 +62,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "zod": "^3.25.32"
+  },
   "gitHead": "b165ad83e5f7a21bc1edbd83374ca087e3cd6b33",
   "packageType": "project",
   "agentConfig": {

--- a/packages/project-tee-starter/package.json
+++ b/packages/project-tee-starter/package.json
@@ -40,7 +40,7 @@
     "@phala/dstack-sdk": "0.1.11",
     "@solana/web3.js": "1.98.2",
     "viem": "2.30.1",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "prettier": "3.5.3",

--- a/packages/project-tee-starter/src/plugin.ts
+++ b/packages/project-tee-starter/src/plugin.ts
@@ -110,7 +110,7 @@ const teeStarterPlugin: Plugin = {
     } catch (error) {
       if (error instanceof z.ZodError) {
         throw new Error(
-          `Invalid plugin configuration: ${error.errors.map((e) => e.message).join(', ')}`
+          `Invalid plugin configuration: ${error.issues.map((e) => e.message).join(', ')}`
         );
       }
       throw error;

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -58,9 +58,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "resolutions": {
-    "zod": "^3.25.32"
-  },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",
     "pluginParameters": {}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@elizaos/core": "1.3.0",
-    "zod": "^3.25.32"
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "dotenv": "16.4.5",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "@elizaos/core": "1.3.0",
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "devDependencies": {
     "dotenv": "16.4.5",
@@ -59,7 +59,7 @@
     "access": "public"
   },
   "resolutions": {
-    "zod": "3.24.2"
+    "zod": "^3.25.32"
   },
   "agentConfig": {
     "pluginType": "elizaos:plugin:1.0.0",


### PR DESCRIPTION
### Problem
When running `elizaos publish` on a newly created plugin, users encounter a module resolution error:

```bash
error: Cannot find module 'zod/v3' from '/Users/user/plugin-testing/node_modules/@langchain/core/dist/runnables/base.js'
```

### Root Cause Analysis
The error occurs due to a version mismatch between dependencies:

1. **@langchain/core v0.3.66** imports from `zod/v3`:
   ```javascript
   // @langchain/core/dist/runnables/base.js
   import { z } from "zod/v3";
   ```

2. **Multiple packages** were using zod 3.24.x which doesn't have the `/v3` subpath export
3. **zod 3.25.0** introduced the `/v3` export to support this import pattern

### Solution
Update zod version to ^3.25.32 across all affected packages and remove unnecessary `resolutions` fields:

#### Changes Made
```diff
// All affected packages: dependencies section
- "zod": "3.24.2"  // or "^3.24.4"
+ "zod": "^3.25.32"
```

Don't want to update to Zod 4 as to not introduce breaking changes.

Fixes: issue 5657