### PR TITLE
fix(plugin-sql): use sql.raw() for SET LOCAL to avoid parameterizatio…

### DIFF
--- a/packages/plugin-sql/src/__tests__/integration/postgres/withEntityContext.test.ts
+++ b/packages/plugin-sql/src/__tests__/integration/postgres/withEntityContext.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { stringToUuid } from '@elizaos/core';
+import { PostgresConnectionManager } from '../../../pg/manager';
+
+// Generate unique UUIDs using stringToUuid with random strings
+const generateUuid = () => stringToUuid(`test-${Date.now()}-${Math.random()}`);
+
+/**
+ * Integration tests for PostgresConnectionManager.withEntityContext()
+ *
+ * These tests verify that withEntityContext correctly executes SET LOCAL
+ * without parameterization errors. This is a regression test for the bug
+ * where sql`SET LOCAL app.entity_id = ${entityId}` produced a parameterized
+ * query that PostgreSQL rejected.
+ *
+ * Requires: POSTGRES_URL environment variable and ENABLE_DATA_ISOLATION=true
+ */
+describe.skipIf(!process.env.POSTGRES_URL)(
+  'PostgresConnectionManager.withEntityContext Integration',
+  () => {
+    let manager: PostgresConnectionManager;
+    const serverId = generateUuid();
+    const testEntityId = generateUuid();
+
+    const POSTGRES_URL =
+      process.env.POSTGRES_URL || 'postgresql://eliza_test:test123@localhost:5432/eliza_test';
+
+    beforeAll(async () => {
+      manager = new PostgresConnectionManager(POSTGRES_URL, serverId);
+
+      // Verify connection works
+      const connected = await manager.testConnection();
+      expect(connected).toBe(true);
+    });
+
+    afterAll(async () => {
+      await manager?.close();
+    });
+
+    describe('when ENABLE_DATA_ISOLATION=false', () => {
+      const originalEnv = process.env.ENABLE_DATA_ISOLATION;
+
+      beforeAll(() => {
+        delete process.env.ENABLE_DATA_ISOLATION;
+      });
+
+      afterAll(() => {
+        if (originalEnv !== undefined) {
+          process.env.ENABLE_DATA_ISOLATION = originalEnv;
+        }
+      });
+
+      it('should execute callback without SET LOCAL', async () => {
+        const result = await manager.withEntityContext(testEntityId as any, async (_tx) => {
+          // Just verify the callback executes successfully
+          return 'success';
+        });
+
+        expect(result).toBe('success');
+      });
+
+      it('should work with null entityId', async () => {
+        const result = await manager.withEntityContext(null, async (tx) => {
+          return 'null-entity-success';
+        });
+
+        expect(result).toBe('null-entity-success');
+      });
+    });
+
+    describe('when ENABLE_DATA_ISOLATION=true', () => {
+      const originalEnv = process.env.ENABLE_DATA_ISOLATION;
+
+      beforeAll(() => {
+        process.env.ENABLE_DATA_ISOLATION = 'true';
+      });
+
+      afterAll(() => {
+        if (originalEnv !== undefined) {
+          process.env.ENABLE_DATA_ISOLATION = originalEnv;
+        } else {
+          delete process.env.ENABLE_DATA_ISOLATION;
+        }
+      });
+
+      it('should execute SET LOCAL without parameterization error (regression test)', async () => {
+        // This is the main regression test for the bug:
+        // Before the fix, this would throw:
+        // "error: syntax error at or near "$1"" because PostgreSQL
+        // doesn't support parameterized SET commands.
+
+        // Note: This may still fail if app.entity_id GUC is not configured,
+        // but it should NOT fail with "syntax error at or near $1"
+        try {
+          const result = await manager.withEntityContext(testEntityId as any, async (tx) => {
+            return 'isolation-enabled-success';
+          });
+
+          expect(result).toBe('isolation-enabled-success');
+        } catch (error: any) {
+          // If it fails, it should NOT be the parameterization error
+          // It might fail because app.entity_id GUC doesn't exist, which is fine
+          // The important thing is it's NOT the $1 syntax error
+          expect(error.message).not.toContain('syntax error at or near "$1"');
+
+          // If the error is about unrecognized configuration parameter,
+          // that's okay - it means SET LOCAL was called correctly
+          if (error.message.includes('unrecognized configuration parameter')) {
+            console.log(
+              '[withEntityContext Test] SET LOCAL called correctly, but app.entity_id not configured'
+            );
+            return; // Test passes - SET LOCAL syntax was correct
+          }
+
+          // Re-throw unexpected errors
+          throw error;
+        }
+      });
+
+      it('should skip SET LOCAL when entityId is null', async () => {
+        const result = await manager.withEntityContext(null, async (tx) => {
+          return 'null-entity-with-isolation';
+        });
+
+        expect(result).toBe('null-entity-with-isolation');
+      });
+
+      it('should properly quote UUID value in SET LOCAL', async () => {
+        // Test with various UUID formats to ensure proper quoting
+        const uuids = [
+          generateUuid(),
+          '00000000-0000-0000-0000-000000000000',
+          'ffffffff-ffff-ffff-ffff-ffffffffffff',
+        ];
+
+        for (const uuid of uuids) {
+          try {
+            await manager.withEntityContext(uuid as any, async (tx) => {
+              return 'uuid-test';
+            });
+          } catch (error: any) {
+            // Should not be parameterization error
+            expect(error.message).not.toContain('syntax error at or near "$1"');
+
+            // Unrecognized config param is okay
+            if (!error.message.includes('unrecognized configuration parameter')) {
+              throw error;
+            }
+          }
+        }
+      });
+    });
+  }
+);

