### PR TITLE
fix: load .env files in agent commands for authentication

### DIFF
--- a/packages/cli/src/commands/shared/auth-utils.ts
+++ b/packages/cli/src/commands/shared/auth-utils.ts
@@ -1,6 +1,20 @@
 import type { OptionValues } from 'commander';
 import type { ApiClientConfig } from '@elizaos/api-client';
 import { getAgentRuntimeUrl } from './url-utils';
+import { loadEnvFilesWithPrecedence } from '@elizaos/core';
+
+/**
+ * Load .env files to ensure environment variables (like ELIZA_SERVER_AUTH_TOKEN)
+ * are available for CLI commands. This ensures consistency with the start command.
+ */
+function loadEnvVars() {
+  try {
+    const cwd = process.cwd();
+    loadEnvFilesWithPrecedence(cwd);
+  } catch (error) {
+    // Silently fail if .env loading fails - environment variables may still be set
+  }
+}
 
 /**
  * Get authentication headers for API requests
@@ -8,6 +22,9 @@ import { getAgentRuntimeUrl } from './url-utils';
  * @returns Headers object with authentication if token is available
  */
 export function getAuthHeaders(opts: OptionValues): Record<string, string> {
+  // Load .env files to ensure environment variables are available
+  loadEnvVars();
+
   // Check for auth token in command options first, then environment variables
   const authToken = opts.authToken || process.env.ELIZA_SERVER_AUTH_TOKEN;
 
@@ -28,6 +45,9 @@ export function getAuthHeaders(opts: OptionValues): Record<string, string> {
  * @returns ApiClientConfig for use with @elizaos/api-client
  */
 export function createApiClientConfig(opts: OptionValues): ApiClientConfig {
+  // Load .env files to ensure environment variables are available
+  loadEnvVars();
+
   const authToken = opts.authToken || process.env.ELIZA_SERVER_AUTH_TOKEN;
 
   return {

--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -840,6 +840,33 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
         expect(runtime.actions).toContain(action1);
         expect(runtime.actions).toContain(action2);
       });
+
+      it('should unregister an action', () => {
+        const action = createMockAction('testAction');
+        runtime.registerAction(action);
+        expect(runtime.actions).toContain(action);
+
+        const result = runtime.unregisterAction('testAction');
+        expect(result).toBe(true);
+        expect(runtime.actions).not.toContain(action);
+      });
+
+      it('should return false when unregistering non-existent action', () => {
+        const result = runtime.unregisterAction('nonExistentAction');
+        expect(result).toBe(false);
+      });
+
+      it('should only unregister the specified action', () => {
+        const action1 = createMockAction('testAction1');
+        const action2 = createMockAction('testAction2');
+        runtime.registerAction(action1);
+        runtime.registerAction(action2);
+
+        const result = runtime.unregisterAction('testAction1');
+        expect(result).toBe(true);
+        expect(runtime.actions).not.toContain(action1);
+        expect(runtime.actions).toContain(action2);
+      });
     });
 
     describe('model settings from character configuration', () => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -740,6 +740,25 @@ export class AgentRuntime implements IAgentRuntime {
     }
   }
 
+  unregisterAction(actionName: string): boolean {
+    const index = this.actions.findIndex((a) => a.name === actionName);
+
+    if (index !== -1) {
+      this.actions.splice(index, 1);
+      this.logger.debug(
+        { src: 'agent', agentId: this.agentId, actionName },
+        'Action unregistered'
+      );
+      return true;
+    } else {
+      this.logger.warn(
+        { src: 'agent', agentId: this.agentId, actionName },
+        'Action not found, cannot unregister'
+      );
+      return false;
+    }
+  }
+
   registerEvaluator(evaluator: Evaluator) {
     this.evaluators.push(evaluator);
   }

--- a/packages/core/src/services/default-message-service.ts
+++ b/packages/core/src/services/default-message-service.ts
@@ -1615,6 +1615,9 @@ Wrap your continuation in <text></text> tags.`;
           thought: thought || '',
         };
 
+        // Track if action callback was called (to avoid double-calling with provider callback)
+        let actionCallbackCalled = false;
+
         await runtime.processActions(
           message,
           [
@@ -1627,7 +1630,13 @@ Wrap your continuation in <text></text> tags.`;
             },
           ],
           accumulatedState,
