### PR TITLE
fix(cli): replace execa and child_process with Bun.spawn and bun-exec utilities

### DIFF
--- a/packages/cli/src/commands/deploy/utils/docker-build.ts
+++ b/packages/cli/src/commands/deploy/utils/docker-build.ts
@@ -6,7 +6,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { logger } from '@elizaos/core';
-import { execa } from 'execa';
+import { bunExec } from '../../../utils/bun-exec';
 import crypto from 'node:crypto';
 import ora from 'ora';
 
@@ -49,9 +49,10 @@ export interface DockerPushResult {
  */
 export async function checkDockerAvailable(): Promise<boolean> {
   try {
-    await execa('docker', ['--version']);
-    await execa('docker', ['info']);
-    return true;
+    const versionResult = await bunExec('docker', ['--version']);
+    if (!versionResult.success) return false;
+    const infoResult = await bunExec('docker', ['info']);
+    return infoResult.success;
   } catch {
     return false;
   }
@@ -196,13 +197,22 @@ export async function buildDockerImage(options: DockerBuildOptions): Promise<Doc
 
     // Execute Docker build
     const startTime = Date.now();
-    const { stdout } = await execa('docker', buildArgs, {
+    const buildResult = await bunExec('docker', buildArgs, {
       env: {
-        ...process.env,
         DOCKER_DEFAULT_PLATFORM: platform,
         DOCKER_BUILDKIT: '1',
       },
     });
+
+    if (!buildResult.success) {
+      return {
+        success: false,
+        imageTag: options.imageTag,
+        error: buildResult.stderr || 'Docker build failed',
+      };
+    }
+
+    const stdout = buildResult.stdout;
     const buildTime = Date.now() - startTime;
 
     logger.debug(
@@ -216,11 +226,19 @@ export async function buildDockerImage(options: DockerBuildOptions): Promise<Doc
     }
 
     // Get image info
-    const inspectResult = await execa('docker', [
+    const inspectResult = await bunExec('docker', [
       'inspect',
       options.imageTag,
       '--format={{.Id}}|{{.Size}}',
     ]);
+
+    if (!inspectResult.success) {
+      return {
+        success: false,
+        imageTag: options.imageTag,
+        error: inspectResult.stderr || 'Failed to inspect Docker image',
+      };
+    }
 
     const [imageId, sizeStr] = inspectResult.stdout.split('|');
     const size = parseInt(sizeStr, 10);
@@ -272,10 +290,25 @@ async function loginToECR(registryUrl: string, authToken: string): Promise<void>
     'Logging in to ECR registry'
   );
 
-  // Docker login
-  await execa('docker', ['login', '--username', username, '--password-stdin', cleanRegistryUrl], {
-    input: password,
+  // Docker login - use Bun.spawn directly for stdin input
+  const proc = Bun.spawn(['docker', 'login', '--username', username, '--password-stdin', cleanRegistryUrl], {
+    stdin: 'pipe',
+    stdout: 'pipe',
+    stderr: 'pipe',
   });
+
+  // Write password to stdin using FileSink API
+  if (proc.stdin) {
+    proc.stdin.write(password);
+    proc.stdin.end();
+  }
+
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`Docker login failed: ${stderr}`);
+  }
 
   logger.info({ src: 'cli', util: 'docker-build' }, 'Logged in to ECR');
 }
@@ -286,7 +319,11 @@ async function loginToECR(registryUrl: string, authToken: string): Promise<void>
 async function tagImageForECR(localTag: string, ecrImageUri: string): Promise<void> {
   logger.info({ src: 'cli', util: 'docker-build', ecrImageUri }, 'Tagging image for ECR');
 
-  await execa('docker', ['tag', localTag, ecrImageUri]);
+  const result = await bunExec('docker', ['tag', localTag, ecrImageUri]);
+
+  if (!result.success) {
+    throw new Error(`Failed to tag image: ${result.stderr}`);
+  }
 
   logger.debug({ src: 'cli', util: 'docker-build', localTag, ecrImageUri }, 'Image tagged for ECR');
 }
@@ -338,65 +375,89 @@ export async function pushDockerImage(options: DockerPushOptions): Promise<Docke
     let completedLayers = 0;
     const layerProgress = new Map<string, { current: number; total: number }>();
 
-    const pushProcess = execa('docker', ['push', ecrImageUri]);
+    // Use Bun.spawn for the push process with streaming stderr
+    const pushProcess = Bun.spawn(['docker', 'push', ecrImageUri], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
 
-    // Track progress from stderr (Docker outputs progress to stderr)
-    if (pushProcess.stderr) {
-      pushProcess.stderr.on('data', (data: Buffer) => {
-        const output = data.toString();
+    // Process stderr stream for progress tracking
+    const processStderr = async () => {
+      if (!pushProcess.stderr) return;
 
-        // Parse Docker layer progress
-        // Format: "layer-id: Pushing [==>     ] 15.5MB/100MB"
-        const lines = output.split('\n');
+      const reader = pushProcess.stderr.getReader();
+      const decoder = new TextDecoder();
 
-        for (const line of lines) {
-          const layerMatch = line.match(
-            /^([a-f0-9]+):\s*(\w+)\s*\[([=>]+)\s*\]\s+([\d.]+)([KMGT]?B)\/([\d.]+)([KMGT]?B)/
-          );
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-          if (layerMatch) {
-            const [, layerId, , , currentStr, currentUnit, totalStr, totalUnit] = layerMatch;
+          const output = decoder.decode(value, { stream: true });
 
-            // Convert to bytes for accurate progress
-            const current = parseSize(currentStr, currentUnit);
-            const total = parseSize(totalStr, totalUnit);
+          // Parse Docker layer progress
+          // Format: "layer-id: Pushing [==>     ] 15.5MB/100MB"
+          const lines = output.split('\n');
 
-            layerProgress.set(layerId, { current, total });
+          for (const line of lines) {
+            const layerMatch = line.match(
+              /^([a-f0-9]+):\s*(\w+)\s*\[([=>]+)\s*\]\s+([\d.]+)([KMGT]?B)\/([\d.]+)([KMGT]?B)/
+            );
 
-            // Calculate overall progress
-            let totalBytes = 0;
-            let uploadedBytes = 0;
+            if (layerMatch) {
+              const [, layerId, , , currentStr, currentUnit, totalStr, totalUnit] = layerMatch;
 
-            for (const [, progress] of layerProgress) {
-              totalBytes += progress.total;
-              uploadedBytes += progress.current;
+              // Convert to bytes for accurate progress
+              const current = parseSize(currentStr, currentUnit);
+              const total = parseSize(totalStr, totalUnit);
+
+              layerProgress.set(layerId, { current, total });
+
+              // Calculate overall progress
+              let totalBytes = 0;
+              let uploadedBytes = 0;
+
+              for (const [, progress] of layerProgress) {
+                totalBytes += progress.total;
+                uploadedBytes += progress.current;
+              }
+
+              const overallPercent =
+                totalBytes > 0 ? Math.floor((uploadedBytes / totalBytes) * 100) : 0;
+              const uploadedMB = (uploadedBytes / 1024 / 1024).toFixed(1);
+              const totalMB = (totalBytes / 1024 / 1024).toFixed(1);
+
+              spinner.text = `Pushing to ECR... ${overallPercent}% (${uploadedMB}/${totalMB} MB, ${layerProgress.size} layers)`;
             }
 
-            const overallPercent =
-              totalBytes > 0 ? Math.floor((uploadedBytes / totalBytes) * 100) : 0;
-            const uploadedMB = (uploadedBytes / 1024 / 1024).toFixed(1);
-            const totalMB = (totalBytes / 1024 / 1024).toFixed(1);
+            // Check for pushed layers
+            if (line.includes(': Pushed')) {
+              completedLayers++;
+            }
 
-            spinner.text = `Pushing to ECR... ${overallPercent}% (${uploadedMB}/${totalMB} MB, ${layerProgress.size} layers)`;
-          }
-
-          // Check for pushed layers
-          if (line.includes(': Pushed')) {
-            completedLayers++;
-          }
-
-          // Check for completion digest
-          const digestMatch = line.match(/digest: (sha256:[a-f0-9]+)/);
-          if (digestMatch) {
-            imageDigest = digestMatch[1];
+            // Check for completion digest
+            const digestMatch = line.match(/digest: (sha256:[a-f0-9]+)/);
+            if (digestMatch) {
+              imageDigest = digestMatch[1];
+            }
           }
         }
-      });
-    }
+      } catch {
+        // Ignore stream errors during processing
+      }
+    };
 
     try {
-      await pushProcess;
+      // Process stderr in parallel with waiting for exit
+      await Promise.all([processStderr(), pushProcess.exited]);
+
+      const exitCode = pushProcess.exitCode;
       const pushTime = Date.now() - startTime;
+
+      if (exitCode !== 0) {
+        spinner.fail('Failed to push image to ECR');
+        throw new Error('Docker push failed');
+      }
 
       spinner.succeed(
         `Image pushed in ${(pushTime / 1000).toFixed(1)}s (${completedLayers} layers)`
@@ -477,8 +538,15 @@ export async function cleanupLocalImages(imageTags: string[]): Promise<void> {
   );
 
   try {
-    await execa('docker', ['rmi', ...imageTags, '--force']);
-    logger.info({ src: 'cli', util: 'docker-build' }, 'Local images cleaned up');
+    const result = await bunExec('docker', ['rmi', ...imageTags, '--force']);
+    if (result.success) {
+      logger.info({ src: 'cli', util: 'docker-build' }, 'Local images cleaned up');
+    } else {
+      logger.warn(
+        { src: 'cli', util: 'docker-build', error: result.stderr },
+        'Failed to clean up some images'
+      );
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     logger.warn(

--- a/packages/cli/src/commands/report/src/__tests__/integration.test.ts
+++ b/packages/cli/src/commands/report/src/__tests__/integration.test.ts
@@ -11,7 +11,6 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import { executeGenerateCommand } from '../../generate';
 import { ScenarioRunResult } from '../../../scenario/src/schema';


### PR DESCRIPTION
## Summary
Per project guidelines in CLAUDE.md, replaced prohibited process execution libraries with Bun-native alternatives.

## Changes
- **docker-build.ts**: Replaced `execa` with `bunExec` for docker commands
- **phala-wrapper.ts**: Replaced Node.js `spawn` with `Bun.spawn` for npx commands  
- **integration.test.ts**: Removed unused `child_process` execSync import

## Detailed Changes
1. `packages/cli/src/commands/deploy/utils/docker-build.ts`
   - Replaced all `execa` calls with `bunExec` from project utilities
   - Used `Bun.spawn` directly for stdin-based docker login
   - Updated ECR push to use Bun's streaming stderr API

2. `packages/cli/src/commands/tee/phala-wrapper.ts`
   - Replaced Node.js `spawn()` with `Bun.spawn()`
   - Used `onExit` callback for handling exit codes and errors

3. `packages/cli/src/commands/report/src/__tests__/integration.test.ts`
   - Removed unused `execSync` import

## Test plan
- [x] CLI package builds successfully
- [ ] Docker deploy commands work correctly
- [ ] TEE Phala wrapper executes properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes CLI process execution per project guidelines.
> 
> - Switches Docker utilities to `bunExec`/`Bun.spawn`: build, inspect, login (stdin), tag, push (streaming stderr with parsed layer progress), and image cleanup with clearer failure reporting
> - Updates `tee/phala-wrapper` to use `Bun.spawn` with `onExit`, pass-through stdio, explicit ENOENT guidance, and proper exit propagation
> - Cleans up tests by removing unused `execSync` import in report integration tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eb2d14ef14904083c2ac93614c22ff1c3d1d732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully replaces prohibited process execution libraries (`execa` and Node.js `child_process`) with Bun-native alternatives as required by CLAUDE.md project guidelines. The changes properly migrate to `bunExec` utility and `Bun.spawn` for process execution.

**Key Changes:**
- `docker-build.ts`: Migrated from `execa` to `bunExec` utility for all docker commands, with proper error handling and streaming support
- `phala-wrapper.ts`: Replaced Node.js `spawn()` with `Bun.spawn()` using `onExit` callback for process lifecycle management
- `integration.test.ts`: Removed unused `execSync` import

**Critical Issue:**
- Environment variable inheritance bug in `docker-build.ts` line 200-205 that will break docker builds requiring environment variables

**Scope Concerns:**
The PR contains 7 commits, but only 1 commit (dbd3e0b12) addresses the stated purpose. The other 6 commits add unrelated features for multi-step workflows, parameter handling, and streaming improvements across `packages/core` and `packages/plugin-bootstrap`. These changes should be in a separate PR for proper review and testing.

<h3>Confidence Score: 2/5</h3>


- This PR has one critical bug and contains unrelated changes that make it risky to merge
- Score reflects: (1) a critical environment variable bug in docker-build.ts that will break docker builds, (2) the PR includes 6 unrelated commits adding 1000+ lines of multi-step workflow features that weren't described in the PR description and haven't been properly isolated for review, (3) mixing unrelated changes makes it difficult to test and rollback if issues arise
- Pay close attention to `packages/cli/src/commands/deploy/utils/docker-build.ts` for the environment variable bug. Also review the unrelated changes in `packages/core/src/services/default-message-service.ts`, `packages/core/src/runtime.ts`, and `packages/plugin-bootstrap/` files which add significant new functionality

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/deploy/utils/docker-build.ts | Replaced `execa` with `bunExec` utility for docker commands. Contains one critical bug where environment variables are not properly inherited. |
| packages/cli/src/commands/tee/phala-wrapper.ts | Properly replaced Node.js `spawn` with `Bun.spawn`. The implementation correctly uses `onExit` callback and handles errors appropriately. |
| packages/cli/src/commands/report/src/__tests__/integration.test.ts | Removed unused `execSync` import from `child_process` module, following project guidelines. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant DockerBuild
    participant BunExec
    participant Docker
    participant PhalaWrapper
    participant BunSpawn

    Note over User,BunSpawn: Docker Build Flow (docker-build.ts)
    User->>CLI: elizaos deploy
    CLI->>DockerBuild: buildDockerImage(options)
    DockerBuild->>BunExec: bunExec('docker', ['build', ...])
    BunExec->>BunExec: ensureBunInPath(env)
    BunExec->>Docker: Bun.spawn(['docker', 'build', ...])
    Docker-->>BunExec: stdout/stderr streams
    BunExec-->>DockerBuild: {success, stdout, stderr, exitCode}
    
    alt Build Success
        DockerBuild->>BunExec: bunExec('docker', ['inspect', ...])
        BunExec->>Docker: Bun.spawn(['docker', 'inspect', ...])
        Docker-->>BunExec: image metadata
        BunExec-->>DockerBuild: image info
        DockerBuild-->>CLI: {success: true, imageId, size}
    else Build Failure
        DockerBuild-->>CLI: {success: false, error}
    end

    Note over User,BunSpawn: Phala CLI Flow (phala-wrapper.ts)
    User->>CLI: elizaos tee phala [args]
    CLI->>PhalaWrapper: phala command
    PhalaWrapper->>BunSpawn: Bun.spawn(['npx', '--yes', 'phala', ...])
    BunSpawn->>BunSpawn: stdio: inherit (pass-through)
    
    alt Process Success
        BunSpawn-->>PhalaWrapper: exitCode: 0
        PhalaWrapper->>PhalaWrapper: process.exit(0)
    else Process Error
        BunSpawn-->>PhalaWrapper: onExit(error)
        PhalaWrapper->>User: Error message
        PhalaWrapper->>PhalaWrapper: process.exit(1)
    end

    Note over User,BunSpawn: Key Changes
    Note right of BunExec: Replaced execa with bunExec utility
    Note right of BunSpawn: Replaced child_process.spawn with Bun.spawn
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=8ef4c9a3-e221-4aef-8556-8c9b88bf6bbb))

<!-- /greptile_comment -->