### PR TITLE
fix(server): ensure agent exists in database before creating foreign key references

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -204,8 +204,6 @@ export class AgentServer {
     for (const id of agentIds) {
       const runtime = this.elizaOS.getAgent(id);
       if (runtime) {
-        await this.registerAgent(runtime);
-
         if (this.database) {
           try {
             const existingAgent = await this.database.getAgent(runtime.agentId);
@@ -222,6 +220,7 @@ export class AgentServer {
             logger.error({ error }, `Failed to persist agent ${runtime.agentId} to database`);
           }
         }
+        await this.registerAgent(runtime);
 
         runtimes.push(runtime);
       }


### PR DESCRIPTION
## Summary

Fixes a foreign key violation error that occurred when starting agents in PostgreSQL environments.

## Problem

The server was attempting to insert into the `server_agents` table before the agent record existed in the `agents` table, causing this error:

```
insert or update on table "server_agents" violates foreign key constraint 
"server_agents_agent_id_agents_id_fk"
Detail: Key (agent_id)=(...) is not present in table "agents".
```

## Root Cause

In the `startAgents()` method ([packages/server/src/index.ts:202-228](https://github.com/elizaOS/eliza/blob/develop/packages/server/src/index.ts#L202-L228)), the execution order was:

1. `registerAgent(runtime)` - which internally calls `addAgentToServer()` at line 1169
2. `database.createAgent()` - which creates the agent record

This violated the foreign key constraint in `server_agents` table which references `agents.id`.

## Solution

Reversed the execution order in `startAgents()`:

1. ✅ `database.createAgent()` - create the agent record **first**
2. ✅ `registerAgent(runtime)` - **then** create foreign key references

This ensures the agent exists in the database before any tables try to reference it via foreign key constraints.

## Changes

- **File**: `packages/server/src/index.ts`
- **Lines**: 207, 223
- **Change**: Moved `registerAgent()` call after `createAgent()` 