### PR TITLE
fix(server): emit MESSAGE_SENT event after sending to central server

### DIFF
--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -10,6 +10,7 @@ import {
   type Plugin,
   type UUID,
   ElizaOS,
+  EventType,
 } from '@elizaos/core';
 import type { AgentServer } from '../index.js';
 import type {
@@ -931,7 +932,18 @@ export class MessageBusService extends Service {
           },
           'Error sending response to central server'
         );
+        return;
       }
+
+      // Emit MESSAGE_SENT event after successfully sending to central server
+      await this.runtime.emitEvent(EventType.MESSAGE_SENT, {
+        runtime: this.runtime,
+        content,
+        roomId: agentRoomId,
+        worldId: agentWorldId,
+        userId: this.runtime.agentId,
+        agentId: this.runtime.agentId,
+      });
     } catch (error) {
       logger.error(
         {

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -7,6 +7,7 @@ import {
   validateUuid,
   type Content,
   type IAgentRuntime,
+  type Memory,
   type Plugin,
   type UUID,
   ElizaOS,
@@ -678,17 +679,19 @@ export class MessageBusService extends Service {
               'Agent generated response, sending to bus'
             );
 
-            await this.runtime.createMemory(
-              {
-                id: responseContent.responseId as UUID | undefined,
-                entityId: this.runtime.agentId,
-                content: responseContent,
-                roomId: agentRoomId,
-                worldId: agentWorldId,
-                agentId: this.runtime.agentId,
-              },
-              'messages'
-            );
+            // Create the message memory object for event emission
+            const memoryData: Memory = {
+              id: responseContent.responseId as UUID | undefined || createUniqueUuid(this.runtime, `response-${Date.now()}`),
+              entityId: this.runtime.agentId,
+              roomId: agentRoomId,
+              worldId: agentWorldId,
+              content: responseContent,
+              agentId: this.runtime.agentId,
+              createdAt: Date.now(),
+            };
+
+            // Create memory in database and get its ID
+            const memoryId = await this.runtime.createMemory(memoryData, 'messages');
 
             // Send response to central bus
             await this.sendAgentResponseToBus(
@@ -696,7 +699,8 @@ export class MessageBusService extends Service {
               agentWorldId,
               responseContent,
               uniqueMemoryId,
-              message
+              message,
+              { ...memoryData, id: memoryId }
             );
           },
           onError: async (error: Error) => {
@@ -834,7 +838,8 @@ export class MessageBusService extends Service {
     agentWorldId: UUID,
     content: Content,
     inReplyToAgentMemoryId?: UUID,
-    originalMessage?: MessageServiceMessage
+    originalMessage?: MessageServiceMessage,
+    messageMemory?: Memory
   ) {
     try {
       const room = await this.runtime.getRoom(agentRoomId);
@@ -936,14 +941,13 @@ export class MessageBusService extends Service {
       }
 
       // Emit MESSAGE_SENT event after successfully sending to central server
-      await this.runtime.emitEvent(EventType.MESSAGE_SENT, {
-        runtime: this.runtime,
-        content,
-        roomId: agentRoomId,
-        worldId: agentWorldId,
-        userId: this.runtime.agentId,
-        agentId: this.runtime.agentId,
-      });
+      if (messageMemory) {
+        await this.runtime.emitEvent(EventType.MESSAGE_SENT, {
+          runtime: this.runtime,
+          source: 'central-bus',
+          message: messageMemory,
+        });
+      }
     } catch (error) {
       logger.error(
         {


### PR DESCRIPTION
This PR fixes #5216 - EventType.MESSAGE_SENT event not being emitted when agent responses are sent to the central server API.

## Problem

The `sendAgentResponseToBus` function in `packages/server/src/services/message.ts` sends agent responses to the central server API endpoint (`/api/messaging/submit`), but it does not emit the `EventType.MESSAGE_SENT` event.

This means that plugins with handlers for the `MESSAGE_SENT` event never get triggered when messages are submitted to the central channel.

## Solution

Added `EventType.MESSAGE_SENT` event emission after a successful response from the central server API.

## Changes

1. Added `EventType` import from `@elizaos/core`
2. Emit `MESSAGE_SENT` event with proper payload:
   - `runtime`: The agent runtime instance
   - `content`: The message content being sent
   - `roomId`: The room ID where the message was sent
   - `worldId`: The world ID
   - `userId`: The user ID (agent ID in this case)
   - `agentId`: The agent ID

## Testing

All existing tests pass (532 pass, 0 fail).

Closes #5216

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `EventType.MESSAGE_SENT` event emission after successfully sending agent responses to the central server API. This fixes issue #5216 where plugins with `MESSAGE_SENT` event handlers were not triggered when messages were submitted to the central channel.

**Changes made:**
- Added `EventType` import from `@elizaos/core`
- Emitted `MESSAGE_SENT` event after successful response from central server API in `sendAgentResponseToBus` function

**Issue found:**
- The event payload structure doesn't match the `MessagePayload` interface - it's passing individual fields instead of the required `message: Memory` field. The memory was already created earlier (line 681) and should be retrieved and included in the event payload.

<h3>Confidence Score: 3/5</h3>


- This PR addresses a real bug but has an implementation issue that will cause runtime errors
- The PR correctly identifies the missing event emission and adds it in the right location, but the event payload structure is incorrect and doesn't match the TypeScript interface, which will cause type errors or runtime failures when plugins try to access `payload.message`
- Pay close attention to `packages/server/src/services/message.ts` - the event payload structure needs to be fixed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/server/src/services/message.ts | Added EventType import and emitted MESSAGE_SENT event, but payload structure doesn't match MessagePayload interface |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant InternalMessageBus
    participant MessageBusService
    participant ElizaOS
    participant Runtime
    participant CentralServer
    participant Plugin

    User->>InternalMessageBus: Send message
    InternalMessageBus->>MessageBusService: new_message event
    MessageBusService->>MessageBusService: handleIncomingMessage()
    MessageBusService->>MessageBusService: Validate subscription & permissions
    MessageBusService->>Runtime: ensureWorldExists()
    MessageBusService->>Runtime: ensureRoomExists()
    MessageBusService->>Runtime: ensureAuthorEntityExists()
    MessageBusService->>ElizaOS: handleMessage()
    ElizaOS->>Runtime: Process message
    Runtime->>Runtime: Generate response
    Runtime->>MessageBusService: onResponse callback
    MessageBusService->>Runtime: createMemory()
    Runtime-->>MessageBusService: Memory created
    MessageBusService->>MessageBusService: sendAgentResponseToBus()
    MessageBusService->>CentralServer: POST /api/messaging/submit
    CentralServer-->>MessageBusService: 200 OK
    MessageBusService->>Runtime: emitEvent(MESSAGE_SENT)
    Runtime->>Plugin: Trigger MESSAGE_SENT handlers
    Plugin-->>Runtime: Event handled
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->