### PR TITLE
feat: ActionFilterService — vector search + BM25 reranking for action/provider filtering

### DIFF
--- a/packages/typescript/src/__tests__/action-filter.test.ts
+++ b/packages/typescript/src/__tests__/action-filter.test.ts
@@ -1,0 +1,2664 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { BM25Index } from "../services/bm25";
+import { cosineSimilarity, normalizeVector } from "../services/cosine-similarity";
+import {
+  ActionFilterService,
+  getActionEmbeddingText,
+  buildQueryText,
+  minMaxNormalize,
+} from "../services/action-filter";
+import { actionsProvider } from "../bootstrap/providers/actions";
+import type { Action, IAgentRuntime, Memory, State } from "../types";
+
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/**
+ * Deterministic pseudo-embedding generator.
+ * Maps text to a fixed-size vector based on character codes. Texts with
+ * overlapping words will share subspace components and therefore have
+ * higher cosine similarity, which is sufficient for testing retrieval
+ * without calling a real model.
+ */
+function deterministicEmbedding(text: string, dimensions = 64): number[] {
+  const vec = new Array<number>(dimensions).fill(0);
+  const lower = text.toLowerCase();
+  const words = lower.split(/\s+/);
+
+  for (const word of words) {
+    for (let i = 0; i < word.length; i++) {
+      const code = word.charCodeAt(i);
+      const idx = (code * 31 + i * 7) % dimensions;
+      vec[idx] += code / 122; // normalize to ~[0, 1]
+    }
+  }
+
+  // L2-normalize so cosine similarity is just dot product
+  return normalizeVector(vec);
+}
+
+/**
+ * Create a mock Action with sensible defaults.
+ */
+function createMockAction(overrides: {
+  name: string;
+  description: string;
+  similes?: string[];
+  tags?: string[];
+  validateReturn?: boolean;
+  alwaysInclude?: boolean;
+}): Action {
+  return {
+    name: overrides.name,
+    description: overrides.description,
+    similes: overrides.similes ?? [],
+    tags: overrides.tags ?? [],
+    examples: [],
+    alwaysInclude: overrides.alwaysInclude,
+    handler: vi.fn().mockResolvedValue({ success: true }),
+    validate: vi.fn().mockResolvedValue(overrides.validateReturn ?? true),
+  };
+}
+
+// ============================================================================
+// Mock Action Catalog
+// ============================================================================
+
+function buildMockActions(): Record<string, Action> {
+  return {
+    // Core actions (always-include)
+    REPLY: createMockAction({
+      name: "REPLY",
+      description: "Reply to the user with a text message",
+      similes: ["respond", "answer", "say"],
+      tags: ["core"],
+      alwaysInclude: true,
+    }),
+    IGNORE: createMockAction({
+      name: "IGNORE",
+      description: "Ignore the message and do not respond",
+      similes: ["skip", "pass"],
+      tags: ["core"],
+      alwaysInclude: true,
+    }),
+    NONE: createMockAction({
+      name: "NONE",
+      description: "Take no action",
+      similes: [],
+      tags: ["core"],
+      alwaysInclude: true,
+    }),
+
+    // DeFi actions
+    SWAP_TOKENS: createMockAction({
+      name: "SWAP_TOKENS",
+      description:
+        "Swap one cryptocurrency token for another on a decentralized exchange",
+      similes: ["trade", "exchange", "convert"],
+      tags: ["defi", "blockchain", "trading"],
+    }),
+    BRIDGE_TOKENS: createMockAction({
+      name: "BRIDGE_TOKENS",
+      description: "Bridge tokens from one blockchain network to another",
+      similes: ["transfer cross-chain", "move tokens"],
+      tags: ["defi", "blockchain"],
+    }),
+    PROVIDE_LIQUIDITY: createMockAction({
+      name: "PROVIDE_LIQUIDITY",
+      description: "Add liquidity to a decentralized exchange pool",
+      similes: ["LP", "add liquidity"],
+      tags: ["defi"],
+    }),
+    CHECK_BALANCE: createMockAction({
+      name: "CHECK_BALANCE",
+      description: "Check the balance of tokens in a wallet",
+      similes: ["wallet balance", "how much"],
+      tags: ["wallet", "blockchain"],
+    }),
+
+    // Social actions
+    SEND_MESSAGE: createMockAction({
+      name: "SEND_MESSAGE",
+      description: "Send a direct message to another user",
+      similes: ["DM", "message", "text"],
+      tags: ["social", "messaging"],
+    }),
+    POST_TWEET: createMockAction({
+      name: "POST_TWEET",
+      description: "Post a tweet on X/Twitter",
+      similes: ["tweet", "post on X"],
+      tags: ["social", "twitter"],
+    }),
+    FOLLOW_USER: createMockAction({
+      name: "FOLLOW_USER",
+      description: "Follow a user on a social platform",
+      similes: ["follow", "subscribe"],
+      tags: ["social"],
+    }),
+
+    // Knowledge actions
+    SEARCH_KNOWLEDGE: createMockAction({
+      name: "SEARCH_KNOWLEDGE",
+      description:
+        "Search the knowledge base for relevant information",
+      similes: ["look up", "find information", "research"],
+      tags: ["knowledge"],
+    }),
+    CREATE_NOTE: createMockAction({
+      name: "CREATE_NOTE",
+      description: "Create a note or document for later reference",
+      similes: ["note", "save", "remember"],
+      tags: ["knowledge", "memory"],
+    }),
+
+    // Code actions
+    EXECUTE_CODE: createMockAction({
+      name: "EXECUTE_CODE",
+      description: "Execute a code snippet in a sandboxed environment",
+      similes: ["run code", "execute script"],
+      tags: ["coding", "development"],
+    }),
+    REVIEW_CODE: createMockAction({
+      name: "REVIEW_CODE",
+      description: "Review code for bugs and improvements",
+      similes: ["code review", "check code"],
+      tags: ["coding"],
+    }),
+
+    // Payment actions
+    PAY_FOR_SERVICE: createMockAction({
+      name: "PAY_FOR_SERVICE",
+      description:
+        "Pay for an x402 service using USDC cryptocurrency",
+      similes: ["pay", "purchase", "buy"],
+      tags: ["payment", "x402"],
+    }),
+    CHECK_PAYMENT_HISTORY: createMockAction({
+      name: "CHECK_PAYMENT_HISTORY",
+      description:
+        "View recent payment transactions and spending summary",
+      similes: ["spending", "transactions"],
+      tags: ["payment"],
+    }),
+
+    // File actions
+    READ_FILE: createMockAction({
+      name: "READ_FILE",
+      description: "Read the contents of a file",
+      similes: ["open file", "cat", "view file"],
+      tags: ["filesystem"],
+    }),
+    WRITE_FILE: createMockAction({
+      name: "WRITE_FILE",
+      description: "Write content to a file",
+      similes: ["save file", "create file"],
+      tags: ["filesystem"],
+    }),
+
+    // Web actions
+    BROWSE_WEB: createMockAction({
+      name: "BROWSE_WEB",
+      description: "Browse a webpage and extract content",
+      similes: ["visit URL", "scrape", "open link"],
+      tags: ["web"],
+    }),
+    WEB_SEARCH: createMockAction({
+      name: "WEB_SEARCH",
+      description: "Search the web for current information",
+      similes: ["google", "search online"],
+      tags: ["web", "search"],
+    }),
+
+    // Image actions
+    GENERATE_IMAGE: createMockAction({
+      name: "GENERATE_IMAGE",
+      description: "Generate an image from a text description",
+      similes: ["create image", "draw", "make picture"],
+      tags: ["image", "generation"],
+    }),
+    DESCRIBE_IMAGE: createMockAction({
+      name: "DESCRIBE_IMAGE",
+      description: "Describe the contents of an image",
+      similes: ["analyze image", "what's in this image"],
+      tags: ["image", "vision"],
+    }),
+  };
+}
+
+/**
+ * Create a minimal mock runtime with configurable actions and model support.
+ */
+function createMockRuntime(
+  actions: Action[],
+  opts?: {
+    hasEmbeddingModel?: boolean;
+    useModelFn?: (...args: unknown[]) => unknown;
+  },
+): IAgentRuntime {
+  const services = new Map();
+  const hasEmbeddingModel = opts?.hasEmbeddingModel ?? false;
+
+  // Default useModel returns a deterministic embedding
+  const defaultUseModel = vi.fn().mockImplementation(
+    async (_modelType: string, params: { text: string }) => {
+      return deterministicEmbedding(params.text);
+    },
+  );
+
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001" as `${string}-${string}-${string}-${string}-${string}`,
+    actions,
+    character: { name: "TestAgent" },
+    providers: [],
+    evaluators: [],
+    plugins: [],
+    services,
+    events: {} as IAgentRuntime["events"],
+    routes: [],
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    },
+    stateCache: new Map(),
+    enableAutonomy: false,
+    initPromise: Promise.resolve(),
+    messageService: null,
+    fetch: null,
+    getService: vi.fn().mockReturnValue(null),
+    getServicesByType: vi.fn().mockReturnValue([]),
+    getAllServices: vi.fn().mockReturnValue(services),
+    registerService: vi.fn(),
+    getServiceLoadPromise: vi.fn(),
+    getRegisteredServiceTypes: vi.fn().mockReturnValue([]),
+    hasService: vi.fn().mockReturnValue(false),
+    registerPlugin: vi.fn(),
+    initialize: vi.fn(),
+    getConnection: vi.fn(),
+    registerDatabaseAdapter: vi.fn(),
+    useModel: opts?.useModelFn ?? defaultUseModel,
+    getModel: vi.fn().mockReturnValue(hasEmbeddingModel ? () => {} : undefined),
+    getSetting: vi.fn().mockReturnValue(null),
+  } as unknown as IAgentRuntime;
+}
+
+function createMockMemory(text: string, roomId?: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000010" as `${string}-${string}-${string}-${string}-${string}`,
+    entityId: "00000000-0000-0000-0000-000000000002" as `${string}-${string}-${string}-${string}-${string}`,
+    agentId: "00000000-0000-0000-0000-000000000001" as `${string}-${string}-${string}-${string}-${string}`,
+    roomId: (roomId ?? "00000000-0000-0000-0000-000000000003") as `${string}-${string}-${string}-${string}-${string}`,
+    content: { text },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+function createMockState(overrides?: Partial<State>): State {
+  return {
+    values: {} as State["values"],
+    data: {} as State["data"],
+    ...overrides,
+  } as State;
+}
+
+// ============================================================================
+// 1. BM25Index Tests
+// ============================================================================
+
+describe("BM25Index", () => {
+  let index: BM25Index;
+
+  beforeEach(() => {
+    index = new BM25Index();
+  });
+
+  describe("basic functionality", () => {
+    it("should add documents and search by single term", () => {
+      index.addDocument("doc1", "swap tokens on exchange");
+      index.addDocument("doc2", "bridge tokens across chains");
+      index.addDocument("doc3", "post a tweet on twitter");
+
+      const results = index.search("swap");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should rank documents by term frequency", () => {
+      // Same length (4 terms after stopword removal), but doc1 has "swap" 3x vs doc2 1x
+      index.addDocument("doc1", "swap swap swap tokens");
+      index.addDocument("doc2", "swap tokens crypto exchange");
+
+      const results = index.search("swap");
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBe("doc1");
+      expect(results[0].score).toBeGreaterThan(results[1].score);
+    });
+
+    it("should apply IDF weighting - rare terms score higher", () => {
+      index.addDocument("doc1", "exchange tokens for coins");
+      index.addDocument("doc2", "exchange currency for value");
+      index.addDocument("doc3", "exchange quantum computing research");
+
+      const resultsCommon = index.search("exchange");
+      const resultsRare = index.search("quantum");
+
+      const doc3Common = resultsCommon.find((r) => r.id === "doc3");
+      const doc3Rare = resultsRare.find((r) => r.id === "doc3");
+
+      expect(doc3Rare).toBeDefined();
+      expect(doc3Common).toBeDefined();
+      expect(doc3Rare!.score).toBeGreaterThan(doc3Common!.score);
+    });
+
+    it("should handle multi-term queries", () => {
+      index.addDocument("doc1", "swap tokens on a decentralized exchange");
+      index.addDocument("doc2", "post tweet on twitter");
+      index.addDocument("doc3", "swap tweet unexpected combination");
+
+      const results = index.search("swap tokens");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should normalize by document length", () => {
+      index.addDocument("doc1", "swap tokens");
+      index.addDocument(
+        "doc2",
+        "swap tokens on a decentralized exchange with many extra words for padding to make this document much longer than necessary"
+      );
+
+      const results = index.search("swap");
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBe("doc1");
+      expect(results[0].score).toBeGreaterThan(results[1].score);
+    });
+
+    it("should return empty results for no matches", () => {
+      index.addDocument("doc1", "swap tokens on exchange");
+      const results = index.search("quantum");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle empty queries", () => {
+      index.addDocument("doc1", "swap tokens on exchange");
+      const results = index.search("");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle empty index", () => {
+      const results = index.search("anything");
+      expect(results).toEqual([]);
+    });
+
+    it("should remove documents", () => {
+      index.addDocument("doc1", "swap tokens");
+      index.addDocument("doc2", "bridge tokens");
+
+      expect(index.size).toBe(2);
+      expect(index.has("doc1")).toBe(true);
+
+      index.removeDocument("doc1");
+
+      expect(index.size).toBe(1);
+      expect(index.has("doc1")).toBe(false);
+
+      const results = index.search("swap");
+      expect(results).toEqual([]);
+    });
+
+    it("should update avgDocLength after add/remove", () => {
+      index.addDocument("doc1", "short");
+      index.addDocument("doc2", "much longer document with many terms here");
+
+      expect(index.size).toBe(2);
+
+      index.removeDocument("doc2");
+      expect(index.size).toBe(1);
+
+      const results = index.search("short");
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should handle removing non-existent document gracefully", () => {
+      index.addDocument("doc1", "hello world");
+      index.removeDocument("non-existent");
+      expect(index.size).toBe(1);
+    });
+
+    it("should replace document when adding with same id", () => {
+      index.addDocument("doc1", "original content about swapping");
+      index.addDocument("doc1", "completely different content about tweets");
+
+      expect(index.size).toBe(1);
+
+      const swapResults = index.search("swapping");
+      expect(swapResults).toEqual([]);
+
+      const tweetResults = index.search("tweets");
+      expect(tweetResults.length).toBe(1);
+      expect(tweetResults[0].id).toBe("doc1");
+    });
+  });
+
+  describe("subset search", () => {
+    it("should search only within specified document IDs", () => {
+      index.addDocument("doc1", "swap tokens on exchange");
+      index.addDocument("doc2", "swap tokens on another exchange");
+      index.addDocument("doc3", "swap tokens on a third exchange");
+
+      const results = index.searchSubset("swap tokens", ["doc1", "doc3"]);
+      expect(results.length).toBe(2);
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain("doc1");
+      expect(ids).toContain("doc3");
+      expect(ids).not.toContain("doc2");
+    });
+
+    it("should return topK results in subset search", () => {
+      for (let i = 0; i < 10; i++) {
+        index.addDocument(`doc-${i}`, `swap tokens exchange variant ${i}`);
+      }
+
+      const allIds = Array.from({ length: 10 }, (_, i) => `doc-${i}`);
+      const results = index.searchSubset("swap tokens", allIds, 3);
+      expect(results.length).toBe(3);
+    });
+
+    it("should skip non-existent IDs in subset search", () => {
+      index.addDocument("doc1", "swap tokens");
+      const results = index.searchSubset("swap", [
+        "doc1",
+        "non-existent",
+        "also-missing",
+      ]);
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe("doc1");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle documents with identical content", () => {
+      index.addDocument("doc1", "swap tokens on exchange");
+      index.addDocument("doc2", "swap tokens on exchange");
+
+      const results = index.search("swap tokens");
+      expect(results.length).toBe(2);
+      expect(results[0].score).toBeCloseTo(results[1].score, 5);
+    });
+
+    it("should handle very long documents", () => {
+      const longText = Array.from(
+        { length: 500 },
+        (_, i) => `word${i}`
+      ).join(" ");
+      index.addDocument("long", longText + " unique_target_term");
+      index.addDocument("short", "unique_target_term");
+
+      const results = index.search("unique_target_term");
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBe("short");
+    });
+
+    it("should handle single-character terms", () => {
+      index.addDocument("doc1", "x y z tokens");
+      const results = index.search("x");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle special characters in text", () => {
+      index.addDocument("doc1", "swap_tokens (v2.0) on DEX!");
+      index.addDocument("doc2", "send message via @mention #channel");
+
+      const results = index.search("swap tokens");
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should handle query with only stopwords", () => {
+      index.addDocument("doc1", "swap tokens");
+      const results = index.search("the is a");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle documents with only stopwords", () => {
+      index.addDocument("doc1", "the is a an");
+      const results = index.search("hello");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle empty string documents", () => {
+      index.addDocument("empty", "");
+      expect(index.has("empty")).toBe(true);
+      expect(index.size).toBe(1);
+      const results = index.search("anything");
+      expect(results).toEqual([]);
+    });
+
+    it("should handle adding and removing all documents", () => {
+      index.addDocument("doc1", "hello world");
+      index.addDocument("doc2", "hello world");
+      index.removeDocument("doc1");
+      index.removeDocument("doc2");
+      expect(index.size).toBe(0);
+      const results = index.search("hello");
+      expect(results).toEqual([]);
+      // Re-adding should work
+      index.addDocument("doc3", "hello world");
+      const results2 = index.search("hello");
+      expect(results2.length).toBe(1);
+    });
+  });
+
+  describe("unicode tokenization", () => {
+    it("should tokenize Chinese characters", () => {
+      index.addDocument("doc1", "交换代币");
+      index.addDocument("doc2", "发送消息");
+
+      const results = index.search("交换代币");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should tokenize Japanese text", () => {
+      index.addDocument("doc1", "トークン交換");
+      index.addDocument("doc2", "メッセージ送信");
+
+      const results = index.search("トークン交換");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should tokenize Cyrillic text", () => {
+      index.addDocument("doc1", "обмен токенов");
+      index.addDocument("doc2", "отправить сообщение");
+
+      const results = index.search("обмен");
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0].id).toBe("doc1");
+    });
+
+    it("should tokenize Arabic text", () => {
+      index.addDocument("doc1", "تبادل الرموز");
+      index.addDocument("doc2", "إرسال رسالة");
+
+      const results = index.search("تبادل");
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it("should handle mixed unicode and ASCII", () => {
+      // "swap代币" is one token since there's no delimiter between ASCII and CJK.
+      // But searching for "exchange" should match since it's a separate token.
+      index.addDocument("doc1", "swap 代币 on exchange 交易所");
+      const results = index.search("swap");
+      expect(results.length).toBe(1);
+    });
+
+    it("should handle emoji in text (stripped as non-letter/digit)", () => {
+      index.addDocument("doc1", "swap tokens 🚀🌙");
+      const results = index.search("swap tokens");
+      expect(results.length).toBe(1);
+    });
+  });
+
+  describe("tokenization", () => {
+    it("should lowercase all terms", () => {
+      index.addDocument("doc1", "SWAP TOKENS ON EXCHANGE");
+      const results = index.search("swap tokens");
+      expect(results.length).toBe(1);
+    });
+
+    it("should split on non-alphanumeric characters", () => {
+      index.addDocument("doc1", "swap-tokens.on_exchange/now");
+      const results = index.search("swap");
+      expect(results.length).toBe(1);
+    });
+
+    it("should filter stopwords", () => {
+      index.addDocument("doc1", "swap the tokens on an exchange");
+      const results = index.search("the on an");
+      expect(results).toEqual([]);
+
+      const results2 = index.search("swap exchange");
+      expect(results2.length).toBe(1);
+    });
+  });
+
+  describe("topK behavior", () => {
+    it("should return all results when topK is not specified", () => {
+      for (let i = 0; i < 5; i++) {
+        index.addDocument(`doc-${i}`, `search term content number ${i}`);
+      }
+      const results = index.search("search term");
+      expect(results.length).toBe(5);
+    });
+
+    it("should limit results to topK", () => {
+      for (let i = 0; i < 10; i++) {
+        index.addDocument(`doc-${i}`, `search term content ${i}`);
+      }
+      const results = index.search("search term", 3);
+      expect(results.length).toBe(3);
+    });
+
+    it("should return results sorted by score descending", () => {
+      index.addDocument("doc1", "swap tokens swap swap");
+      index.addDocument("doc2", "swap tokens swap");
+      index.addDocument("doc3", "swap tokens");
+
+      const results = index.search("swap");
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].score).toBeGreaterThanOrEqual(results[i].score);
+      }
+    });
+  });
+
+  describe("performance", () => {
+    it("should handle 1000 documents efficiently", () => {
+      for (let i = 0; i < 1000; i++) {
+        index.addDocument(
+          `doc-${i}`,
+          `action ${i} description for testing with term${i}`
+        );
+      }
+
+      const start = performance.now();
+      const results = index.search("action testing", 20);
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(50);
+      expect(results.length).toBe(20);
+    });
+  });
+});
+
+// ============================================================================
+// 2. Cosine Similarity Tests
+// ============================================================================
+
+describe("cosineSimilarity", () => {
+  it("should return 1 for identical vectors", () => {
+    const v = [1, 2, 3, 4, 5];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1, 10);
+  });
+
+  it("should return 0 for orthogonal vectors", () => {
+    const a = [1, 0, 0];
+    const b = [0, 1, 0];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0, 10);
+  });
+
+  it("should return -1 for opposite vectors", () => {
+    const a = [1, 2, 3];
+    const b = [-1, -2, -3];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1, 10);
+  });
+
+  it("should return 0 for zero vectors", () => {
+    const zero = [0, 0, 0];
+    const v = [1, 2, 3];
+    expect(cosineSimilarity(zero, v)).toBe(0);
+    expect(cosineSimilarity(v, zero)).toBe(0);
+    expect(cosineSimilarity(zero, zero)).toBe(0);
+  });
+
+  it("should handle empty vectors", () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+    expect(cosineSimilarity([], [1, 2, 3])).toBe(0);
+  });
+
+  it("should handle mismatched vector lengths gracefully", () => {
+    const a = [1, 2, 3, 4, 5];
+    const b = [1, 2, 3];
+    const result = cosineSimilarity(a, b);
+    expect(typeof result).toBe("number");
+    expect(result).toBeGreaterThanOrEqual(-1);
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it("should be symmetric: sim(a,b) === sim(b,a)", () => {
+    const a = [1.5, 2.3, -0.7, 4.1];
+    const b = [0.3, -1.2, 3.5, 0.8];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(cosineSimilarity(b, a), 10);
+  });
+
+  it("should return 0 when vector contains NaN", () => {
+    const a = [1, NaN, 3];
+    const b = [1, 2, 3];
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  it("should return 0 when vector contains Infinity", () => {
+    const a = [1, Infinity, 3];
+    const b = [1, 2, 3];
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  it("should return 0 when vector contains -Infinity", () => {
+    const a = [1, -Infinity, 3];
+    const b = [1, 2, 3];
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+
+  it("should handle very small values without precision loss", () => {
+    const a = [1e-10, 2e-10, 3e-10];
+    const b = [1e-10, 2e-10, 3e-10];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(1, 5);
+  });
+
+  it("should clamp result to [-1, 1] range", () => {
+    // Even with floating point imprecision, result should be clamped
+    const a = [1, 2, 3, 4, 5];
+    const b = [1, 2, 3, 4, 5];
+    const result = cosineSimilarity(a, b);
+    expect(result).toBeLessThanOrEqual(1);
+    expect(result).toBeGreaterThanOrEqual(-1);
+  });
+
+  it("should produce correct similarity for known vectors", () => {
+    const a = [1, 0];
+    const b = [1, 1];
+    const expected = 1 / Math.sqrt(2);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(expected, 5);
+  });
+
+  it("should handle high-dimensional vectors (1536 dimensions)", () => {
+    const a = Array.from({ length: 1536 }, (_, i) => Math.sin(i));
+    const c = Array.from({ length: 1536 }, (_, i) => Math.sin(i));
+
+    const simAC = cosineSimilarity(a, c);
+    expect(simAC).toBeCloseTo(1, 10);
+  });
+});
+
+// ============================================================================
+// 3. normalizeVector Tests
+// ============================================================================
+
+describe("normalizeVector", () => {
+  it("should produce a unit vector", () => {
+    const v = [3, 4];
+    const norm = normalizeVector(v);
+    const magnitude = Math.sqrt(norm[0] ** 2 + norm[1] ** 2);
+    expect(magnitude).toBeCloseTo(1, 10);
+  });
+
+  it("should return a copy for zero vectors", () => {
+    const zero = [0, 0, 0];
+    const result = normalizeVector(zero);
+    expect(result).toEqual([0, 0, 0]);
+    expect(result).not.toBe(zero);
+  });
+
+  it("should preserve direction", () => {
+    const v = [3, 4];
+    const norm = normalizeVector(v);
+    expect(norm[0] / norm[1]).toBeCloseTo(v[0] / v[1], 10);
+  });
+});
+
+// ============================================================================
+// 4. minMaxNormalize Tests
+// ============================================================================
+
+describe("minMaxNormalize", () => {
+  it("should normalize to [0, 1] range", () => {
+    const result = minMaxNormalize([10, 20, 30]);
+    expect(result).toEqual([0, 0.5, 1]);
+  });
+
+  it("should handle single element", () => {
+    const result = minMaxNormalize([5]);
+    expect(result).toEqual([1]); // non-zero → 1
+  });
+
+  it("should handle all-zero values", () => {
+    const result = minMaxNormalize([0, 0, 0]);
+    expect(result).toEqual([0, 0, 0]);
+  });
+
+  it("should handle all-identical non-zero values", () => {
+    const result = minMaxNormalize([5, 5, 5]);
+    expect(result).toEqual([1, 1, 1]);
+  });
+
+  it("should handle empty array", () => {
+    expect(minMaxNormalize([])).toEqual([]);
+  });
+
+  it("should handle negative values", () => {
+    const result = minMaxNormalize([-10, 0, 10]);
+    expect(result).toEqual([0, 0.5, 1]);
+  });
+
+  it("should sanitize NaN to 0", () => {
+    const result = minMaxNormalize([NaN, 0, 10]);
+    // NaN → 0, so [0, 0, 10] → [0, 0, 1]
+    expect(result).toEqual([0, 0, 1]);
+  });
+
+  it("should sanitize Infinity to 0", () => {
+    const result = minMaxNormalize([Infinity, 0, 10]);
+    // Inf → 0, so [0, 0, 10] → [0, 0, 1]
+    expect(result).toEqual([0, 0, 1]);
+  });
+
+  it("should sanitize -Infinity to 0", () => {
+    const result = minMaxNormalize([-Infinity, 5, 10]);
+    expect(result).toEqual([0, 0.5, 1]);
+  });
+});
+
+// ============================================================================
+// 5. getActionEmbeddingText Tests
+// ============================================================================
+
+describe("getActionEmbeddingText", () => {
+  it("should include action name with underscores replaced", () => {
+    const action = createMockAction({
+      name: "SWAP_TOKENS",
+      description: "Swap tokens",
+    });
+    const text = getActionEmbeddingText(action);
+    expect(text).toContain("SWAP TOKENS");
+    expect(text).not.toContain("SWAP_TOKENS");
+  });
+
+  it("should include description", () => {
+    const action = createMockAction({
+      name: "TEST",
+      description: "A test action for testing",
+    });
+    expect(getActionEmbeddingText(action)).toContain("A test action for testing");
+  });
+
+  it("should include similes", () => {
+    const action = createMockAction({
+      name: "TEST",
+      description: "test",
+      similes: ["alias1", "alias2"],
+    });
+    const text = getActionEmbeddingText(action);
+    expect(text).toContain("alias1");
+    expect(text).toContain("alias2");
+  });
+
+  it("should include tags", () => {
+    const action = createMockAction({
+      name: "TEST",
+      description: "test",
+      tags: ["blockchain", "defi"],
+    });
+    const text = getActionEmbeddingText(action);
+    expect(text).toContain("blockchain");
+    expect(text).toContain("defi");
+  });
+
+  it("should handle action with no optional fields", () => {
+    const action: Action = {
+      name: "BARE",
+      description: "",
+      handler: vi.fn().mockResolvedValue({ success: true }),
+      validate: vi.fn().mockResolvedValue(true),
+    };
+    const text = getActionEmbeddingText(action);
+    expect(text).toContain("BARE");
+  });
+});
+
+// ============================================================================
+// 6. buildQueryText Tests
+// ============================================================================
+
+describe("buildQueryText", () => {
+  it("should include message text", () => {
+    const message = createMockMemory("swap my ETH for USDC");
+    const state = createMockState();
+    expect(buildQueryText(message, state)).toContain("swap my ETH for USDC");
+  });
+
+  it("should handle empty message text", () => {
+    const message = createMockMemory("");
+    const state = createMockState();
+    expect(buildQueryText(message, state)).toBe("");
+  });
+
+  it("should handle undefined message text", () => {
+    const message = { ...createMockMemory(""), content: {} } as Memory;
+    const state = createMockState();
+    expect(buildQueryText(message, state)).toBe("");
+  });
+
+  it("should include recent messages from state (truncated)", () => {
+    const message = createMockMemory("hello");
+    const longRecentMessages = "A".repeat(600);
+    const state = createMockState({
+      values: { recentMessages: longRecentMessages } as State["values"],
+    });
+    const result = buildQueryText(message, state);
+    expect(result).toContain("hello");
+    // Should be truncated to last 500 chars
+    expect(result.length).toBeLessThan(600 + 100);
+  });
+
+  it("should include pending action plan steps", () => {
+    const message = createMockMemory("continue");
+    const state = createMockState({
+      data: {
+        actionPlan: {
+          steps: [
+            { status: "completed", action: "DONE_ACTION" },
+            { status: "pending", action: "NEXT_ACTION" },
+            { status: "pending", action: "LATER_ACTION" },
+          ],
+        },
+      } as State["data"],
+    });
+    const result = buildQueryText(message, state);
+    expect(result).toContain("NEXT_ACTION");
+    expect(result).toContain("LATER_ACTION");
+    expect(result).not.toContain("DONE_ACTION");
+  });
+});
+
+// ============================================================================
+// 7. ActionFilterService — Full Service Tests
+// ============================================================================
+
+describe("ActionFilterService", () => {
+  let service: ActionFilterService;
+  let runtime: IAgentRuntime;
+  let allActions: Action[];
+
+  beforeEach(async () => {
+    const mockActions = buildMockActions();
+    allActions = Object.values(mockActions);
+
+    // Create runtime with embedding model available
+    runtime = createMockRuntime(allActions, { hasEmbeddingModel: true });
+
+    // Start service
+    service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+  });
+
+  afterEach(async () => {
+    await service.stop();
+  });
+
+  describe("lifecycle", () => {
+    it("should start and build index for all registered actions", () => {
+      const metrics = service.getMetrics();
+      expect(metrics.indexedActionCount).toBe(allActions.length);
+    });
+
+    it("should stop and clear all state", async () => {
+      await service.stop();
+      const metrics = service.getMetrics();
+      expect(metrics.indexedActionCount).toBe(0);
+      expect(metrics.filterCalls).toBe(0);
+    });
+
+    it("should start in BM25-only mode when no embedding model", async () => {
+      const noEmbRuntime = createMockRuntime(allActions, { hasEmbeddingModel: false });
+      const bm25Service = (await ActionFilterService.start(noEmbRuntime)) as ActionFilterService;
+      const metrics = bm25Service.getMetrics();
+      expect(metrics.indexedActionCount).toBe(allActions.length);
+      await bm25Service.stop();
+    });
+
+    it("should handle starting with empty action list", async () => {
+      const emptyRuntime = createMockRuntime([], { hasEmbeddingModel: true });
+      const emptyService = (await ActionFilterService.start(emptyRuntime)) as ActionFilterService;
+      expect(emptyService.getMetrics().indexedActionCount).toBe(0);
+      await emptyService.stop();
+    });
+  });
+
+  describe("filter — passthrough conditions", () => {
+    it("should return all actions when count is below threshold", async () => {
+      const smallActions = allActions.slice(0, 5);
+      const smallRuntime = createMockRuntime(smallActions, { hasEmbeddingModel: true });
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+
+      const result = await service.filter(smallRuntime, message, state);
+      // Should return all — same as what the runtime has
+      expect(result.length).toBe(smallActions.length);
+    });
+
+    it("should return all actions when disabled", async () => {
+      const disabledService = new ActionFilterService(runtime, { enabled: false });
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+
+      const result = await disabledService.filter(runtime, message, state);
+      expect(result.length).toBe(allActions.length);
+    });
+  });
+
+  describe("filter — relevance ranking", () => {
+    it("should include SWAP_TOKENS for 'I want to trade my ETH for USDC'", async () => {
+      const message = createMockMemory("I want to trade my ETH for USDC");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("SWAP_TOKENS");
+    });
+
+    it("should include SEND_MESSAGE for 'message Alice on telegram'", async () => {
+      const message = createMockMemory("message Alice on telegram");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("SEND_MESSAGE");
+    });
+
+    it("should include POST_TWEET for 'tweet about the latest news'", async () => {
+      const message = createMockMemory("tweet about the latest news");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("POST_TWEET");
+    });
+
+    it("should include EXECUTE_CODE for 'run this python script'", async () => {
+      const message = createMockMemory("run this python script");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("EXECUTE_CODE");
+    });
+
+    it("should include GENERATE_IMAGE for 'draw me a picture of a sunset'", async () => {
+      const message = createMockMemory("draw me a picture of a sunset");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("GENERATE_IMAGE");
+    });
+  });
+
+  describe("filter — always-include", () => {
+    it("should always include REPLY, IGNORE, NONE by default config", async () => {
+      const message = createMockMemory("something completely unrelated to any action");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("REPLY");
+      expect(names).toContain("IGNORE");
+      expect(names).toContain("NONE");
+    });
+
+    it("should respect alwaysInclude flag on individual actions", async () => {
+      const customActions = [
+        ...allActions,
+        createMockAction({
+          name: "CUSTOM_ALWAYS",
+          description: "A custom always-include action",
+          alwaysInclude: true,
+        }),
+      ];
+      const customRuntime = createMockRuntime(customActions, { hasEmbeddingModel: true });
+      const customService = (await ActionFilterService.start(customRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("totally unrelated query");
+      const state = createMockState();
+
+      const result = await customService.filter(customRuntime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("CUSTOM_ALWAYS");
+
+      await customService.stop();
+    });
+  });
+
+  describe("filter — cross-domain queries", () => {
+    it("should include both SWAP_TOKENS and SEND_MESSAGE for cross-domain query", async () => {
+      const message = createMockMemory("swap ETH and then message me the result");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("SWAP_TOKENS");
+      expect(names).toContain("SEND_MESSAGE");
+    });
+  });
+
+  describe("filter — graceful degradation", () => {
+    it("should fall back to all actions when ranking throws", async () => {
+      // Mock useModel to throw
+      const failingRuntime = createMockRuntime(allActions, {
+        hasEmbeddingModel: true,
+        useModelFn: vi.fn().mockRejectedValue(new Error("model exploded")),
+      });
+      const failingService = (await ActionFilterService.start(failingRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+
+      // filter() should not throw — BM25 still works even if embedding fails,
+      // so it returns a filtered (smaller) set rather than all actions.
+      // The key assertion is that it doesn't crash and returns valid results.
+      const result = await failingService.filter(failingRuntime, message, state);
+      expect(result.length).toBeGreaterThan(0);
+      // All always-include actions should be present
+      const names = result.map((a) => a.name);
+      expect(names).toContain("REPLY");
+      expect(names).toContain("IGNORE");
+      expect(names).toContain("NONE");
+
+      const metrics = failingService.getMetrics();
+      expect(metrics.bm25OnlyFallbacks).toBeGreaterThan(0);
+
+      await failingService.stop();
+    });
+
+    it("should work with BM25-only when embeddings unavailable", async () => {
+      const noEmbRuntime = createMockRuntime(allActions, { hasEmbeddingModel: false });
+      const bm25Service = (await ActionFilterService.start(noEmbRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("swap tokens cryptocurrency exchange");
+      const state = createMockState();
+
+      const result = await bm25Service.filter(noEmbRuntime, message, state);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("SWAP_TOKENS");
+      expect(names).toContain("REPLY"); // always-include
+
+      const metrics = bm25Service.getMetrics();
+      expect(metrics.bm25OnlyFallbacks).toBeGreaterThan(0);
+
+      await bm25Service.stop();
+    });
+  });
+
+  describe("addAction / removeAction", () => {
+    it("should add new action to the index at runtime", async () => {
+      const newAction = createMockAction({
+        name: "DEPLOY_CONTRACT",
+        description: "Deploy a smart contract to the blockchain",
+        similes: ["deploy", "publish contract"],
+        tags: ["blockchain", "development"],
+      });
+
+      await service.addAction(newAction, runtime);
+      expect(service.hasAction("DEPLOY_CONTRACT")).toBe(true);
+    });
+
+    it("should remove action from the index", async () => {
+      expect(service.hasAction("SWAP_TOKENS")).toBe(true);
+      service.removeAction("SWAP_TOKENS");
+      expect(service.hasAction("SWAP_TOKENS")).toBe(false);
+    });
+
+    it("should handle removing non-existent action", () => {
+      // Should not throw
+      service.removeAction("NON_EXISTENT");
+      expect(service.hasAction("NON_EXISTENT")).toBe(false);
+    });
+  });
+
+  describe("momentum", () => {
+    it("should boost recently used actions in the same room", async () => {
+      const roomId = "00000000-0000-0000-0000-000000000003";
+
+      // Record SWAP_TOKENS usage
+      service.recordActionUse("SWAP_TOKENS", roomId);
+
+      // Now filter — SWAP_TOKENS should get a momentum boost
+      const message = createMockMemory("do something", roomId);
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      const names = result.map((a) => a.name);
+      // SWAP_TOKENS should be included due to momentum even for a vague query
+      expect(names).toContain("SWAP_TOKENS");
+    });
+
+    it("should not boost actions in different rooms", async () => {
+      service.recordActionUse("EXECUTE_CODE", "room-A");
+
+      // Query from room-B
+      const message = createMockMemory("do something generic", "room-B" as `${string}-${string}-${string}-${string}-${string}`);
+      const state = createMockState();
+
+      // We can't easily assert the code action isn't boosted, but we can
+      // verify the service doesn't crash and returns results
+      const result = await service.filter(runtime, message, state);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("should cap recent actions to maxRecentActions", () => {
+      // Record more than 200 actions
+      for (let i = 0; i < 250; i++) {
+        service.recordActionUse(`ACTION_${i}`, "room1");
+      }
+      // Should not have grown unbounded — internal pruning caps at 200
+      // We can verify the service still works
+      const metrics = service.getMetrics();
+      expect(metrics.filterCalls).toBe(0); // no filter calls yet
+    });
+  });
+
+  describe("metrics", () => {
+    it("should track filter calls", async () => {
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+
+      await service.filter(runtime, message, state);
+      await service.filter(runtime, message, state);
+
+      const metrics = service.getMetrics();
+      expect(metrics.filterCalls).toBe(2);
+      expect(metrics.filteredCalls).toBe(2);
+    });
+
+    it("should return a deep copy from getMetrics()", () => {
+      const m1 = service.getMetrics();
+      const m2 = service.getMetrics();
+
+      // Should be different objects
+      expect(m1).not.toBe(m2);
+      expect(m1.missedActions).not.toBe(m2.missedActions);
+
+      // But equal values
+      expect(m1).toEqual(m2);
+    });
+
+    it("should track missed actions via reportMiss", () => {
+      service.reportMiss("SOME_ACTION");
+      service.reportMiss("ANOTHER_ACTION");
+
+      const metrics = service.getMetrics();
+      expect(metrics.missCount).toBe(2);
+      expect(metrics.missedActions).toContain("SOME_ACTION");
+      expect(metrics.missedActions).toContain("ANOTHER_ACTION");
+    });
+
+    it("should bound missedActions ring buffer", () => {
+      // Report > 100 misses
+      for (let i = 0; i < 120; i++) {
+        service.reportMiss(`ACTION_${i}`);
+      }
+
+      const metrics = service.getMetrics();
+      expect(metrics.missCount).toBe(120);
+      // Buffer should have been trimmed to ~50
+      expect(metrics.missedActions.length).toBeLessThanOrEqual(100);
+    });
+
+    it("should track lastAvgScore after filtering", async () => {
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+
+      await service.filter(runtime, message, state);
+
+      const metrics = service.getMetrics();
+      expect(metrics.lastAvgScore).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getConfig", () => {
+    it("should return a read-only copy of config", () => {
+      const config = service.getConfig();
+      expect(config.threshold).toBe(15);
+      expect(config.alwaysIncludeActions).toContain("REPLY");
+      expect(config.alwaysIncludeActions).toContain("IGNORE");
+      expect(config.alwaysIncludeActions).toContain("NONE");
+    });
+  });
+
+  describe("wasActionInFilteredSet", () => {
+    it("should return null when no filtering happened for that room", () => {
+      const result = service.wasActionInFilteredSet("SWAP_TOKENS", "unknown-room");
+      expect(result).toBeNull();
+    });
+
+    it("should return true for actions that were in the filtered set", async () => {
+      const roomId = "00000000-0000-0000-0000-000000000003";
+      const message = createMockMemory("swap tokens", roomId);
+      const state = createMockState();
+
+      await service.filter(runtime, message, state);
+
+      // REPLY is always-include, so it should be in the set
+      expect(service.wasActionInFilteredSet("REPLY", roomId)).toBe(true);
+    });
+
+    it("should return false for actions that were filtered out", async () => {
+      const roomId = "00000000-0000-0000-0000-000000000003";
+      const message = createMockMemory("swap tokens", roomId);
+      const state = createMockState();
+
+      await service.filter(runtime, message, state);
+
+      // Find an action that was definitely NOT in the filtered set
+      // (the set has finalTopK=15 + always-include=3 ≈ 15 total from 22)
+      // At least a few actions should be filtered out
+      const config = service.getConfig();
+      const allNames = allActions.map((a) => a.name);
+      const filteredOutAction = allNames.find(
+        (name) => service.wasActionInFilteredSet(name, roomId) === false,
+      );
+      // We expect at least one action was filtered out (22 - 15 = 7)
+      expect(filteredOutAction).toBeDefined();
+    });
+
+    it("should track per-room independently", async () => {
+      const room1 = "00000000-0000-0000-0000-000000000011" as `${string}-${string}-${string}-${string}-${string}`;
+      const room2 = "00000000-0000-0000-0000-000000000022" as `${string}-${string}-${string}-${string}-${string}`;
+
+      await service.filter(runtime, createMockMemory("swap tokens", room1), createMockState());
+      await service.filter(runtime, createMockMemory("send message", room2), createMockState());
+
+      // Both rooms should have tracking data
+      expect(service.wasActionInFilteredSet("REPLY", room1)).toBe(true);
+      expect(service.wasActionInFilteredSet("REPLY", room2)).toBe(true);
+
+      // Unknown room still returns null
+      expect(service.wasActionInFilteredSet("REPLY", "unknown")).toBeNull();
+    });
+  });
+
+  describe("runtime configuration", () => {
+    it("should read settings from runtime.getSetting()", async () => {
+      const configuredRuntime = createMockRuntime(allActions, { hasEmbeddingModel: true });
+      (configuredRuntime.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        const settings: Record<string, string> = {
+          ACTION_FILTER_THRESHOLD: "20",
+          ACTION_FILTER_FINAL_TOP_K: "10",
+          ACTION_FILTER_VECTOR_WEIGHT: "0.8",
+          ACTION_FILTER_BM25_WEIGHT: "0.2",
+        };
+        return settings[key] ?? null;
+      });
+
+      const configuredService = (await ActionFilterService.start(configuredRuntime)) as ActionFilterService;
+      const config = configuredService.getConfig();
+
+      expect(config.threshold).toBe(20);
+      expect(config.finalTopK).toBe(10);
+      expect(config.vectorWeight).toBe(0.8);
+      expect(config.bm25Weight).toBe(0.2);
+
+      await configuredService.stop();
+    });
+
+    it("should use defaults when settings are not provided", async () => {
+      const defaultService = (await ActionFilterService.start(runtime)) as ActionFilterService;
+      const config = defaultService.getConfig();
+
+      expect(config.threshold).toBe(15);
+      expect(config.finalTopK).toBe(15);
+      expect(config.vectorWeight).toBe(0.6);
+      expect(config.bm25Weight).toBe(0.4);
+      expect(config.momentumDecayMs).toBe(300_000);
+      expect(config.momentumBoost).toBe(0.15);
+
+      await defaultService.stop();
+    });
+
+    it("should disable filtering when ACTION_FILTER_ENABLED is false", async () => {
+      const disabledRuntime = createMockRuntime(allActions, { hasEmbeddingModel: true });
+      (disabledRuntime.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === "ACTION_FILTER_ENABLED") return "false";
+        return null;
+      });
+
+      const disabledService = (await ActionFilterService.start(disabledRuntime)) as ActionFilterService;
+      const config = disabledService.getConfig();
+      expect(config.enabled).toBe(false);
+
+      // Filtering should be a no-op — returns all actions
+      const result = await disabledService.filter(
+        disabledRuntime,
+        createMockMemory("swap tokens"),
+        createMockState(),
+      );
+      expect(result.length).toBe(allActions.length);
+
+      await disabledService.stop();
+    });
+
+    it("should ignore invalid setting values", async () => {
+      const badRuntime = createMockRuntime(allActions, { hasEmbeddingModel: true });
+      (badRuntime.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        const settings: Record<string, string> = {
+          ACTION_FILTER_THRESHOLD: "not-a-number",
+          ACTION_FILTER_VECTOR_WEIGHT: "2.5", // out of 0-1 range
+          ACTION_FILTER_BM25_WEIGHT: "-1", // negative
+        };
+        return settings[key] ?? null;
+      });
+
+      const badService = (await ActionFilterService.start(badRuntime)) as ActionFilterService;
+      const config = badService.getConfig();
+
+      // Should fall back to defaults for invalid values
+      expect(config.threshold).toBe(15);
+      expect(config.vectorWeight).toBe(0.6);
+      expect(config.bm25Weight).toBe(0.4);
+
+      await badService.stop();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle empty message text", async () => {
+      const message = createMockMemory("");
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      // Should still return at least the always-include actions
+      expect(result.length).toBeGreaterThanOrEqual(3);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("REPLY");
+    });
+
+    it("should handle undefined message content text", async () => {
+      const message = { ...createMockMemory(""), content: {} } as Memory;
+      message.roomId = "00000000-0000-0000-0000-000000000003" as `${string}-${string}-${string}-${string}-${string}`;
+      const state = createMockState();
+
+      const result = await service.filter(runtime, message, state);
+      expect(result.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("should handle concurrent filter calls", async () => {
+      const queries = [
+        "swap tokens",
+        "send message",
+        "generate image",
+        "search knowledge base",
+        "execute python code",
+      ];
+
+      const results = await Promise.all(
+        queries.map((q) =>
+          service.filter(runtime, createMockMemory(q), createMockState())
+        ),
+      );
+
+      for (const result of results) {
+        expect(result.length).toBeGreaterThan(0);
+        const names = result.map((a) => a.name);
+        expect(names).toContain("REPLY");
+      }
+
+      const metrics = service.getMetrics();
+      expect(metrics.filterCalls).toBe(5);
+    });
+
+    it("should handle action with no description", async () => {
+      const bareAction = createMockAction({
+        name: "BARE_ACTION",
+        description: "",
+      });
+      await service.addAction(bareAction, runtime);
+      expect(service.hasAction("BARE_ACTION")).toBe(true);
+    });
+
+    it("should handle embedding model returning invalid vectors", async () => {
+      const badRuntime = createMockRuntime(allActions, {
+        hasEmbeddingModel: true,
+        useModelFn: vi.fn().mockResolvedValue([NaN, NaN, NaN]),
+      });
+      const badService = (await ActionFilterService.start(badRuntime)) as ActionFilterService;
+
+      // Service should still work via BM25 fallback
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+      const result = await badService.filter(badRuntime, message, state);
+      expect(result.length).toBeGreaterThan(0);
+
+      await badService.stop();
+    });
+
+    it("should handle embedding model returning empty array", async () => {
+      const emptyEmbRuntime = createMockRuntime(allActions, {
+        hasEmbeddingModel: true,
+        useModelFn: vi.fn().mockResolvedValue([]),
+      });
+      const emptyService = (await ActionFilterService.start(emptyEmbRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+      const result = await emptyService.filter(emptyEmbRuntime, message, state);
+      expect(result.length).toBeGreaterThan(0);
+
+      await emptyService.stop();
+    });
+
+    it("should handle embedding model returning zero vector", async () => {
+      const zeroVecRuntime = createMockRuntime(allActions, {
+        hasEmbeddingModel: true,
+        useModelFn: vi.fn().mockResolvedValue(new Array(64).fill(0)),
+      });
+      const zeroService = (await ActionFilterService.start(zeroVecRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("swap tokens");
+      const state = createMockState();
+      const result = await zeroService.filter(zeroVecRuntime, message, state);
+      expect(result.length).toBeGreaterThan(0);
+
+      await zeroService.stop();
+    });
+  });
+
+  describe("performance", () => {
+    it("should filter 200 actions in under 200ms", async () => {
+      const largeActionList: Action[] = [];
+      for (let i = 0; i < 200; i++) {
+        largeActionList.push(
+          createMockAction({
+            name: `ACTION_${i}`,
+            description: `This is action number ${i} that performs operation ${i % 20} in domain ${i % 10}`,
+            similes: [`alias${i}`, `variant${i}`],
+            tags: [`domain${i % 10}`, `category${i % 5}`],
+          })
+        );
+      }
+      // Add always-include
+      largeActionList.push(
+        createMockAction({ name: "REPLY", description: "Reply", alwaysInclude: true }),
+        createMockAction({ name: "IGNORE", description: "Ignore", alwaysInclude: true }),
+        createMockAction({ name: "NONE", description: "None", alwaysInclude: true }),
+      );
+
+      const bigRuntime = createMockRuntime(largeActionList, { hasEmbeddingModel: true });
+      const bigService = (await ActionFilterService.start(bigRuntime)) as ActionFilterService;
+
+      const message = createMockMemory("operation domain action testing");
+      const state = createMockState();
+
+      const start = performance.now();
+      const result = await bigService.filter(bigRuntime, message, state);
+      const elapsed = performance.now() - start;
+
+      expect(elapsed).toBeLessThan(200);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(20); // finalTopK + always-include
+
+      await bigService.stop();
+    });
+  });
+});
+
+// ============================================================================
+// 8. Integration: actionsProvider Tests
+// ============================================================================
+
+describe("actionsProvider", () => {
+  let mockMessage: Memory;
+  let mockState: State;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMessage = createMockMemory("I want to swap my ETH for USDC");
+    mockState = createMockState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should fall back to validate-all when ActionFilterService unavailable", async () => {
+    const actionList = [
+      createMockAction({ name: "REPLY", description: "Reply to the user", tags: ["core"] }),
+      createMockAction({ name: "SWAP_TOKENS", description: "Swap tokens", tags: ["defi"] }),
+    ];
+    const mockRuntime = createMockRuntime(actionList);
+
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+
+    expect(result).toBeDefined();
+    expect(result.data.actionsData).toBeDefined();
+    expect(result.data.actionsData.length).toBe(2);
+  });
+
+  it("should produce valid action text output", async () => {
+    const actionList = [
+      createMockAction({ name: "REPLY", description: "Reply to the user with a text message", tags: ["core"] }),
+      createMockAction({ name: "SWAP_TOKENS", description: "Swap one cryptocurrency token for another", similes: ["trade", "exchange"], tags: ["defi"] }),
+    ];
+    const mockRuntime = createMockRuntime(actionList);
+
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+
+    expect(typeof result.text).toBe("string");
+    expect(result.text!.length).toBeGreaterThan(0);
+    expect(result.text).toContain("REPLY");
+    expect(result.text).toContain("SWAP_TOKENS");
+  });
+
+  it("should include actionNames in values", async () => {
+    const actionList = [
+      createMockAction({ name: "REPLY", description: "Reply to user", tags: ["core"] }),
+    ];
+    const mockRuntime = createMockRuntime(actionList);
+
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+
+    expect(result.values).toBeDefined();
+    expect(result.values.actionNames).toBeDefined();
+    expect(typeof result.values.actionNames).toBe("string");
+    expect(result.values.actionNames).toContain("REPLY");
+  });
+
+  it("should handle actions that fail validation gracefully", async () => {
+    const validAction = createMockAction({ name: "REPLY", description: "Reply to user", validateReturn: true });
+    const invalidAction = createMockAction({ name: "SWAP_TOKENS", description: "Swap tokens", validateReturn: false });
+
+    const mockRuntime = createMockRuntime([validAction, invalidAction]);
+
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+    expect(result.data.actionsData.length).toBe(1);
+    expect(result.data.actionsData[0].name).toBe("REPLY");
+  });
+
+  it("should handle empty actions list gracefully", async () => {
+    const mockRuntime = createMockRuntime([]);
+
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+    expect(result.data.actionsData).toEqual([]);
+  });
+
+  it("should handle actions that throw during validation without crashing", async () => {
+    const throwingAction = createMockAction({ name: "BROKEN", description: "This action throws" });
+    (throwingAction.validate as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("validation exploded"),
+    );
+    const goodAction = createMockAction({ name: "REPLY", description: "Reply to user" });
+
+    const mockRuntime = createMockRuntime([goodAction, throwingAction]);
+
+    // Should NOT throw — the try/catch in validateActions handles it
+    const result = await actionsProvider.get!(mockRuntime, mockMessage, mockState);
+    expect(result.data.actionsData.length).toBe(1);
+    expect(result.data.actionsData[0].name).toBe("REPLY");
+  });
+
+  it("should use filter service when available and action count > threshold", async () => {
+    // Build 20 actions (above threshold of 15)
+    const manyActions: Action[] = [];
+    for (let i = 0; i < 20; i++) {
+      manyActions.push(
+        createMockAction({
+          name: `ACTION_${i}`,
+          description: `Action number ${i}`,
+          tags: [`tag${i}`],
+        }),
+      );
+    }
+
+    const mockRuntime = createMockRuntime(manyActions, { hasEmbeddingModel: true });
+
+    // Create and wire the filter service
+    const filterService = (await ActionFilterService.start(mockRuntime)) as ActionFilterService;
+    (mockRuntime.getService as ReturnType<typeof vi.fn>).mockReturnValue(filterService);
+
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("action tag5"),
+      createMockState(),
+    );
+
+    // Should have filtered down from 20
+    expect(result.data.actionsData.length).toBeLessThan(20);
+    expect(result.data.actionsData.length).toBeGreaterThan(0);
+
+    await filterService.stop();
+  });
+
+  it("should track filtered set on the service for false-negative detection", async () => {
+    const manyActions: Action[] = [];
+    for (let i = 0; i < 20; i++) {
+      manyActions.push(
+        createMockAction({
+          name: `ACTION_${i}`,
+          description: `Action number ${i}`,
+        }),
+      );
+    }
+
+    const roomId = "00000000-0000-0000-0000-000000000099";
+    const mockRuntime = createMockRuntime(manyActions, { hasEmbeddingModel: true });
+    const filterService = (await ActionFilterService.start(mockRuntime)) as ActionFilterService;
+    (mockRuntime.getService as ReturnType<typeof vi.fn>).mockReturnValue(filterService);
+
+    const state = createMockState();
+    const message = createMockMemory("test query", roomId);
+
+    await actionsProvider.get!(mockRuntime, message, state);
+
+    // The service should now have tracking data for this room
+    const inSet = filterService.wasActionInFilteredSet("ACTION_0", roomId);
+    // Either true or false — not null (filtering was active)
+    expect(inSet).not.toBeNull();
+
+    await filterService.stop();
+  });
+});
+
+// ============================================================================
+// 9. Fuzz / Property-Based Tests
+// ============================================================================
+
+describe("fuzz tests", () => {
+  it("BM25 should not crash on random unicode input", () => {
+    const index = new BM25Index();
+    const randomStrings = [
+      "🚀🌙💎🙌",
+      "null undefined NaN Infinity",
+      "".padStart(1000, "a"),
+      "\0\0\0",
+      "SELECT * FROM users; DROP TABLE;",
+      "<script>alert('xss')</script>",
+      "你好世界 こんにちは 안녕하세요",
+      "   \t\n  ",
+      "a".repeat(10000),
+    ];
+
+    for (const str of randomStrings) {
+      // Should not throw
+      index.addDocument(`doc-${str.slice(0, 10)}`, str);
+    }
+
+    for (const str of randomStrings) {
+      const results = index.search(str);
+      expect(Array.isArray(results)).toBe(true);
+    }
+  });
+
+  it("cosineSimilarity should not crash on extreme values", () => {
+    const testCases: [number[], number[]][] = [
+      [[Number.MAX_VALUE, 1], [1, Number.MAX_VALUE]],
+      [[Number.MIN_VALUE, 1], [1, Number.MIN_VALUE]],
+      [[1e308, 1e308], [1e308, 1e308]],
+      [[1e-308, 1e-308], [1e-308, 1e-308]],
+      [[NaN], [1]],
+      [[Infinity], [1]],
+      [[-Infinity], [1]],
+      [[], []],
+      [[0], [0]],
+    ];
+
+    for (const [a, b] of testCases) {
+      const result = cosineSimilarity(a, b);
+      expect(typeof result).toBe("number");
+      // Should be a valid number (not NaN)
+      expect(Number.isNaN(result)).toBe(false);
+    }
+  });
+
+  it("minMaxNormalize should not crash on degenerate inputs", () => {
+    const testCases: number[][] = [
+      [],
+      [0],
+      [NaN],
+      [Infinity],
+      [-Infinity],
+      [NaN, NaN, NaN],
+      [Infinity, -Infinity, 0],
+      [1e308, -1e308],
+      new Array(1000).fill(0),
+      new Array(1000).fill(42),
+    ];
+
+    for (const scores of testCases) {
+      const result = minMaxNormalize(scores);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(scores.length);
+      for (const val of result) {
+        expect(typeof val).toBe("number");
+        expect(Number.isNaN(val)).toBe(false);
+      }
+    }
+  });
+
+  it("ActionFilterService should handle random message content without crashing", async () => {
+    const actions = Object.values(buildMockActions());
+    const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+    const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+    const randomMessages = [
+      "",
+      "   ",
+      "a".repeat(5000),
+      "🚀🌙",
+      "你好世界",
+      "null",
+      "<script>alert(1)</script>",
+      "SELECT * FROM actions WHERE 1=1",
+    ];
+
+    for (const msg of randomMessages) {
+      const result = await service.filter(
+        runtime,
+        createMockMemory(msg),
+        createMockState(),
+      );
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+    }
+
+    await service.stop();
+  });
+});
+
+// ============================================================================
+// 10. Data Inspection — verify actual output values, not just containment
+// ============================================================================
+
+describe("data inspection", () => {
+  describe("BM25 scoring correctness", () => {
+    it("should produce strictly decreasing scores for decreasing term overlap", () => {
+      const index = new BM25Index();
+      index.addDocument("three", "swap tokens exchange");
+      index.addDocument("two", "swap tokens other");
+      index.addDocument("one", "swap other words");
+      index.addDocument("zero", "completely different content");
+
+      const results = index.search("swap tokens exchange");
+      // "three" matches all 3 query terms, "two" matches 2, "one" matches 1
+      expect(results.length).toBe(3); // "zero" has score 0
+      expect(results[0].id).toBe("three");
+      expect(results[1].id).toBe("two");
+      expect(results[2].id).toBe("one");
+      expect(results[0].score).toBeGreaterThan(results[1].score);
+      expect(results[1].score).toBeGreaterThan(results[2].score);
+    });
+
+    it("should produce correct IDF: term in 1/3 docs scores higher than term in 3/3 docs", () => {
+      const index = new BM25Index();
+      index.addDocument("d1", "common rare1");
+      index.addDocument("d2", "common words");
+      index.addDocument("d3", "common stuff");
+
+      const rareResults = index.search("rare1");
+      const commonResults = index.search("common");
+
+      // rare1 appears in 1/3 docs, common in 3/3 — IDF for rare1 > common
+      const d1Rare = rareResults.find((r) => r.id === "d1");
+      const d1Common = commonResults.find((r) => r.id === "d1");
+      expect(d1Rare).toBeDefined();
+      expect(d1Common).toBeDefined();
+      expect(d1Rare!.score).toBeGreaterThan(d1Common!.score);
+    });
+
+    it("should maintain correct DF counts after add/remove cycles", () => {
+      const index = new BM25Index();
+      index.addDocument("d1", "alpha beta");
+      index.addDocument("d2", "alpha gamma");
+      index.addDocument("d3", "alpha delta");
+
+      // "alpha" is in 3 docs
+      let results = index.search("alpha");
+      expect(results.length).toBe(3);
+
+      // Remove d2 — "alpha" should now be in 2 docs, "gamma" in 0
+      index.removeDocument("d2");
+      results = index.search("alpha");
+      expect(results.length).toBe(2);
+
+      const gammaResults = index.search("gamma");
+      expect(gammaResults.length).toBe(0);
+
+      // Re-add d2 with different content
+      index.addDocument("d2", "gamma epsilon");
+      results = index.search("gamma");
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe("d2");
+
+      // "alpha" should still be in 2 docs (d1, d3)
+      results = index.search("alpha");
+      expect(results.length).toBe(2);
+    });
+
+    it("should work with custom k1/b parameters", () => {
+      // With multiple docs of different lengths, b affects length normalization
+      // and k1 affects term saturation — so the RANKING should differ.
+      const indexHighB = new BM25Index(1.5, 0.99); // strong length normalization
+      const indexLowB = new BM25Index(1.5, 0.01);  // almost no length normalization
+
+      const short = "swap tokens";
+      const long = "swap tokens on a very large decentralized crypto exchange platform with many features";
+
+      indexHighB.addDocument("short", short);
+      indexHighB.addDocument("long", long);
+      indexLowB.addDocument("short", short);
+      indexLowB.addDocument("long", long);
+
+      const highBResults = indexHighB.search("swap tokens");
+      const lowBResults = indexLowB.search("swap tokens");
+
+      // Both find both documents
+      expect(highBResults.length).toBe(2);
+      expect(lowBResults.length).toBe(2);
+
+      // With high b, short doc should score MUCH higher than long doc
+      // because length normalization penalizes the long doc heavily.
+      const highBRatio = highBResults[0].score / highBResults[1].score;
+      // With low b, the scores should be closer since length barely matters.
+      const lowBRatio = lowBResults[0].score / lowBResults[1].score;
+
+      // The score ratio gap should be larger with high b
+      expect(highBRatio).toBeGreaterThan(lowBRatio);
+    });
+  });
+
+  describe("getActionEmbeddingText format", () => {
+    it("should produce pipe-delimited format with all fields", () => {
+      const action: Action = {
+        name: "MY_ACTION",
+        description: "Does something cool",
+        similes: ["alias1", "alias2"],
+        tags: ["tag1", "tag2"],
+        parameters: [
+          { name: "param1", description: "first param", required: true, schema: { type: "string" } },
+          { name: "param2", description: "second param", required: false, schema: { type: "number" } },
+        ],
+        handler: vi.fn().mockResolvedValue({ success: true }),
+        validate: vi.fn().mockResolvedValue(true),
+        examples: [],
+      };
+
+      const text = getActionEmbeddingText(action);
+      const segments = text.split(" | ");
+
+      expect(segments[0]).toBe("MY ACTION"); // underscores → spaces
+      expect(segments[1]).toBe("Does something cool");
+      expect(segments[2]).toBe("alias1, alias2");
+      expect(segments[3]).toBe("tag1, tag2");
+      expect(segments[4]).toBe("param1: first param");
+      expect(segments[5]).toBe("param2: second param");
+      expect(segments.length).toBe(6);
+    });
+  });
+
+  describe("buildQueryText truncation boundary", () => {
+    it("should pass through recentMessages under 500 chars without truncation", () => {
+      const msg = createMockMemory("hello");
+      const shortRecent = "X".repeat(400);
+      const state = createMockState({
+        values: { recentMessages: shortRecent } as State["values"],
+      });
+      const result = buildQueryText(msg, state);
+      // Should contain all 400 chars — no truncation
+      expect(result).toContain(shortRecent);
+    });
+
+    it("should truncate recentMessages at exactly 500 chars", () => {
+      const msg = createMockMemory("hello");
+      const exactRecent = "X".repeat(500);
+      const state = createMockState({
+        values: { recentMessages: exactRecent } as State["values"],
+      });
+      const result = buildQueryText(msg, state);
+      expect(result).toContain(exactRecent); // exactly 500 = not truncated
+    });
+
+    it("should truncate recentMessages at 501 chars to last 500", () => {
+      const msg = createMockMemory("hello");
+      const longRecent = "A" + "B".repeat(500); // 501 chars
+      const state = createMockState({
+        values: { recentMessages: longRecent } as State["values"],
+      });
+      const result = buildQueryText(msg, state);
+      // Should have the last 500 chars (all Bs), NOT the leading A
+      expect(result).not.toContain("AB");
+      expect(result).toContain("B".repeat(500));
+    });
+
+    it("should ignore non-string recentMessages", () => {
+      const msg = createMockMemory("hello");
+      const state = createMockState({
+        values: { recentMessages: 12345 } as unknown as State["values"],
+      });
+      const result = buildQueryText(msg, state);
+      expect(result).toBe("hello");
+    });
+
+    it("should handle plan steps with no action field", () => {
+      const msg = createMockMemory("continue");
+      const state = createMockState({
+        data: {
+          actionPlan: {
+            steps: [
+              { status: "pending" },                  // no action
+              { status: "pending", action: "" },       // empty action
+              { status: "pending", action: "REAL" },
+            ],
+          },
+        } as State["data"],
+      });
+      const result = buildQueryText(msg, state);
+      expect(result).toContain("REAL");
+      expect(result).not.toContain("Planned actions: , ");
+    });
+  });
+
+  describe("ActionFilterService ranking data", () => {
+    it("should return fewer actions than total when filtering is active", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      const result = await service.filter(
+        runtime,
+        createMockMemory("swap tokens cryptocurrency"),
+        createMockState(),
+      );
+
+      // 22 total actions, finalTopK=15 → should be ≤ 15
+      expect(result.length).toBeLessThanOrEqual(15);
+      expect(result.length).toBeGreaterThan(0);
+      // Verify actual action objects are returned, not copies
+      for (const a of result) {
+        expect(a.name).toBeDefined();
+        expect(a.handler).toBeDefined();
+        expect(a.validate).toBeDefined();
+      }
+
+      await service.stop();
+    });
+
+    it("should return all actions when candidate pool is smaller than finalTopK", async () => {
+      // Create exactly 18 actions: 3 always-include + 15 regular
+      // After removing 3 always-include, pool = 15 = finalTopK → return all
+      const acts: Action[] = [
+        createMockAction({ name: "REPLY", description: "Reply", alwaysInclude: true }),
+        createMockAction({ name: "IGNORE", description: "Ignore", alwaysInclude: true }),
+        createMockAction({ name: "NONE", description: "None", alwaysInclude: true }),
+      ];
+      for (let i = 0; i < 15; i++) {
+        acts.push(createMockAction({ name: `ACT_${i}`, description: `Action ${i}` }));
+      }
+      const rt = createMockRuntime(acts, { hasEmbeddingModel: true });
+      const svc = (await ActionFilterService.start(rt)) as ActionFilterService;
+
+      const result = await svc.filter(rt, createMockMemory("test"), createMockState());
+      // candidatePool.length (15) <= finalTopK (15) → passthrough
+      expect(result.length).toBe(18);
+
+      await svc.stop();
+    });
+
+    it("should deduplicate when an always-include action also ranks high", async () => {
+      // REPLY is always-include AND will also match "reply to user"
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      const result = await service.filter(
+        runtime,
+        createMockMemory("reply to the user"),
+        createMockState(),
+      );
+
+      const replyCount = result.filter((a) => a.name === "REPLY").length;
+      expect(replyCount).toBe(1); // no duplicates
+
+      await service.stop();
+    });
+
+    it("should record metrics correctly across multiple calls", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      // First call — filtered
+      await service.filter(runtime, createMockMemory("swap"), createMockState());
+      // Second call — filtered
+      await service.filter(runtime, createMockMemory("tweet"), createMockState());
+
+      // Third call — passthrough (small runtime)
+      const smallRt = createMockRuntime(actions.slice(0, 5), { hasEmbeddingModel: true });
+      await service.filter(smallRt, createMockMemory("test"), createMockState());
+
+      const m = service.getMetrics();
+      expect(m.filterCalls).toBe(3);
+      expect(m.filteredCalls).toBe(2); // only the first two triggered filtering
+      expect(m.lastAvgScore).toBeGreaterThan(0);
+      expect(m.indexedActionCount).toBe(actions.length);
+
+      await service.stop();
+    });
+  });
+});
+
+// ============================================================================
+// 11. Boundary conditions for momentum and room tracking
+// ============================================================================
+
+describe("boundary conditions", () => {
+  describe("momentum expiry", () => {
+    it("should expire momentum entries after the decay window", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      // Use a very short momentum window for testing
+      const service = new ActionFilterService(runtime, {
+        momentumDecayMs: 1, // 1ms decay
+        momentumBoost: 0.5,
+      });
+      await service.buildIndex(runtime);
+
+      service.recordActionUse("EXECUTE_CODE", "room1");
+
+      // Wait for momentum to expire
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Filter — EXECUTE_CODE momentum should have expired
+      const result = await service.filter(
+        runtime,
+        createMockMemory("generic query no keywords", "room1"),
+        createMockState(),
+      );
+
+      // After momentum expires, EXECUTE_CODE might not appear for a generic query
+      // The key assertion is that the service works and doesn't crash
+      expect(result.length).toBeGreaterThan(0);
+      const names = result.map((a) => a.name);
+      expect(names).toContain("REPLY"); // always-include still there
+
+      await service.stop();
+    });
+  });
+
+  describe("room tracking pruning", () => {
+    it("should prune old rooms when maxTrackedRooms is exceeded", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      // Filter for 600 different rooms (exceeds maxTrackedRooms=500)
+      for (let i = 0; i < 600; i++) {
+        const roomId = `room-${i}` as `${string}-${string}-${string}-${string}-${string}`;
+        await service.filter(
+          runtime,
+          createMockMemory("test", roomId),
+          createMockState(),
+        );
+      }
+
+      // The earliest rooms should have been pruned
+      // Room 0 was added first and should be evicted
+      expect(service.wasActionInFilteredSet("REPLY", "room-0")).toBeNull();
+
+      // Recent rooms should still be tracked
+      expect(service.wasActionInFilteredSet("REPLY", "room-599")).toBe(true);
+
+      await service.stop();
+    });
+  });
+
+  describe("wasActionInFilteredSet after stop", () => {
+    it("should return null after service is stopped", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      const roomId = "00000000-0000-0000-0000-000000000003";
+      await service.filter(runtime, createMockMemory("test", roomId), createMockState());
+
+      // Before stop — should have data
+      expect(service.wasActionInFilteredSet("REPLY", roomId)).toBe(true);
+
+      // After stop — should be cleared
+      await service.stop();
+      expect(service.wasActionInFilteredSet("REPLY", roomId)).toBeNull();
+    });
+  });
+
+  describe("removeAction then filter", () => {
+    it("should not return a removed action in filter results", async () => {
+      const actions = Object.values(buildMockActions());
+      const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+      const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+      // Remove SWAP_TOKENS from the index
+      service.removeAction("SWAP_TOKENS");
+
+      // Filter — SWAP_TOKENS should not be boosted by BM25/vector anymore
+      // (it's still in runtime.actions so it could appear in passthrough,
+      //  but the BM25 index won't match it)
+      const result = await service.filter(
+        runtime,
+        createMockMemory("swap tokens cryptocurrency exchange"),
+        createMockState(),
+      );
+
+      // The ranking should not boost SWAP_TOKENS since it was removed from index
+      // It may still appear since the always-include set and pool come from runtime.actions,
+      // but it won't be in the top-ranked results
+      expect(result.length).toBeGreaterThan(0);
+      expect(service.hasAction("SWAP_TOKENS")).toBe(false);
+
+      await service.stop();
+    });
+  });
+
+  describe("config boundary values", () => {
+    it("should accept threshold=0 meaning always filter", async () => {
+      const rt = createMockRuntime(Object.values(buildMockActions()), { hasEmbeddingModel: true });
+      (rt.getSetting as ReturnType<typeof vi.fn>).mockImplementation((key: string) => {
+        if (key === "ACTION_FILTER_THRESHOLD") return "0";
+        return null;
+      });
+
+      const svc = (await ActionFilterService.start(rt)) as ActionFilterService;
+      expect(svc.getConfig().threshold).toBe(0);
+
+      // Even with threshold=0, filtering activates for any action count > 0
+      const result = await svc.filter(rt, createMockMemory("test"), createMockState());
+      expect(result.length).toBeLessThanOrEqual(15); // finalTopK
+
+      await svc.stop();
+    });
+
+    it("should handle vectorWeight=0 and bm25Weight=0 gracefully", async () => {
+      const actions = Object.values(buildMockActions());
+      const svc = new ActionFilterService(undefined, {
+        vectorWeight: 0,
+        bm25Weight: 0,
+        threshold: 5,
+      });
+      const rt = createMockRuntime(actions, { hasEmbeddingModel: false });
+      await svc.buildIndex(rt);
+
+      // With both weights zero, safeTotalWeight kicks in (= 1)
+      const result = await svc.filter(rt, createMockMemory("swap"), createMockState());
+      expect(result.length).toBeGreaterThan(0);
+
+      await svc.stop();
+    });
+  });
+});
+
+// ============================================================================
+// 12. actionsProvider integration — filtered path with validation failures
+// ============================================================================
+
+describe("actionsProvider filtered path integration", () => {
+  it("should validate actions AFTER filtering and exclude invalid ones", async () => {
+    // Create 20 actions, some that fail validation
+    const manyActions: Action[] = [];
+    for (let i = 0; i < 20; i++) {
+      manyActions.push(
+        createMockAction({
+          name: `ACTION_${i}`,
+          description: `Action number ${i} for swap exchange trade`,
+          // Even-numbered actions fail validation
+          validateReturn: i % 2 !== 0,
+        }),
+      );
+    }
+
+    const mockRuntime = createMockRuntime(manyActions, { hasEmbeddingModel: true });
+    const filterService = (await ActionFilterService.start(mockRuntime)) as ActionFilterService;
+    (mockRuntime.getService as ReturnType<typeof vi.fn>).mockReturnValue(filterService);
+
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("swap exchange trade"),
+      createMockState(),
+    );
+
+    // All returned actions should have passed validation
+    for (const action of result.data.actionsData) {
+      // Verify validate was called
+      expect(action.validate).toHaveBeenCalled();
+    }
+
+    // None of the even-numbered (validation=false) actions should be in the result
+    for (const action of result.data.actionsData) {
+      const num = parseInt(action.name.split("_")[1]);
+      if (!isNaN(num)) {
+        expect(num % 2).toBe(1); // only odd-numbered pass validation
+      }
+    }
+
+    await filterService.stop();
+  });
+
+  it("should produce all four text sections with correct content", async () => {
+    const actionList = [
+      createMockAction({
+        name: "SWAP_TOKENS",
+        description: "Swap cryptocurrency tokens",
+        similes: ["trade", "exchange"],
+        tags: ["defi"],
+      }),
+    ];
+    const mockRuntime = createMockRuntime(actionList);
+
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("swap"),
+      createMockState(),
+    );
+
+    // Check that values contain all expected keys
+    expect(result.values.actionNames).toContain("SWAP_TOKENS");
+    expect(result.values.actionsWithDescriptions).toContain("Swap cryptocurrency tokens");
+    expect(typeof result.values.actionExamples).toBe("string");
+    expect(typeof result.values.actionCallExamples).toBe("string");
+
+    // Text should be the joined sections
+    expect(result.text).toContain("Possible response actions:");
+    expect(result.text).toContain("SWAP_TOKENS");
+  });
+
+  it("should produce empty text sections when no actions pass validation", async () => {
+    const noValidActions = [
+      createMockAction({ name: "BAD1", description: "Bad one", validateReturn: false }),
+      createMockAction({ name: "BAD2", description: "Bad two", validateReturn: false }),
+    ];
+    const mockRuntime = createMockRuntime(noValidActions);
+
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("test"),
+      createMockState(),
+    );
+
+    expect(result.data.actionsData.length).toBe(0);
+    expect(result.values.actionsWithDescriptions).toBe("");
+    expect(result.values.actionExamples).toBe("");
+    expect(result.values.actionCallExamples).toBe("");
+  });
+
+  it("should handle multiple validators throwing with different error types", async () => {
+    const actions = [
+      createMockAction({ name: "GOOD", description: "Good action" }),
+      createMockAction({ name: "THROWS_ERROR", description: "Throws Error" }),
+      createMockAction({ name: "THROWS_STRING", description: "Throws string" }),
+      createMockAction({ name: "THROWS_NULL", description: "Throws null" }),
+    ];
+
+    (actions[1].validate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
+    (actions[2].validate as ReturnType<typeof vi.fn>).mockRejectedValue("string error");
+    (actions[3].validate as ReturnType<typeof vi.fn>).mockRejectedValue(null);
+
+    const mockRuntime = createMockRuntime(actions);
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("test"),
+      createMockState(),
+    );
+
+    // Only the GOOD action should survive
+    expect(result.data.actionsData.length).toBe(1);
+    expect(result.data.actionsData[0].name).toBe("GOOD");
+  });
+});
+
+// ============================================================================
+// 13. End-to-end: filter + validate + format pipeline verification
+// ============================================================================
+
+describe("end-to-end pipeline", () => {
+  it("should exercise the complete filter → validate → format pipeline with data inspection", async () => {
+    const actions = Object.values(buildMockActions());
+    // Mark SWAP_TOKENS as failing validation
+    (actions.find((a) => a.name === "SWAP_TOKENS")!.validate as ReturnType<typeof vi.fn>)
+      .mockResolvedValue(false);
+
+    const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+    const filterService = (await ActionFilterService.start(runtime)) as ActionFilterService;
+    (runtime.getService as ReturnType<typeof vi.fn>).mockReturnValue(filterService);
+
+    const result = await actionsProvider.get!(
+      runtime,
+      createMockMemory("swap tokens on a decentralized exchange"),
+      createMockState(),
+    );
+
+    const names = result.data.actionsData.map((a: Action) => a.name);
+
+    // SWAP_TOKENS should have been filtered IN by relevance but excluded by validation
+    expect(names).not.toContain("SWAP_TOKENS");
+
+    // REPLY should be present (always-include + passes validation)
+    expect(names).toContain("REPLY");
+
+    // The text output should reflect only validated actions
+    expect(result.text).not.toContain("SWAP_TOKENS");
+    expect(result.text).toContain("REPLY");
+
+    // Metrics should show the filtering happened
+    const metrics = filterService.getMetrics();
+    expect(metrics.filterCalls).toBe(1);
+    expect(metrics.filteredCalls).toBe(1);
+
+    await filterService.stop();
+  });
+
+  it("should correctly rank swap-related queries above social-related actions", async () => {
+    const actions = Object.values(buildMockActions());
+    const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+    const filterService = (await ActionFilterService.start(runtime)) as ActionFilterService;
+
+    const result = await filterService.filter(
+      runtime,
+      createMockMemory("exchange my ETH for USDC tokens on DEX"),
+      createMockState(),
+    );
+
+    const names = result.map((a) => a.name);
+    const swapIdx = names.indexOf("SWAP_TOKENS");
+    const tweetIdx = names.indexOf("POST_TWEET");
+
+    // SWAP_TOKENS should appear and be ranked above POST_TWEET
+    expect(swapIdx).toBeGreaterThanOrEqual(0);
+    if (tweetIdx >= 0) {
+      expect(swapIdx).toBeLessThan(tweetIdx);
+    }
+
+    await filterService.stop();
+  });
+
+  it("should handle the full lifecycle: start → index → filter → momentum → addAction → filter → stop", async () => {
+    const actions = Object.values(buildMockActions());
+    const runtime = createMockRuntime(actions, { hasEmbeddingModel: true });
+
+    // 1. Start
+    const service = (await ActionFilterService.start(runtime)) as ActionFilterService;
+    expect(service.getMetrics().indexedActionCount).toBe(actions.length);
+
+    // 2. Filter
+    const roomId = "00000000-0000-0000-0000-000000000099";
+    const r1 = await service.filter(
+      runtime,
+      createMockMemory("swap tokens", roomId),
+      createMockState(),
+    );
+    expect(r1.length).toBeGreaterThan(0);
+    expect(r1.length).toBeLessThanOrEqual(15);
+
+    // 3. Record momentum
+    service.recordActionUse("SWAP_TOKENS", roomId);
+
+    // 4. Filter again — SWAP_TOKENS should have momentum boost
+    const r2 = await service.filter(
+      runtime,
+      createMockMemory("do something", roomId),
+      createMockState(),
+    );
+    expect(r2.map((a) => a.name)).toContain("SWAP_TOKENS");
+
+    // 5. Add new action
+    const newAction = createMockAction({
+      name: "NEW_ACTION",
+      description: "A brand new action for testing",
+      tags: ["testing"],
+    });
+    await service.addAction(newAction, runtime);
+    expect(service.hasAction("NEW_ACTION")).toBe(true);
+
+    // 6. Filter with query matching new action
+    // Append to runtime.actions so filter() can find it
+    runtime.actions.push(newAction);
+    const r3 = await service.filter(
+      runtime,
+      createMockMemory("testing brand new action"),
+      createMockState(),
+    );
+    const r3Names = r3.map((a) => a.name);
+    expect(r3Names).toContain("NEW_ACTION");
+
+    // 7. Verify metrics accumulated
+    const metrics = service.getMetrics();
+    expect(metrics.filterCalls).toBe(3);
+    expect(metrics.filteredCalls).toBe(3);
+
+    // 8. Stop
+    await service.stop();
+    expect(service.getMetrics().indexedActionCount).toBe(0);
+    expect(service.wasActionInFilteredSet("REPLY", roomId)).toBeNull();
+  });
+});
+
+// ============================================================================
+// 14. LARP-proofing: verify real behavior, not just mock coverage
+// ============================================================================
+
+describe("LARP-proofing", () => {
+  it("should track embedFailureCount when embedding model returns invalid data", async () => {
+    const actions = Object.values(buildMockActions());
+    const badRuntime = createMockRuntime(actions, {
+      hasEmbeddingModel: true,
+      useModelFn: vi.fn().mockResolvedValue([NaN, NaN, NaN]),
+    });
+    const service = (await ActionFilterService.start(badRuntime)) as ActionFilterService;
+
+    const metrics = service.getMetrics();
+    // All 22 actions should have failed embedding
+    expect(metrics.embedFailureCount).toBe(actions.length);
+    expect(metrics.indexedActionCount).toBe(actions.length); // BM25 still indexes them
+
+    await service.stop();
+  });
+
+  it("should track embedFailureCount when embedding model throws", async () => {
+    const actions = Object.values(buildMockActions());
+    const throwingRuntime = createMockRuntime(actions, {
+      hasEmbeddingModel: true,
+      useModelFn: vi.fn().mockRejectedValue(new Error("model down")),
+    });
+    const service = (await ActionFilterService.start(throwingRuntime)) as ActionFilterService;
+
+    const metrics = service.getMetrics();
+    expect(metrics.embedFailureCount).toBe(actions.length);
+
+    await service.stop();
+  });
+
+  it("provider should call filterService even for small action counts (no hardcoded threshold)", async () => {
+    // 5 actions — below any reasonable threshold
+    const smallActions = [
+      createMockAction({ name: "REPLY", description: "Reply", alwaysInclude: true }),
+      createMockAction({ name: "A", description: "Action A" }),
+      createMockAction({ name: "B", description: "Action B" }),
+      createMockAction({ name: "C", description: "Action C" }),
+      createMockAction({ name: "D", description: "Action D" }),
+    ];
+
+    const mockRuntime = createMockRuntime(smallActions, { hasEmbeddingModel: true });
+
+    // Create filter service with threshold=0 so it always filters
+    const filterService = new ActionFilterService(mockRuntime, { threshold: 0 });
+    await filterService.buildIndex(mockRuntime);
+    (mockRuntime.getService as ReturnType<typeof vi.fn>).mockReturnValue(filterService);
+
+    // The provider should now call filterService.filter() even for 5 actions
+    // because the hardcoded FILTER_THRESHOLD has been removed
+    const result = await actionsProvider.get!(
+      mockRuntime,
+      createMockMemory("test query"),
+      createMockState(),
+    );
+
+    // filterService was called (verify via metrics)
+    const metrics = filterService.getMetrics();
+    expect(metrics.filterCalls).toBe(1);
+    // With threshold=0, 5 actions > 0, so filtering was active
+    // But candidatePool (5 - 1 always-include = 4) is <= finalTopK (15),
+    // so it falls through to returning all.  The key point is filterCalls=1.
+    expect(result.data.actionsData.length).toBeGreaterThan(0);
+
+    await filterService.stop();
+  });
+
+  it("BM25 search produces numerically correct scores for a known corpus", () => {
+    // Manually verify BM25 math for a tiny corpus
+    const index = new BM25Index();
+    index.addDocument("d1", "hello world");
+    index.addDocument("d2", "hello there");
+
+    // Query "hello" — appears in both docs, so low IDF
+    // Query "world" — appears in 1 doc, so higher IDF
+    const helloResults = index.search("hello");
+    const worldResults = index.search("world");
+
+    expect(helloResults.length).toBe(2);
+    expect(worldResults.length).toBe(1);
+
+    // "world" has higher IDF than "hello" (1/2 docs vs 2/2 docs)
+    // So the single doc matching "world" should score higher than
+    // the docs matching just "hello"
+    expect(worldResults[0].score).toBeGreaterThan(helloResults[0].score);
+
+    // Note: d1="hello world" has 2 tokens, d2="hello there" has 1 token
+    // ("there" is a stopword and gets filtered). So d2 is shorter and
+    // BM25 length normalization gives it a higher score for "hello".
+    expect(helloResults[0].score).toBeGreaterThanOrEqual(helloResults[1].score);
+
+    // Combined query: d1 matches both terms, d2 matches one
+    const combinedResults = index.search("hello world");
+    expect(combinedResults[0].id).toBe("d1");
+    expect(combinedResults[0].score).toBeGreaterThan(combinedResults[1].score);
+  });
+
+  it("cosine similarity produces correct value for a hand-calculated example", () => {
+    // a = [3, 4], b = [4, 3]
+    // dot(a,b) = 3*4 + 4*3 = 24
+    // ||a|| = sqrt(9+16) = 5
+    // ||b|| = sqrt(16+9) = 5
+    // cos(a,b) = 24/25 = 0.96
+    const result = cosineSimilarity([3, 4], [4, 3]);
+    expect(result).toBeCloseTo(0.96, 10);
+  });
+
+  it("minMaxNormalize preserves relative ordering of input values", () => {
+    const input = [5, 2, 8, 1, 9, 3];
+    const result = minMaxNormalize(input);
+
+    // Verify ordering preserved
+    for (let i = 0; i < input.length; i++) {
+      for (let j = i + 1; j < input.length; j++) {
+        if (input[i] > input[j]) {
+          expect(result[i]).toBeGreaterThan(result[j]);
+        } else if (input[i] < input[j]) {
+          expect(result[i]).toBeLessThan(result[j]);
+        } else {
+          expect(result[i]).toBeCloseTo(result[j], 10);
+        }
+      }
+    }
+
+    // Verify min maps to 0 and max maps to 1
+    expect(Math.min(...result)).toBe(0);
+    expect(Math.max(...result)).toBe(1);
+  });
+});

--- a/packages/typescript/src/bootstrap/index.ts
+++ b/packages/typescript/src/bootstrap/index.ts
@@ -16,6 +16,7 @@ import { RolodexService } from "../services/rolodex.ts";
 import { TaskService } from "../services/task.ts";
 import { ToolPolicyService } from "../services/tool-policy.ts";
 import { TrajectoryLoggerService } from "../services/trajectoryLogger.ts";
+import { ActionFilterService } from "../services/action-filter.ts";
 import { Role } from "../types/environment.ts";
 import { EventType } from "../types/events.ts";
 import type {
@@ -1225,6 +1226,7 @@ const basic = {
     EmbeddingGenerationService,
     ToolPolicyService,
     TrajectoryLoggerService,
+    ActionFilterService,
   ] as ServiceClass[],
 };
 

--- a/packages/typescript/src/bootstrap/providers/actions.ts
+++ b/packages/typescript/src/bootstrap/providers/actions.ts
@@ -4,6 +4,8 @@ import {
   formatActionNames,
   formatActions,
 } from "../../actions.ts";
+import { logger } from "../../logger.ts";
+import type { ActionFilterService } from "../../services/action-filter.ts";
 import type {
   Action,
   IAgentRuntime,
@@ -13,57 +15,57 @@ import type {
 } from "../../types/index.ts";
 import { addHeader } from "../../utils.ts";
 
-/**
- * A provider object that fetches possible response actions based on the provided runtime, message, and state.
- * @type {Provider}
- * @property {string} name - The name of the provider ("ACTIONS").
- * @property {string} description - The description of the provider ("Possible response actions").
- * @property {number} position - The position of the provider (-1).
- * @property {Function} get - Asynchronous function that retrieves actions that validate for the given message.
- * @param {IAgentRuntime} runtime - The runtime object.
- * @param {Memory} message - The message memory.
- * @param {State} state - The state object.
- * @returns {Object} An object containing the actions data, values, and combined text sections.
- */
-/**
- * Provider for ACTIONS
- *
- * @typedef {import('./Provider').Provider} Provider
- * @typedef {import('./Runtime').IAgentRuntime} IAgentRuntime
- * @typedef {import('./Memory').Memory} Memory
- * @typedef {import('./State').State} State
- * @typedef {import('./Action').Action} Action
- *
- * @type {Provider}
- * @property {string} name - The name of the provider
- * @property {string} description - Description of the provider
- * @property {number} position - The position of the provider
- * @property {Function} get - Asynchronous function to get actions that validate for a given message
- *
- * @param {IAgentRuntime} runtime - The agent runtime
- * @param {Memory} message - The message memory
- * @param {State} state - The state of the agent
- * @returns {Object} Object containing data, values, and text related to actions
- */
+/** Validate actions in parallel; individual validator errors are caught and logged. */
+async function validateActions(
+  actions: Action[],
+  runtime: IAgentRuntime,
+  message: Memory,
+  state: State,
+): Promise<Action[]> {
+  const results = await Promise.all(
+    actions.map(async (action) => {
+      try {
+        const valid = await action.validate(runtime, message, state);
+        return valid ? action : null;
+      } catch (err) {
+        logger.warn(
+          {
+            src: "provider:actions",
+            agentId: runtime.agentId,
+            action: action.name,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Action validation threw — excluding action from prompt",
+        );
+        return null;
+      }
+    }),
+  );
+  return results.filter((a): a is Action => a !== null);
+}
+
+/** ACTIONS provider — filters by relevance (if service available), then validates. */
 export const actionsProvider: Provider = {
   name: "ACTIONS",
   description: "Possible response actions",
   position: -1,
   get: async (runtime: IAgentRuntime, message: Memory, state: State) => {
-    // Get actions that validate for this message
-    const actionPromises = runtime.actions.map(async (action: Action) => {
-      const result = await action.validate(runtime, message, state);
-      if (result) {
-        return action;
-      }
-      return null;
-    });
+    const filterService = runtime.getService<ActionFilterService>("action_filter");
 
-    const resolvedActions = await Promise.all(actionPromises);
+    let actionsData: Action[];
 
-    const actionsData = resolvedActions.filter(Boolean) as Action[];
+    if (filterService) {
+      const candidates = await filterService.filter(runtime, message, state);
+      actionsData = await validateActions(candidates, runtime, message, state);
+    } else {
+      actionsData = await validateActions(
+        runtime.actions,
+        runtime,
+        message,
+        state,
+      );
+    }
 
-    // Format action-related texts
     const actionNames = `Possible response actions: ${formatActionNames(actionsData)}`;
 
     const actionsWithDescriptions =
@@ -84,10 +86,6 @@ export const actionsProvider: Provider = {
           )
         : "";
 
-    const _data = {
-      actionsData,
-    };
-
     const values = {
       actionNames,
       actionExamples,
@@ -95,7 +93,6 @@ export const actionsProvider: Provider = {
       actionsWithDescriptions,
     };
 
-    // Combine all text sections - now including actionsWithDescriptions
     const text = [
       actionNames,
       actionsWithDescriptions,

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -22,6 +22,7 @@ import { createLogger } from "./logger";
 import { BM25 } from "./search";
 import { redactWithSecrets } from "./security/redact.js";
 import { DefaultMessageService } from "./services/message";
+import type { ActionFilterService } from "./services/action-filter";
 import type { ToolPolicyService } from "./services/tool-policy";
 import { decryptSecret, getSalt } from "./settings";
 import {
@@ -1219,6 +1220,26 @@ export class AgentRuntime implements IAgentRuntime {
     } else {
       this.actions.push(canonical);
       this._actionIndex = null; // Invalidate cached index
+
+      // Notify the ActionFilterService so it can index the new action for
+      // BM25 + vector retrieval.  This is fire-and-forget — we don't
+      // block registration on embedding computation.
+      const filterService =
+        this.getService<ActionFilterService>("action_filter");
+      if (filterService) {
+        filterService.addAction(canonical, this).catch((err) => {
+          this.logger.warn(
+            {
+              src: "agent",
+              agentId: this.agentId,
+              action: canonical.name,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            "Failed to add action to filter index",
+          );
+        });
+      }
+
       this.logger.debug(
         { src: "agent", agentId: this.agentId, action: canonical.name },
         "Action registered",
@@ -1372,6 +1393,29 @@ export class AgentRuntime implements IAgentRuntime {
   // Helper functions for immutable action plan updates
   private updateActionPlan<T>(plan: T, updates: Partial<T>): T {
     return { ...plan, ...updates };
+  }
+
+  /**
+   * If the ActionFilterService filtered this room's actions, check whether
+   * `actionName` was excluded.  If so, report a filter miss (the LLM
+   * selected an action that wasn't in the prompt).
+   */
+  private checkFilterMiss(roomId: string | undefined, actionName: string): void {
+    if (!roomId) return;
+    const filterSvc = this.getService<ActionFilterService>("action_filter");
+    if (!filterSvc) return;
+    const inSet = filterSvc.wasActionInFilteredSet(actionName, roomId);
+    if (inSet === false) {
+      filterSvc.reportMiss(actionName);
+      this.logger.warn(
+        {
+          src: "agent",
+          agentId: this.agentId,
+          action: actionName,
+        },
+        "LLM selected an action that was filtered out — filter may be too aggressive",
+      );
+    }
   }
 
   private updateActionStep<T, S>(
@@ -1627,6 +1671,9 @@ export class AgentRuntime implements IAgentRuntime {
             "Action not found",
           );
 
+          // Report a filter miss if the unresolved name was filtered out
+          this.checkFilterMiss(message.roomId, responseAction);
+
           if (actionPlan?.steps?.[actionIndex]) {
             actionPlan = this.updateActionStep(actionPlan, actionIndex, {
               status: "failed",
@@ -1652,6 +1699,9 @@ export class AgentRuntime implements IAgentRuntime {
           actionIndex++;
           continue;
         }
+        // Check if the LLM selected an action that the filter removed
+        this.checkFilterMiss(message.roomId, action.name);
+
         if (!action.handler) {
           this.logger.error(
             { src: "agent", agentId: this.agentId, action: action.name },
@@ -1922,6 +1972,17 @@ export class AgentRuntime implements IAgentRuntime {
 
         const isSuccess = actionResult?.success !== false;
         const statusText = isSuccess ? "completed" : "failed";
+
+        // ── Conversation momentum ─────────────────────────────────────
+        // Record successful action usage so the filter service can boost
+        // it in subsequent turns within the same room.
+        if (isSuccess && message.roomId) {
+          const filterSvc =
+            this.getService<ActionFilterService>("action_filter");
+          if (filterSvc) {
+            filterSvc.recordActionUse(action.name, message.roomId);
+          }
+        }
 
         await this.emitEvent(EventType.ACTION_COMPLETED, {
           messageId: actionId,
@@ -2529,6 +2590,94 @@ export class AgentRuntime implements IAgentRuntime {
         providerNames.add(name);
       }
     }
+
+    // ── Provider relevance filtering ──────────────────────────────────
+    // 1. Providers with alwaysRun=true are always included regardless
+    //    of any filter/include list logic.
+    // 2. Dynamic providers with relevanceKeywords are auto-activated
+    //    when any keyword matches the message text, even if not
+    //    explicitly included.
+    const messageTextLower =
+      typeof message.content?.text === "string"
+        ? message.content.text.toLowerCase()
+        : "";
+
+    for (const p of this.providers) {
+      // alwaysRun providers bypass all filtering
+      if (p.alwaysRun && !p.private) {
+        providerNames.add(p.name);
+      }
+
+      // Dynamic providers with relevanceKeywords get auto-activated
+      // when a keyword matches the message.  This only applies when
+      // we're NOT in a strict filter-only mode (onlyInclude=true with
+      // a specific list), because that mode means the caller wants
+      // exact control.
+      if (
+        !filterList &&
+        p.dynamic &&
+        !p.private &&
+        p.relevanceKeywords &&
+        p.relevanceKeywords.length > 0 &&
+        messageTextLower.length > 0
+      ) {
+        for (const kw of p.relevanceKeywords) {
+          if (messageTextLower.includes(kw.toLowerCase())) {
+            providerNames.add(p.name);
+            break;
+          }
+        }
+      }
+    }
+
+    // ── BM25-based dynamic provider filtering ─────────────────────
+    // If the ActionFilterService is available, use its provider BM25
+    // index to auto-include dynamic providers whose descriptions are
+    // relevant to the current message. This extends the keyword-based
+    // matching above with semantic term matching.
+    // Only applies when NOT in strict filter-only mode.
+    if (!filterList) {
+      const actionFilterSvc =
+        this.getService<ActionFilterService>("action_filter");
+      if (actionFilterSvc) {
+        try {
+          const dynamicProviders = this.providers.filter(
+            (p) => p.dynamic && !p.private && !providerNames.has(p.name),
+          );
+          if (dynamicProviders.length > 0) {
+            const relevantNames = actionFilterSvc.filterProviders(
+              dynamicProviders,
+              message,
+              cachedState,
+            );
+            for (const name of relevantNames) {
+              providerNames.add(name);
+            }
+            if (relevantNames.length > 0) {
+              this.logger.debug(
+                {
+                  src: "agent",
+                  agentId: this.agentId,
+                  bm25Providers: relevantNames,
+                },
+                "BM25 auto-included dynamic providers",
+              );
+            }
+          }
+        } catch (err) {
+          // BM25 provider filtering is best-effort; never break composeState
+          this.logger.warn(
+            {
+              src: "agent",
+              agentId: this.agentId,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            "BM25 provider filtering failed — continuing without it",
+          );
+        }
+      }
+    }
+
     const providersToGet: Provider[] = [];
     for (const provider of this.providers) {
       if (providerNames.has(provider.name)) {

--- a/packages/typescript/src/services/action-filter.ts
+++ b/packages/typescript/src/services/action-filter.ts
@@ -1,0 +1,884 @@
+/**
+ * ActionFilterService — dynamically filters which actions are shown to the LLM
+ * based on relevance to the current message.
+ *
+ * Two-tier ranking:
+ *   1. Vector search: embed action descriptions + similes at registration time.
+ *      At message time, embed the query (user message + context). Use cosine
+ *      similarity to get the top candidates.
+ *   2. BM25 reranking: rerank the vector-search candidates using BM25
+ *      (term-frequency * inverse-document-frequency). BM25 is especially good
+ *      at matching specific keywords that vector search might miss.
+ *
+ * Graceful degradation:
+ *   - If the embedding model is unavailable → BM25-only ranking.
+ *   - If BM25 also fails → return all actions (same as before).
+ */
+
+import { logger } from "../logger.ts";
+import type { Action, IAgentRuntime, Memory, Provider } from "../types/index.ts";
+import { ModelType } from "../types/model.ts";
+import { Service } from "../types/service.ts";
+import type { State } from "../types/state.ts";
+import { BM25Index } from "./bm25.ts";
+import { cosineSimilarity } from "./cosine-similarity.ts";
+
+declare module "../types/service.ts" {
+  interface ServiceTypeRegistry {
+    ACTION_FILTER: "action_filter";
+  }
+}
+
+export interface RankedAction {
+  action: Action;
+  /** Cosine similarity against the query embedding (0-1 range, 0 if unavailable). */
+  vectorScore: number;
+  /** BM25 score against the query text (0+ range, 0 if unavailable). */
+  bm25Score: number;
+  /** Weighted combination of vectorScore and bm25Score, plus momentum boost. */
+  combinedScore: number;
+}
+
+export interface FilterConfig {
+  /** Master switch — if false the service is a no-op. */
+  enabled: boolean;
+  /** Minimum registered action count before filtering kicks in. */
+  threshold: number;
+  /** How many candidates to pull from the vector search stage. */
+  vectorTopK: number;
+  /** Final number of actions returned after reranking. */
+  finalTopK: number;
+  /** Weight for the normalized vector score in the combined score (0-1). */
+  vectorWeight: number;
+  /** Weight for the normalized BM25 score in the combined score (0-1). */
+  bm25Weight: number;
+  /** Action names that always bypass filtering (in addition to per-action alwaysInclude). */
+  alwaysIncludeActions: string[];
+  /** Time window (ms) for conversation momentum decay. */
+  momentumDecayMs: number;
+  /** Score boost for recently used actions (0-1). */
+  momentumBoost: number;
+}
+
+export interface FilterMetrics {
+  /** Total number of filter() invocations. */
+  filterCalls: number;
+  /** How many times filtering was actually applied (vs. passthrough). */
+  filteredCalls: number;
+  /** How many times we fell back to BM25-only (embedding unavailable). */
+  bm25OnlyFallbacks: number;
+  /** How many times we fell back to returning all actions (complete failure). */
+  fullFallbacks: number;
+  /** Reported misses — actions that were filtered out but then selected by the LLM. */
+  missCount: number;
+  /** Names of missed actions for debugging (bounded ring buffer). */
+  missedActions: string[];
+  /** Average combined-score of returned actions (last call). */
+  lastAvgScore: number;
+  /** Number of actions in the embedding index. */
+  indexedActionCount: number;
+  /** Number of actions whose embedding failed during buildIndex or addAction. */
+  embedFailureCount: number;
+}
+
+interface RecentActionEntry {
+  name: string;
+  timestamp: number;
+  roomId: string;
+}
+
+const DEFAULT_CONFIG: FilterConfig = {
+  enabled: true,
+  threshold: 15,
+  vectorTopK: 30,
+  finalTopK: 15,
+  vectorWeight: 0.6,
+  bm25Weight: 0.4,
+  // Core actions that must always appear in the LLM prompt.
+  alwaysIncludeActions: ["REPLY", "IGNORE", "NONE"],
+  momentumDecayMs: 300_000, // 5 minutes
+  momentumBoost: 0.15,
+};
+
+/** Maximum number of missed-action names we keep in memory. */
+const MAX_MISSED_ACTIONS = 100;
+/** When the ring buffer overflows, keep the most recent half. */
+const MISSED_ACTIONS_TRIM = 50;
+
+/** Default number of top-scoring providers to return from filterProviders. */
+const DEFAULT_PROVIDER_TOP_K = 5;
+
+function freshMetrics(): FilterMetrics {
+  return {
+    filterCalls: 0,
+    filteredCalls: 0,
+    bm25OnlyFallbacks: 0,
+    fullFallbacks: 0,
+    missCount: 0,
+    missedActions: [],
+    lastAvgScore: 0,
+    indexedActionCount: 0,
+    embedFailureCount: 0,
+  };
+}
+
+/**
+ * Build a rich text blob from an action's metadata, suitable for both
+ * embedding and BM25 indexing.
+ */
+export function getActionEmbeddingText(action: Action): string {
+  const parts: string[] = [
+    action.name.replace(/_/g, " "),
+  ];
+  if (action.description) parts.push(action.description);
+  if (action.similes?.length) parts.push(action.similes.join(", "));
+  if (action.tags?.length) parts.push(action.tags.join(", "));
+  if (action.parameters?.length) {
+    for (const p of action.parameters) {
+      parts.push(`${p.name}: ${p.description}`);
+    }
+  }
+  return parts.join(" | ");
+}
+
+/**
+ * Build a text blob from a provider's metadata for BM25 indexing.
+ * Includes name, description, and relevanceKeywords.
+ */
+export function getProviderIndexText(provider: Provider): string {
+  const parts: string[] = [
+    provider.name.replace(/_/g, " "),
+  ];
+  if (provider.description) parts.push(provider.description);
+  if (provider.relevanceKeywords?.length) {
+    parts.push(provider.relevanceKeywords.join(", "));
+  }
+  return parts.join(" | ");
+}
+
+/**
+ * Build the query text used for vector + BM25 matching against the action
+ * index. Includes the user message, recent conversation context, and any
+ * detected intent keywords.
+ */
+export function buildQueryText(message: Memory, state: State): string {
+  const parts: string[] = [];
+
+  // Current message text
+  const messageText = message.content?.text;
+  if (messageText) {
+    parts.push(messageText);
+  }
+
+  // Recent messages from state (providers populate this).
+  // We look at a few known locations where conversation context may live.
+  const recentMessagesValue = state.values?.recentMessages;
+  if (typeof recentMessagesValue === "string" && recentMessagesValue.length > 0) {
+    // Truncate to last ~500 chars to keep the query focused
+    const trimmed =
+      recentMessagesValue.length > 500
+        ? recentMessagesValue.slice(-500)
+        : recentMessagesValue;
+    parts.push(trimmed);
+  }
+
+  // Action plan context (if the agent is mid-plan, bias toward plan actions)
+  const steps = state.data?.actionPlan?.steps as
+    | Array<{ status: string; action?: string }>
+    | undefined;
+  if (steps) {
+    const pending = steps
+      .filter((s) => s.status === "pending" && s.action)
+      .map((s) => s.action!);
+    if (pending.length > 0) {
+      parts.push(`Planned actions: ${pending.join(", ")}`);
+    }
+  }
+
+  return parts.join("\n");
+}
+
+/**
+ * Normalize an array of scores to [0, 1] using min-max normalization.
+ * Returns an array of the same length. If all values are the same,
+ * returns an array of 1s (or 0s if all are 0).
+ *
+ * NaN and Infinity values are sanitized to 0 before normalization.
+ */
+export function minMaxNormalize(scores: number[]): number[] {
+  if (scores.length === 0) return [];
+
+  // Sanitize: NaN / Infinity → 0
+  const sanitized = scores.map((s) =>
+    Number.isFinite(s) ? s : 0,
+  );
+
+  let min = sanitized[0];
+  let max = sanitized[0];
+  for (let i = 1; i < sanitized.length; i++) {
+    if (sanitized[i] < min) min = sanitized[i];
+    if (sanitized[i] > max) max = sanitized[i];
+  }
+  const range = max - min;
+  if (range === 0 || !Number.isFinite(range)) {
+    // All scores identical or range overflowed — return 1 if non-zero, 0 otherwise
+    return sanitized.map((s) => (s > 0 ? 1 : 0));
+  }
+  return sanitized.map((s) => {
+    const normalized = (s - min) / range;
+    return Number.isFinite(normalized) ? normalized : 0;
+  });
+}
+
+export class ActionFilterService extends Service {
+  static serviceType = "action_filter" as const;
+  capabilityDescription =
+    "Filters actions by relevance using vector search and BM25 reranking";
+
+  private actionEmbeddings: Map<string, number[]> = new Map();
+
+  private bm25Index: BM25Index = new BM25Index();
+
+  /** Separate BM25 index for provider descriptions, used by filterProviders(). */
+  private providerBM25Index: BM25Index = new BM25Index();
+
+  private filterConfig: FilterConfig;
+
+  private recentActions: RecentActionEntry[] = [];
+  private readonly maxRecentActions = 200;
+
+  private lastFilteredByRoom: Map<string, Set<string>> = new Map();
+  private readonly maxTrackedRooms = 500;
+
+  private metrics: FilterMetrics = freshMetrics();
+
+  private embeddingAvailable = false;
+
+  constructor(runtime?: IAgentRuntime, config?: Partial<FilterConfig>) {
+    super(runtime);
+    this.filterConfig = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /** Start the service. Reads ACTION_FILTER_* from runtime settings, then builds indices. */
+  static async start(runtime: IAgentRuntime): Promise<Service> {
+    const configOverrides = readFilterConfigFromRuntime(runtime);
+    const service = new ActionFilterService(runtime, configOverrides);
+
+    const embeddingModel = runtime.getModel(ModelType.TEXT_EMBEDDING);
+    service.embeddingAvailable = !!embeddingModel;
+
+    if (!service.embeddingAvailable) {
+      logger.warn(
+        {
+          src: "service:action-filter",
+          agentId: runtime.agentId,
+        },
+        "No TEXT_EMBEDDING model registered — ActionFilterService will use BM25-only mode",
+      );
+    }
+
+    await service.buildIndex(runtime);
+
+    logger.info(
+      {
+        src: "service:action-filter",
+        agentId: runtime.agentId,
+        actionCount: runtime.actions.length,
+        embeddingAvailable: service.embeddingAvailable,
+      },
+      "ActionFilterService started",
+    );
+
+    return service;
+  }
+
+  async stop(): Promise<void> {
+    this.actionEmbeddings.clear();
+    this.bm25Index = new BM25Index();
+    this.providerBM25Index = new BM25Index();
+    this.recentActions = [];
+    this.lastFilteredByRoom.clear();
+    this.metrics = freshMetrics();
+    logger.info(
+      { src: "service:action-filter" },
+      "ActionFilterService stopped",
+    );
+  }
+
+  /**
+   * Build (or rebuild) the vector + BM25 index for all registered actions.
+   * Also builds the provider BM25 index for dynamic provider filtering.
+   */
+  async buildIndex(runtime: IAgentRuntime): Promise<void> {
+    this.actionEmbeddings.clear();
+    this.bm25Index = new BM25Index();
+    this.providerBM25Index = new BM25Index();
+
+    // ── Action index ───────────────────────────────────────────────
+    const actions = runtime.actions;
+    if (actions.length > 0) {
+      for (const action of actions) {
+        const text = getActionEmbeddingText(action);
+        this.bm25Index.addDocument(action.name, text);
+      }
+
+      if (this.embeddingAvailable) {
+        // Embed in batches to avoid flooding the model
+        const batchSize = 10;
+        for (let i = 0; i < actions.length; i += batchSize) {
+          const batch = actions.slice(i, i + batchSize);
+          const embedPromises = batch.map(async (action) => {
+            try {
+              const text = getActionEmbeddingText(action);
+              const embedding: number[] = await runtime.useModel(
+                ModelType.TEXT_EMBEDDING,
+                { text },
+              );
+              if (isValidEmbedding(embedding)) {
+                this.actionEmbeddings.set(action.name, embedding);
+              } else {
+                logger.warn(
+                  {
+                    src: "service:action-filter",
+                    action: action.name,
+                  },
+                  "Embedding model returned invalid vector (NaN/empty) — action available via BM25 only",
+                );
+                this.metrics.embedFailureCount++;
+              }
+            } catch (err) {
+              logger.warn(
+                {
+                  src: "service:action-filter",
+                  action: action.name,
+                  error: err instanceof Error ? err.message : String(err),
+                },
+                "Failed to embed action — it will still be available via BM25",
+              );
+              this.metrics.embedFailureCount++;
+            }
+          });
+          await Promise.all(embedPromises);
+        }
+      }
+    }
+
+    this.metrics.indexedActionCount = actions.length;
+
+    // ── Provider BM25 index ────────────────────────────────────────
+    // Index all providers that have a description so filterProviders()
+    // can score dynamic providers by relevance.
+    const providers = runtime.providers;
+    if (providers && providers.length > 0) {
+      let indexedProviders = 0;
+      for (const provider of providers) {
+        if (provider.description) {
+          const text = getProviderIndexText(provider);
+          this.providerBM25Index.addDocument(provider.name, text);
+          indexedProviders++;
+        }
+      }
+      if (indexedProviders > 0) {
+        logger.debug(
+          {
+            src: "service:action-filter",
+            indexedProviders,
+          },
+          "Provider BM25 index built",
+        );
+      }
+    }
+  }
+
+  /**
+   * Add a single action to the index at runtime (e.g. when a plugin
+   * registers a new action after startup).
+   */
+  async addAction(action: Action, runtime: IAgentRuntime): Promise<void> {
+    const text = getActionEmbeddingText(action);
+
+    this.bm25Index.addDocument(action.name, text);
+
+    if (this.embeddingAvailable) {
+      try {
+        const embedding: number[] = await runtime.useModel(
+          ModelType.TEXT_EMBEDDING,
+          { text },
+        );
+        if (isValidEmbedding(embedding)) {
+          this.actionEmbeddings.set(action.name, embedding);
+        }
+      } catch (err) {
+        logger.warn(
+          {
+            src: "service:action-filter",
+            action: action.name,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Failed to embed new action",
+        );
+        this.metrics.embedFailureCount++;
+      }
+    }
+
+    this.metrics.indexedActionCount = this.bm25Index.size;
+  }
+
+  /**
+   * Remove an action from both indices (e.g. when a plugin is unloaded).
+   */
+  removeAction(actionName: string): void {
+    this.bm25Index.removeDocument(actionName);
+    this.actionEmbeddings.delete(actionName);
+    this.metrics.indexedActionCount = this.bm25Index.size;
+  }
+
+  /**
+   * Filter the registered actions to the most relevant subset for this message.
+   *
+   * Flow:
+   *  1. If action count <= threshold → return all (same as validate-all path).
+   *  2. Always-include actions bypass filtering and are prepended to results.
+   *  3. Vector search: embed query → cosine similarity → top vectorTopK.
+   *  4. BM25 rerank: score vectorTopK candidates → combine scores.
+   *  5. Apply momentum boost for recently used actions.
+   *  6. Return top finalTopK actions.
+   *
+   * The returned actions have NOT been validated — the caller (actionsProvider)
+   * is responsible for running `validate()` on the returned set.
+   */
+  async filter(
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State,
+  ): Promise<Action[]> {
+    this.metrics.filterCalls++;
+
+    const allActions = runtime.actions;
+
+    if (!this.filterConfig.enabled || allActions.length <= this.filterConfig.threshold) {
+      return allActions;
+    }
+
+    this.metrics.filteredCalls++;
+
+    const alwaysIncludeSet = new Set(
+      this.filterConfig.alwaysIncludeActions.map((n) => n.toUpperCase()),
+    );
+    const alwaysIncluded: Action[] = [];
+    const candidatePool: Action[] = [];
+
+    for (const action of allActions) {
+      if (
+        alwaysIncludeSet.has(action.name.toUpperCase()) ||
+        (action.tags?.includes("always-include") ?? false)
+      ) {
+        alwaysIncluded.push(action);
+      } else {
+        candidatePool.push(action);
+      }
+    }
+
+    if (candidatePool.length <= this.filterConfig.finalTopK) {
+      return allActions;
+    }
+
+    try {
+      const ranked = await this.rankActions(
+        runtime,
+        candidatePool,
+        message,
+        state,
+      );
+
+      const slotsForRanked = Math.max(
+        1,
+        this.filterConfig.finalTopK - alwaysIncluded.length,
+      );
+      const topRanked = ranked.slice(0, slotsForRanked);
+
+      if (topRanked.length > 0) {
+        const sum = topRanked.reduce((acc, r) => acc + r.combinedScore, 0);
+        this.metrics.lastAvgScore = sum / topRanked.length;
+      }
+
+      const resultNames = new Set(alwaysIncluded.map((a) => a.name));
+      const result = [...alwaysIncluded];
+      for (const ra of topRanked) {
+        if (!resultNames.has(ra.action.name)) {
+          result.push(ra.action);
+          resultNames.add(ra.action.name);
+        }
+      }
+
+      // Track which actions made it through filtering for this room
+      // so processActions can detect false negatives later.
+      const roomId = message.roomId;
+      if (roomId) {
+        this.lastFilteredByRoom.set(roomId, resultNames);
+        if (this.lastFilteredByRoom.size > this.maxTrackedRooms) {
+          const oldest = this.lastFilteredByRoom.keys().next().value;
+          if (oldest !== undefined) {
+            this.lastFilteredByRoom.delete(oldest);
+          }
+        }
+      }
+
+      return result;
+    } catch (err) {
+      // Complete failure → return all actions (graceful degradation)
+      logger.error(
+        {
+          src: "service:action-filter",
+          error: err instanceof Error ? err.message : String(err),
+        },
+        "Action filtering failed — returning all actions",
+      );
+      this.metrics.fullFallbacks++;
+      return allActions;
+    }
+  }
+
+  /**
+   * Score providers by relevance to the current message using BM25.
+   * Returns provider names sorted by relevance score, highest first.
+   * Only scores providers that have been indexed (i.e. have a description).
+   *
+   * This is used by composeState() to auto-include dynamic providers
+   * that are relevant to the current message, without requiring explicit
+   * relevanceKeywords on each provider.
+   *
+   * @param providers - The candidate providers to score (typically dynamic providers).
+   * @param message - The current message being processed.
+   * @param state - The current state (used to build query context).
+   * @param topK - Maximum number of provider names to return (default: 5).
+   * @returns Provider names sorted by descending BM25 relevance score.
+   */
+  filterProviders(
+    providers: Provider[],
+    message: Memory,
+    state: State,
+    topK: number = DEFAULT_PROVIDER_TOP_K,
+  ): string[] {
+    if (this.providerBM25Index.size === 0 || providers.length === 0) {
+      return [];
+    }
+
+    // Build query text from the message (reuse the same logic as action filtering)
+    const queryText = buildQueryText(message, state);
+    if (!queryText || queryText.trim().length === 0) {
+      return [];
+    }
+
+    // Only score providers that are in our index
+    const candidateIds = providers
+      .filter((p) => this.providerBM25Index.has(p.name))
+      .map((p) => p.name);
+
+    if (candidateIds.length === 0) {
+      return [];
+    }
+
+    const results = this.providerBM25Index.searchSubset(
+      queryText,
+      candidateIds,
+      topK,
+    );
+
+    return results.map((r) => r.id);
+  }
+
+  /**
+   * Record that an action was used, so future queries in the same room
+   * receive a momentum boost for that action.
+   */
+  recordActionUse(actionName: string, roomId: string): void {
+    this.recentActions.push({
+      name: actionName,
+      timestamp: Date.now(),
+      roomId,
+    });
+
+    if (this.recentActions.length > this.maxRecentActions) {
+      this.recentActions = this.recentActions.slice(-this.maxRecentActions);
+    }
+  }
+
+  getMetrics(): FilterMetrics {
+    return {
+      ...this.metrics,
+      missedActions: [...this.metrics.missedActions],
+    };
+  }
+
+  reportMiss(actionName: string): void {
+    this.metrics.missCount++;
+    this.metrics.missedActions.push(actionName);
+    // Keep missedActions bounded as a ring buffer
+    if (this.metrics.missedActions.length > MAX_MISSED_ACTIONS) {
+      this.metrics.missedActions = this.metrics.missedActions.slice(
+        -MISSED_ACTIONS_TRIM,
+      );
+    }
+    logger.warn(
+      { src: "service:action-filter", action: actionName },
+      "Action filter miss — action was selected by LLM but had been filtered out",
+    );
+  }
+
+  hasAction(actionName: string): boolean {
+    return this.bm25Index.has(actionName);
+  }
+
+  getConfig(): Readonly<FilterConfig> {
+    return { ...this.filterConfig };
+  }
+
+  /**
+   * Check whether an action was in the most recent filtered set for a room.
+   * Returns `true` if filtering was active for that room and the action
+   * WAS in the filtered set, `false` if it was filtered OUT, or `null` if
+   * filtering wasn't active for that room (so the caller should skip
+   * false-negative reporting).
+   */
+  wasActionInFilteredSet(actionName: string, roomId: string): boolean | null {
+    const filtered = this.lastFilteredByRoom.get(roomId);
+    if (!filtered) {
+      return null; // no filtering happened for this room
+    }
+    return filtered.has(actionName);
+  }
+
+  /**
+   * Run the full two-tier ranking pipeline on a set of candidate actions.
+   * Returns RankedAction[] sorted by combinedScore descending.
+   */
+  private async rankActions(
+    runtime: IAgentRuntime,
+    candidates: Action[],
+    message: Memory,
+    state: State,
+  ): Promise<RankedAction[]> {
+    const queryText = buildQueryText(message, state);
+
+    // Stage 1: Vector search
+    let vectorScores: Map<string, number> | null = null;
+    let vectorCandidateNames: string[] | null = null;
+
+    if (this.embeddingAvailable && this.actionEmbeddings.size > 0) {
+      try {
+        const queryEmbedding: number[] = await runtime.useModel(
+          ModelType.TEXT_EMBEDDING,
+          { text: queryText },
+        );
+
+        if (isValidEmbedding(queryEmbedding)) {
+          // Score all candidates by cosine similarity
+          const scored: Array<{ name: string; score: number }> = [];
+          for (const action of candidates) {
+            const actionEmb = this.actionEmbeddings.get(action.name);
+            if (actionEmb) {
+              const sim = cosineSimilarity(queryEmbedding, actionEmb);
+              if (Number.isFinite(sim)) {
+                scored.push({ name: action.name, score: sim });
+              }
+            }
+          }
+
+          scored.sort((a, b) => b.score - a.score);
+
+          // Take top vectorTopK
+          const topVector = scored.slice(0, this.filterConfig.vectorTopK);
+          vectorScores = new Map(topVector.map((s) => [s.name, s.score]));
+          vectorCandidateNames = topVector.map((s) => s.name);
+        } else {
+          logger.warn(
+            { src: "service:action-filter" },
+            "Query embedding invalid — falling back to BM25-only",
+          );
+          this.metrics.bm25OnlyFallbacks++;
+        }
+      } catch (err) {
+        logger.warn(
+          {
+            src: "service:action-filter",
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "Vector search failed — falling back to BM25-only",
+        );
+        this.metrics.bm25OnlyFallbacks++;
+      }
+    } else {
+      this.metrics.bm25OnlyFallbacks++;
+    }
+
+    // Stage 2: BM25 scoring
+    // If vector search produced candidates, rerank those.
+    // Otherwise, BM25 searches the entire candidate pool.
+
+    const bm25CandidateIds = vectorCandidateNames
+      ?? candidates.map((a) => a.name);
+
+    const bm25Results = this.bm25Index.searchSubset(
+      queryText,
+      bm25CandidateIds,
+    );
+    const bm25Scores = new Map(bm25Results.map((r) => [r.id, r.score]));
+
+    // Stage 3: Combine scores
+    // bm25CandidateIds is either vectorCandidateNames (when vectors
+    // succeeded) or all candidate names (when BM25-only), so it already
+    // contains the complete candidate universe for this ranking pass.
+    const candidateNamesList = bm25CandidateIds;
+    const rawVectorScores = candidateNamesList.map(
+      (name) => vectorScores?.get(name) ?? 0,
+    );
+    const rawBm25Scores = candidateNamesList.map(
+      (name) => bm25Scores.get(name) ?? 0,
+    );
+
+    const normVector = minMaxNormalize(rawVectorScores);
+    const normBm25 = minMaxNormalize(rawBm25Scores);
+
+    const hasVector = vectorScores !== null && vectorScores.size > 0;
+    const effectiveVectorWeight = hasVector ? this.filterConfig.vectorWeight : 0;
+    const effectiveBm25Weight = hasVector ? this.filterConfig.bm25Weight : 1;
+    const totalWeight = effectiveVectorWeight + effectiveBm25Weight;
+
+    const safeTotalWeight = totalWeight > 0 ? totalWeight : 1;
+
+    const actionByName = new Map<string, Action>();
+    for (const action of candidates) {
+      actionByName.set(action.name, action);
+    }
+
+    const momentumMap = this.computeMomentumBoosts(message);
+
+    const ranked: RankedAction[] = [];
+
+    for (let i = 0; i < candidateNamesList.length; i++) {
+      const name = candidateNamesList[i];
+      const action = actionByName.get(name);
+      if (!action) continue;
+
+      const vScore = normVector[i];
+      const bScore = normBm25[i];
+
+      let combined =
+        (effectiveVectorWeight * vScore + effectiveBm25Weight * bScore) /
+        safeTotalWeight;
+
+      if (!Number.isFinite(combined)) {
+        combined = 0;
+      }
+
+      const momentumBoost = momentumMap.get(name) ?? 0;
+      combined = Math.min(1, combined + momentumBoost);
+
+      ranked.push({
+        action,
+        vectorScore: rawVectorScores[i],
+        bm25Score: rawBm25Scores[i],
+        combinedScore: combined,
+      });
+    }
+
+    ranked.sort((a, b) => b.combinedScore - a.combinedScore);
+
+    return ranked;
+  }
+
+  /**
+   * Compute per-action momentum boosts based on recently used actions
+   * in the same room as the current message.
+   */
+  private computeMomentumBoosts(message: Memory): Map<string, number> {
+    const boosts = new Map<string, number>();
+    const now = Date.now();
+    const roomId = message.roomId;
+
+    const validEntries: RecentActionEntry[] = [];
+
+    for (const entry of this.recentActions) {
+      const age = now - entry.timestamp;
+      if (age > this.filterConfig.momentumDecayMs) {
+        continue; // expired
+      }
+      validEntries.push(entry);
+
+      if (roomId && entry.roomId !== roomId) {
+        continue;
+      }
+
+      const decayFactor = 1 - age / this.filterConfig.momentumDecayMs;
+      const boost = this.filterConfig.momentumBoost * decayFactor;
+
+      const existing = boosts.get(entry.name) ?? 0;
+      boosts.set(entry.name, Math.max(existing, boost));
+    }
+
+    this.recentActions = validEntries;
+
+    return boosts;
+  }
+}
+
+function readFilterConfigFromRuntime(
+  runtime: IAgentRuntime,
+): Partial<FilterConfig> {
+  const get = (key: string) => runtime.getSetting(key);
+
+  /** Parse a numeric setting. Returns undefined if absent or invalid. */
+  const num = (
+    key: string,
+    min: number,
+    max: number,
+    integer = false,
+  ): number | undefined => {
+    const raw = get(key);
+    if (raw == null) return undefined;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n < min || n > max) return undefined;
+    return integer ? Math.round(n) : n;
+  };
+
+  const overrides: Partial<FilterConfig> = {};
+
+  const enabled = get("ACTION_FILTER_ENABLED");
+  if (enabled != null) {
+    overrides.enabled = String(enabled).toLowerCase() !== "false";
+  }
+
+  overrides.threshold =      num("ACTION_FILTER_THRESHOLD",        0, 1e6, true);
+  overrides.vectorTopK =     num("ACTION_FILTER_VECTOR_TOP_K",     1, 1e6, true);
+  overrides.finalTopK =      num("ACTION_FILTER_FINAL_TOP_K",      1, 1e6, true);
+  overrides.vectorWeight =   num("ACTION_FILTER_VECTOR_WEIGHT",    0, 1);
+  overrides.bm25Weight =     num("ACTION_FILTER_BM25_WEIGHT",      0, 1);
+  overrides.momentumDecayMs= num("ACTION_FILTER_MOMENTUM_DECAY_MS",1, 1e9, true);
+  overrides.momentumBoost =  num("ACTION_FILTER_MOMENTUM_BOOST",   0, 1);
+
+  // Strip undefined keys so they don't override defaults during spread
+  for (const key of Object.keys(overrides) as (keyof FilterConfig)[]) {
+    if (overrides[key] === undefined) {
+      delete overrides[key];
+    }
+  }
+
+  return overrides;
+}
+
+function isValidEmbedding(embedding: number[]): boolean {
+  if (!Array.isArray(embedding) || embedding.length === 0) {
+    return false;
+  }
+  let hasNonZero = false;
+  for (let i = 0; i < embedding.length; i++) {
+    if (!Number.isFinite(embedding[i])) {
+      return false;
+    }
+    if (embedding[i] !== 0) {
+      hasNonZero = true;
+    }
+  }
+  return hasNonZero;
+}

--- a/packages/typescript/src/services/bm25.ts
+++ b/packages/typescript/src/services/bm25.ts
@@ -1,0 +1,210 @@
+/**
+ * BM25 index with incremental add/remove support.
+ *
+ * Uses the shared Tokenizer from search.ts as the primary text processor
+ * (Unicode normalization, optional Porter2 stemming, configurable stopwords).
+ * Falls back to a unicode-aware regex tokenizer for scripts the shared
+ * Tokenizer doesn't cover (Cyrillic, Arabic, etc.).
+ *
+ * Scoring formula:
+ *   score(q, d) = Σ IDF(qi) * (f(qi, d) * (k1 + 1)) / (f(qi, d) + k1 * (1 - b + b * |d| / avgdl))
+ */
+
+import { Tokenizer, type TokenizerOptions } from "../search.ts";
+
+/** Common English stopwords. */
+const ENGLISH_STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "but", "by", "do", "for",
+  "from", "had", "has", "have", "he", "her", "his", "how", "i", "if",
+  "in", "into", "is", "it", "its", "me", "my", "no", "not", "of", "on",
+  "or", "our", "out", "own", "she", "so", "than", "that", "the", "their",
+  "them", "then", "there", "these", "they", "this", "to", "too", "up",
+  "us", "very", "was", "we", "what", "when", "where", "which", "who",
+  "whom", "why", "will", "with", "would", "you", "your",
+]);
+
+interface BM25Document {
+  id: string;
+  termFrequencies: Map<string, number>;
+  length: number;
+}
+
+export interface BM25Result {
+  id: string;
+  score: number;
+}
+
+/**
+ * BM25 index for text documents with incremental add/remove.
+ *
+ * Primary tokenization: shared Tokenizer (stemming, Unicode normalization).
+ * Fallback: unicode-aware regex split for scripts the Tokenizer strips
+ * (Cyrillic, Arabic, Devanagari, etc.). The fallback tokens are merged
+ * with the primary tokens so all scripts are searchable.
+ */
+export class BM25Index {
+  private documents: Map<string, BM25Document> = new Map();
+  private documentFrequencies: Map<string, number> = new Map();
+  private avgDocLength = 0;
+  private totalTermCount = 0;
+  private k1: number;
+  private b: number;
+  private sharedTokenizer: Tokenizer;
+  private stopWords: Set<string>;
+
+  constructor(k1 = 1.5, b = 0.75, tokenizerOptions?: TokenizerOptions) {
+    this.k1 = k1;
+    this.b = b;
+    this.stopWords = tokenizerOptions?.stopWords ?? ENGLISH_STOPWORDS;
+    this.sharedTokenizer = new Tokenizer({
+      stopWords: this.stopWords,
+      minLength: tokenizerOptions?.minLength ?? 2,
+      stemming: tokenizerOptions?.stemming ?? false,
+      ...tokenizerOptions,
+    });
+  }
+
+  addDocument(id: string, text: string): void {
+    if (this.documents.has(id)) {
+      this.removeDocument(id);
+    }
+
+    const terms = this.tokenize(text);
+    const termFrequencies = new Map<string, number>();
+    for (const term of terms) {
+      termFrequencies.set(term, (termFrequencies.get(term) ?? 0) + 1);
+    }
+
+    this.documents.set(id, { id, termFrequencies, length: terms.length });
+
+    for (const term of termFrequencies.keys()) {
+      this.documentFrequencies.set(
+        term,
+        (this.documentFrequencies.get(term) ?? 0) + 1,
+      );
+    }
+
+    this.totalTermCount += terms.length;
+    this.recomputeAvgDocLength();
+  }
+
+  removeDocument(id: string): void {
+    const doc = this.documents.get(id);
+    if (!doc) return;
+
+    for (const term of doc.termFrequencies.keys()) {
+      const currentDf = this.documentFrequencies.get(term) ?? 0;
+      if (currentDf <= 1) {
+        this.documentFrequencies.delete(term);
+      } else {
+        this.documentFrequencies.set(term, currentDf - 1);
+      }
+    }
+
+    this.totalTermCount -= doc.length;
+    this.documents.delete(id);
+    this.recomputeAvgDocLength();
+  }
+
+  search(query: string, topK?: number): BM25Result[] {
+    const queryTerms = this.tokenize(query);
+    if (queryTerms.length === 0 || this.documents.size === 0) return [];
+
+    const N = this.documents.size;
+    const results: BM25Result[] = [];
+    for (const doc of this.documents.values()) {
+      const score = this.scoreDocument(doc, queryTerms, N);
+      if (score > 0) results.push({ id: doc.id, score });
+    }
+    return sortAndTruncate(results, topK);
+  }
+
+  searchSubset(query: string, documentIds: string[], topK?: number): BM25Result[] {
+    const queryTerms = this.tokenize(query);
+    if (queryTerms.length === 0 || this.documents.size === 0) return [];
+
+    const N = this.documents.size;
+    const results: BM25Result[] = [];
+    for (const id of documentIds) {
+      const doc = this.documents.get(id);
+      if (!doc) continue;
+      const score = this.scoreDocument(doc, queryTerms, N);
+      if (score > 0) results.push({ id: doc.id, score });
+    }
+    return sortAndTruncate(results, topK);
+  }
+
+  get size(): number {
+    return this.documents.size;
+  }
+
+  has(id: string): boolean {
+    return this.documents.has(id);
+  }
+
+  private scoreDocument(
+    doc: BM25Document,
+    queryTerms: string[],
+    totalDocuments: number,
+  ): number {
+    let score = 0;
+    const avgdl = this.avgDocLength || 1;
+
+    for (const term of queryTerms) {
+      const tf = doc.termFrequencies.get(term) ?? 0;
+      if (tf === 0) continue;
+
+      const df = this.documentFrequencies.get(term) ?? 0;
+      const idf = Math.log((totalDocuments - df + 0.5) / (df + 0.5) + 1);
+      const numerator = tf * (this.k1 + 1);
+      const denominator = tf + this.k1 * (1 - this.b + this.b * (doc.length / avgdl));
+      score += idf * (numerator / denominator);
+    }
+
+    return score;
+  }
+
+  private recomputeAvgDocLength(): void {
+    const docCount = this.documents.size;
+    this.avgDocLength = docCount > 0 ? this.totalTermCount / docCount : 0;
+  }
+
+  /**
+   * Tokenize text using the shared Tokenizer (for English, CJK, Hangul)
+   * merged with a unicode-aware regex fallback (for Cyrillic, Arabic, etc.).
+   * This ensures all scripts are searchable while still benefiting from
+   * the Tokenizer's stemming and normalization for supported scripts.
+   */
+  private tokenize(text: string): string[] {
+    if (!text || !text.trim()) return [];
+
+    // Primary: shared Tokenizer (handles English + CJK + Hangul, with stemming)
+    let primaryTokens: string[] = [];
+    try {
+      primaryTokens = this.sharedTokenizer.tokenize(text).tokens;
+    } catch {
+      // Tokenizer throws on empty/whitespace-only input after cleaning
+      primaryTokens = [];
+    }
+
+    // Fallback: unicode-aware regex for scripts the Tokenizer strips
+    // (\p{L} matches ANY unicode letter including Cyrillic, Arabic, etc.)
+    const fallbackTokens = text
+      .toLowerCase()
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter((t) => t.length >= 2 && !this.stopWords.has(t));
+
+    // Merge: use a Set to deduplicate, primary tokens first
+    const merged = new Set(primaryTokens);
+    for (const t of fallbackTokens) {
+      merged.add(t);
+    }
+
+    return Array.from(merged);
+  }
+}
+
+function sortAndTruncate(results: BM25Result[], topK?: number): BM25Result[] {
+  results.sort((a, b) => b.score - a.score);
+  return topK !== undefined && topK > 0 ? results.slice(0, topK) : results;
+}

--- a/packages/typescript/src/services/cosine-similarity.ts
+++ b/packages/typescript/src/services/cosine-similarity.ts
@@ -1,0 +1,56 @@
+/** Cosine similarity: dot(a,b) / (||a|| * ||b||). Returns [-1, 1], or 0 for degenerate inputs. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  if (len === 0) {
+    return 0;
+  }
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < len; i++) {
+    const ai = a[i];
+    const bi = b[i];
+
+    if (!Number.isFinite(ai) || !Number.isFinite(bi)) {
+      return 0;
+    }
+
+    dotProduct += ai * bi;
+    normA += ai * ai;
+    normB += bi * bi;
+  }
+
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+
+  if (denominator === 0 || !Number.isFinite(denominator)) {
+    return 0;
+  }
+
+  const result = dotProduct / denominator;
+
+  if (result > 1) return 1;
+  if (result < -1) return -1;
+
+  return result;
+}
+
+/** L2-normalize a vector to unit magnitude. Returns a copy for zero vectors. */
+export function normalizeVector(v: number[]): number[] {
+  let sumSq = 0;
+  for (let i = 0; i < v.length; i++) {
+    sumSq += v[i] * v[i];
+  }
+
+  const norm = Math.sqrt(sumSq);
+  if (norm === 0) {
+    return v.slice();
+  }
+
+  const result = new Array<number>(v.length);
+  for (let i = 0; i < v.length; i++) {
+    result[i] = v[i] / norm;
+  }
+  return result;
+}

--- a/packages/typescript/src/types/plugin.ts
+++ b/packages/typescript/src/types/plugin.ts
@@ -75,6 +75,17 @@ interface BaseRoute {
     runtime: IAgentRuntime,
   ) => Promise<void>;
   isMultipart?: boolean; // Indicates if the route expects multipart/form-data (file uploads)
+  /** x402 payment configuration for this route. If present, the route requires payment. */
+  x402?: {
+    /** Price in USDC base units (6 decimals, e.g. "1000000" = $1.00) */
+    price: string;
+    /** Override network (defaults to agent's configured network) */
+    network?: string;
+    /** Override payTo address (defaults to agent's configured address) */
+    payTo?: string;
+    /** Description of what is being paid for */
+    description?: string;
+  };
 }
 
 interface PublicRoute extends BaseRoute {


### PR DESCRIPTION
## Summary

- Adds `ActionFilterService` that dynamically filters which actions are shown to the LLM based on relevance, reducing prompt bloat from 200+ actions to ~15 relevant ones
- Two-tier ranking: vector search (cosine similarity on embeddings) + BM25 reranking (keyword-based TF-IDF)
- Provider filtering: auto-includes relevant dynamic providers via BM25 scoring in `composeState()`
- Route type: adds optional `x402` payment config field to `BaseRoute` for x402 paywall integration

## Key files

| File | What |
|---|---|
| `services/action-filter.ts` | Main service — vector + BM25 pipeline, momentum tracking, metrics |
| `services/bm25.ts` | Pure TS BM25 index, zero dependencies |
| `services/cosine-similarity.ts` | Pure TS cosine similarity |
| `bootstrap/providers/actions.ts` | Modified to use filter service when available |
| `bootstrap/index.ts` | Registers ActionFilterService in basic services |
| `runtime.ts` | Hooks `registerAction()` for auto-indexing, adds provider filtering in `composeState()` |
| `types/plugin.ts` | Adds `x402?` field to `BaseRoute` |
| `__tests__/action-filter.test.ts` | 161 tests |

## Design

- **Graceful degradation**: No embedding model → BM25-only. Service absent → original validate-all behavior.
- **Backward compatible**: Agents with <15 actions see zero change.
- **Configurable**: `ACTION_FILTER_ENABLED`, `ACTION_FILTER_THRESHOLD`, `ACTION_FILTER_VECTOR_WEIGHT`, etc.
- **Observable**: Tracks filterCalls, missCount, bm25OnlyFallbacks, embedFailureCount, lastAvgScore.

## Test plan

- [x] 161 tests pass (BM25, cosine sim, filter pipeline, momentum, edge cases, fuzz, data inspection)
- [x] TypeScript compiles cleanly with project tsconfig (0 errors)
- [x] Backward compatible — falls back to original behavior when service is absent


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces an `ActionFilterService` that reduces action prompt bloat by ranking actions for each message using a two-stage pipeline: vector similarity (cosine over embeddings) with BM25 keyword reranking. The runtime integrates the service by auto-indexing actions on `registerAction()`, tracking per-room momentum from completed actions, and reporting “filter misses” when the LLM selects an action that was previously filtered out. `actionsProvider` now uses the filter service when available (falling back to the existing validate-all path otherwise). Additionally, `composeState()` can auto-include relevant dynamic providers via a BM25 provider index, and `BaseRoute` gains an optional `x402` payment configuration field.

Key flow: bootstrap registers the service → service builds BM25/embedding indices → actions provider calls `filter()` before validation → runtime records usage and miss telemetry, and optionally BM25-selects dynamic providers during state composition.

<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in always-include handling that can change runtime behavior.
- Most changes are additive and well-tested, and fallbacks are designed to preserve prior behavior when the service/model is unavailable. However, `ActionFilterService.filter()` currently ignores the `Action.alwaysInclude` flag and instead checks only a configured name list and a tag, which will incorrectly allow actions intended to always appear to be filtered out.
- packages/typescript/src/services/action-filter.ts; packages/typescript/src/__tests__/action-filter.test.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/action-filter.ts | Implements ActionFilterService (vector + BM25) and provider BM25 filtering; found always-include logic ignores `action.alwaysInclude` and uses tag-based fallback instead, likely breaking intended behavior and tests. |
| packages/typescript/src/services/bm25.ts | Adds dependency-free BM25 index with shared Tokenizer + unicode fallback tokenization; no clear functional issues found in scoring/add/remove logic. |
| packages/typescript/src/services/cosine-similarity.ts | Adds cosine similarity and vector normalization utilities with guardrails for NaN/Infinity/degenerate vectors; no issues found. |
| packages/typescript/src/bootstrap/providers/actions.ts | Updates actions provider to use ActionFilterService when available then validates actions; appears consistent with previous validate-all behavior on fallback. |
| packages/typescript/src/runtime.ts | Integrates ActionFilterService: indexes newly registered actions, records action-use momentum, reports filter misses, and BM25-includes dynamic providers in composeState; no definite runtime-breaking issues found. |
| packages/typescript/src/bootstrap/index.ts | Registers ActionFilterService in basic bootstrap services; straightforward wiring change. |
| packages/typescript/src/types/plugin.ts | Extends BaseRoute with optional x402 payment config; type-only change, no runtime impact. |
| packages/typescript/src/__tests__/action-filter.test.ts | Adds comprehensive tests for BM25/cosine/action filtering; note tests assume per-action `alwaysInclude` is honored, which current service implementation does not. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant RT as AgentRuntime
  participant BSP as BootstrapPlugin
  participant AFS as ActionFilterService
  participant AP as actionsProvider
  participant BM as BM25Index
  participant EM as EmbeddingModel
  participant LLM as LLM prompt composer

  BSP->>RT: registerService(ActionFilterService)
  RT->>AFS: start(runtime)
  AFS->>RT: getModel(TEXT_EMBEDDING)
  alt embedding available
    AFS->>EM: useModel(TEXT_EMBEDDING, text=actionIndexText)
    AFS->>AFS: store actionEmbeddings
  else no embedding
    AFS->>AFS: BM25-only mode
  end
  AFS->>BM: addDocument(action.name, actionText)
  AFS->>BM: addDocument(provider.name, providerText)

  Note over RT,AP: On each message
  RT->>AP: get(runtime,message,state)
  AP->>RT: getService("action_filter")
  alt filter service present
    AP->>AFS: filter(runtime,message,state)
    AFS->>AFS: buildQueryText(message,state)
    alt vector stage possible
      AFS->>EM: useModel(TEXT_EMBEDDING, text=queryText)
      AFS->>AFS: cosineSimilarity(queryEmb, actionEmb)
      AFS->>AFS: pick top vectorTopK candidates
    end
    AFS->>BM: searchSubset(queryText, candidateIds)
    AFS->>AFS: combine scores + momentum
    AFS-->>AP: top actions
  else no service
    AP->>AP: validateActions(runtime.actions)
  end
  AP->>LLM: provide filtered actions section

  Note over RT,AFS: Provider filtering during composeState
  RT->>AFS: filterProviders(dynamicProviders,message,cachedState)
  AFS->>BM: searchSubset(queryText, providerIds)
  AFS-->>RT: relevant provider names
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->