### PR TITLE
fix: remove broken example paths from README quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,7 @@ Create a `.env` file in the project root:
 OPENAI_API_KEY=your_api_key_here
 ```
 
-### 3. Run an Example Agent
-
-```bash
-# Interactive chat
-OPENAI_API_KEY=your_key bun run examples/typescript/chat.ts
-
-# Basic message processing
-OPENAI_API_KEY=your_key bun run examples/typescript/standalone.ts
-```
-
-### 4. Use the Library in Your Own Project
+### 3. Use the Library in Your Own Project
 
 Install the core package:
 


### PR DESCRIPTION
# Relates to

No existing issues - apparently I'm the only dummy needing to use the README quick-start.

# Risks

Low - Documentation-only change, no code impact.

# Background

## What does this PR do?

Removes references to non-existent example files (`examples/typescript/chat.ts` and `examples/typescript/standalone.ts`) from the README quick-start section. Instead of getting an error trying to run an example agent in Step 3, users are now directed to the working "Use the Library in Your Own Project" section which actually provides functional example code.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes require a change to the project documentation, and I have updated it accordingly (README.md)

# Testing

## Where should a reviewer start?

Review the changes in README.md - the quick-start section now goes directly from step 2 (Configure API Key) to step 3 (Use the Library).

## Detailed testing steps

- Searched the entire repo for these example files: found `chat.ts` exists in `/packages/rust/examples/wasm/chat.ts` but **not** at the referenced `examples/typescript/chat.ts`
- Confirmed `examples/typescript/standalone.ts` doesn't exist anywhere in the repo
- Verified the remaining section has valid code for creating an agent
- Checked that the README makes sense without the broken examples


## Discord username

dannywalter

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only fix that removes a broken "Run an Example Agent" quick-start step which referenced two TypeScript files (`examples/typescript/chat.ts` and `examples/typescript/standalone.ts`) that do not exist in the repository. The subsequent step is renumbered from 4 → 3, resulting in a cleaner three-step quick-start flow.

Key observations:
- The removed file paths are confirmed absent from the repository — this is a correct and justified removal that unblocks users.
- The Architecture Overview section at line 117 still lists `examples/` as containing "Example agents and usage patterns" while the directory does not exist; this stale reference should be removed or the examples should be created to match the documentation.

This change correctly fixes the immediate problem and guides users to working code via the "Use the Library in Your Own Project" section.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — documentation-only change with no code impact, and correctly removes references to non-existent files.
- The change correctly removes a broken quick-start step that referenced non-existent example files, unblocking users and directing them to working code. However, the Architecture section at line 117 still contains a stale reference to an `examples/` directory that does not exist. While this is a minor issue, it represents incomplete documentation cleanup in the same file being modified, reducing confidence from 5 to 4.
- README.md line 117 — remove stale `examples/` directory reference or create the examples to match the documentation.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Step 1: Clone the Repository\ngit clone + bun install"] --> B["Step 2: Configure API Key\nCreate .env with OPENAI_API_KEY"]
    B --> C["Step 3: Use the Library in Your Own Project\nbun add @elizaos/core"]
    C --> D["Create an AgentRuntime\nwith character + plugins"]
    D --> E["await runtime.initialize()"]

    style A fill:#4CAF50,color:#fff
    style B fill:#2196F3,color:#fff
    style C fill:#9C27B0,color:#fff
    style D fill:#FF9800,color:#fff
    style E fill:#F44336,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `README.md`, line 117 ([link](https://github.com/elizaos/eliza/blob/033b56a83ec1b0d9477487c05a800ff609043f5e/README.md#L117)) 

   Stale reference to empty `examples/` directory

   The Architecture Overview section still lists `├── examples/           # Example agents and usage patterns`, but as confirmed in this PR the `examples/` directory does not exist in the repository. This creates confusion for users who, after following the quick-start, may look inside `examples/` expecting to find working samples.

   Consider either:
   1. Removing the `examples/` entry from the architecture tree until real examples exist, or
   2. Following this PR up with actual example files so the listing is accurate.

   **Context Used:** Rule from `dashboard` - Fix problems properly; never remove functionality as a workaround ([source](https://app.greptile.com/review/custom-context?memory=40c7cbee-e6a7-411f-b8e6-a68f95b1a87e))
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 033b56a</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Rule from `dashboard` - Fix problems properly; never remove functionality as a workaround ([source](https://app.greptile.com/review/custom-context?memory=40c7cbee-e6a7-411f-b8e6-a68f95b1a87e))
- Rule from `dashboard` - Docs in README.md only; consolidate files; avoid bloat ([source](https://app.greptile.com/review/custom-context?memory=f1b31979-50d7-43aa-acb8-b2c2dbc5fccd))

<!-- /greptile_comment -->