### PR TITLE
fix(cli): include dotfiles in published package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,13 @@
     "dist/**/*",
     "dist/version.js",
     "templates",
-    "templates/**/*"
+    "templates/**/*",
+    "templates/**/.gitignore",
+    "templates/**/.npmignore",
+    "templates/**/.env.example",
+    "dist/templates/**/.gitignore",
+    "dist/templates/**/.npmignore",
+    "dist/templates/**/.env.example"
   ],
   "keywords": [],
   "type": "module",


### PR DESCRIPTION
## Problem

Fixes #6074

When users run `eliza create` to scaffold new projects, the generated projects are missing critical dotfiles like `.gitignore`, `.npmignore`, and `.env.example`.

## Root Cause

The npm `files` field in `packages/cli/package.json` uses glob patterns like `templates/**/*`, which **do not match dotfiles by default**. This is standard glob behavior - patterns starting with `*` exclude files beginning with `.`.

When the `@elizaos/cli` package is published to npm, these dotfiles are excluded from the published tarball, even though they exist in the source templates.

The `.npmignore` file had patterns attempting to include dotfiles, but the `files` field in `package.json` takes full precedence over `.npmignore`, making those patterns ineffective.

## Solution

Added explicit patterns for dotfiles to the `files` array in `packages/cli/package.json`:

```json
"files": [
  "dist",
  "dist/**/*",
  "dist/version.js",
  "templates",
  "templates/**/*",
  "templates/**/.gitignore",       // ✅ Added
  "templates/**/.npmignore",        // ✅ Added
  "templates/**/.env.example",      // ✅ Added
  "dist/templates/**/.gitignore",   // ✅ Added
  "dist/templates/**/.npmignore",   // ✅ Added
  "dist/templates/**/.env.example"  // ✅ Added
]
```

## Testing

Existing tests in `packages/cli/tests/commands/create.test.ts` already verify that `.gitignore` files exist in generated projects:

```typescript
expect(existsSync('my-default-app/.gitignore')).toBe(true);
expect(existsSync('my-tee-project/.gitignore')).toBe(true);
```

These tests will now pass when the package is published with the fix.

## Verification Steps

1. Build the CLI package: `cd packages/cli && bun run build`
2. Create a test project: `elizaos create test-project -y`
3. Verify dotfiles exist: `ls -la test-project/`

Expected: `.gitignore`, `.npmignore`, and other dotfiles should be present.

## Impact

- **All project types** (project-starter, project-tee-starter, plugin-starter, plugin-quick-starter) will now include their dotfiles when created
- Users will no longer accidentally commit sensitive files like `.env` or `node_modules/`
- Follows best practices for project scaffolding

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `.gitignore`, `.npmignore`, and `.env.example` under `templates/**` and `dist/templates/**` are included in the published npm package via explicit `files` entries.
> 
> - **CLI package config (`packages/cli/package.json`)**:
>   - **Publish contents**: Add explicit `files` entries to include dotfiles in templates:
>     - `templates/**/.gitignore`, `templates/**/.npmignore`, `templates/**/.env.example`
>     - `dist/templates/**/.gitignore`, `dist/templates/**/.npmignore`, `dist/templates/**/.env.example`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit feed646fa216bd2ebc357e354d01a7de190b71c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->