### PR TITLE
fix(plugin-sql): skip pgcrypto extension for PGLite

### DIFF
--- a/packages/plugin-sql/src/runtime-migrator/runtime-migrator.ts
+++ b/packages/plugin-sql/src/runtime-migrator/runtime-migrator.ts
@@ -385,12 +385,12 @@ export class RuntimeMigrator {
         );
       }
 
-      // Install required extensions (same as old migrator)
-      await this.extensionManager.installRequiredExtensions([
-        'vector',
-        'fuzzystrmatch',
-        'pgcrypto',
-      ]);
+      // Install required extensions
+      // pgcrypto is only needed for real PostgreSQL (PGLite uses native gen_random_uuid)
+      const extensions = isRealPostgres
+        ? ['vector', 'fuzzystrmatch', 'pgcrypto']
+        : ['vector', 'fuzzystrmatch'];
+      await this.extensionManager.installRequiredExtensions(extensions);
 
       // Generate current snapshot from schema
       const currentSnapshot = await generateSnapshot(schema);


### PR DESCRIPTION
- Skip installing `pgcrypto` extension for PGLite/development databases
- PGLite uses native `gen_random_uuid()` and doesn't support pgcrypto
- Eliminates unnecessary warning logs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves database compatibility by conditionally skipping the `pgcrypto` extension installation for PGLite databases. The change leverages the existing `isRealPostgresDatabase()` detection logic to determine whether to include `pgcrypto` in the list of required extensions.

**Key changes:**
- PGLite databases now install only `vector` and `fuzzystrmatch` extensions
- Real PostgreSQL databases continue to install all three extensions including `pgcrypto`
- Eliminates unnecessary warning logs when using PGLite, which has native `gen_random_uuid()` support

The implementation follows the established pattern already used for advisory locks in the same file (lines 333 and 620), ensuring consistency. The schema files use `gen_random_uuid()` extensively (found in `room.ts`, `world.ts`, `relationship.ts`, `component.ts`, `participant.ts`), which works natively in PGLite without requiring the `pgcrypto` extension.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple, well-targeted fix that follows existing patterns in the codebase. It reuses the `isRealPostgresDatabase()` method that's already used elsewhere in the same file for advisory locks. The logic is sound: PGLite has native `gen_random_uuid()` support and doesn't need the `pgcrypto` extension, while real PostgreSQL databases continue to receive all required extensions. The change eliminates unnecessary warning logs without affecting functionality, and there's no risk of breaking existing behavior since the extension installation uses `CREATE EXTENSION IF NOT EXISTS` with error handling that continues on failure.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/plugin-sql/src/runtime-migrator/runtime-migrator.ts | Conditionally skips `pgcrypto` extension installation for PGLite, which natively supports `gen_random_uuid()` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Migrator as RuntimeMigrator
    participant EnvCheck as Environment Check
    participant ExtManager as ExtensionManager
    participant DB as Database

    Migrator->>EnvCheck: Get POSTGRES_URL/DATABASE_URL
    EnvCheck->>EnvCheck: isRealPostgresDatabase()
    
    alt Real PostgreSQL
        EnvCheck-->>Migrator: isRealPostgres = true
        Migrator->>Migrator: extensions = ['vector', 'fuzzystrmatch', 'pgcrypto']
        Migrator->>ExtManager: installRequiredExtensions(extensions)
        ExtManager->>DB: CREATE EXTENSION vector
        ExtManager->>DB: CREATE EXTENSION fuzzystrmatch
        ExtManager->>DB: CREATE EXTENSION pgcrypto
    else PGLite/Development
        EnvCheck-->>Migrator: isRealPostgres = false
        Migrator->>Migrator: extensions = ['vector', 'fuzzystrmatch']
        Note over Migrator: Skip pgcrypto (native gen_random_uuid)
        Migrator->>ExtManager: installRequiredExtensions(extensions)
        ExtManager->>DB: CREATE EXTENSION vector
        ExtManager->>DB: CREATE EXTENSION fuzzystrmatch
    end
    
    DB-->>ExtManager: Extensions installed/skipped
    ExtManager-->>Migrator: Continue migration
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->