### PR TITLE
docs: add environment variables documentation

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,78 @@
+# Environment Variables
+
+This document describes the server configuration environment variables for ElizaOS.
+
+## Server Security & Authentication
+
+### ELIZA_SERVER_AUTH_TOKEN
+
+Controls API authentication for the ElizaOS server.
+
+- **Purpose**: When set, requires all `/api/*` routes to include an `X-API-KEY` header with this token value
+- **Default**: Unset (no authentication required)
+- **Security**: When unset, all API endpoints are publicly accessible
+- **Usage**:
+  ```bash
+  ELIZA_SERVER_AUTH_TOKEN=your-secret-token
+  ```
+- **Headers**: Clients must send `X-API-KEY: your-secret-token` header
+- **Behavior**:
+  - If unset: All requests allowed (no authentication)
+  - If set: Only requests with matching `X-API-KEY` header allowed
+  - Returns `401 Unauthorized` for invalid/missing keys
+
+## Web UI Control
+
+### ELIZA_UI_ENABLE
+
+Controls whether the web user interface is served by the server.
+
+- **Purpose**: Enable or disable the web UI for security and deployment flexibility
+- **Values**:
+  - `true` - Force enable UI
+  - `false` - Force disable UI
+  - Unset/empty - Automatic behavior (enabled in development, disabled in production)
+- **Default Behavior**:
+  - Development (`NODE_ENV=development`): UI enabled
+  - Production (`NODE_ENV=production`): UI disabled for security
+- **Usage**:
+  ```bash
+  # Force enable in production
+  ELIZA_UI_ENABLE=true
+
+  # Force disable in development
+  ELIZA_UI_ENABLE=false
+
+  # Use automatic behavior
+  ELIZA_UI_ENABLE=
+  ```
+- **Security**: Disabling UI reduces attack surface by removing web interface
+- **API Access**: API endpoints remain available regardless of UI setting
+
+## Examples
+
+### Production Deployment (Secure)
+```bash
+NODE_ENV=production
+ELIZA_SERVER_AUTH_TOKEN=secure-random-token-here
+ELIZA_UI_ENABLE=false
+```
+
+### Development Setup (Convenient)
+```bash
+NODE_ENV=development
+# ELIZA_SERVER_AUTH_TOKEN=  # Unset for easy development
+# ELIZA_UI_ENABLE=         # Unset for automatic behavior (UI enabled)
+```
+
+### Headless API Server
+```bash
+ELIZA_SERVER_AUTH_TOKEN=api-only-token
+ELIZA_UI_ENABLE=false
+```
+
+## Related Files
+
+- **Configuration**: `.env.example` - Template with all available environment variables
+- **Authentication**: `packages/server/src/authMiddleware.ts` - API key validation logic
+- **UI Control**: `packages/server/src/index.ts` - Web UI enable/disable logic


### PR DESCRIPTION
Reopened from #6377 (was merged then rolled back)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added new documentation file explaining two server environment variables: `ELIZA_SERVER_AUTH_TOKEN` for API authentication and `ELIZA_UI_ENABLE` for web UI control. The documentation includes:

- Clear explanations of each variable's purpose and default behavior
- Security implications when variables are set or unset
- Usage examples for different deployment scenarios (production, development, headless)
- References to related configuration files

**Issue found:**
- Incorrect file path reference for authentication middleware (line 77)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor correction needed
- Documentation is well-structured and accurate except for one incorrect file path reference. Content correctly describes the behavior of both environment variables based on the actual implementation.
- Fix the file path reference in `docs/environment-variables.md` line 77

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/environment-variables.md | Added comprehensive documentation for ELIZA_SERVER_AUTH_TOKEN and ELIZA_UI_ENABLE with examples; one incorrect file path reference |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Doc as environment-variables.md
    participant Env as .env.example
    participant Middleware as API Key Middleware
    participant Config as Config Utils
    
    Dev->>Doc: Reads documentation
    Note over Doc: Explains ELIZA_SERVER_AUTH_TOKEN<br/>and ELIZA_UI_ENABLE variables
    
    Doc->>Env: References template
    Dev->>Env: Sets configuration
    
    alt API Authentication Flow
        Env->>Middleware: AUTH_TOKEN configured
        Note over Middleware: Validates X-API-KEY header<br/>Returns 401 if invalid
    else No Auth Flow
        Env->>Middleware: AUTH_TOKEN not set
        Note over Middleware: Skips validation<br/>Allows all requests
    end
    
    alt UI Toggle Flow
        Env->>Config: UI_ENABLE set to true/false
        Config->>Dev: Force enable or disable UI
    else Automatic UI Flow
        Env->>Config: UI_ENABLE not set
        Config->>Dev: Enable in dev, disable in prod
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->