### PR TITLE
fix(plugin-bootstrap): ensure entity connection before saving facts in reflection evaluator

### DIFF
--- a/packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts
+++ b/packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { v4 as uuidv4 } from 'uuid';
+import type { UUID } from '@elizaos/core';
+import { reflectionEvaluator } from '../evaluators/reflection';
+import { createMockRuntime } from './test-utils';
+
+// Import the actual module first
+const coreModule = await import('@elizaos/core');
+
+// Mock the getEntityDetails function while preserving other exports
+mock.module('@elizaos/core', () => ({
+  ...coreModule, // Spread all the actual exports
+  getEntityDetails: mock().mockImplementation(() => {
+    return Promise.resolve([
+      { id: 'test-entity-id', names: ['Test Entity'], metadata: {} },
+      { id: 'test-agent-id', names: ['Test Agent'], metadata: {} },
+    ]);
+  }),
+}));
+
+describe('Reflection Evaluator - Entity Connection', () => {
+  let mockRuntime: ReturnType<typeof createMockRuntime>;
+  let mockMessage: {
+    entityId: UUID;
+    agentId: UUID;
+    roomId: UUID;
+    content: { text: string };
+  };
+
+  beforeEach(() => {
+    mock.restore();
+    // Setup mock runtime
+    mockRuntime = createMockRuntime({
+      character: {
+        name: 'TestAgent',
+        id: 'test-agent-id' as UUID,
+      },
+    });
+
+    // Setup mock message - use IDs that match the getEntityDetails mock
+    const testRoomId = uuidv4() as UUID;
+    const testAgentId = 'test-agent-id' as UUID;
+    const testEntityId = 'test-entity-id' as UUID;
+
+    mockMessage = {
+      entityId: testEntityId,
+      agentId: testAgentId,
+      roomId: testRoomId,
+      content: { text: 'Test message' },
+    };
+
+    // Mock getRoom to return a room with worldId
+    mockRuntime.getRoom.mockResolvedValue({
+      id: testRoomId,
+      worldId: uuidv4() as UUID,
+    } as any);
+
+    // Mock ensureConnection
+    mockRuntime.ensureConnection.mockResolvedValue(undefined);
+
+    // Mock useModel to return valid reflection XML
+    mockRuntime.useModel.mockResolvedValue(`
+      <response>
+        <thought>Test thought</thought>
+        <facts>
+          <fact>
+            <claim>Test fact about the conversation</claim>
+            <type>fact</type>
+            <in_bio>false</in_bio>
+            <already_known>false</already_known>
+          </fact>
+        </facts>
+        <relationships>
+          <relationship>
+            <sourceEntityId>${testEntityId}</sourceEntityId>
+            <targetEntityId>${testAgentId}</targetEntityId>
+            <tags>test_interaction</tags>
+          </relationship>
+        </relationships>
+      </response>
+    `);
+
+    // Mock createMemory
+    mockRuntime.createMemory.mockResolvedValue(uuidv4() as UUID);
+
+    // Mock queueEmbeddingGeneration
+    mockRuntime.queueEmbeddingGeneration.mockResolvedValue(undefined);
+
+    // Mock getRelationships to return empty array
+    mockRuntime.getRelationships.mockResolvedValue([]);
+
+    // Mock getMemories to return empty facts
+    mockRuntime.getMemories.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('should log error if room is not found', async () => {
+    // Arrange - override the getRoom mock to return null
+    mockRuntime.getRoom.mockResolvedValue(null as any);
+
+    // Act
+    await reflectionEvaluator.handler(mockRuntime, mockMessage as any, {});
+
+    // Assert - ensureConnection should not be called
+    expect(mockRuntime.ensureConnection).not.toHaveBeenCalled();
+    // createMemory should not be called
+    expect(mockRuntime.createMemory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes issue where reflection evaluator fails with "Entity not found" error
- Adds room information lookup before saving facts
- Calls `ensureConnection()` to initialize entity in database

## Problem
The reflection evaluator in `packages/plugin-bootstrap/src/evaluators/reflection.ts` was saving facts without ensuring the agent entity exists in the database. This caused "Entity not found" errors when the UPDATE_CONTACT action was triggered.

## Solution
Added room lookup and `ensureConnection()` call before saving facts. If room or world ID is not found, the operation fails gracefully with a warning message.

## Changes
- `packages/plugin-bootstrap/src/evaluators/reflection.ts`: Added room lookup and ensureConnection call
- `packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts`: Added test for entity connection behavior

Fixes #6364

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the "Entity not found" error in the reflection evaluator by ensuring the agent entity is properly initialized in the database before saving facts.

**Key Changes:**
- Added room lookup to retrieve `worldId` (required for entity connection)
- Added `ensureConnection()` call before saving facts to initialize entity in database
- Added graceful error handling when room/worldId is not found
- Added test coverage for the entity connection behavior
- Minor code quality improvement: changed `fact != null` to `fact !== null` for strict equality

**How it works:**
The reflection evaluator processes conversations to extract facts and relationships. Previously, it attempted to save facts directly without ensuring the agent entity existed in the database, causing UPDATE operations to fail. The fix retrieves the room information (which contains the worldId), then calls `ensureConnection()` to create or update the entity before proceeding with fact storage.

The solution follows the established pattern used elsewhere in the codebase (e.g., `packages/plugin-bootstrap/src/index.ts:814`, `packages/core/src/elizaos.ts:496`).

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it adds necessary entity initialization before database operations
- The fix properly addresses the root cause by ensuring entity existence before UPDATE operations. The implementation follows established patterns in the codebase and includes appropriate error handling. Minor deduction for limited test coverage (only tests the error path, not the success path) and potential optimization opportunity with the room lookup fallback.
- No files require special attention - the changes are straightforward and well-structured

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/plugin-bootstrap/src/evaluators/reflection.ts | Added room lookup and `ensureConnection()` call before saving facts to fix "Entity not found" error |
| packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts | Added test to verify evaluator returns early when room is not found |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant RE as Reflection Evaluator
    participant RT as Runtime
    participant DB as Database
    
    RE->>RT: getRelationships(entityId)
    RT->>DB: Query relationships
    DB-->>RT: Return relationships
    RT-->>RE: Return relationships
    
    RE->>RT: getEntityDetails(runtime, roomId)
    RT->>DB: Query entities in room
    DB-->>RT: Return entities
    RT-->>RE: Return entities
    
    RE->>RT: getMemories(facts, roomId)
    RT->>DB: Query existing facts
    DB-->>RT: Return facts
    RT-->>RE: Return facts
    
    RE->>RT: useModel(prompt)
    RT-->>RE: XML reflection response
    
    Note over RE: Parse facts and relationships from XML
    
    alt Room lookup from state
        RE->>RE: Get room from state.data.room
    else Room lookup from database
        RE->>RT: getRoom(roomId)
        RT->>DB: Query room
        DB-->>RT: Return room with worldId
        RT-->>RE: Return room
    end
    
    alt Room or worldId not found
        RE->>RT: logger.warn("Room or world ID not found")
        RE-->>RE: Return early (skip fact saving)
    else Room and worldId found
        RE->>RT: ensureConnection({entityId, roomId, worldId, name, source})
        RT->>DB: Check if entity exists
        alt Entity does not exist
            DB-->>RT: Entity not found
            RT->>DB: Create entity
            DB-->>RT: Entity created
        else Entity exists
            DB-->>RT: Entity found
            RT->>DB: Update entity metadata
            DB-->>RT: Entity updated
        end
        RT-->>RE: Connection ensured
        
        loop For each new fact
            RE->>RT: createMemory(factMemory, 'facts', true)
            RT->>DB: Insert fact into facts table
            DB-->>RT: Return memory ID
            RT-->>RE: Return memory ID
            RE->>RT: queueEmbeddingGeneration(memory, 'low')
            RT-->>RE: Queued
        end
        
        loop For each relationship
            alt Relationship exists
                RE->>RT: updateRelationship({...existingRelationship, updated tags/metadata})
                RT->>DB: Update relationship
                DB-->>RT: Updated
            else New relationship
                RE->>RT: createRelationship({sourceEntityId, targetEntityId, tags, metadata})
                RT->>DB: Insert relationship
                DB-->>RT: Created
            end
        end
        
        RE->>RT: setCache(reflection-last-processed, messageId)
        RT-->>RE: Cache set
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->