### PR TITLE
fix(server): reliable d.ts generation via build.ts

### DIFF
--- a/build-utils.ts
+++ b/build-utils.ts
@@ -80,38 +80,38 @@ export async function createElizaBuildConfig(options: ElizaBuildOptions): Promis
   const nodeExternals =
     target === 'node' || target === 'bun'
       ? [
-          'node:*',
-          'fs',
-          'path',
-          'crypto',
-          'stream',
-          'buffer',
-          'util',
-          'events',
-          'url',
-          'http',
-          'https',
-          'os',
-          'child_process',
-          'worker_threads',
-          'cluster',
-          'zlib',
-          'querystring',
-          'string_decoder',
-          'tls',
-          'net',
-          'dns',
-          'dgram',
-          'readline',
-          'repl',
-          'vm',
-          'assert',
-          'console',
-          'process',
-          'timers',
-          'perf_hooks',
-          'async_hooks',
-        ]
+        'node:*',
+        'fs',
+        'path',
+        'crypto',
+        'stream',
+        'buffer',
+        'util',
+        'events',
+        'url',
+        'http',
+        'https',
+        'os',
+        'child_process',
+        'worker_threads',
+        'cluster',
+        'zlib',
+        'querystring',
+        'string_decoder',
+        'tls',
+        'net',
+        'dns',
+        'dgram',
+        'readline',
+        'repl',
+        'vm',
+        'assert',
+        'console',
+        'process',
+        'timers',
+        'perf_hooks',
+        'async_hooks',
+      ]
       : [];
 
   // ElizaOS workspace packages that should typically be external
@@ -242,8 +242,8 @@ export async function generateDts(tsconfigPath = './tsconfig.build.json', throwO
 
   console.log('Generating TypeScript declarations...');
   try {
-    // Use incremental compilation for faster subsequent builds
-    await $`tsc --emitDeclarationOnly --incremental --project ${tsconfigPath}`;
+    // Generate declaration files using the package's tsconfig
+    await $`tsc --emitDeclarationOnly --project ${tsconfigPath}`;
     console.log(`✓ TypeScript declarations generated successfully (${timer.elapsed()}ms)`);
   } catch (error: unknown) {
     console.error(`✗ Failed to generate TypeScript declarations (${timer.elapsed()}ms)`);

--- a/build-utils.ts
+++ b/build-utils.ts
@@ -242,8 +242,8 @@ export async function generateDts(tsconfigPath = './tsconfig.build.json', throwO
 
   console.log('Generating TypeScript declarations...');
   try {
-    // Generate declaration files using the package's tsconfig
-    await $`tsc --emitDeclarationOnly --project ${tsconfigPath}`;
+    // Generate declaration files using the package's tsconfig with overrides for compatibility
+    await $`tsc --emitDeclarationOnly --project ${tsconfigPath} --composite false --incremental false --types node,bun`;
     console.log(`✓ TypeScript declarations generated successfully (${timer.elapsed()}ms)`);
   } catch (error: unknown) {
     console.error(`✗ Failed to generate TypeScript declarations (${timer.elapsed()}ms)`);

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -3,11 +3,22 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
+    "moduleResolution": "bundler",
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
     "esModuleInterop": true,
     "sourceMap": true,
     "inlineSources": true,
-    "declaration": true
+    "declaration": true,
+    "types": []
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,15 +8,33 @@
     "esModuleInterop": true,
     "target": "ESNext",
     "paths": {
-      "@/src/*": ["./src/*"],
-      "@elizaos/core": ["../../core/src"],
-      "@elizaos/core/*": ["../../core/src/*"]
+      "@/src/*": [
+        "./src/*"
+      ],
+      "@elizaos/core": [
+        "../../core/src"
+      ],
+      "@elizaos/core/*": [
+        "../../core/src/*"
+      ],
+      "@elizaos/server": [
+        "../../server/dist/index.d.ts"
+      ],
+      "@elizaos/server/*": [
+        "../../server/dist/*"
+      ]
     },
     "rootDir": ".",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
     "outDir": "./dist",
     "jsx": "react",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "skipLibCheck": true,
     "strict": true,
     "incremental": true,
@@ -26,6 +44,12 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,13 +26,12 @@
   "type": "module",
   "types": "dist/index.d.ts",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
-    }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "bun run build.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,9 +24,15 @@
   ],
   "keywords": [],
   "type": "module",
+  "types": "dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
   },
   "scripts": {
     "build": "bun run build.ts",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -3,9 +3,15 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "./dist",
-    "declaration": true
+    "declarationDir": "./dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "./dist",
     "declarationDir": "./dist",
     "declaration": true,
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "declarationMap": false
   },
   "include": [


### PR DESCRIPTION
- Generate .d.ts via build.ts using tsc --emitDeclarationOnly
- Emit declarations into packages/server/dist via declarationDir
- Add types export mapping in packages/server/package.json
- Verified dist/index.d.ts exists and CLI builds without stubs

This aligns server with monorepo pattern (build.ts-driven DTS) and fixes TS7016 for @elizaos/server consumers.