--- a/packages/plugin-sql/src/pg/manager.ts
+++ b/packages/plugin-sql/src/pg/manager.ts
@@ -81,7 +81,8 @@ export class PostgresConnectionManager {
       // Only set entity context if ENABLE_DATA_ISOLATION is true AND entityId is provided
       if (dataIsolationEnabled && entityId) {
         try {
-          await tx.execute(sql`SET LOCAL app.entity_id = ${entityId}`);
+          // SET LOCAL does not support parameterized queries, so we must use sql.raw()
+          await tx.execute(sql.raw(`SET LOCAL app.entity_id = '${entityId}'`));
           logger.debug(`[Entity Context] Set app.entity_id = ${entityId}`);
         } catch (error) {
           // This is an unexpected error since we already checked ENABLE_DATA_ISOLATION


### PR DESCRIPTION
PostgreSQL SET commands do not support parameterized queries. The previous
implementation used Drizzle's sql tagged template which auto-parameterizes
values, causing "syntax error at or near $1" when ENABLE_DATA_ISOLATION=true.

- Change sql`SET LOCAL app.entity_id = ${entityId}` to sql.raw() with inline value
- Add unit tests for withEntityContext in manager.test.ts
- Add integration test to verify fix against real PostgreSQL

Fixes critical bug that broke all database operations with data isolation enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes PostgreSQL errors from parameterized `SET` by inlining the value.
> 
> - Replace `sql\`SET LOCAL app.entity_id = ${entityId}\`` with `sql.raw('SET LOCAL app.entity_id = \'' + entityId + '\'')` in `withEntityContext`
> - Maintain guards: only `SET LOCAL` when `ENABLE_DATA_ISOLATION==='true'` and `entityId` is provided
> - Unit tests: verify skipping when isolation disabled or `entityId` is null, ensure raw SQL contains UUID and not `$1`, and propagate callback errors
> - Integration tests (Postgres): confirm no `$1` syntax error, handle missing GUC gracefully, and validate UUID quoting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa252f2d1973cee9ff0b8150c8e7c3d4da4cf6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed PostgreSQL parameterization error in `withEntityContext` by replacing `sql\`SET LOCAL app.entity_id = ${entityId}\`` with `sql.raw()` to inline the UUID value. PostgreSQL's `SET` command doesn't support parameterized queries, which was causing "syntax error at or near $1" when `ENABLE_DATA_ISOLATION=true`.

**Major changes:**
- `manager.ts:85` - Changed from Drizzle's parameterized sql template to `sql.raw()` with string interpolation
- Added comprehensive unit tests (4 test cases) verifying isolation flag handling, null entityId handling, raw SQL generation, and error propagation
- Added integration tests against real PostgreSQL to verify the fix works end-to-end and handles edge cases like missing GUC configuration

**Critical security concern:**
The fix introduces a potential SQL injection vulnerability. While `entityId` has TypeScript type `UUID`, this provides no runtime validation. A malicious caller could bypass TypeScript typing and inject SQL. The UUID format should be validated before insertion into the raw SQL query.

<h3>Confidence Score: 3/5</h3>


- This PR fixes a critical bug but introduces a SQL injection vulnerability that must be addressed before merging
- The fix correctly resolves the PostgreSQL parameterization error and includes good test coverage. However, the implementation uses `sql.raw()` with direct string interpolation without validating the UUID format, creating a SQL injection vector. The TypeScript `UUID` type provides compile-time safety only - runtime validation is needed to prevent malicious input.
- `packages/plugin-sql/src/pg/manager.ts:85` requires UUID validation before inserting into raw SQL

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/plugin-sql/src/pg/manager.ts | Fixed PostgreSQL parameterization error by using sql.raw() for SET LOCAL, but introduced potential SQL injection vulnerability |
| packages/plugin-sql/src/__tests__/unit/pg/manager.test.ts | Added comprehensive unit tests for withEntityContext covering isolation flags, null handling, and raw SQL verification |
| packages/plugin-sql/src/__tests__/integration/postgres/withEntityContext.test.ts | Added new integration tests against real PostgreSQL to verify the parameterization fix and UUID quoting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Database Client
    participant Manager as PostgresConnectionManager
    participant DB as PostgreSQL Database
    participant Tx as Transaction

    Client->>Manager: withEntityContext(entityId, callback)
    Manager->>Manager: Check ENABLE_DATA_ISOLATION flag
    Manager->>DB: Begin transaction
    DB->>Tx: Create transaction context
    
    alt ENABLE_DATA_ISOLATION=true AND entityId exists
        Manager->>Tx: execute(sql.raw(`SET LOCAL app.entity_id = '${entityId}'`))
        Tx->>DB: SET LOCAL app.entity_id = 'uuid-value'
        DB-->>Tx: Context set (or error if GUC not configured)
        Tx-->>Manager: Success/Error
        alt SET LOCAL fails
            Manager->>Manager: Log error
            Manager-->>Client: Throw error
        end
    else ENABLE_DATA_ISOLATION=false OR entityId=null
        Manager->>Manager: Skip SET LOCAL
    end
    
    Manager->>Manager: Execute callback(tx)
    Manager->>Tx: Run database operations
    Tx->>DB: Execute queries with entity context
    DB-->>Tx: Query results
    Tx-->>Manager: Callback result
    Manager->>DB: Commit transaction
    DB-->>Manager: Transaction committed
    Manager-->>Client: Return callback result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->