### PR TITLE
fix: update import statement in elizaos.js to use package alias

### DIFF
--- a/packages/elizaos/bin/elizaos.js
+++ b/packages/elizaos/bin/elizaos.js
@@ -2,4 +2,4 @@
 
 // Thin shim that defers to @elizaos/cli's binary (ESM).
 // Keeps this package as an alias while ensuring the same behavior.
-import '@elizaos/cli/dist/index.js';
+import '@elizaos/cli';


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Updated the import statement in `elizaos.js` to use the package alias (`@elizaos/cli`) instead of the direct path (`@elizaos/cli/dist/index.js`). This follows Node.js best practices by relying on the package's exports field defined in `@elizaos/cli/package.json`, which maps `.` to `./dist/index.js`.

**Changes:**
- Replaced direct dist path import with package alias for better maintainability
- The change is functionally equivalent and resolves to the same file via package.json exports
- Improves consistency with standard Node.js module resolution patterns

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple refactor from a direct path import to a package alias, which is functionally equivalent and follows Node.js best practices. The `@elizaos/cli` package correctly defines its exports in package.json, mapping the default export to dist/index.js. This is a clean improvement that enhances maintainability without changing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/elizaos/bin/elizaos.js | Updated import to use package alias instead of direct dist path |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant elizaos as elizaos package
    participant cli as @elizaos/cli package
    participant index as dist/index.js
    
    User->>elizaos: Run `elizaos` command
    elizaos->>elizaos: Load bin/elizaos.js
    Note over elizaos: import '@elizaos/cli'
    elizaos->>cli: Resolve package alias
    cli->>cli: Check package.json exports
    Note over cli: "." → "./dist/index.js"
    cli->>index: Execute CLI entry point
    index->>User: Run CLI command
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->