### PR TITLE
feat(plugin-sql): add ownerId field to Agent with camelCase mapping

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1530,7 +1530,7 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
-    "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
 
     "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
 
@@ -4401,6 +4401,8 @@
     "@types/jsdom/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "@types/pg-pool/@types/pg": ["@types/pg@8.15.5", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ=="],
+
+    "@types/serve-static/@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -101,12 +101,14 @@ export enum AgentStatus {
  * It includes:
  * - `enabled`: A boolean indicating if the agent is currently active or disabled.
  * - `status`: The current operational status, typically `AgentStatus.ACTIVE` or `AgentStatus.INACTIVE`.
+ * - `ownerId`: Optional UUID of the user/entity that owns this agent.
  * - `createdAt`, `updatedAt`: Timestamps for when the agent record was created and last updated in the database.
  * This interface is primarily used by the `IDatabaseAdapter` for agent management.
  */
 export interface Agent extends Character {
   enabled?: boolean;
   status?: AgentStatus;
+  ownerId?: UUID;
   createdAt: number;
   updatedAt: number;
 }

--- a/packages/plugin-sql/src/__tests__/integration/agent.test.ts
+++ b/packages/plugin-sql/src/__tests__/integration/agent.test.ts
@@ -231,6 +231,75 @@ describe('Agent Integration Tests', () => {
         expect(createdAgent?.enabled).toBe(true); // Should use the default value
         expect(createdAgent?.settings).toEqual({}); // Should have empty settings object
       });
+
+      it('should create and retrieve agent with ownerId in camelCase', async () => {
+        const ownerUuid = uuidv4() as UUID;
+        const agentWithOwner: Agent = {
+          id: uuidv4() as UUID,
+          name: 'Agent with Owner',
+          bio: 'This agent has an owner',
+          ownerId: ownerUuid,
+          enabled: true,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          username: 'owned-agent',
+          system: 'System message',
+          messageExamples: [],
+          postExamples: [],
+          topics: [],
+          adjectives: [],
+          knowledge: [],
+          plugins: [],
+          settings: {},
+          style: {},
+        };
+
+        const result = await adapter.createAgent(agentWithOwner);
+        expect(result).toBe(true);
+
+        // Retrieve the agent and verify ownerId is returned in camelCase
+        const retrievedAgent = await adapter.getAgent(agentWithOwner.id);
+        expect(retrievedAgent).not.toBeNull();
+        expect(retrievedAgent?.ownerId).toBe(ownerUuid);
+        expect(retrievedAgent?.name).toBe('Agent with Owner');
+      });
+
+      it('should update agent ownerId', async () => {
+        const initialOwnerId = uuidv4() as UUID;
+        const newOwnerId = uuidv4() as UUID;
+
+        const agent: Agent = {
+          id: uuidv4() as UUID,
+          name: 'Agent Owner Update Test',
+          bio: 'Testing owner update',
+          ownerId: initialOwnerId,
+          enabled: true,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          username: 'owner-update-test',
+          system: 'System message',
+          messageExamples: [],
+          postExamples: [],
+          topics: [],
+          adjectives: [],
+          knowledge: [],
+          plugins: [],
+          settings: {},
+          style: {},
+        };
+
+        await adapter.createAgent(agent);
+
+        // Update ownerId
+        const updateResult = await adapter.updateAgent(agent.id, {
+          ownerId: newOwnerId,
+        });
+        expect(updateResult).toBe(true);
+
+        // Verify ownerId was updated
+        const updatedAgent = await adapter.getAgent(agent.id);
+        expect(updatedAgent?.ownerId).toBe(newOwnerId);
+      });
     });
 
     describe('getAgent and getAgents', () => {

--- a/packages/plugin-sql/src/rls.ts
+++ b/packages/plugin-sql/src/rls.ts
@@ -223,13 +223,13 @@ export async function assignAgentToOwner(
 
   if (agents.length > 0) {
     const agent = agents[0];
-    const currentOwnerId = agent.owner_id;
+    const currentOwnerId = agent.ownerId;
 
     if (currentOwnerId === ownerId) {
       logger.debug(`[RLS] Agent ${agent.name} already owned by correct owner`);
     } else {
       // Update agent owner using Drizzle
-      await db.update(agentTable).set({ owner_id: ownerId }).where(eq(agentTable.id, agentId));
+      await db.update(agentTable).set({ ownerId: ownerId }).where(eq(agentTable.id, agentId));
 
       if (currentOwnerId === null) {
         logger.info(`[RLS] Agent ${agent.name} assigned to owner`);

--- a/packages/plugin-sql/src/schema/agent.ts
+++ b/packages/plugin-sql/src/schema/agent.ts
@@ -10,7 +10,7 @@ import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-c
 export const agentTable = pgTable('agents', {
   id: uuid('id').primaryKey().defaultRandom(),
   enabled: boolean('enabled').default(true).notNull(),
-  owner_id: uuid('owner_id'),
+  ownerId: uuid('owner_id'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .default(sql`now()`)
     .notNull(),


### PR DESCRIPTION
- Add ownerId field to Agent interface in core types
- Update agentTable schema to use camelCase alias for owner_id column
- Update RLS code to use camelCase ownerId property
- Add integration tests for creating and updating agents with ownerId
- Ensures TypeScript uses camelCase while maintaining snake_case in database

This change improves type safety and follows JavaScript/TypeScript naming
conventions while maintaining backward compatibility with the database schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ownerId` to `Agent`, maps DB `owner_id` to camelCase, updates RLS usage, and adds integration tests for create/update flows.
> 
> - **Core Types**:
>   - Add optional `ownerId` to `Agent` in `packages/core/src/types/agent.ts`.
> - **Plugin SQL**:
>   - Schema: Map DB column `owner_id` to camelCase `ownerId` in `packages/plugin-sql/src/schema/agent.ts`.
>   - RLS: Use `agent.ownerId` and update assignment writes via `{ ownerId: ownerId }` in `packages/plugin-sql/src/rls.ts`.
> - **Tests**:
>   - Integration: Add tests for creating, retrieving, and updating `ownerId` in `packages/plugin-sql/src/__tests__/integration/agent.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46979963e8affc64545144b66a38379f1116ad3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->