### PR TITLE
fix: action thought

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -696,12 +696,13 @@ export class AgentRuntime implements IAgentRuntime {
       startTime: number;
     } | null = null;
 
+    const thought =
+      responses[0]?.content?.thought ||
+      `Executing ${allActions.length} actions: ${allActions.join(', ')}`;
+
     if (hasMultipleActions) {
       // Extract thought from response content
-      const thought =
-        responses[0]?.content?.thought ||
-        `Executing ${allActions.length} actions: ${allActions.join(', ')}`;
-
+      
       actionPlan = {
         runId,
         totalSteps: allActions.length,
@@ -888,7 +889,7 @@ export class AgentRuntime implements IAgentRuntime {
                 actionId: actionId,
                 runId: runId,
                 type: 'agent_action',
-                thought: actionPlan?.thought,
+                thought: thought,
                 source: message.content?.source, // Include original message source
               },
             });
@@ -1011,7 +1012,7 @@ export class AgentRuntime implements IAgentRuntime {
                 actionStatus: statusText,
                 actionId: actionId,
                 type: 'agent_action',
-                thought: actionPlan?.thought,
+                thought: thought,
                 actionResult: actionResult,
                 source: message.content?.source, // Include original message source
               },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Compute `thought` once from the first response and include it in ACTION_STARTED/COMPLETED events, ensuring availability even for single-action runs.
> 
> - **Runtime (`packages/core/src/runtime.ts`)**:
>   - Compute `thought` once from `responses[0].content.thought` (fallback to default) outside the multi-action branch.
>   - Use this `thought` when creating both `ACTION_STARTED` and `ACTION_COMPLETED` events instead of `actionPlan?.thought`.
>   - Minor refactor: remove duplicate `thought` declaration inside multi-action block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a34d91010aca8f44e8327f03b82442b91f60a94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->