### PR TITLE
fix: add null checks to Object.entries calls in settings utilities

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -204,6 +204,10 @@ export function unsaltSettingValue(setting: Setting, salt: string): Setting {
  * Applies salt to all settings in a WorldSettings object
  */
 export function saltWorldSettings(worldSettings: WorldSettings, salt: string): WorldSettings {
+  if (!worldSettings || typeof worldSettings !== 'object') {
+    return {};
+  }
+
   const saltedSettings: WorldSettings = {};
 
   for (const [key, setting] of Object.entries(worldSettings)) {
@@ -217,6 +221,10 @@ export function saltWorldSettings(worldSettings: WorldSettings, salt: string): W
  * Removes salt from all settings in a WorldSettings object
  */
 export function unsaltWorldSettings(worldSettings: WorldSettings, salt: string): WorldSettings {
+  if (!worldSettings || typeof worldSettings !== 'object') {
+    return {};
+  }
+
   const unsaltedSettings: WorldSettings = {};
 
   for (const [key, setting] of Object.entries(worldSettings)) {
@@ -386,6 +394,10 @@ export function encryptObjectValues(
   obj: Record<string, unknown>,
   salt: string
 ): Record<string, unknown> {
+  if (!obj || typeof obj !== 'object') {
+    return {};
+  }
+
   const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {
@@ -409,6 +421,10 @@ export function decryptObjectValues(
   obj: Record<string, unknown>,
   salt: string
 ): Record<string, unknown> {
+  if (!obj || typeof obj !== 'object') {
+    return {};
+  }
+
   const result: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {


### PR DESCRIPTION
## Summary

This PR adds defensive null/undefined checks before Object.entries() calls in the @elizaos/core package's settings utilities to prevent runtime errors.

## Changes

### packages/core/src/settings.ts

Added null/undefined guards to the following functions:

1. saltWorldSettings() - Check worldSettings parameter before calling Object.entries()
2. unsaltWorldSettings() - Check worldSettings parameter before calling Object.entries()
3. encryptObjectValues() - Check obj parameter before calling Object.entries()
4. decryptObjectValues() - Check obj parameter before calling Object.entries()

## Problem Solved

These functions are called throughout the codebase with data from database queries and metadata that may be null or undefined. Without these checks, the code throws:

Object.entries requires that input parameter not be null or undefined

This causes providers and handlers to crash, leading to agents ignoring messages.

## Related Issues

- Complements PR #6470 (plugin-bootstrap null checks)
- Fixes same root cause in @elizaos/core package

## Testing

- Functions now return empty objects {} when input is null/undefined instead of crashing
- Maintains backward compatibility - valid inputs continue to work as before
- Safe for all existing call sites that may pass null/undefined values

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds defensive guards around `Object.entries()` usage in core settings utilities to prevent crashes when upstream data is `null`/`undefined`.
- Updates `saltWorldSettings`/`unsaltWorldSettings` to return `{}` on invalid input instead of throwing.
- Updates `encryptObjectValues`/`decryptObjectValues` similarly to avoid runtime errors when secrets/settings objects are missing.
- Change is localized to `packages/core/src/settings.ts` and affects how invalid inputs are handled (now silently coerced to empty objects).

<h3>Confidence Score: 4/5</h3>

- Generally safe to merge, but the new guards change function contracts and may silently mask invalid inputs (arrays/functions) without updating types.
- The change is small and addresses a real runtime exception, but returning `{}` for non-record inputs without updating TypeScript signatures can hide bugs and produce surprising output for arrays (numeric keys).
- packages/core/src/settings.ts (input guards and type signatures)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/settings.ts | Adds guard clauses before Object.entries() in salt/unsalt world settings and encrypt/decrypt object helpers to avoid null/undefined runtime errors; no other logic changes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant Caller as Caller (runtime/handlers)
  participant Settings as packages/core/src/settings.ts
  participant World as runtime.getWorld/updateWorld

  Caller->>World: getWorld(worldId)
  World-->>Caller: world (metadata may be null)
  Caller->>Settings: getWorldSettings(runtime, serverId)
  Settings->>Settings: read world.metadata.settings
  Settings->>Settings: unsaltWorldSettings(worldSettings, salt)
  alt worldSettings is null/undefined/non-object
    Settings-->>Caller: {}
  else valid WorldSettings
    Settings->>Settings: Object.entries(worldSettings)
    Settings->>Settings: unsaltSettingValue(...) per key
    Settings-->>Caller: unsalted WorldSettings
  end

  Caller->>Settings: encryptedCharacter(character)
  Settings->>Settings: encryptObjectValues(secretsObj, salt)
  alt secretsObj is null/undefined/non-object
    Settings-->>Caller: {}
  else valid object
    Settings->>Settings: Object.entries(secretsObj)
    Settings->>Settings: encryptStringValue(...) per key
    Settings-->>Caller: encrypted secrets object
  end
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=8ef4c9a3-e221-4aef-8556-8c9b88bf6bbb))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=00074882-001f-44b1-89c4-859ed3656db9))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=51febe90-8918-4f18-be1f-d43bb68d696c))
</details>


<!-- /greptile_comment -->