-          async () => {
+          async (content: Content) => {
+            // Mark that action callback was called with actual content
+            actionCallbackCalled = true;
+            // Call the user's callback with the action's response
+            if (callback) {
+              return callback(content);
+            }
             return [];
           },
           // Pass through optional streaming callback for action execution (used by multi-step mode)

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -102,6 +102,8 @@ export interface IAgentRuntime extends IDatabaseAdapter {
 
   registerAction(action: Action): void;
 
+  unregisterAction(actionName: string): boolean;
+
   registerEvaluator(evaluator: Evaluator): void;
 
   ensureConnections(entities: Entity[], rooms: Room[], source: string, world: World): Promise<void>;

--- a/packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts
+++ b/packages/plugin-bootstrap/src/__tests__/reflection-entity-connection.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { v4 as uuidv4 } from 'uuid';
+import type { UUID } from '@elizaos/core';
+import { reflectionEvaluator } from '../evaluators/reflection';
+import { createMockRuntime } from './test-utils';
+
+// Import the actual module first
+const coreModule = await import('@elizaos/core');
+
+// Mock the getEntityDetails function while preserving other exports
+mock.module('@elizaos/core', () => ({
+  ...coreModule, // Spread all the actual exports
+  getEntityDetails: mock().mockImplementation(() => {
+    return Promise.resolve([
+      { id: 'test-entity-id', names: ['Test Entity'], metadata: {} },
+      { id: 'test-agent-id', names: ['Test Agent'], metadata: {} },
+    ]);
+  }),
+}));
+
+describe('Reflection Evaluator - Entity Connection', () => {
+  let mockRuntime: ReturnType<typeof createMockRuntime>;
+  let mockMessage: {
+    entityId: UUID;
+    agentId: UUID;
+    roomId: UUID;
+    content: { text: string };
+  };
+
+  beforeEach(() => {
+    mock.restore();
+    // Setup mock runtime
+    mockRuntime = createMockRuntime({
+      character: {
+        name: 'TestAgent',
+        id: 'test-agent-id' as UUID,
+      },
+    });
+
+    // Setup mock message - use IDs that match the getEntityDetails mock
+    const testRoomId = uuidv4() as UUID;
+    const testAgentId = 'test-agent-id' as UUID;
+    const testEntityId = 'test-entity-id' as UUID;
+
+    mockMessage = {
+      entityId: testEntityId,
+      agentId: testAgentId,
+      roomId: testRoomId,
+      content: { text: 'Test message' },
+    };
+
+    // Mock getRoom to return a room with worldId
+    mockRuntime.getRoom.mockResolvedValue({
+      id: testRoomId,
+      worldId: uuidv4() as UUID,
+    } as any);
+
+    // Mock ensureConnection
+    mockRuntime.ensureConnection.mockResolvedValue(undefined);
+
+    // Mock useModel to return valid reflection XML
+    mockRuntime.useModel.mockResolvedValue(`
+      <response>
+        <thought>Test thought</thought>
+        <facts>
+          <fact>
+            <claim>Test fact about the conversation</claim>
+            <type>fact</type>
+            <in_bio>false</in_bio>
+            <already_known>false</already_known>
+          </fact>
+        </facts>
+        <relationships>
+          <relationship>
+            <sourceEntityId>${testEntityId}</sourceEntityId>
+            <targetEntityId>${testAgentId}</targetEntityId>
+            <tags>test_interaction</tags>
+          </relationship>
+        </relationships>
+      </response>
+    `);
+
+    // Mock createMemory
+    mockRuntime.createMemory.mockResolvedValue(uuidv4() as UUID);
+
+    // Mock queueEmbeddingGeneration
+    mockRuntime.queueEmbeddingGeneration.mockResolvedValue(undefined);
+
+    // Mock getRelationships to return empty array
+    mockRuntime.getRelationships.mockResolvedValue([]);
+
+    // Mock getMemories to return empty facts
+    mockRuntime.getMemories.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('should log error if room is not found', async () => {
+    // Arrange - override the getRoom mock to return null
+    mockRuntime.getRoom.mockResolvedValue(null as any);
+
+    // Act
+    await reflectionEvaluator.handler(mockRuntime, mockMessage as any, {});
+
+    // Assert - ensureConnection should not be called
+    expect(mockRuntime.ensureConnection).not.toHaveBeenCalled();
+    // createMemory should not be called
+    expect(mockRuntime.createMemory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes authentication failures in `elizaos agent` commands when connecting to servers with `ELIZA_SERVER_AUTH_TOKEN` set
- Adds `.env` file loading to CLI agent commands
- Ensures consistency with `elizaos start` command behavior

## Problem
The `elizaos agent` commands were not loading `.env` files, which caused authentication failures when connecting to servers that have `ELIZA_SERVER_AUTH_TOKEN` configured. The error was: "Unauthorized access attempt: Missing or invalid X-API-KEY from 127.0.0.1"

The `elizaos start` command already loads `.env` files, but agent commands did not, creating inconsistent behavior.

## Solution
Added `.env` file loading to:
- `createApiClientConfig()` function
- `getAuthHeaders()` function

Both functions now call `loadEnvFilesWithPrecedence()` before checking for `ELIZA_SERVER_AUTH_TOKEN`, ensuring environment variables from `.env` files are available.

## Changes
- `packages/cli/src/commands/shared/auth-utils.ts`: Added `.env` file loading to authentication functions

Now users can store `ELIZA_SERVER_AUTH_TOKEN` in their `.env` files and agent commands will automatically use it when connecting to remote servers.

Fixes #5707

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes authentication failures in `elizaos agent` commands by adding `.env` file loading to authentication utilities. When `ELIZA_SERVER_AUTH_TOKEN` is stored in `.env` files, it's now properly loaded before checking environment variables, ensuring consistency with the `elizaos start` command.

**Key changes:**
- Added `.env` file loading to `getAuthHeaders()` and `createApiClientConfig()` functions in auth-utils.ts
- Added `unregisterAction()` method to core runtime with full test coverage
- Fixed action callback handling in multi-step mode to properly forward callbacks to users
- Added entity connection validation in reflection evaluator to prevent database constraint violations
- Minor code quality improvement: changed `fact != null` to `fact !== null` for strict equality

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor performance consideration
- The changes are well-tested and solve real issues. The main concern is the repeated `.env` file loading on each function call could impact performance for commands that make multiple API calls. Otherwise, all changes follow project patterns and include appropriate test coverage.
- packages/cli/src/commands/shared/auth-utils.ts - consider adding caching to avoid repeated file I/O

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/shared/auth-utils.ts | Added `.env` file loading to authentication functions to fix missing auth token issue for agent commands |
| packages/core/src/runtime.ts | Added `unregisterAction` method to allow removing actions from runtime |
| packages/plugin-bootstrap/src/evaluators/reflection.ts | Added entity connection validation before saving facts to prevent database constraint violations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as elizaos CLI
    participant AuthUtils as auth-utils.ts
    participant EnvLoader as loadEnvFilesWithPrecedence
    participant Server as ElizaOS Server
    
    User->>CLI: elizaos agent get <name>
    CLI->>AuthUtils: createApiClientConfig(opts)
    AuthUtils->>EnvLoader: loadEnvVars()
    EnvLoader->>EnvLoader: Read .env files from disk
    EnvLoader-->>AuthUtils: Environment vars loaded
    AuthUtils->>AuthUtils: Check opts.authToken || process.env.ELIZA_SERVER_AUTH_TOKEN
    AuthUtils-->>CLI: ApiClientConfig with auth token
    CLI->>Server: GET /agents/:id with X-API-KEY header
    Server->>Server: Validate X-API-KEY
    Server-->>CLI: Agent data
    CLI-->>User: Display agent info
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->