### PR TITLE
fix(client): improve markdown content spacing

### DIFF
--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -352,11 +352,20 @@
 
   /* Blockquotes */
   .markdown-content blockquote {
-    margin: 12px 0 !important;
-    padding: 8px 16px !important;
+    margin: 8px 0 !important;
+    padding: 4px 16px !important;
     border-left: 3px solid rgba(255, 255, 255, 0.3);
     color: rgba(255, 255, 255, 0.85);
     font-style: italic;
+  }
+
+  /* Blockquote paragraphs should be compact */
+  .markdown-content blockquote p {
+    margin-bottom: 4px !important;
+  }
+
+  .markdown-content blockquote p:last-child {
+    margin-bottom: 0 !important;
   }
 
   /* Code blocks */


### PR DESCRIPTION
This PR includes two fixes for markdown content spacing in the client:

1. Add missing heading and separator spacing to markdown-content
2. Reduce blockquote vertical spacing for more compact display

These changes improve the visual consistency and readability of markdown content rendered in the client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds consistent styles and spacing for markdown headings, separators, blockquotes, and code (blocks/inline) in `packages/client/src/index.css`.
> 
> - **Client CSS (`packages/client/src/index.css`)**:
>   - **Markdown headings (`h1–h6`)**: add consistent sizes, weights, line-heights, margins, and first-child top-margin removal.
>   - **Separators**: style `hr` with uniform spacing and subtle border.
>   - **Blockquotes**: add compact margins, padding, left border, color, italic text, and tighter paragraph spacing.
>   - **Code styling**:
>     - `pre`: add margins, padding, rounded corners, overflow handling, and background.
>     - `code`: set monospace font and size; add inline code background, padding, and radius.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a70e5b8f0be7a0b3b8be503df0b23b0566cbb05d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->