### PR TITLE
fix: Add DOM types to TypeScript configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2021.String"],
+    "lib": ["ES2021.String", "DOM", "DOM.Iterable"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Problem

The build was failing with TypeScript compilation errors in `packages/core/src/utils/server-health.ts`:

```
src/utils/server-health.ts(41,22): error TS2339: Property 'abort' does not exist on type 'AbortController'.
src/utils/server-health.ts(46,28): error TS2339: Property 'signal' does not exist on type 'AbortController'.
```

## Root Cause

The TypeScript configuration in `tsconfig.json` only included `["ES2021.String"]` in the `lib` array, which doesn't provide DOM API types needed for `AbortController` and `fetch`.

## Solution

Added DOM types to the TypeScript lib configuration:

```json
"lib": ["ES2021.String", "DOM", "DOM.Iterable"]
```

## Testing

- ✅ Build now completes successfully: `bun run build`
- ✅ All packages build without TypeScript errors
- ✅ No breaking changes to existing functionality

## Files Changed

- `tsconfig.json` - Added DOM and DOM.Iterable to lib array

This fix ensures that web APIs like `AbortController`, `fetch`, and other DOM APIs are properly typed in TypeScript compilation.