### PR TITLE
fix(cli): validate directory path in ensureDir to prevent ENOENT error

### DIFF
--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -181,6 +181,9 @@ export async function getElizaDirectories(targetProjectDir?: string) {
  * @param dirPath Path to the directory
  */
 async function ensureDir(dirPath: string) {
+  if (!dirPath || dirPath.trim() === '') {
+    throw new Error('Directory path cannot be empty');
+  }
   if (!existsSync(dirPath)) {
     await fs.mkdir(dirPath, { recursive: true });
     logger.debug({ src: 'cli', util: 'get-config', dirPath }, 'Created directory');


### PR DESCRIPTION
Reopened from #6379 (was merged then rolled back)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds defensive validation to the `ensureDir` function in `packages/cli/src/utils/get-config.ts` to prevent ENOENT errors when directory paths are empty or contain only whitespace.

**Key Changes:**
- Added guard clause checking if `dirPath` is empty or contains only whitespace
- Throws clear error message: "Directory path cannot be empty" instead of allowing confusing ENOENT errors from `fs.mkdir`

**Root Cause:**
When environment variables like `PGLITE_DATA_DIR` are set to empty strings (as opposed to being undefined), the nullish coalescing operator (`??`) in `resolvePgliteDir` doesn't skip them, leading to empty paths being passed to `ensureDir`.

**Impact:**
This is a defensive programming fix that improves error messages and prevents runtime crashes. The change is minimal, safe, and directly addresses the issue described in the original PR #6379.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change adds a simple validation check that prevents empty directory paths from causing ENOENT errors. It's a defensive programming practice with clear benefits: better error messages, no breaking changes to existing functionality, and addresses a real edge case where environment variables might be set to empty strings. The fix is minimal (3 lines), well-scoped, and doesn't alter any logic paths for valid inputs.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/get-config.ts | Added validation to prevent empty directory paths in `ensureDir`, fixing ENOENT errors when environment variables are set to empty strings |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI
    participant getConfig as get-config.ts
    participant ensureDir
    participant fs as Node.js fs

    User->>CLI: Start CLI with empty PGLITE_DATA_DIR env var
    CLI->>getConfig: configureDatabaseSettings()
    getConfig->>getConfig: resolvePgliteDir()
    Note over getConfig: env var = "" (empty string)<br/>fallbackDir is ignored
    getConfig->>getConfig: Returns empty string
    getConfig->>ensureDir: ensureDir("")
    
    alt With PR Fix
        ensureDir->>ensureDir: Check if dirPath is empty/whitespace
        ensureDir-->>getConfig: throw Error("Directory path cannot be empty")
        Note over getConfig: Clear error message
    else Without PR Fix
        ensureDir->>fs: mkdir("", {recursive: true})
        fs-->>ensureDir: ENOENT error
        Note over ensureDir: Confusing error message
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->