### PR TITLE
feat: remove claude code / upgrade / plugin gen from CLI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/api-client": {
       "name": "@elizaos/api-client",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -35,7 +35,7 @@
     },
     "packages/app": {
       "name": "@elizaos/app",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/cli": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/cli": {
       "name": "@elizaos/cli",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "bin": {
         "elizaos": "./dist/index.js",
       },
@@ -113,7 +113,7 @@
     },
     "packages/client": {
       "name": "@elizaos/client",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/api-client": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -216,7 +216,7 @@
     },
     "packages/config": {
       "name": "@elizaos/config",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "devDependencies": {
         "prettier": "^3.5.3",
         "typescript": "^5.8.2",
@@ -224,7 +224,7 @@
     },
     "packages/core": {
       "name": "@elizaos/core",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "adze": "^2.2.5",
         "crypto-browserify": "^3.12.0",
@@ -247,7 +247,7 @@
     },
     "packages/elizaos": {
       "name": "elizaos",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "bin": {
         "elizaos": "bin/elizaos.js",
       },
@@ -257,7 +257,7 @@
     },
     "packages/plugin-bootstrap": {
       "name": "@elizaos/plugin-bootstrap",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-sql": "workspace:*",
@@ -276,7 +276,7 @@
     },
     "packages/plugin-dummy-services": {
       "name": "@elizaos/plugin-dummy-services",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "uuid": "^9.0.0",
@@ -291,7 +291,7 @@
     },
     "packages/plugin-quick-starter": {
       "name": "@elizaos/plugin-quick-starter",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "4.1.11",
@@ -305,7 +305,7 @@
     },
     "packages/plugin-sql": {
       "name": "@elizaos/plugin-sql",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@electric-sql/pglite": "^0.3.3",
         "@elizaos/core": "workspace:*",
@@ -327,7 +327,7 @@
     },
     "packages/plugin-starter": {
       "name": "@elizaos/plugin-starter",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@tanstack/react-query": "^5.80.7",
@@ -349,7 +349,7 @@
     },
     "packages/project-starter": {
       "name": "@elizaos/project-starter",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/client": "workspace:*",
@@ -376,7 +376,7 @@
     },
     "packages/project-tee-starter": {
       "name": "@elizaos/project-tee-starter",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/cli": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -408,7 +408,7 @@
     },
     "packages/server": {
       "name": "@elizaos/server",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-sql": "workspace:*",
@@ -436,7 +436,7 @@
     },
     "packages/service-interfaces": {
       "name": "@elizaos/service-interfaces",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -451,7 +451,7 @@
     },
     "packages/test-utils": {
       "name": "@elizaos/test-utils",
-      "version": "1.6.3-alpha.10",
+      "version": "1.6.3-alpha.11",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "3.24.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "packages": [
     "packages/*"
   ],

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/api-client",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/app",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "scripts": {
     "start": "tauri dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cli",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "elizaOS CLI - Manage your AI agents and plugins",
   "publishConfig": {
     "access": "public",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/client",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "Web client interface for ElizaOS agents",
   "repository": {
     "type": "git",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/config",
   "description": "Shared configuration for ElizaOS projects and plugins",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/core",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1182,6 +1182,11 @@ export class AgentRuntime implements IAgentRuntime {
     }
   }
 
+  getActionResults(messageId: UUID): ActionResult[] {
+    const cachedState = this.stateCache?.get(`${messageId}_action_results`);
+    return (cachedState?.data?.actionResults as ActionResult[]) || [];
+  }
+
   async evaluate(
     message: Memory,
     state: State,

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -1,5 +1,5 @@
 import type { Character } from './agent';
-import type { Action, Evaluator, Provider } from './components';
+import type { Action, Evaluator, Provider, ActionResult } from './components';
 import { HandlerCallback } from './components';
 import type { IDatabaseAdapter } from './database';
 import type { Entity, Room, World, ChannelType } from './environment';
@@ -77,6 +77,8 @@ export interface IAgentRuntime extends IDatabaseAdapter {
     state?: State,
     callback?: HandlerCallback
   ): Promise<void>;
+
+  getActionResults(messageId: UUID): ActionResult[];
 
   evaluate(
     message: Memory,

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elizaos",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "Alias package for @elizaos/cli",
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-bootstrap/package.json
+++ b/packages/plugin-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-bootstrap",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-dummy-services/package.json
+++ b/packages/plugin-dummy-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-dummy-services",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-quick-starter",
   "description": "Quick backend-only plugin template for ElizaOS",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-sql/package.json
+++ b/packages/plugin-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-sql",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-starter",
   "description": "${PLUGINDESCRIPTION}",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/project-starter",
   "description": "Project starter for elizaOS",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",

--- a/packages/project-tee-starter/package.json
+++ b/packages/project-tee-starter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/project-tee-starter",
   "description": "Project starter for elizaOS with TEE capabilities",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/server",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "ElizaOS Server - Core server infrastructure for ElizaOS agents",
   "publishConfig": {
     "access": "public",

--- a/packages/service-interfaces/package.json
+++ b/packages/service-interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/service-interfaces",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "description": "Service interface definitions for ElizaOS plugins",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/test-utils",
   "description": "Utilities and objects for unit testing",
-  "version": "1.6.3-alpha.10",
+  "version": "1.6.3-alpha.11",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Remove Anthropic Claude Code Dependencies and AI-Powered Plugin Commands

### Summary
This PR removes the AI-powered plugin upgrade and generation functionality from the CLI package, along with all associated Anthropic/Claude Code dependencies. This resolves TypeScript compilation errors and removes unused experimental features.

### Changes Made

#### Removed Files
- **Commands:**
  - `src/commands/plugins/actions/upgrade.ts` - AI-powered 0.x → 1.x plugin migration
  - `src/commands/plugins/actions/generate.ts` - AI-powered plugin generation
  
- **Utilities:**
  - `src/utils/upgrade/` (entire directory)
    - `simple-migration-agent.ts`
    - `migration-guide-loader.ts`
    - `CLAUDE.md`
    - `README.md`
  - `src/utils/plugin-creator.ts`
  
- **Tests:**
  - `tests/unit/utils/simple-migration-agent-eventemitter-compatibility.test.ts`
  
- **Examples:**
  - `examples/upgrade-giphy.sh`
  - `examples/generate-*.sh`
  - `examples/create-*-plugin*.sh`

#### Code Changes
- **`src/commands/plugins/index.ts`:**
  - Removed `upgrade` command registration
  - Removed `generate` command registration
  - Removed imports for `upgradePlugin` and `generatePlugin`
  
- **`src/commands/plugins/types.ts`:**
  - Removed `UpgradePluginOptions` interface
  - Removed `GeneratePluginOptions` interface
  - Removed `MigrationResult` interface
  
- **`package.json`:**
  - Removed `@anthropic-ai/claude-code` dependency
  - Removed `@anthropic-ai/sdk` dependency

### Impact
- ✅ **Build:** CLI package now builds without TypeScript errors
- ✅ **Dependencies:** Reduced package size by removing unused AI SDK dependencies
- ✅ **Maintenance:** Simplified codebase by removing experimental features
- ⚠️ **Breaking Change:** Users relying on `elizaos plugins upgrade` or `elizaos plugins generate` commands will need alternative migration paths

### Verification
```bash
# Clean build succeeds
bun run clean
# ✅ All packages build successfully

# CLI build succeeds
bun run build --filter=@elizaos/cli
# ✅ @elizaos/cli build complete!

# No Anthropic references remain
grep -r "@anthropic\|claude-code" packages/cli/src
# ✅ No matches found
```

### Rationale
The upgrade and generate commands were experimental features that:
1. Introduced complex dependencies (`@anthropic-ai/claude-code`, `@anthropic-ai/sdk`)
2. Caused TypeScript compilation errors during type declaration generation
3. Were not widely used or documented in the main workflow
4. Required external API keys and additional setup

Removing these features simplifies the CLI and eliminates build issues while maintaining all core plugin management functionality (install, remove, list).

---

**Type:** `chore(cli)`  
**Scope:** Dependency cleanup and experimental feature removal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes AI-powered plugin upgrade/generation from the CLI and drops Anthropic/Claude Code dependencies, deleting related commands, utilities, examples, and tests.
> 
> - **CLI**:
>   - Remove `plugins upgrade` and `plugins generate` commands from `src/commands/plugins/index.ts`.
>   - Delete related option types from `src/commands/plugins/types.ts`.
> - **Utilities**:
>   - Remove AI generation/migration code: delete `src/utils/plugin-creator.ts` and `src/utils/upgrade/**` (guides, loader, migration agent, docs).
> - **Examples**:
>   - Delete plugin generation/upgrade scripts in `packages/cli/examples/*`.
> - **Tests**:
>   - Remove `tests/unit/utils/simple-migration-agent-eventemitter-compatibility.test.ts`.
> - **Dependencies**:
>   - Drop `@anthropic-ai/claude-code` and `@anthropic-ai/sdk` from `packages/cli/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f72f8e446819d626f655aade75e752f2f6aeedd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->