### PR TITLE
fix: merge .env variables with character

### DIFF
--- a/packages/core/src/elizaos.ts
+++ b/packages/core/src/elizaos.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { AgentRuntime } from './runtime';
-import { hasCharacterSecrets, setDefaultSecretsFromEnv } from './secrets';
+import { setDefaultSecretsFromEnv } from './secrets';
 import { resolvePlugins } from './plugin';
 import type {
   Character,
@@ -139,11 +139,10 @@ export class ElizaOS extends EventTarget {
     options?: { isTestMode?: boolean }
   ): Promise<UUID[]> {
     const promises = agents.map(async (agent) => {
-      // Set default secrets from environment if character doesn't have them
+      // Always merge environment secrets with character secrets
+      // Priority: .env < character.json (character overrides)
       const character = agent.character;
-      if (!hasCharacterSecrets(character)) {
-        await setDefaultSecretsFromEnv(character);
-      }
+      await setDefaultSecretsFromEnv(character);
 
       const resolvedPlugins = agent.plugins
         ? await resolvePlugins(agent.plugins, options?.isTestMode || false)

--- a/packages/server/src/loader.ts
+++ b/packages/server/src/loader.ts
@@ -133,14 +133,17 @@ export async function jsonToCharacter(character: unknown): Promise<Character> {
     }, {});
 
   if (Object.keys(characterSettings).length > 0) {
-    // Collect all secrets from various sources
+    // Collect all secrets from various sources with correct priority order:
+    // 1. character.secrets (lowest - base level)
+    // 2. character.settings.secrets (medium - from character.json merged with .env)
+    // 3. characterSettings from CHARACTER.* prefix (highest - runtime overrides)
     const combinedSecrets = {
-      ...characterSettings,
       ...(validatedCharacter.secrets || {}),
       ...(typeof validatedCharacter.settings?.secrets === 'object' &&
       validatedCharacter.settings?.secrets !== null
         ? validatedCharacter.settings.secrets
         : {}),
+      ...characterSettings,
     };
 
     const updatedCharacter: Character = {


### PR DESCRIPTION
# Relates to

Fixes the issue where `.env` variables are completely ignored when `character.settings.secrets` exists, preventing proper configuration merging between global defaults and character-specific overrides.

# Risks

**Low Risk**

- **Affected Areas**: Character configuration loading, environment variable resolution
- **Backward Compatibility**: ✅ Fully backward compatible - existing characters without `.env` or with empty settings work the same way
- **Breaking Changes**: None - only changes behavior from "all or nothing" to "proper merge"
- **Side Effects**: Characters now have access to ALL `.env` variables via `runtime.getSetting()`, which was the intended behavior

# Background

## What does this PR do?

This PR fixes the environment variable merging logic to properly combine `.env` files with character configuration:

### Core Changes (`packages/core/src/secrets.ts`)
- **Always merge** `.env` variables into `character.settings` (for all configs)
- **Always merge** `.env` variables into `character.settings.secrets` (for secrets)
- Respects priority: `.env` (defaults) < `character.json` (overrides)
- Preserves `character.secrets` (root) for runtime-only secrets

### Server Changes (`packages/server/src/loader.ts`)
- Fixes priority order in `combinedSecrets` merge
- `CHARACTER.*` prefixed environment variables now have highest priority
- Correct order: `character.secrets` < `character.settings.secrets` < `CHARACTER.* prefix`

### Priority Resolution Order
```typescript
runtime.getSetting(key) // Resolves in this order:
1. character.secrets[key]           // Highest - runtime only (via setSetting)
2. character.settings[key]          // High - merged with .env
3. character.settings.secrets[key]  // Medium - merged with .env
4. runtime.settings[key]            // Lowest - fallback
```

## What kind of change is this?

**Bug fixes** (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation, but could benefit from documentation explaining:
- The priority order for `runtime.getSetting()`
- When to use `character.settings` vs `character.settings.secrets` vs `character.secrets`
- How to override settings at runtime with `CHARACTER.*` prefix

# Testing

## Where should a reviewer start?

1. Review the test changes in `packages/core/src/__tests__/secrets.test.ts` to understand the new merge behavior
2. Review the core logic changes in `packages/core/src/secrets.ts` (lines 21-65)
3. Review the priority fix in `packages/server/src/loader.ts` (lines 136-147)

## Detailed testing steps

### Automated Tests
```bash
cd packages/core
bun test src/__tests__/secrets.test.ts
bun test src/__tests__/settings.test.ts
```

**Result**: ✅ All 57 tests pass

### Manual Testing

#### Test 1: Basic Merge
1. Create a `.env` file:
   ```env
   OPENAI_API_KEY=sk-global-key
   DATABASE_URL=postgres://localhost:5432/test
   LOG_LEVEL=info
   ```

2. Create a `character.json`:
   ```json
   {
     "name": "test",
     "bio": "test character",
     "settings": {
       "LOG_LEVEL": "debug"
     }
   }
   ```

3. Load character and verify:
   - `runtime.getSetting('OPENAI_API_KEY')` → `"sk-global-key"` (from .env)
   - `runtime.getSetting('DATABASE_URL')` → `"postgres://localhost:5432/test"` (from .env)
   - `runtime.getSetting('LOG_LEVEL')` → `"debug"` (character override)

#### Test 2: Character Overrides
1. Create `character.json` with secrets:
   ```json
   {
     "name": "test",
     "bio": "test character",
     "settings": {
       "secrets": {
         "OPENAI_API_KEY": "character-specific-key"
       }
     }
   }
   ```

2. Verify:
   - `runtime.getSetting('OPENAI_API_KEY')` → `"character-specific-key"` (override)
   - `runtime.getSetting('DATABASE_URL')` → `"postgres://localhost:5432/test"` (from .env)

#### Test 3: Runtime Override
1. Start with `CHARACTER.TEST.OPENAI_API_KEY=runtime-override`:
   ```bash
   CHARACTER.TEST.OPENAI_API_KEY=runtime-override npm start
   ```

2. Verify:
   - `runtime.getSetting('OPENAI_API_KEY')` → `"runtime-override"` (highest priority)

#### Test 4: Complex Settings Preservation
1. Create `character.json` with complex settings:
   ```json
   {
     "name": "test",
     "bio": "test character",
     "settings": {
       "discord": {
         "shouldIgnoreBotMessages": true,
         "allowedChannelIds": ["123", "456"]
       }
     }
   }
   ```

2. Verify:
   - Complex objects are preserved
   - `.env` variables are still accessible
   - No corruption of nested structures

## Test Coverage

### New Tests Added
- `secrets.test.ts`:
  - ✅ Merge `.env` with existing `character.settings.secrets` (character overrides)
  - ✅ Merge `.env` into `character.settings` (for non-secret configs)
  - ✅ Do NOT touch `character.secrets` (root level)

- `settings.test.ts`:
  - ✅ Handle complex character settings without corrupting them during merge

### Existing Tests
- ✅ All 48 existing tests in `settings.test.ts` still pass
- ✅ All 8 existing tests in `secrets.test.ts` updated and passing

**Total**: 57/57 tests passing

# Before and After Behavior

## Before (Broken)

```typescript
// .env
OPENAI_API_KEY=sk-global
DATABASE_URL=postgres://localhost

// character.json
{
  "settings": {
    "secrets": {
      "CUSTOM_KEY": "value"
    }
  }
}

// Result: .env is COMPLETELY IGNORED
runtime.getSetting('OPENAI_API_KEY') → null ❌
runtime.getSetting('DATABASE_URL') → null ❌
runtime.getSetting('CUSTOM_KEY') → "value" ✅
```

## After (Fixed)

```typescript
// .env
OPENAI_API_KEY=sk-global
DATABASE_URL=postgres://localhost

// character.json
{
  "settings": {
    "secrets": {
      "CUSTOM_KEY": "value"
    }
  }
}

// Result: Proper merge with correct priorities
runtime.getSetting('OPENAI_API_KEY') → "sk-global" ✅
runtime.getSetting('DATABASE_URL') → "postgres://localhost" ✅
runtime.getSetting('CUSTOM_KEY') → "value" ✅
```

# Implementation Details

# Deployment Notes

## Database changes

None - this is pure runtime logic changes.

## Deployment instructions

Standard deployment - no special instructions needed:
1. Merge PR
2. Build packages: `bun run build`
3. Deploy as usual

## Migration Notes

**No migration required** - this is fully backward compatible:
- Existing characters without `.env` work the same
- Existing characters with `.env` but no settings work the same
- Existing characters with settings now properly get `.env` defaults (bug fix)

# Verification Commands

```bash
# Build all packages
cd elizaos/eliza
bun run build

# Run tests
cd packages/core
bun test src/__tests__/secrets.test.ts src/__tests__/settings.test.ts

# Expected output: 57/57 tests passing
```
