### PR TITLE
feat(core): support EMBEDDING_DIMENSION setting to skip API call

### DIFF
--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -299,18 +299,6 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
         },
       ]);
       (
-        mockDatabaseAdapter.getEntitiesByIds as BunMockFunction<
-          IDatabaseAdapter['getEntitiesByIds']
-        >
-      ).mockResolvedValue([
-        {
-          id: agentId,
-          agentId: agentId,
-          names: [mockCharacter.name],
-          metadata: {},
-        },
-      ]);
-      (
         mockDatabaseAdapter.getRoomsByIds as BunMockFunction<IDatabaseAdapter['getRoomsByIds']>
       ).mockResolvedValue([]);
       (
@@ -352,18 +340,6 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
         },
       ]);
       (
-        mockDatabaseAdapter.getEntitiesByIds as BunMockFunction<
-          IDatabaseAdapter['getEntitiesByIds']
-        >
-      ).mockResolvedValue([
-        {
-          id: agentId,
-          agentId: agentId,
-          names: [mockCharacter.name],
-          metadata: {},
-        },
-      ]);
-      (
         mockDatabaseAdapter.getRoomsByIds as BunMockFunction<IDatabaseAdapter['getRoomsByIds']>
       ).mockResolvedValue([]);
       (
@@ -371,7 +347,6 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
           IDatabaseAdapter['getParticipantsForRoom']
         >
       ).mockResolvedValue([]);
-      // mockDatabaseAdapter.getAgent is NOT called by initialize anymore after ensureAgentExists returns the agent
     });
 
     afterEach(() => {
@@ -1419,6 +1394,115 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
         expect(typeof result2).toBe('string');
         expect(typeof result3).toBe('string');
       });
