### PR TITLE
feat(core): add skipMigrations option to runtime.initialize() for ser…

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4156,19 +4156,19 @@
 
     "@cypress/xvfb/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
-    "@elizaos/api-client/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/api-client/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/app/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@elizaos/app/typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
-    "@elizaos/cli/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/cli/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/cli/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
     "@elizaos/cli/vite": ["vite@7.1.12", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug=="],
 
-    "@elizaos/client/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/client/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/client/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
@@ -4176,7 +4176,7 @@
 
     "@elizaos/config/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
-    "@elizaos/core/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/core/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/core/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 
@@ -4202,7 +4202,7 @@
 
     "@elizaos/plugin-redpill/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
 
-    "@elizaos/plugin-sql/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/plugin-sql/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/plugin-sql/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -4228,7 +4228,7 @@
 
     "@elizaos/project-starter/tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
-    "@elizaos/project-tee-starter/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/project-tee-starter/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/project-tee-starter/@types/react": ["@types/react@18.3.26", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.0.2" } }, "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA=="],
 
@@ -4244,7 +4244,7 @@
 
     "@elizaos/project-tee-starter/tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
-    "@elizaos/server/@types/node": ["@types/node@24.9.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA=="],
+    "@elizaos/server/@types/node": ["@types/node@24.10.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A=="],
 
     "@elizaos/server/prettier": ["prettier@3.6.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="],
 

--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -397,6 +397,40 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
       );
     });
 
