### PR TITLE
fix(plugin-bootstrap): add null check for runtime.providers

### DIFF
--- a/packages/plugin-bootstrap/src/providers/providers.ts
+++ b/packages/plugin-bootstrap/src/providers/providers.ts
@@ -20,7 +20,7 @@ export const providersProvider: Provider = {
   name: 'PROVIDERS',
   description: 'List of all data providers the agent can use to get additional information',
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
-    const allProviders = runtime.providers;
+    const allProviders = runtime.providers || [];
 
     // Filter providers with dynamic: true
     const dynamicProviders = allProviders.filter((provider) => provider.dynamic === true);


### PR DESCRIPTION
## Summary

- **Fix**: Add null check for `runtime.providers` in `providersProvider`
- **Impact**: Prevents `TypeError: Cannot read properties of null (reading 'filter')`

## Problem

When `runtime.providers` is `null` or `undefined`, the code crashes when attempting to call `.filter()` on it:

```typescript
const allProviders = runtime.providers;  // Can be null/undefined
const dynamicProviders = allProviders.filter(...);  // CRASHES
```

## Solution

Added defensive null check:

```typescript
const allProviders = runtime.providers || [];  // Safe fallback
const dynamicProviders = allProviders.filter(...);  // Safe
```

## Testing

- ✅ Verified fix prevents crash when providers is null/undefined
- ✅ Verified normal operation when providers array exists

## Files Changed

- `packages/plugin-bootstrap/src/providers/providers.ts` - Line 23

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Adds a defensive fallback when reading `runtime.providers` in plugin-bootstrap’s `providersProvider` to avoid calling `.filter()` on `null`/`undefined`.
- Keeps existing provider filtering behavior by treating missing provider lists as an empty array.
- Change is localized to `packages/plugin-bootstrap/src/providers/providers.ts` and affects how bootstrap providers are enumerated at runtime.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is a small, localized defensive fix that prevents a concrete runtime crash when `runtime.providers` is null/undefined, without altering behavior when providers are present.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/plugin-bootstrap/src/providers/providers.ts | Adds a safe fallback (`runtime.providers || []`) so provider enumeration and `.filter()`/`.map()` don’t throw when `runtime.providers` is null/undefined; behavior is unchanged when the array exists. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant C as Core runtime
  participant P as providersProvider.get

  C->>P: get(runtime, message, state)
  P->>P: allProviders = runtime.providers || []
  P->>P: dynamicProviders = allProviders.filter(p.dynamic===true)
  P->>P: Build descriptions (map)
  P->>P: dynamicSection = addHeader(...)
  P-->>C: { text: dynamicSection, data, values }
```

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=8ef4c9a3-e221-4aef-8556-8c9b88bf6bbb))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=00074882-001f-44b1-89c4-859ed3656db9))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=51febe90-8918-4f18-be1f-d43bb68d696c))
</details>


<!-- /greptile_comment -->