### PR TITLE
fix: various typo fixes

### DIFF
--- a/packages/computeruse/crates/computeruse-mcp-agent/examples/computeruse-ai-summarizer/src/utils.rs
+++ b/packages/computeruse/crates/computeruse-mcp-agent/examples/computeruse-ai-summarizer/src/utils.rs
@@ -11,7 +11,7 @@ pub struct Args {
     #[arg(
         short,
         long,
-        default_value = "you're are screen summarizer assitant and here is the data of ui element tree as context. the ui element tree data would be in json format. use the `name` and `text` attr of ui tree to summarize the screen context consicely"
+        default_value = "you're are screen summarizer assistant and here is the data of ui element tree as context. the ui element tree data would be in json format. use the `name` and `text` attr of ui tree to summarize the screen context consicely"
     )]
     pub system_prompt: String,
     #[arg(short, long, default_value = "gemma3:1b")]

--- a/packages/computeruse/crates/computeruse/browser-extension/worker.js
+++ b/packages/computeruse/crates/computeruse/browser-extension/worker.js
@@ -573,7 +573,7 @@ async function evalInTab(tabId, code, awaitPromise, evalId) {
       get the selector of iframe from main document
     * after that we'll get the `frameId` of the iframe to execute
       raw js code inside the iframe's document to avoid CORS issue
-    * rewrite the raw js code so it removes the unneccesary `IFRAMESELCTOR` from eval code
+    * rewrite the raw js code so it removes the unnecessary `IFRAMESELCTOR` from eval code
     * run user code safely by creating a Function rather than eval (still executes arbitrary code)
   */
   if (code.includes("IFRAMESELCTOR")) {

--- a/packages/computeruse/crates/computeruse/src/platforms/windows/engine.rs
+++ b/packages/computeruse/crates/computeruse/src/platforms/windows/engine.rs
@@ -1214,7 +1214,7 @@ impl AccessibilityEngine for WindowsEngine {
 
                 if let Some(name) = name {
                     // use contains_name, its undetermined right now
-                    // wheather we should use `name` or `contains_name`
+                    // whether we should use `name` or `contains_name`
                     matcher_builder = matcher_builder.contains_name(name);
                 }
 
@@ -2005,7 +2005,7 @@ impl AccessibilityEngine for WindowsEngine {
 
                 if let Some(name) = name {
                     // use contains_name, its undetermined right now
-                    // wheather we should use `name` or `contains_name`
+                    // whether we should use `name` or `contains_name`
                     matcher_builder = matcher_builder.filter(Box::new(NameFilter {
                         value: name.clone(),
                         casesensitive: false,

--- a/packages/computeruse/examples/recaptcha-resolver/README.md
+++ b/packages/computeruse/examples/recaptcha-resolver/README.md
@@ -3,4 +3,4 @@ automate the resolving of checkbox based and image based recaptcha. it uses gemi
 
 ## Prerequisite 
 - [bun](https://bun.sh/)
-- make sure you've computeruse brige installed in chrome browser
+- make sure you've computeruse bridge installed in chrome browser

--- a/packages/computeruse/vagrant/scripts/install-openssh.ps1
+++ b/packages/computeruse/vagrant/scripts/install-openssh.ps1
@@ -37,7 +37,7 @@ if ($(Get-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0).State -eq "
 }
 $ErrorActionPreference = "Stop"
 
-#Stop and remove existing services (Perhaps an exisitng OpenSSH install)
+#Stop and remove existing services (Perhaps an existing OpenSSH install)
 if (Get-Service sshd -ErrorAction SilentlyContinue) {
     Stop-Service sshd -ErrorAction SilentlyContinue
     sc.exe delete sshd 1>$null

--- a/packages/docs/guides/deploy-a-project.mdx
+++ b/packages/docs/guides/deploy-a-project.mdx
@@ -70,7 +70,7 @@ The easiest deployment method, best for rapid prototyping. These platforms handl
 <Note>
   **Cost Reality Check:** A simple agent might cost ~$20 dollars per month, but
   as you scale up, the costs can quickly balloon. For this reason, it's smart to
-  set spending threshholds and closely monitor resource usage.
+  set spending thresholds and closely monitor resource usage.
 </Note>
 
 ### Pros & Cons
@@ -231,7 +231,7 @@ Render is comparable to Railway, but its Free/Hobby plan is less generous and sl
 </Step>
 
 <Step title="Add environment variables">
-  Put all your environment variables in here, even if you commited your .env
+  Put all your environment variables in here, even if you committed your .env
   file, you still need to add it on Render-side:
   <img
     src="/images/render-env.png"

--- a/packages/skills/skills/testing-handbook-skills/skills/aflpp/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/aflpp/SKILL.md
@@ -56,7 +56,7 @@ AFL++ has many dependencies including LLVM, Python, and Rust. We recommend using
 
 ### Ubuntu/Debian
 
-Prior to installing afl++, check the clang version dependency of the packge with `apt-cache show afl++`, and install the matching `lld` version (e.g., `lld-17`).
+Prior to installing afl++, check the clang version dependency of the package with `apt-cache show afl++`, and install the matching `lld` version (e.g., `lld-17`).
 
 
 ```bash


### PR DESCRIPTION
This PR fixes several typos found in the codebase.

Closes #6532

## Changes:
- threshholds -> thresholds
- commited -> committed
- packge -> package
- brige -> bridge
- unneccesary -> unnecessary
- wheather -> whether
- assitant -> assistant
- exisitng -> existing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed 8 typos across 7 files in documentation, code comments, and string literals.

- `assitant` → `assistant` in Rust system prompt
- `unneccesary` → `unnecessary` in JavaScript comment
- `wheather` → `whether` in Rust comments (2 instances)
- `brige` → `bridge` in README
- `exisitng` → `existing` in PowerShell comment
- `threshholds` → `thresholds` and `commited` → `committed` in MDX docs
- `packge` → `package` in SKILL.md

All corrections are accurate and improve code quality without affecting functionality.

<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge with zero risk
- All changes are non-functional spelling corrections in comments, documentation, and string literals. No logic or behavior changes. Properly addresses issue #6532.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/computeruse/crates/computeruse-mcp-agent/examples/computeruse-ai-summarizer/src/utils.rs | Fixed typo: `assitant` -> `assistant` in system prompt default value |
| packages/computeruse/crates/computeruse/browser-extension/worker.js | Fixed typo: `unneccesary` -> `unnecessary` in code comment |
| packages/computeruse/crates/computeruse/src/platforms/windows/engine.rs | Fixed typo: `wheather` -> `whether` in two code comments |
| packages/computeruse/examples/recaptcha-resolver/README.md | Fixed typo: `brige` -> `bridge` in documentation |
| packages/computeruse/vagrant/scripts/install-openssh.ps1 | Fixed typo: `exisitng` -> `existing` in code comment |
| packages/docs/guides/deploy-a-project.mdx | Fixed typos: `threshholds` -> `thresholds` and `commited` -> `committed` in documentation |
| packages/skills/skills/testing-handbook-skills/skills/aflpp/SKILL.md | Fixed typo: `packge` -> `package` in documentation |

</details>



<sub>Last reviewed commit: c1d2c2b</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->