+    it('should skip plugin migrations when skipMigrations option is true', async () => {
+      const runtimeWithMigrations = new AgentRuntime({
+        character: mockCharacter,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Spy on runPluginMigrations
+      const runMigrationsSpy = spyOn(runtimeWithMigrations as any, 'runPluginMigrations');
+
+      // Initialize with skipMigrations = true
+      await runtimeWithMigrations.initialize({ skipMigrations: true });
+
+      // Verify migrations were not called
+      expect(runMigrationsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should run plugin migrations by default when skipMigrations is not specified', async () => {
+      const runtimeDefault = new AgentRuntime({
+        character: mockCharacter,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Spy on runPluginMigrations
+      const runMigrationsSpy = spyOn(runtimeDefault as any, 'runPluginMigrations');
+
+      // Initialize without skipMigrations option (default behavior)
+      await runtimeDefault.initialize();
+
+      // Verify migrations were called
+      expect(runMigrationsSpy).toHaveBeenCalled();
+    });
+
     // Add more tests for initialize: existing entity, existing room, knowledge processing etc.
   });
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -374,7 +374,7 @@ export class AgentRuntime implements IAgentRuntime {
     }
   }
 
-  async initialize(): Promise<void> {
+  async initialize(options?: { skipMigrations?: boolean }): Promise<void> {
     try {
       const pluginRegistrationPromises: Promise<void>[] = [];
 
@@ -406,10 +406,15 @@ export class AgentRuntime implements IAgentRuntime {
       // Initialize message service
       this.messageService = new DefaultMessageService();
 
-      // Run migrations for all loaded plugins
-      this.logger.info('Running plugin migrations...');
-      await this.runPluginMigrations();
-      this.logger.info('Plugin migrations completed.');
+      // Run migrations for all loaded plugins (unless explicitly skipped for serverless mode)
+      const skipMigrations = options?.skipMigrations ?? false;
+      if (skipMigrations) {
+        this.logger.info('Skipping plugin migrations (skipMigrations=true)');
+      } else {
+        this.logger.info('Running plugin migrations...');
+        await this.runPluginMigrations();
+        this.logger.info('Plugin migrations completed.');
+      }
 
       // Ensure character has the agent ID set before calling ensureAgentExists
       // We create a new object with the ID to avoid mutating the original character
@@ -427,26 +432,29 @@ export class AgentRuntime implements IAgentRuntime {
       if (existingAgent.settings) {
         this.character.settings = {
           ...existingAgent.settings,
-          ...this.character.settings,  // Character file overrides DB
+          ...this.character.settings, // Character file overrides DB
         };
 
         // Merge secrets from both character.secrets and settings.secrets
         // getSetting() checks character.secrets first, so we need to merge there too
-        const dbSecrets = existingAgent.settings.secrets && typeof existingAgent.settings.secrets === 'object'
-          ? existingAgent.settings.secrets
-          : {};
-        const settingsSecrets = this.character.settings.secrets && typeof this.character.settings.secrets === 'object'
-          ? this.character.settings.secrets
-          : {};
-        const characterSecrets = this.character.secrets && typeof this.character.secrets === 'object'
-          ? this.character.secrets
-          : {};
+        const dbSecrets =
+          existingAgent.settings.secrets && typeof existingAgent.settings.secrets === 'object'
+            ? existingAgent.settings.secrets
+            : {};
+        const settingsSecrets =
+          this.character.settings.secrets && typeof this.character.settings.secrets === 'object'
+            ? this.character.settings.secrets
+            : {};
+        const characterSecrets =
+          this.character.secrets && typeof this.character.secrets === 'object'
+            ? this.character.secrets
+            : {};
 
         // Merge into both locations that getSetting() checks
         const mergedSecrets = {
           ...dbSecrets,
           ...characterSecrets,
-          ...settingsSecrets,  // settings.secrets has priority
+          ...settingsSecrets, // settings.secrets has priority
         };
 
         if (Object.keys(mergedSecrets).length > 0) {
@@ -2398,8 +2406,8 @@ export class AgentRuntime implements IAgentRuntime {
       // Merge DB-persisted settings with character configuration
       // Priority: DB (persisted runtime settings) < character.json (file overrides)
       const mergedSettings = {
-        ...existingAgent.settings,  // Keep all DB-persisted settings
-        ...agent.settings,          // Override only keys present in character.json
+        ...existingAgent.settings, // Keep all DB-persisted settings
+        ...agent.settings, // Override only keys present in character.json
       };
 
       // Deep merge secrets to preserve runtime-generated secrets
@@ -2408,11 +2416,9 @@ export class AgentRuntime implements IAgentRuntime {
         typeof agent.settings?.secrets === 'object'
           ? {
               ...(typeof existingAgent.settings?.secrets === 'object'
-                  ? existingAgent.settings.secrets
-                  : {}),
-              ...(typeof agent.settings?.secrets === 'object'
-                  ? agent.settings.secrets
-                  : {}),
+                ? existingAgent.settings.secrets
+                : {}),
+              ...(typeof agent.settings?.secrets === 'object' ? agent.settings.secrets : {}),
             }
           : undefined;
 
@@ -2421,9 +2427,9 @@ export class AgentRuntime implements IAgentRuntime {
       }
 
       const updatedAgent = {
-        ...existingAgent,           // Keep all DB-persisted data
-        ...agent,                   // Override with character.json values
-        settings: mergedSettings,   // Use intelligently merged settings
+        ...existingAgent, // Keep all DB-persisted data
+        ...agent, // Override with character.json values
+        settings: mergedSettings, // Use intelligently merged settings
         id: agent.id,
         updatedAt: Date.now(),
       };
@@ -2435,7 +2441,9 @@ export class AgentRuntime implements IAgentRuntime {
         throw new Error(`Failed to retrieve agent after update: ${agent.id}`);
       }
 
-      this.logger.debug(`Updated existing agent ${agent.id} on restart (merged ${Object.keys(existingAgent.settings || {}).length} DB settings with ${Object.keys(agent.settings || {}).length} character settings)`);
+      this.logger.debug(
+        `Updated existing agent ${agent.id} on restart (merged ${Object.keys(existingAgent.settings || {}).length} DB settings with ${Object.keys(agent.settings || {}).length} character settings)`
+      );
       return refreshedAgent;
     }
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -44,7 +44,7 @@ export interface IAgentRuntime extends IDatabaseAdapter {
   // Methods
   registerPlugin(plugin: Plugin): Promise<void>;
 
-  initialize(): Promise<void>;
+  initialize(options?: { skipMigrations?: boolean }): Promise<void>;
 
   getConnection(): Promise<any>;
 


### PR DESCRIPTION
- Add optional skipMigrations parameter to initialize() method in IAgentRuntime interface
- Implement skipMigrations logic in AgentRuntime.initialize() to conditionally skip plugin migrations
- Default behavior unchanged - migrations run by default for backward compatibility
- Add unit tests to verify skipMigrations flag works correctly
- Enable manual migration handling for serverless environments where migrations should be managed externally

Breaking Changes: None - new optional parameter maintains backward compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional skipMigrations flag to runtime.initialize() to optionally bypass plugin migrations (default still runs), with tests and interface updates.
> 
> - **Core (runtime)**:
>   - Update `AgentRuntime.initialize(options?: { skipMigrations?: boolean })` to accept `skipMigrations`.
>   - Conditionally run `runPluginMigrations()` based on `options.skipMigrations` (default: run).
> - **Types**:
>   - Update `IAgentRuntime.initialize` signature to include `options?: { skipMigrations?: boolean }` in `packages/core/src/types/runtime.ts`.
> - **Tests**:
>   - Add unit tests in `packages/core/src/__tests__/runtime.test.ts` verifying migrations are skipped when `skipMigrations: true` and run by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a760a27d8717b34a7ea43bc571690ca4175962. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->