### PR TITLE
fix(core): add generic type support for custom event handlers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ ELIZA_SERVER_AUTH_TOKEN=
 EXPRESS_MAX_PAYLOAD=2mb
 
 ####################################
+#### Provider Configuration ####
+####################################
+
+# Total timeout for all providers running in parallel (in milliseconds)
+# When providers exceed this timeout, the pipeline aborts and returns an error message
+# Default: 1000 (1 second)
+PROVIDERS_TOTAL_TIMEOUT_MS=1000
+
+####################################
 #### Database Configuration ####
 ####################################
 

--- a/packages/cli/tests/test-timeouts.ts
+++ b/packages/cli/tests/test-timeouts.ts
@@ -49,7 +49,7 @@ export const TEST_TIMEOUTS = {
     ? 150 * 1000 // 2.5 minutes in CI (increased to handle slow postinstall scripts)
     : process.platform === 'win32'
       ? 3 * 60 * 1000
-      : 2 * 60 * 1000, // 3/2 minutes locally
+      : 3 * 60 * 1000, // 3 minutes locally (mac/linux)
   PROJECT_CREATION: isCI
     ? 150 * 1000 // 2.5 minutes in CI (increased for slower CI environments)
     : process.platform === 'win32'

--- a/packages/core/src/__tests__/register-event.test.ts
+++ b/packages/core/src/__tests__/register-event.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { AgentRuntime } from '../runtime';
+import type { Character, EventPayload } from '../types';
+import { stringToUuid } from '../utils';
+
+interface CustomEventPayload extends EventPayload {
+  customField: string;
+  count: number;
+}
+
+describe('registerEvent', () => {
+  let runtime: AgentRuntime;
+
+  const mockCharacter: Character = {
+    id: stringToUuid('test-character'),
+    name: 'TestBot',
+    bio: 'A test bot',
+  };
+
+  beforeEach(() => {
+    runtime = new AgentRuntime({
+      character: mockCharacter,
+    });
+  });
+
+  it('should register and emit custom typed events', async () => {
+    const receivedPayloads: CustomEventPayload[] = [];
+
+    runtime.registerEvent<CustomEventPayload>('CUSTOM_EVENT', async (params) => {
+      receivedPayloads.push(params);
+    });
+
+    await runtime.emitEvent('CUSTOM_EVENT', {
+      customField: 'test-value',
+      count: 42,
+    });
+
+    expect(receivedPayloads).toHaveLength(1);
+    expect(receivedPayloads[0].customField).toBe('test-value');
+    expect(receivedPayloads[0].count).toBe(42);
+    // emitEvent injects runtime and source
+    expect(receivedPayloads[0].runtime).toBeDefined();
+    expect(receivedPayloads[0].source).toBeDefined();
+  });
+
+  it('should support multiple handlers for same event', async () => {
+    let handler1Called = false;
+    let handler2Called = false;
+
+    runtime.registerEvent<CustomEventPayload>('MULTI_HANDLER_EVENT', async () => {
+      handler1Called = true;
+    });
+
+    runtime.registerEvent<CustomEventPayload>('MULTI_HANDLER_EVENT', async () => {
+      handler2Called = true;
+    });
+
+    await runtime.emitEvent('MULTI_HANDLER_EVENT', {
+      customField: 'test',
+      count: 1,
+    });
+
+    expect(handler1Called).toBe(true);
+    expect(handler2Called).toBe(true);
+  });
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2466,11 +2466,11 @@ export class AgentRuntime implements IAgentRuntime {
   }
 
   registerEvent<T extends keyof EventPayloadMap>(event: T, handler: EventHandler<T>): void;
-  registerEvent(event: string, handler: (params: EventPayload) => Promise<void>): void;
-  registerEvent(
+  registerEvent<P extends EventPayload = EventPayload>(
     event: string,
-    handler: ((params: EventPayload) => Promise<void>) | ((params: unknown) => Promise<void>)
-  ): void {
+    handler: (params: P) => Promise<void>
+  ): void;
+  registerEvent(event: string, handler: (params: EventPayload) => Promise<void>): void {
     if (!this.events[event]) {
       this.events[event] = [];
     }

--- a/packages/core/src/services/default-message-service.ts
+++ b/packages/core/src/services/default-message-service.ts
@@ -1237,7 +1237,7 @@ export class DefaultMessageService implements IMessageService {
           });
         }
 
-        return;
+        return { responseContent: null, responseMessages: [], state, mode: 'none' };
       }
 
       // Providers completed in time

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -187,7 +187,10 @@ export interface IAgentRuntime extends IDatabaseAdapter {
   ): ((runtime: IAgentRuntime, params: Record<string, unknown>) => Promise<unknown>) | undefined;
 
   registerEvent<T extends keyof EventPayloadMap>(event: T, handler: EventHandler<T>): void;
-  registerEvent(event: string, handler: (params: EventPayload) => Promise<void>): void;
+  registerEvent<P extends EventPayload = EventPayload>(
+    event: string,
+    handler: (params: P) => Promise<void>
+  ): void;
 
   getEvent<T extends keyof EventPayloadMap>(event: T): EventHandler<T>[] | undefined;
   getEvent(event: string): ((params: EventPayload) => Promise<void>)[] | undefined;


### PR DESCRIPTION
## Summary
- Add generic type parameter to `registerEvent` for custom events
- Allows plugins to define typed event payloads that extend `EventPayload`

## Example usage
```typescript
interface MyCustomPayload extends EventPayload {
  myField: string;
}

runtime.registerEvent<MyCustomPayload>('MY_CUSTOM_EVENT', async (params) => {
  // params is typed as MyCustomPayload
  console.log(params.myField);
});
```