### PR TITLE
chore(license): update year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Shaw Walters and elizaOS Contributors
+Copyright (c) 2026 Shaw Walters and elizaOS Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Annual copyright year update.

- Updated year: 2025 -> 2026
- Files affected: LICENSE

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updated the copyright year in the MIT License from 2025 to 2026. This is a standard annual maintenance update with no functional changes.

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge with zero risk
- This is a trivial, single-line change updating only the copyright year in the LICENSE file - a standard annual maintenance task with no code changes, no dependencies affected, and no potential for runtime issues
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| LICENSE | Updated copyright year from 2025 to 2026 - routine annual update |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant License as LICENSE File
    participant Repo as Repository
    
    Dev->>License: Update copyright year
    Note over License: 2025 → 2026
    Dev->>Repo: Commit change
    Note over Repo: Annual maintenance update
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->