+    });
+  });
+
+  describe('ensureEmbeddingDimension', () => {
+    it('should use EMBEDDING_DIMENSION from settings and skip API call', async () => {
+      const characterWithEmbeddingDimension: Character = {
+        ...mockCharacter,
+        settings: {
+          EMBEDDING_DIMENSION: 1536,
+        },
+      };
+
+      const runtimeWithDimension = new AgentRuntime({
+        character: characterWithEmbeddingDimension,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Register a mock embedding model
+      const embeddingHandler = mock().mockResolvedValue([0.1, 0.2, 0.3]);
+      runtimeWithDimension.registerModel(ModelType.TEXT_EMBEDDING, embeddingHandler, 'test-provider');
+
+      // Reset mock call counts
+      (mockDatabaseAdapter.ensureEmbeddingDimension as any).mockClear();
+
+      await runtimeWithDimension.ensureEmbeddingDimension();
+
+      // Should call ensureEmbeddingDimension with the configured value
+      expect(mockDatabaseAdapter.ensureEmbeddingDimension).toHaveBeenCalledWith(1536);
+      // Should NOT call the embedding model since dimension was provided
+      expect(embeddingHandler).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to API call when EMBEDDING_DIMENSION is not set', async () => {
+      const runtimeWithoutDimension = new AgentRuntime({
+        character: mockCharacter,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Register a mock embedding model that returns a 768-dim vector
+      const embeddingHandler = mock().mockResolvedValue(new Array(768).fill(0.1));
+      runtimeWithoutDimension.registerModel(ModelType.TEXT_EMBEDDING, embeddingHandler, 'test-provider');
+
+      // Reset mock call counts
+      (mockDatabaseAdapter.ensureEmbeddingDimension as any).mockClear();
+
+      await runtimeWithoutDimension.ensureEmbeddingDimension();
+
+      // Should call the embedding model to determine dimension
+      expect(embeddingHandler).toHaveBeenCalled();
+      // Should call ensureEmbeddingDimension with the inferred dimension
+      expect(mockDatabaseAdapter.ensureEmbeddingDimension).toHaveBeenCalledWith(768);
+    });
+
+    it('should fall back to API call when EMBEDDING_DIMENSION is invalid', async () => {
+      const characterWithInvalidDimension: Character = {
+        ...mockCharacter,
+        settings: {
+          EMBEDDING_DIMENSION: 'not-a-number',
+        },
+      };
+
+      const runtimeWithInvalidDimension = new AgentRuntime({
+        character: characterWithInvalidDimension,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Register a mock embedding model
+      const embeddingHandler = mock().mockResolvedValue(new Array(512).fill(0.1));
+      runtimeWithInvalidDimension.registerModel(ModelType.TEXT_EMBEDDING, embeddingHandler, 'test-provider');
+
+      // Reset mock call counts
+      (mockDatabaseAdapter.ensureEmbeddingDimension as any).mockClear();
+
+      await runtimeWithInvalidDimension.ensureEmbeddingDimension();
+
+      // Should fall back to API call since dimension is invalid
+      expect(embeddingHandler).toHaveBeenCalled();
+      expect(mockDatabaseAdapter.ensureEmbeddingDimension).toHaveBeenCalledWith(512);
+    });
+
+    it('should handle string EMBEDDING_DIMENSION setting', async () => {
+      const characterWithStringDimension: Character = {
+        ...mockCharacter,
+        settings: {
+          EMBEDDING_DIMENSION: '3072',
+        },
+      };
+
+      const runtimeWithStringDimension = new AgentRuntime({
+        character: characterWithStringDimension,
+        agentId: agentId,
+        adapter: mockDatabaseAdapter,
+      });
+
+      // Register a mock embedding model
+      const embeddingHandler = mock().mockResolvedValue([0.1]);
+      runtimeWithStringDimension.registerModel(ModelType.TEXT_EMBEDDING, embeddingHandler, 'test-provider');
+
+      // Reset mock call counts
+      (mockDatabaseAdapter.ensureEmbeddingDimension as any).mockClear();
+
+      await runtimeWithStringDimension.ensureEmbeddingDimension();
+
+      // Should parse string and use it
+      expect(mockDatabaseAdapter.ensureEmbeddingDimension).toHaveBeenCalledWith(3072);
+      expect(embeddingHandler).not.toHaveBeenCalled();
     });
   });
 }); // End of main describe block


### PR DESCRIPTION
## Summary
- Add support for configuring embedding dimension via `EMBEDDING_DIMENSION` character setting, which skips the expensive ~500ms embedding API call during agent initialization
- Simplify `ensureEmbeddingDimension` method (38 → 27 lines) while maintaining functionality
- Clean up duplicate mock setup code in runtime tests

## Test plan
- [x] Added 4 new tests for `ensureEmbeddingDimension`:
  - Uses numeric EMBEDDING_DIMENSION from settings (skips API call)
  - Falls back to API call when setting is not provided
  - Falls back to API call when EMBEDDING_DIMENSION is invalid
  - Parses string EMBEDDING_DIMENSION values correctly
- [x] All 51 runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 36f9a818a8e322086bf13a40934665cc04b6f44d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds support for configuring the embedding dimension via `EMBEDDING_DIMENSION` character setting to skip the ~500ms API call during agent initialization. The implementation simplifies the `ensureEmbeddingDimension` method by checking for a configured dimension first before falling back to the API call.

**Key Changes:**
- Adds `EMBEDDING_DIMENSION` setting support in `runtime.ts`
- Refactors `ensureEmbeddingDimension` from 38 to 27 lines
- Adds 4 comprehensive tests covering various scenarios
- Removes duplicate mock setup code in tests

**Critical Issue:**
The implementation is missing validation to ensure the provided dimension is one of the supported values (384, 512, 768, 1024, 1536, 3072). The database adapter expects these exact values to map to column names (`dim384`, `dim512`, etc.). Invalid dimensions will cause `DIMENSION_MAP[dimension]` to return `undefined`, breaking embedding operations at runtime.

### Confidence Score: 1/5

- Not safe to merge - contains a blocking bug that will break embedding operations with invalid dimension values
- The P0 issue with unsupported dimension values will cause runtime failures when users configure EMBEDDING_DIMENSION to any value outside the supported set. This breaks the core functionality and must be fixed before merging.
- packages/core/src/runtime.ts - needs validation for supported dimension values

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/core/src/runtime.ts | 2/5 | Added EMBEDDING_DIMENSION config support to skip API call, but missing validation for supported dimension values (384, 512, 768, 1024, 1536, 3072) |
| packages/core/src/__tests__/runtime.test.ts | 5/5 | Added comprehensive tests for EMBEDDING_DIMENSION feature and cleaned up duplicate mock setup |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AgentRuntime
    participant Settings
    participant EmbeddingAPI
    participant DatabaseAdapter
    
    User->>AgentRuntime: initialize()
    AgentRuntime->>AgentRuntime: ensureEmbeddingDimension()
    
    alt EMBEDDING_DIMENSION configured
        AgentRuntime->>Settings: getSetting('EMBEDDING_DIMENSION')
        Settings-->>AgentRuntime: dimension value
        AgentRuntime->>AgentRuntime: Number(dimension)
        AgentRuntime->>AgentRuntime: validate parsedDimension > 0
        Note over AgentRuntime: ⚠️ Missing: validate against [384,512,768,1024,1536,3072]
        AgentRuntime->>DatabaseAdapter: ensureEmbeddingDimension(parsedDimension)
        DatabaseAdapter->>DatabaseAdapter: DIMENSION_MAP[dimension]
        Note over DatabaseAdapter: ⚠️ Returns undefined for invalid dimensions
    else No EMBEDDING_DIMENSION configured
        AgentRuntime->>EmbeddingAPI: useModel(TEXT_EMBEDDING, {text: ''})
        EmbeddingAPI-->>AgentRuntime: embedding array
        AgentRuntime->>AgentRuntime: get embedding.length
        AgentRuntime->>DatabaseAdapter: ensureEmbeddingDimension(length)
        DatabaseAdapter->>DatabaseAdapter: DIMENSION_MAP[dimension]
    end
    
    DatabaseAdapter-->>AgentRuntime: success
    AgentRuntime-->>User: initialized
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->