### PR TITLE
rollback(plugin-sql): revert build configuration changes from 08d5141…

### DIFF
--- a/packages/plugin-sql/build.ts
+++ b/packages/plugin-sql/build.ts
@@ -98,8 +98,8 @@ async function buildAll() {
   // Node alias to index.node (stable entry)
   const nodeIndexDtsPath = join(nodeDir, 'index.d.ts');
   const nodeAlias = [
-    'export * from "./src/index.node";',
-    'export { default } from "./src/index.node";',
+    'export * from "./index.node";',
+    'export { default } from "./index.node";',
     '',
   ].join('\n');
   await writeFile(nodeIndexDtsPath, nodeAlias, 'utf8');

--- a/packages/plugin-sql/package.json
+++ b/packages/plugin-sql/package.json
@@ -16,7 +16,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./types/index.d.ts",
       "browser": {
         "types": "./dist/browser/index.d.ts",
         "import": "./dist/browser/index.browser.js",
@@ -47,7 +47,8 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "drizzle"
+    "drizzle",
+    "types"
   ],
   "dependencies": {
     "@electric-sql/pglite": "^0.3.3",

--- a/packages/plugin-sql/tsconfig.build.json
+++ b/packages/plugin-sql/tsconfig.build.json
@@ -4,8 +4,7 @@
     "outDir": "dist/browser",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
-    "noEmit": false
+    "emitDeclarationOnly": true
   },
   "include": [
     "src/index.browser.ts",

--- a/packages/plugin-sql/tsconfig.build.node.json
+++ b/packages/plugin-sql/tsconfig.build.node.json
@@ -4,8 +4,7 @@
     "outDir": "dist/node",
     "declaration": true,
     "declarationMap": false,
-    "emitDeclarationOnly": true,
-    "noEmit": false
+    "emitDeclarationOnly": true
   },
   "include": [
     "src/index.node.ts",


### PR DESCRIPTION
# Rollback plugin-sql build configuration

Reverts build configuration changes from commits 08d5141 and 726b1d7 in plugin-sql package.

## Changes

- Restore types path to `./types/index.d.ts` in package.json exports
- Add `types` directory back to files array
- Fix index.d.ts aliases in build.ts
- Remove redundant noEmit option from tsconfig files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restore `types` export to `./types/index.d.ts`, fix Node `index.d.ts` alias path, and remove redundant `noEmit` from build tsconfigs.
> 
> - **Build script (`packages/plugin-sql/build.ts`)**:
>   - Fix Node `index.d.ts` alias to point to `./index.node` instead of `./src/index.node`.
> - **Package config (`packages/plugin-sql/package.json`)**:
>   - Change export types for `"."` to `"./types/index.d.ts"`.
>   - Add `"types"` directory to published `files`.
> - **TypeScript configs**:
>   - Remove redundant `noEmit` (keep `emitDeclarationOnly: true`) in `tsconfig.build.json` and `tsconfig.build.node.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edecb27ac188295e2c5840cfd0cabac6cdc8a49d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->