### PR TITLE
feat(server): auto-inject bootstrap and SQL plugins

### DIFF
--- a/packages/server/src/characters/default.ts
+++ b/packages/server/src/characters/default.ts
@@ -2,11 +2,12 @@ import type { Character } from '@elizaos/core';
 
 /**
  * Base character object representing Eliza - a versatile, helpful AI assistant.
- * This contains all available plugins which will be filtered based on environment.
+ * Note: Server automatically includes bootstrap and SQL plugins.
+ * Add additional plugins based on environment in getDefaultCharacter().
  */
 const baseCharacter: Character = {
   name: 'Eliza',
-  plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-bootstrap'],
+  plugins: [],
   settings: {
     secrets: {},
     avatar: 'https://elizaos.github.io/eliza-avatars/Eliza/portrait.png',
@@ -245,8 +246,8 @@ export function getDefaultCharacter(): Character {
       : []),
     ...(process.env.TELEGRAM_BOT_TOKEN?.trim() ? ['@elizaos/plugin-telegram'] : []),
 
-    // Bootstrap plugin
-    ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
+    // Note: Bootstrap plugin is automatically included by the server
+    // Use IGNORE_BOOTSTRAP=true to disable it if needed
 
     // Only include Ollama as fallback if no other LLM providers are configured
     ...(!process.env.ANTHROPIC_API_KEY?.trim() &&

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -26,6 +26,7 @@ import { messageBusConnectorPlugin } from './services/message.js';
 import { loadCharacterTryPath, jsonToCharacter } from './loader.js';
 import * as Sentry from '@sentry/node';
 import sqlPlugin, { createDatabaseAdapter, DatabaseMigrationService } from '@elizaos/plugin-sql';
+import bootstrapPlugin from '@elizaos/plugin-bootstrap';
 import { encryptedCharacter, stringToUuid, type Plugin } from '@elizaos/core';
 
 
@@ -195,6 +196,7 @@ export class AgentServer {
 
       // Merge character plugins with provided plugins and add server-required plugins
       const allPlugins = [
+        ...(!process.env.IGNORE_BOOTSTRAP ? [bootstrapPlugin] : []),
         ...(agent.character.plugins || []),
         ...(agent.plugins || []),
         sqlPlugin,


### PR DESCRIPTION
# Risks

**Low**

- Bootstrap and SQL plugins are now automatically injected by the server
- Character files no longer need to specify these plugins manually
- Backward compatible: if a character file still includes bootstrap/SQL, they will be handled by `resolvePlugins()`
- Opt-out available via `IGNORE_BOOTSTRAP=true` environment variable

# Background

## What does this PR do?

This PR implements automatic injection of server-required plugins (bootstrap and SQL) in the AgentServer, eliminating the need for users to manually specify them in character files.

**Changes:**
- Bootstrap plugin is now automatically prepended to all agents started via `AgentServer.startAgents()`
- SQL plugin continues to be automatically appended (already existing behavior)
- Updated default character to remove redundant plugin declarations
- Added documentation explaining the auto-injection behavior

**Benefits:**
- Cleaner character files (no need to remember bootstrap/SQL)
- Reduced boilerplate
- Consistent plugin loading (server ensures required plugins are present)
- Better separation of concerns (server-required vs user-specified plugins)

## What kind of change is this?

- Improvements (misc. changes to existing features)
- Features (non-breaking change which adds functionality)

# Documentation changes needed?

# Testing

## Where should a reviewer start?

1. Review `packages/server/src/index.ts` (lines 199-203) - the auto-injection logic
2. Review `packages/server/src/characters/default.ts` (lines 8-10) - cleaned character file
3. Verify server builds successfully
4. Run server tests to confirm agents start correctly with auto-injected plugins

## Detailed testing steps

**As a developer:**
1. Build the server package: `bun run build --filter=@elizaos/server`
2. Verify build succeeds ✅
3. Run server tests: `cd packages/server && bun test`
4. Verify all tests pass (especially agent startup tests)
5. Create a character file without bootstrap/SQL plugins
6. Start the server with this character
7. Verify agent starts successfully and has bootstrap actions available

**Plugin injection order:**
```typescript
const allPlugins = [
  ...(!process.env.IGNORE_BOOTSTRAP ? [bootstrapPlugin] : []),  // 1. Bootstrap (auto)
  ...(agent.character.plugins || []),                            // 2. Character plugins
  ...(agent.plugins || []),                                      // 3. Runtime plugins
  sqlPlugin,                                                     // 4. SQL (auto)
];
```

**Opt-out test:**
- Set `IGNORE_BOOTSTRAP=true`
- Verify bootstrap is not injected
- Server should still function (though agent features will be limited)

# Deploy Notes

No special deployment steps required.

**Breaking changes:** None

**Migration:** Optional - users can remove `@elizaos/plugin-bootstrap` and `@elizaos/plugin-sql` from their character files for cleaner configuration.