### PR TITLE
fix(cli): load .env files in agent commands for authentication

### DIFF
--- a/packages/cli/src/commands/agent/utils/validation.ts
+++ b/packages/cli/src/commands/agent/utils/validation.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { AgentBasic } from '../../shared';
 import { createApiClientConfig } from '../../shared';
 import { AgentsService } from '@elizaos/api-client';
+import { loadEnvironment } from '../../../utils/get-config';
 
 // Zod schemas for validation
 export const AgentBasicSchema = z
@@ -21,6 +22,9 @@ export const AgentsListResponseSchema = z.object({
  * Asynchronously fetches a list of basic agent information from the server.
  */
 export async function getAgents(opts: OptionValues): Promise<AgentBasic[]> {
+  // Load environment variables to ensure ELIZA_SERVER_AUTH_TOKEN is available
+  await loadEnvironment();
+
   const config = createApiClientConfig(opts);
   const agentsService = new AgentsService(config);
   const result = await agentsService.listAgents();


### PR DESCRIPTION
Reopened from #6376 (was merged then rolled back)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the agent command validation utilities to load environment variables (via `loadEnvironment()`) before constructing the API client config, so `ELIZA_SERVER_AUTH_TOKEN` can be picked up from a `.env` file when listing agents.

The change is localized to `getAgents()` in `packages/cli/src/commands/agent/utils/validation.ts`, which is used by `resolveAgentId()` to fetch agents and resolve IDs/names/indices.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe but may not fix the intended auth issue in common CLI invocation contexts.
- Change is small and easy to reason about, but `loadEnvironment()` defaults to `process.cwd()`, which can be different from the target project directory; in those cases the auth token still won’t be loaded and the original bug persists. There are no obvious type/runtime errors introduced.
- packages/cli/src/commands/agent/utils/validation.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/agent/utils/validation.ts | Loads environment variables before creating API client config in getAgents() to make auth token available. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Cmd as agent CLI command
  participant Val as validation.getAgents
  participant Env as loadEnvironment
  participant Cfg as createApiClientConfig
  participant API as AgentsService

  Cmd->>Val: resolveAgentId() / getAgents(opts)
  Val->>Env: loadEnvironment(process.cwd())
  Env-->>Val: process.env populated (maybe)
  Val->>Cfg: createApiClientConfig(opts)
  Cfg-->>Val: config (auth token from env)
  Val->>API: listAgents()
  API-->>Val: {agents: ...}
  Val-->>Cmd: agents / agentId
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->