### PR TITLE
fix(cli): load .env files in agent commands for authentication

### DIFF
--- a/packages/cli/src/commands/agent/utils/validation.ts
+++ b/packages/cli/src/commands/agent/utils/validation.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { AgentBasic } from '../../shared';
 import { createApiClientConfig } from '../../shared';
 import { AgentsService } from '@elizaos/api-client';
+import { loadEnvironment } from '../../../utils/get-config';
 
 // Zod schemas for validation
 export const AgentBasicSchema = z
@@ -21,6 +22,9 @@ export const AgentsListResponseSchema = z.object({
  * Asynchronously fetches a list of basic agent information from the server.
  */
 export async function getAgents(opts: OptionValues): Promise<AgentBasic[]> {
+  // Load environment variables to ensure ELIZA_SERVER_AUTH_TOKEN is available
+  await loadEnvironment();
+
   const config = createApiClientConfig(opts);
   const agentsService = new AgentsService(config);
   const result = await agentsService.listAgents();


### PR DESCRIPTION
This PR fixes #5707 - an issue where `elizaos agent` commands would fail when connecting to a remote server that uses `ELIZA_SERVER_AUTH_TOKEN`.

## Problem

When running `elizaos agent list` (or other agent commands) against a remote server with authentication enabled via `ELIZA_SERVER_AUTH_TOKEN`, the command would fail with:

```
WARN: Unauthorized access attempt: Missing or invalid X-API-KEY from 127.0.0.1
```

This happened because the CLI was not loading environment variables from `.env` files before making API requests.

## Solution

Added `loadEnvironment()` call at the beginning of the `getAgents()` function in `packages/cli/src/commands/agent/utils/validation.ts`.

This ensures that:
- `.env` files are loaded before API requests
- `ELIZA_SERVER_AUTH_TOKEN` is properly read
- All agent commands (list, get, stop, remove, etc.) work with authenticated servers

## Testing

All existing tests pass (13 pass, 0 fail).

Closes #5707

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes authentication issues when running `elizaos agent` commands against a remote server with `ELIZA_SERVER_AUTH_TOKEN` enabled. The fix adds a `loadEnvironment()` call at the beginning of `getAgents()` to ensure `.env` files are loaded before making API requests.

**Key Changes:**
- Added import for `loadEnvironment` from `../../../utils/get-config`
- Added `await loadEnvironment()` call before creating API client config in `getAgents()`
- This ensures `ELIZA_SERVER_AUTH_TOKEN` is available in `process.env` when `createApiClientConfig()` reads it

**Impact:**
- All agent commands (`list`, `get`, `stop`, `remove`, etc.) that use `getAgents()` or `resolveAgentId()` will now properly load environment variables
- Fixes unauthorized access errors when connecting to authenticated servers

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is minimal, focused, and addresses the root cause of the authentication issue. The `loadEnvironment()` function is already used elsewhere in the codebase and is safe to call. The fix is placed at the right location (before API config creation), and all existing tests pass. The change follows the established pattern of loading environment variables before making API calls.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/agent/utils/validation.ts | Added `loadEnvironment()` call to ensure `.env` files are loaded before API requests, fixing authentication issues |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as elizaos agent CLI
    participant getAgents as getAgents()
    participant loadEnv as loadEnvironment()
    participant dotenv
    participant createConfig as createApiClientConfig()
    participant AgentsService
    participant Server as ElizaOS Server

    User->>CLI: elizaos agent list
    CLI->>getAgents: call with opts
    getAgents->>loadEnv: await loadEnvironment()
    loadEnv->>dotenv: load .env file
    dotenv-->>loadEnv: environment variables loaded
    loadEnv-->>getAgents: ELIZA_SERVER_AUTH_TOKEN available
    getAgents->>createConfig: createApiClientConfig(opts)
    createConfig->>createConfig: read process.env.ELIZA_SERVER_AUTH_TOKEN
    createConfig-->>getAgents: config with apiKey
    getAgents->>AgentsService: new AgentsService(config)
    getAgents->>AgentsService: listAgents()
    AgentsService->>Server: GET /agents with X-API-KEY header
    Server-->>AgentsService: 200 OK with agents list
    AgentsService-->>getAgents: agents data
    getAgents-->>CLI: agents array
    CLI-->>User: display agents list
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->