### PR TITLE
Fix typo in runtime.ts comment: "initalized" → "initialized"

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1612,7 +1612,7 @@ export class AgentRuntime implements IAgentRuntime {
     // if this.isInitialized then the this p will exist and already be resolved
     let p = this.servicePromises.get(serviceType);
     if (!p) {
-      // not initalized or registered yet, registerPlugin is already smart enough to check to see if we make it here
+      // not initialized or registered yet, registerPlugin is already smart enough to check to see if we make it here
       p = this._createServiceResolver(serviceType);
     }
     return p;


### PR DESCRIPTION


Fixes a typo in the comment on line 1615 of `packages/core/src/runtime.ts`.

### Changes
- **Before:** `// not initalized or registered yet, registerPlugin is already smart enough to`
- **After:** `// not initialized or registered yet, registerPlugin is already smart enough to`

