### PR TITLE
feat: improve skill descriptions across 57 skills

### DIFF
--- a/packages/skills/skills/apple-reminders/SKILL.md
+++ b/packages/skills/skills/apple-reminders/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apple-reminders
-description: Manage Apple Reminders via the `remindctl` CLI on macOS (list, add, edit, complete, delete). Supports lists, date filters, and JSON/plain output.
+description: Manage Apple Reminders via the `remindctl` CLI on macOS (list, add, edit, complete, delete). Supports lists, date filters, and JSON/plain output. Use when the user asks about reminders, todos, tasks, to-do lists, "remind me", scheduling tasks, checking what is due today, completing or deleting reminders, or managing reminder lists on macOS.
 homepage: https://github.com/steipete/remindctl
 metadata:
   {

--- a/packages/skills/skills/bear-notes/SKILL.md
+++ b/packages/skills/skills/bear-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bear-notes
-description: Create, search, and manage Bear notes via grizzly CLI.
+description: Create, search, read, tag, and append to Bear app notes on macOS via the grizzly CLI. Use when the user wants to create a new note in Bear, search Bear notes by tag, read or open a Bear note by ID, append text to an existing Bear note, list Bear tags, or automate note-taking in Bear. Requires the grizzly binary and Bear app running on macOS.
 homepage: https://bear.app
 metadata:
   {

--- a/packages/skills/skills/bird/SKILL.md
+++ b/packages/skills/skills/bird/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bird
-description: X/Twitter CLI for reading, searching, posting, and engagement via cookies.
+description: X/Twitter CLI for reading, searching, posting, and engagement via cookies. Provides direct access to tweets, timelines, social media feeds, bookmarks, lists, and trending topics through GraphQL and cookie-based authentication. Use when the user wants to tweet, read a tweet, search Twitter, check their timeline, browse social media, view replies, follow or unfollow accounts, manage bookmarks, or interact with X/Twitter from the command line.
 homepage: https://bird.fast
 metadata:
   {

--- a/packages/skills/skills/blogwatcher/SKILL.md
+++ b/packages/skills/skills/blogwatcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blogwatcher
-description: Monitor blogs and RSS/Atom feeds for updates using the blogwatcher CLI.
+description: Monitor blogs and RSS/Atom feeds for updates using the blogwatcher CLI. Use when the user wants to subscribe to blogs, track news feeds, manage a feed reader, scan for new articles, add or remove RSS or Atom subscriptions, or mark posts as read.
 homepage: https://github.com/Hyaxia/blogwatcher
 metadata:
   {

--- a/packages/skills/skills/blucli/SKILL.md
+++ b/packages/skills/skills/blucli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blucli
-description: BluOS CLI (blu) for discovery, playback, grouping, and volume.
+description: BluOS CLI (blu) for discovery, playback, grouping, and volume control of Bluesound and NAD speakers. Use when the user wants to play music, stream audio, control speakers, adjust volume, group or ungroup Bluesound players, search TuneIn radio, or manage multi-room streaming setups.
 homepage: https://blucli.sh
 metadata:
   {

--- a/packages/skills/skills/bluebubbles/SKILL.md
+++ b/packages/skills/skills/bluebubbles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bluebubbles
-description: Use when you need to send or manage iMessages via BlueBubbles (recommended iMessage integration). Calls go through the generic message tool with channel="bluebubbles".
+description: Handles sending and managing iMessages through BlueBubbles, the recommended iMessage integration. Triggers when the user wants to send a text message, send an iMessage, send a text, text someone, message a contact, react with a tapback, reply to a message thread, send an attachment via iMessage, edit or unsend a sent message, or manage group chat participants. All calls go through the generic message tool with channel="bluebubbles".
 metadata: { "otto": { "emoji": "🫧", "requires": { "config": ["channels.bluebubbles"] } } }
 ---
 

--- a/packages/skills/skills/camsnap/SKILL.md
+++ b/packages/skills/skills/camsnap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: camsnap
-description: Capture frames or clips from RTSP/ONVIF cameras.
+description: Capture frames or clips from RTSP/ONVIF cameras. Grabs snapshots, video clips, and motion events from IP cameras, security cameras, and video streams. Use when the user wants to take a snapshot from a camera, record a clip from an RTSP stream, monitor motion on a security camera, discover ONVIF devices on the network, or configure camera access for automated surveillance capture.
 homepage: https://camsnap.ai
 metadata:
   {

--- a/packages/skills/skills/canvas/SKILL.md
+++ b/packages/skills/skills/canvas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas
-description: "Display HTML content on connected Otto nodes (Mac app, iOS, Android). Use for games, visualizations, dashboards, and interactive demos."
+description: "Display, present, and render HTML content on connected Otto nodes (Mac app, iOS, Android). Show on device, preview on mobile, push to screen, or navigate to a URL on any connected node. Use for games, visualizations, dashboards, interactive demos, and live-reloading development previews. Supports presenting, hiding, navigating, evaluating JavaScript, and capturing screenshots of canvas content across Mac, iOS, and Android devices."
 ---
 
 # Canvas Skill

--- a/packages/skills/skills/coding-agent/SKILL.md
+++ b/packages/skills/skills/coding-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: coding-agent
-description: Run Codex CLI, Claude Code, OpenCode, or Pi Coding Agent via background process for programmatic control.
+description: Run Codex CLI, Claude Code, OpenCode, or Pi Coding Agent via background process for programmatic control. Use when the agent needs to spawn, monitor, or orchestrate coding agents in a terminal session, delegate programming tasks to a sub-agent, review pull requests with an external CLI tool, or run parallel background coding workflows across git worktrees.
 metadata:
   {
     "otto": { "emoji": "🧩", "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] } },

--- a/packages/skills/skills/eightctl/SKILL.md
+++ b/packages/skills/skills/eightctl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: eightctl
-description: Control Eight Sleep pods (status, temperature, alarms, schedules).
+description: Control Eight Sleep pods (status, temperature, alarms, schedules). Use when the user asks to check bed temperature, adjust sleep settings, turn the pod on or off, set a sleep schedule, manage alarms, or control Eight Sleep audio and base features.
 homepage: https://eightctl.sh
 metadata:
   {

--- a/packages/skills/skills/gemini/SKILL.md
+++ b/packages/skills/skills/gemini/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini
-description: Gemini CLI for one-shot Q&A, summaries, and generation.
+description: Gemini CLI for one-shot Q&A, summaries, and generation. Use when the user asks to query Gemini, generate text with Google AI, summarize content using Gemini, run a one-shot prompt, get a Gemini response, or produce JSON output via the Gemini CLI. Supports model selection, output formatting, and extension management.
 homepage: https://ai.google.dev/
 metadata:
   {

--- a/packages/skills/skills/gifgrep/SKILL.md
+++ b/packages/skills/skills/gifgrep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gifgrep
-description: Search GIF providers with CLI/TUI, download results, and extract stills/sheets.
+description: Search GIF providers with CLI/TUI, download results, and extract stills/sheets. Use when the user wants to find a GIF, search for animated images, browse GIFs by keyword, download a GIF from Tenor or Giphy, extract a still frame from a GIF, create a contact sheet of GIF frames, or preview GIFs in the terminal.
 homepage: https://gifgrep.com
 metadata:
   {

--- a/packages/skills/skills/github/SKILL.md
+++ b/packages/skills/skills/github/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github
-description: "Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries."
+description: "Interact with GitHub using the `gh` CLI to manage repositories, issues, pull requests, CI/CD workflow runs, and API queries. Use when the user asks to create, list, view, merge, or close pull requests and issues; check CI status or workflow run logs; query the GitHub API for repository data; or perform any GitHub operation from the command line. Covers `gh issue`, `gh pr`, `gh run`, `gh repo`, and `gh api` subcommands."
 metadata:
   {
     "otto":

--- a/packages/skills/skills/gog/SKILL.md
+++ b/packages/skills/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when the user asks to send an email, check inbox, search Gmail, create or list calendar events, search Google Drive files, look up contacts, read or update spreadsheets, or export Google Docs. Handles OAuth-authenticated access to Google services via the gog command-line tool.
 homepage: https://gogcli.sh
 metadata:
   {

--- a/packages/skills/skills/himalaya/SKILL.md
+++ b/packages/skills/skills/himalaya/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: himalaya
-description: "CLI to manage emails via IMAP/SMTP. Use `himalaya` to list, read, write, reply, forward, search, and organize emails from the terminal. Supports multiple accounts and message composition with MML (MIME Meta Language)."
+description: "CLI to manage emails via IMAP/SMTP. Use `himalaya` to list, read, write, reply, forward, search, and organize emails from the terminal. Supports multiple accounts and message composition with MML (MIME Meta Language). Use when the user wants to check email, read mail, send email, compose a message, search inbox, reply to a message, forward mail, manage folders, download attachments, or organize messages from the command line."
 homepage: https://github.com/pimalaya/himalaya
 metadata:
   {

--- a/packages/skills/skills/imsg/SKILL.md
+++ b/packages/skills/skills/imsg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imsg
-description: iMessage/SMS CLI for listing chats, history, watch, and sending.
+description: iMessage/SMS CLI for listing chats, fetching history, watching conversations, and sending messages on macOS via the Messages app. Use when the user wants to send a text message, read iMessages, check recent texts, reply to a conversation, send an SMS, or interact with the Messages app from the terminal. Supports texting contacts by phone number or email, attaching files, and streaming incoming messages in real time.
 homepage: https://imsg.to
 metadata:
   {

--- a/packages/skills/skills/local-places/SKILL.md
+++ b/packages/skills/skills/local-places/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-places
-description: Search for places (restaurants, cafes, etc.) via Google Places API proxy on localhost.
+description: Searches for local businesses and points of interest via a Google Places API proxy running on localhost. Resolves vague locations, applies filters for type, rating, and price, and returns structured place details. Use when the user asks to find restaurants, nearby places, coffee shops, business search, local recommendations, or anything involving place discovery by location.
 homepage: https://github.com/Hyaxia/local_places
 metadata:
   {

--- a/packages/skills/skills/mcporter/SKILL.md
+++ b/packages/skills/skills/mcporter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcporter
-description: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+description: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation. Use when the user needs to interact with MCP servers, call remote tools, manage server authentication or OAuth flows, inspect available MCP tools and their schemas, generate CLI wrappers or TypeScript types from MCP servers, or manage the mcporter daemon and configuration.
 homepage: http://mcporter.dev
 metadata:
   {

--- a/packages/skills/skills/nano-banana-pro/SKILL.md
+++ b/packages/skills/skills/nano-banana-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana-pro
-description: Generate or edit images via Gemini 3 Pro Image (Nano Banana Pro).
+description: Generate or edit images via Gemini 3 Pro Image (Nano Banana Pro). Use when the user asks to create an image, generate a picture, produce AI-generated artwork, edit a photo, compose multiple images, or upscale an image to higher resolution. Supports text-to-image generation, single-image editing, and multi-image composition using the Gemini API.
 homepage: https://ai.google.dev/
 metadata:
   {

--- a/packages/skills/skills/nano-pdf/SKILL.md
+++ b/packages/skills/skills/nano-pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-pdf
-description: Edit PDFs with natural-language instructions using the nano-pdf CLI.
+description: Edits PDF files using natural-language instructions via the nano-pdf CLI. Supports modifying text, changing titles, fixing typos, and updating content on specific pages. Use when the user wants to edit a PDF, modify PDF content, update PDF text, fix a typo in a PDF, change a PDF title, or rewrite part of a PDF page.
 homepage: https://pypi.org/project/nano-pdf/
 metadata:
   {

--- a/packages/skills/skills/notion/SKILL.md
+++ b/packages/skills/skills/notion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notion
-description: Notion API for creating and managing pages, databases, and blocks.
+description: Notion API for creating and managing pages, databases, and blocks. Use when the user wants to create a Notion page, query a Notion database, update Notion properties, search Notion, add content to Notion, manage Notion blocks, or interact with Notion data sources and workspaces via the API.
 homepage: https://developers.notion.com
 metadata:
   {

--- a/packages/skills/skills/obsidian/SKILL.md
+++ b/packages/skills/skills/obsidian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian
-description: Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli.
+description: Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli. Use when the user asks about notes, vault management, PKM, knowledge base organization, wikilinks, or personal knowledge management in Obsidian.
 homepage: https://help.obsidian.md
 metadata:
   {

--- a/packages/skills/skills/openai-image-gen/SKILL.md
+++ b/packages/skills/skills/openai-image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-image-gen
-description: Batch-generate images via OpenAI Images API. Random prompt sampler + `index.html` gallery.
+description: Batch-generate images via the OpenAI Images API using DALL-E 2, DALL-E 3, or GPT image models. Produces random-but-structured prompts, renders them, and outputs a browsable `index.html` gallery. Use when the user asks to generate AI images, create pictures with DALL-E, batch-produce image assets, render AI art, or build an image gallery from text prompts.
 homepage: https://platform.openai.com/docs/api-reference/images
 metadata:
   {

--- a/packages/skills/skills/openai-whisper-api/SKILL.md
+++ b/packages/skills/skills/openai-whisper-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-whisper-api
-description: Transcribe audio via OpenAI Audio Transcriptions API (Whisper).
+description: Transcribe audio via OpenAI Audio Transcriptions API (Whisper). Use when the user wants to transcribe, convert speech to text, extract words from audio or voice recordings, generate a transcript from an audio file, or perform speech recognition on m4a, ogg, or wav files using the Whisper model.
 homepage: https://platform.openai.com/docs/guides/speech-to-text
 metadata:
   {

--- a/packages/skills/skills/openai-whisper/SKILL.md
+++ b/packages/skills/skills/openai-whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-whisper
-description: Local speech-to-text with the Whisper CLI (no API key).
+description: Local speech-to-text with the Whisper CLI (no API key). Use when the user needs to transcribe audio, convert speech to text, generate subtitles, translate spoken language, or produce SRT/VTT captions from mp3, m4a, or wav files using the local Whisper model.
 homepage: https://openai.com/research/whisper
 metadata:
   {

--- a/packages/skills/skills/openhue/SKILL.md
+++ b/packages/skills/skills/openhue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhue
-description: Control Philips Hue lights/scenes via the OpenHue CLI.
+description: Controls Philips Hue smart lights, rooms, and scenes via the OpenHue CLI and a Hue Bridge. Use when the user asks to turn lights on or off, change brightness or color, activate a scene, list rooms, discover bridges, or manage smart lighting. Handles setup, querying light state, and adjusting individual or grouped lights by name or ID.
 homepage: https://www.openhue.io/cli
 metadata:
   {

--- a/packages/skills/skills/oracle/SKILL.md
+++ b/packages/skills/skills/oracle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oracle
-description: Best practices for using the oracle CLI (prompt + file bundling, engines, sessions, and file attachment patterns).
+description: Best practices for using the oracle CLI (prompt + file bundling, engines, sessions, and file attachment patterns). Use when the developer needs to send a one-shot prompt with file context to another model, bundle repository files for external LLM review, run oracle browser or API queries, manage oracle sessions, attach or exclude files with glob patterns, or preview token costs with dry-run mode.
 homepage: https://askoracle.dev
 metadata:
   {

--- a/packages/skills/skills/ordercli/SKILL.md
+++ b/packages/skills/skills/ordercli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ordercli
-description: Foodora-only CLI for checking past orders and active order status (Deliveroo WIP).
+description: Foodora-only CLI for checking past orders and active order status (Deliveroo WIP). Use when the user asks to check food delivery orders, track a Foodora delivery, view order history, reorder a meal, look up past food orders, check delivery status, or manage Foodora sessions and authentication.
 homepage: https://ordercli.sh
 metadata:
   {

--- a/packages/skills/skills/peekaboo/SKILL.md
+++ b/packages/skills/skills/peekaboo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: peekaboo
-description: Capture and automate macOS UI with the Peekaboo CLI.
+description: Capture and automate macOS UI with the Peekaboo CLI. Provides screenshot capture, screen recording, click automation, keyboard input, window management, menu interaction, and accessibility-driven element targeting on macOS. Use when the user asks to take a screenshot, capture the screen, click a UI element, automate mouse or keyboard input, manage application windows, interact with menus or the Dock, scroll, drag, swipe, type text into fields, or inspect on-screen elements.
 homepage: https://peekaboo.boo
 metadata:
   {

--- a/packages/skills/skills/sag/SKILL.md
+++ b/packages/skills/skills/sag/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sag
-description: ElevenLabs text-to-speech with mac-style say UX.
+description: ElevenLabs text-to-speech with mac-style say UX. Use when the user asks to convert text to speech, generate voice audio, speak text aloud, read aloud, produce TTS output, create a voice generation, or synthesize spoken audio using ElevenLabs.
 homepage: https://sag.sh
 metadata:
   {

--- a/packages/skills/skills/session-logs/SKILL.md
+++ b/packages/skills/skills/session-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-logs
-description: Search and analyze your own session logs (older/parent conversations) using jq.
+description: Search and analyze session logs (older/parent conversations) stored as JSONL files using jq and rg. Use when the user asks about prior chats, previous conversations, conversation history, what was said before, session costs, token usage, or tool usage breakdown across past sessions.
 metadata: { "otto": { "emoji": "📜", "requires": { "bins": ["jq", "rg"] } } }
 ---
 

--- a/packages/skills/skills/sherpa-onnx-tts/SKILL.md
+++ b/packages/skills/skills/sherpa-onnx-tts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sherpa-onnx-tts
-description: Local text-to-speech via sherpa-onnx (offline, no cloud)
+description: Local text-to-speech via sherpa-onnx (offline, no cloud). Converts text to speech audio using the sherpa-onnx runtime and Piper VITS voices with no cloud dependency. Use when the user asks to generate speech, read text aloud, produce a voice audio file, perform TTS, speech synthesis, or convert text to WAV output locally.
 metadata:
   {
     "otto":

--- a/packages/skills/skills/skill-creator/SKILL.md
+++ b/packages/skills/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Creates, updates, and packages AgentSkills with proper SKILL.md frontmatter, bundled scripts, references, and assets. Provides guidance on skill naming, progressive disclosure, and context-efficient design. Use when building a new skill from scratch, restructuring an existing skill, writing or improving SKILL.md files, organizing skill resources into scripts/references/assets folders, packaging skills for distribution, or iterating on skill quality after testing.
 ---
 
 # Skill Creator

--- a/packages/skills/skills/slack/SKILL.md
+++ b/packages/skills/skills/slack/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slack
-description: Use when you need to control Slack from Otto via the slack tool, including reacting to messages or pinning/unpinning items in Slack channels or DMs.
+description: Use when the agent needs to send, edit, delete, or read Slack messages, add or list emoji reactions, pin or unpin messages, fetch member info, or list custom emoji in Slack channels and DMs. Handles all Slack workspace interactions including message management, reaction workflows, pinned-item management, and user lookups via the configured bot token.
 metadata: { "otto": { "emoji": "💬", "requires": { "config": ["channels.slack"] } } }
 ---
 

--- a/packages/skills/skills/songsee/SKILL.md
+++ b/packages/skills/skills/songsee/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: songsee
-description: Generate spectrograms and feature-panel visualizations from audio with the songsee CLI.
+description: Generate spectrograms and feature-panel visualizations from audio with the songsee CLI. Use when the user wants to visualize an audio file, create a spectrogram image, render mel or chroma panels, analyze frequency content, or produce a multi-panel audio feature grid from MP3 or WAV files.
 homepage: https://github.com/steipete/songsee
 metadata:
   {

--- a/packages/skills/skills/sonoscli/SKILL.md
+++ b/packages/skills/skills/sonoscli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sonoscli
-description: Control Sonos speakers (discover/status/play/volume/group).
+description: Control Sonos speakers (discover/status/play/volume/group). Use when the user wants to play music, pause playback, adjust volume, check speaker status, discover Sonos devices, group or ungroup speakers, manage favorites, browse the queue, or search Spotify on Sonos.
 homepage: https://sonoscli.sh
 metadata:
   {

--- a/packages/skills/skills/spotify-player/SKILL.md
+++ b/packages/skills/skills/spotify-player/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spotify-player
-description: Terminal Spotify playback/search via spogo (preferred) or spotify_player.
+description: Terminal Spotify playback/search via spogo (preferred) or spotify_player. Use when the user asks to play music, search for a song, skip a track, pause playback, check what is currently playing, control Spotify, list audio devices, or manage a Spotify queue from the terminal.
 homepage: https://www.spotify.com
 metadata:
   {

--- a/packages/skills/skills/summarize/SKILL.md
+++ b/packages/skills/skills/summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize
-description: Summarize or extract text/transcripts from URLs, podcasts, and local files (great fallback for “transcribe this YouTube/video”).
+description: Summarizes, condenses, or extracts text, transcripts, and key points from URLs, articles, web pages, PDFs, podcasts, YouTube videos, and local files. Acts as a fallback transcription tool when the user asks to transcribe, digest, recap, or get the gist of a link, video, or document.
 homepage: https://summarize.sh
 metadata:
   {

--- a/packages/skills/skills/testing-handbook-skills/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-handbook-skills
-description: "Application security testing toolkit from the Trail of Bits Testing Handbook. Covers fuzzing (libFuzzer, AFL++, cargo-fuzz, Atheris, Ruzzy), coverage analysis, harness writing, sanitizers, static analysis (Semgrep, CodeQL), and cryptographic testing (Wycheproof, constant-time)."
+description: "Application security testing toolkit from the Trail of Bits Testing Handbook. Helps the agent set up fuzzing campaigns, write fuzz harnesses, run coverage-guided fuzzers (libFuzzer, AFL++, cargo-fuzz, Atheris, Ruzzy), and triage crashes. Covers memory-safety sanitizers (AddressSanitizer, UBSan, MSan), static analysis with Semgrep and CodeQL, cryptographic validation using Wycheproof test vectors, and constant-time verification. Use when testing C, C++, Rust, Python, or Ruby code for vulnerabilities, improving code coverage, building seed corpora, creating fuzzing dictionaries, overcoming fuzzing obstacles, or integrating security checks into CI/CD with OSS-Fuzz."
 ---
 
 # Testing Handbook Skills

--- a/packages/skills/skills/testing-handbook-skills/skills/atheris/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/atheris/SKILL.md
@@ -2,8 +2,15 @@
 name: atheris
 type: fuzzer
 description: >
-  Atheris is a coverage-guided Python fuzzer based on libFuzzer.
-  Use for fuzzing pure Python code and Python C extensions.
+  Atheris is a coverage-guided Python fuzzing framework built on libFuzzer
+  for finding bugs, crashes, and security vulnerabilities in pure Python code
+  and Python C extensions. It provides AddressSanitizer integration for
+  detecting memory corruption, buffer overflows, and use-after-free errors.
+  Assists with writing fuzz harnesses, configuring sanitizers, managing
+  corpora, running fuzzing campaigns, and setting up Docker-based fuzzing
+  environments. Covers instrumentation of Python imports, parallel fuzzing
+  with workers, corpus minimization, and troubleshooting common issues like
+  LD_PRELOAD configuration and compiler flag setup.
 ---
 
 # Atheris

--- a/packages/skills/skills/testing-handbook-skills/skills/cargo-fuzz/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/cargo-fuzz/SKILL.md
@@ -2,8 +2,14 @@
 name: cargo-fuzz
 type: fuzzer
 description: >
-  cargo-fuzz is the de facto fuzzing tool for Rust projects using Cargo.
-  Use for fuzzing Rust code with libFuzzer backend.
+  cargo-fuzz is the primary fuzzing tool for Rust projects built with Cargo.
+  It enables developers to set up fuzz testing, write fuzz harnesses, and run
+  fuzzing campaigns using the libFuzzer backend. Covers installation, harness
+  writing, structure-aware fuzzing with the arbitrary crate, sanitizer
+  integration including AddressSanitizer, coverage analysis, seed corpus
+  management, and troubleshooting common issues. Useful when a developer needs
+  to fuzz Rust code, find memory bugs, test parsers, or improve test coverage
+  in a Cargo-based project.
 ---
 
 # cargo-fuzz

--- a/packages/skills/skills/testing-handbook-skills/skills/codeql/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/codeql/SKILL.md
@@ -2,8 +2,11 @@
 name: codeql
 type: tool
 description: >
-  CodeQL is a static analysis framework that queries code as a database.
-  Use when you need interprocedural analysis or complex data flow tracking.
+  Guides the agent through CodeQL static analysis, including creating databases,
+  writing custom QL queries, running interprocedural data flow and control flow
+  analysis, detecting security vulnerabilities, setting up GitHub Actions code
+  scanning, and managing query packs. Covers C, C++, Go, Java, Kotlin, JavaScript,
+  TypeScript, Python, Ruby, Swift, and SARIF output processing.
 ---
 
 # CodeQL

--- a/packages/skills/skills/testing-handbook-skills/skills/constant-time-testing/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/constant-time-testing/SKILL.md
@@ -2,8 +2,13 @@
 name: constant-time-testing
 type: domain
 description: >
-  Constant-time testing detects timing side channels in cryptographic code.
-  Use when auditing crypto implementations for timing vulnerabilities.
+  Guides developers through detecting and preventing side-channel attacks,
+  timing leaks, and constant-time violations in cryptographic implementations.
+  Covers techniques for identifying timing side channels in crypto code,
+  including cache-timing attacks, secret-dependent branching, and
+  microarchitectural leakage. Applies formal verification, statistical
+  analysis (dudect), and dynamic tracing (timecop) to audit crypto
+  primitives for timing vulnerabilities and ensure constant-time execution.
 ---
 
 # Constant-Time Testing

--- a/packages/skills/skills/testing-handbook-skills/skills/coverage-analysis/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/coverage-analysis/SKILL.md
@@ -2,8 +2,13 @@
 name: coverage-analysis
 type: technique
 description: >
-  Coverage analysis measures code exercised during fuzzing.
-  Use when assessing harness effectiveness or identifying fuzzing blockers.
+  The agent uses coverage analysis to measure which code paths, branches, and functions
+  are exercised during fuzzing campaigns. It generates LLVM and GCC coverage reports,
+  identifies uncovered code blocks, detects magic value checks that block fuzzer progress,
+  and tracks coverage trends over time. The agent applies this technique when assessing
+  harness effectiveness, diagnosing coverage plateaus, comparing differential coverage
+  between campaigns, or integrating coverage instrumentation into CMake and Rust builds
+  using llvm-cov, gcovr, and cargo-fuzz coverage toolchains.
 ---
 
 # Coverage Analysis

--- a/packages/skills/skills/testing-handbook-skills/skills/fuzzing-dictionary/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/fuzzing-dictionary/SKILL.md
@@ -2,8 +2,14 @@
 name: fuzzing-dictionary
 type: technique
 description: >
-  Fuzzing dictionaries guide fuzzers with domain-specific tokens.
-  Use when fuzzing parsers, protocols, or format-specific code.
+  The agent creates and manages fuzzing dictionaries containing domain-specific tokens,
+  magic bytes, protocol keywords, and format-specific strings to guide mutation-based
+  fuzzers past early validation checks. It generates dictionary entries from header files,
+  binary strings, man pages, and LLM prompts, and passes them to libFuzzer via -dict=,
+  AFL++ via -x, or cargo-fuzz. The agent applies this technique when fuzzing parsers
+  (JSON, XML, config files), protocol handlers (HTTP, DNS), file format processors
+  (PNG, PDF, media codecs), or when coverage plateaus indicate the fuzzer cannot
+  discover keyword-guarded code paths without token hints.
 ---
 
 # Fuzzing Dictionary

--- a/packages/skills/skills/testing-handbook-skills/skills/fuzzing-obstacles/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/fuzzing-obstacles/SKILL.md
@@ -2,8 +2,15 @@
 name: fuzzing-obstacles
 type: technique
 description: >
-  Techniques for patching code to overcome fuzzing obstacles.
-  Use when checksums, global state, or other barriers block fuzzer progress.
+  The agent patches the system under test (SUT) to overcome common fuzzing obstacles
+  using conditional compilation. It bypasses checksum and hash verification, replaces
+  non-deterministic PRNG seeding with fixed seeds, skips complex multi-stage validation,
+  and provides safe default values to prevent false positives. The agent uses
+  FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION in C/C++ and cfg!(fuzzing) in Rust to ensure
+  patches apply only during fuzzing builds. It applies this technique when coverage
+  reports reveal unreachable code behind checksums, cryptographic signatures, time-seeded
+  random state, or expensive validation logic that blocks fuzzer exploration of deeper
+  code paths in libFuzzer, AFL++, honggfuzz, cargo-fuzz, and LibAFL targets.
 ---
 
 # Overcoming Fuzzing Obstacles

--- a/packages/skills/skills/testing-handbook-skills/skills/harness-writing/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/harness-writing/SKILL.md
@@ -2,8 +2,15 @@
 name: harness-writing
 type: technique
 description: >
-  Techniques for writing effective fuzzing harnesses across languages.
-  Use when creating new fuzz targets or improving existing harness code.
+  The agent writes and improves fuzzing harnesses — the entrypoint functions that receive
+  random data from fuzzers and route it to the system under test (SUT). It implements
+  LLVMFuzzerTestOneInput for C/C++ with libFuzzer and AFL++ persistent mode, fuzz_target!
+  macros for Rust with cargo-fuzz and the arbitrary crate, and go-fuzz Fuzz functions for
+  Go. The agent structures inputs using FuzzedDataProvider, applies interleaved fuzzing
+  patterns for multi-operation targets, handles input size validation, resets global state
+  for determinism, and mocks blocking I/O. It applies this technique when creating new
+  fuzz targets, improving code coverage of existing harnesses, fixing non-reproducible
+  crashes, or building structure-aware harnesses with Protocol Buffers.
 ---
 
 # Writing Fuzzing Harnesses

--- a/packages/skills/skills/testing-handbook-skills/skills/libafl/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/libafl/SKILL.md
@@ -2,8 +2,15 @@
 name: libafl
 type: fuzzer
 description: >
-  LibAFL is a modular fuzzing library for building custom fuzzers. Use for
-  advanced fuzzing needs, custom mutators, or non-standard fuzzing targets.
+  The agent uses LibAFL, a modular Rust fuzzing library, to build custom fuzzers with
+  fine-grained control over observers, feedback mechanisms, mutators, schedulers, and
+  executors. It supports drop-in libFuzzer replacement mode via libFuzzer.a, fully custom
+  fuzzer construction with InProcessExecutor and coverage-guided feedback, multi-core
+  fuzzing with Launcher, crash deduplication via BacktraceObserver, and dictionary-based
+  token mutations. The agent applies LibAFL when standard fuzzers like libFuzzer or AFL++
+  lack needed customization — such as custom mutation strategies, novel feedback mechanisms,
+  non-standard target architectures, or fuzzing research requiring component-level control
+  over the fuzzing loop, corpus management, and sanitizer integration.
 ---
 
 # LibAFL

--- a/packages/skills/skills/testing-handbook-skills/skills/ossfuzz/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/ossfuzz/SKILL.md
@@ -2,8 +2,16 @@
 name: ossfuzz
 type: technique
 description: >
-  OSS-Fuzz provides free continuous fuzzing for open source projects.
-  Use when setting up continuous fuzzing infrastructure or enrolling projects.
+  The agent uses OSS-Fuzz, Google's free distributed continuous fuzzing platform, to build,
+  run, and manage fuzzing infrastructure for open-source projects. It configures project
+  enrollment files (project.yaml, Dockerfile, build.sh), builds fuzzers locally with
+  helper.py, runs harnesses with AddressSanitizer and other sanitizers, generates coverage
+  reports, and troubleshoots build failures. The agent applies this technique when setting
+  up continuous fuzzing for C/C++, Rust, Python (Atheris), or Go projects, reproducing
+  crashes from OSS-Fuzz bug reports, analyzing Fuzz Introspector coverage data, evaluating
+  criticality scores for project acceptance, or hosting a private OSS-Fuzz instance for
+  closed-source targets that need Docker-based fuzzing infrastructure with libFuzzer or
+  AFL++ engines.
 ---
 
 # OSS-Fuzz

--- a/packages/skills/skills/testing-handbook-skills/skills/semgrep/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/semgrep/SKILL.md
@@ -2,8 +2,12 @@
 name: semgrep
 type: tool
 description: >
-  Semgrep is a fast static analysis tool for finding bugs and enforcing code standards.
-  Use when scanning code for security issues or integrating into CI/CD pipelines.
+  Semgrep is a fast, lightweight static analysis tool for finding bugs, security
+  vulnerabilities, and enforcing code standards across a codebase. The agent should
+  use this skill when asked to run static analysis, scan code for security issues,
+  detect code patterns or anti-patterns, write or test custom Semgrep rules, set up
+  SAST in CI/CD pipelines, triage scan findings, suppress false positives, or
+  perform a rapid security audit without building the project.
 ---
 
 # Semgrep

--- a/packages/skills/skills/testing-handbook-skills/skills/wycheproof/SKILL.md
+++ b/packages/skills/skills/testing-handbook-skills/skills/wycheproof/SKILL.md
@@ -2,8 +2,14 @@
 name: wycheproof
 type: domain
 description: >
-  Wycheproof provides test vectors for validating cryptographic implementations.
-  Use when testing crypto code for known attacks and edge cases.
+  Guides agents in using Wycheproof test vectors to validate cryptographic
+  implementations against known attacks, edge cases, and vulnerability patterns.
+  Covers integrating test vectors for AES-GCM, ECDSA, ECDH, EdDSA, RSA, and
+  ChaCha20-Poly1305 into testing workflows. Helps when writing crypto tests,
+  checking for signature malleability, invalid curve attacks, padding oracle
+  issues, DER encoding bugs, or setting up CI for cryptographic libraries.
+  Applies to verifying encryption, decryption, signing, and key exchange
+  correctness using structured JSON test vector suites.
 ---
 
 # Wycheproof

--- a/packages/skills/skills/tmux/SKILL.md
+++ b/packages/skills/skills/tmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tmux
-description: Remote-control tmux sessions for interactive CLIs by sending keystrokes and scraping pane output.
+description: Remote-control tmux sessions for interactive CLIs by sending keystrokes, capturing pane output, and managing terminal multiplexer windows. Enables parallel coding-agent orchestration, background process management, and REPL interaction via sockets. Use when the agent needs to launch, monitor, or coordinate long-running terminal processes, run multiple agents in parallel, interact with a Python REPL, or scrape live shell output from a persistent session.
 metadata:
   { "otto": { "emoji": "🧵", "os": ["darwin", "linux"], "requires": { "bins": ["tmux"] } } }
 ---

--- a/packages/skills/skills/trello/SKILL.md
+++ b/packages/skills/skills/trello/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trello
-description: Manage Trello boards, lists, and cards via the Trello REST API.
+description: Manages Trello boards, lists, and cards via the Trello REST API. Use when the user wants to create cards, move tasks between lists, list boards, add comments, archive cards, or check what is on a Trello board. Handles authentication, pagination, and rate-limit awareness for all Trello REST endpoints.
 homepage: https://developer.atlassian.com/cloud/trello/rest/
 metadata:
   {

--- a/packages/skills/skills/video-frames/SKILL.md
+++ b/packages/skills/skills/video-frames/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-frames
-description: Extract frames or short clips from videos using ffmpeg.
+description: Extract frames or short clips from videos using ffmpeg. Use when the user asks to grab a frame, capture a screenshot from a video, extract a thumbnail, pull a still image from footage, or snapshot a specific timestamp in a video file.
 homepage: https://ffmpeg.org
 metadata:
   {

--- a/packages/skills/skills/voice-call/SKILL.md
+++ b/packages/skills/skills/voice-call/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: voice-call
-description: Start voice calls via the Otto voice-call plugin.
+description: Initiates, manages, and inspects voice calls through the Otto voice-call plugin using Twilio, Telnyx, Plivo, or mock providers. Supports starting outbound calls, continuing conversations, speaking messages, ending calls, and checking call status. Use when the user wants to make a phone call, dial a number, place a voice call, check call status, send a voice message, or speak to someone over the phone.
 metadata:
   {
     "otto":

--- a/packages/skills/skills/wacli/SKILL.md
+++ b/packages/skills/skills/wacli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wacli
-description: Send WhatsApp messages to other people or search/sync WhatsApp history via the wacli CLI (not for normal user chats).
+description: Send WhatsApp messages to other people or search/sync WhatsApp history via the wacli CLI (not for normal user chats). Use when the user asks to send a WhatsApp message, text someone on WhatsApp, search WhatsApp chat history, sync WhatsApp conversations, backfill message history, or forward a file via WhatsApp to a third party.
 homepage: https://wacli.sh
 metadata:
   {

--- a/packages/skills/skills/weather/SKILL.md
+++ b/packages/skills/skills/weather/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weather
-description: Get current weather and forecasts (no API key required).
+description: Get current weather and forecasts (no API key required). Use when the user asks about the weather, temperature, forecast, wind, humidity, or climate conditions for a city or location. Fetches real-time weather data from free services using curl.
 homepage: https://wttr.in/:help
 metadata: { "otto": { "emoji": "🌤️", "requires": { "bins": ["curl"] } } }
 ---


### PR DESCRIPTION
Hullo 👋

# Risks

- Low, medium, large. List what kind of risks and what could be affected.

- [X] Low

The changes do not affect code, but the use of the skills packaged in this repo. The changes aim to improve agent use of the skills.

# Background

## What does this PR do?

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the ten most improved:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/2390fca2-61e3-4b3c-bba0-96c84e46587d" />

Here's the full before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| peekaboo | 56% | 94% | +38% |
| voice-call | 48% | 86% | +38% |
| gemini | 66% | 100% | +34% |
| gog | 60% | 94% | +34% |
| nano-pdf | 60% | 94% | +34% |
| notion | 56% | 90% | +34% |
| openai-whisper | 66% | 100% | +34% |
| session-logs | 60% | 94% | +34% |
| weather | 66% | 100% | +34% |
| bear-notes | 64% | 94% | +30% |
| bird | 64% | 94% | +30% |
| blucli | 64% | 94% | +30% |
| camsnap | 64% | 94% | +30% |
| coding-agent | 59% | 89% | +30% |
| eightctl | 69% | 94% | +25% |
| gifgrep | 69% | 94% | +25% |
| imsg | 64% | 94% | +30% |
| local-places | 66% | 94% | +28% |
| nano-banana-pro | 66% | 94% | +28% |
| openai-image-gen | 64% | 94% | +30% |
| openai-whisper-api | 70% | 95% | +25% |
| openhue | 64% | 94% | +30% |
| oracle | 66% | 96% | +30% |
| ordercli | 64% | 94% | +30% |
| spotify-player | 64% | 94% | +30% |
| trello | 64% | 94% | +30% |
| blogwatcher | 70% | 95% | +25% |
| cargo-fuzz | 68% | 93% | +25% |
| songsee | 75% | 100% | +25% |
| video-frames | 70% | 100% | +30% |
| sherpa-onnx-tts | 56% | 86% | +30% |
| obsidian | 60% | 89% | +29% |
| sag | 66% | 89% | +23% |
| mcporter | 74% | 94% | +20% |
| wacli | 73% | 94% | +21% |
| sonoscli | 75% | 94% | +19% |
| atheris | 65% | 84% | +19% |
| constant-time-testing | 55% | 76% | +21% |
| apple-reminders | 78% | 94% | +16% |
| github | 78% | 94% | +16% |
| slack | 77% | 94% | +17% |
| tmux | 78% | 94% | +16% |
| skill-creator | 76% | 93% | +17% |
| wycheproof | 65% | 81% | +16% |
| bluebubbles | 81% | 94% | +13% |
| summarize | 76% | 90% | +14% |
| canvas | 76% | 89% | +13% |
| coverage-analysis | 76% | 89% | +13% |
| fuzzing-obstacles | 76% | 89% | +13% |
| harness-writing | 76% | 89% | +13% |
| ossfuzz | 76% | 89% | +13% |
| th-semgrep | 72% | 89% | +17% |
| fuzzing-dictionary | 76% | 86% | +10% |
| libafl | 76% | 85% | +9% |
| himalaya | 78% | 86% | +8% |
| testing-handbook-skills | 78% | 86% | +8% |
| th-codeql | 72% | 80% | +8% |

The main improvement across all 57 skills was expanding the frontmatter description field to include:

- Explicit "Use when..." clauses for clear trigger guidance
- Natural trigger terms users would actually say
- Specific action verbs replacing vague terms like "manage"
- Tool and platform context for better matching

No body content, workflows, or code examples were modified. All changes are description-only to improve skill discoverability and selection.


## What kind of change is this?

- [X] Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

Agents load skills first by pulling in the front-matter. The user may or may not trigger the use of a skill, depending on what requests they make. If the frontmatter is not formatted well, the agent may not load the rest of the skill at all. This can lead to hallucinations, inefficient use of tokens, and extended context usage.

These changes attempt to fix these problems, by adhering to the standards set out by Anthropic, to ensure efficienrt use of skills and the agent context.

# Documentation changes needed?

- [X] My changes do not require a change to the project documentation.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

Load up your favourite AI agent without this PR, and another with it, and try to trigger the skills by asking normal end-user questions.

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

p.o.p.e.y

-->

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at this Tessl guide and ask it to optimize your skill: https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices Ping me - @popey - if you hit any snags.

Thanks in advance 🙏

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the frontmatter `description` field across 57 SKILL.md files to enhance skill discoverability and LLM-driven selection. The descriptions are the primary mechanism by which the agent decides whether to load a skill (via `formatSkillsForPrompt()` in `formatter.ts`), so richer descriptions directly improve skill matching.

- **Description-only changes**: All 57 files modify only the YAML frontmatter `description` field. No body content, workflows, or code examples were changed.
- **Pattern applied**: Each description was expanded with explicit "Use when..." trigger clauses, natural user phrases, specific action verbs, and tool/platform context.
- **Validation passes**: All descriptions are well within the 1024-character `MAX_DESCRIPTION_LENGTH` limit enforced by `loader.ts` (longest is ossfuzz at 799 chars after YAML folding). Multi-line YAML `>` block scalars in the testing-handbook sub-skills are correctly formatted.
- **No functional risk**: Changes only affect how the LLM matches user requests to skills — no runtime code, tool invocations, or skill logic was modified.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only modifies YAML frontmatter description text in SKILL.md files with no functional code changes.
- All 57 changes are description-only text edits in SKILL.md frontmatter. No code, workflows, or skill body content was modified. All descriptions are within the 1024-char validation limit. YAML syntax is correct across all files including multi-line block scalars. The changes improve skill discoverability without any risk of breaking existing behavior.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/skills/skills/peekaboo/SKILL.md | Description expanded from 1 sentence to detailed trigger keywords and capabilities (478 chars, well within 1024 limit). Accurately reflects skill body content. |
| packages/skills/skills/testing-handbook-skills/SKILL.md | Parent skill description expanded with explicit "Use when" triggers covering fuzzing, coverage, static analysis and cryptographic testing. 670 chars, within limit. |
| packages/skills/skills/testing-handbook-skills/skills/ossfuzz/SKILL.md | Longest description at 799 chars after YAML folding. Multi-line `>` block scalar format is correct. Content accurately describes OSS-Fuzz capabilities. |
| packages/skills/skills/weather/SKILL.md | Simple inline description expanded with natural trigger terms (weather, temperature, forecast, wind, humidity, climate). Clean, accurate. |
| packages/skills/skills/bird/SKILL.md | X/Twitter skill description expanded with platform-specific trigger terms (tweet, timeline, bookmarks, follow/unfollow). 444 chars, within limit. |
| packages/skills/skills/github/SKILL.md | GitHub skill description now includes specific subcommands (gh issue, gh pr, gh run, gh repo, gh api) and action verbs. 422 chars. |
| packages/skills/skills/slack/SKILL.md | Slack description improved with explicit trigger terms for message operations, reactions, pinning, and user lookups. 352 chars. |
| packages/skills/skills/bluebubbles/SKILL.md | iMessage integration description expanded with natural trigger phrases (send a text, text someone, message a contact). 436 chars. |
| packages/skills/skills/testing-handbook-skills/skills/atheris/SKILL.md | Multi-line YAML description expanded from 2 lines to 9 lines covering specific capabilities. Uses `>` block scalar correctly. 632 chars after folding. |
| packages/skills/skills/voice-call/SKILL.md | Voice call description expanded from one short sentence to include provider names (Twilio, Telnyx, Plivo) and natural trigger phrases. 404 chars. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User Request"] --> B["Agent loads skill descriptions\nfrom SKILL.md frontmatter"]
    B --> C["formatSkillsForPrompt()\nformatter.ts"]
    C --> D["XML skill list injected\ninto system prompt"]
    D --> E{"LLM matches request\nto skill description"}
    E -->|"Before: vague descriptions\n(e.g. 'Manage Apple Reminders')"| F["❌ Skill may not trigger\n→ hallucination / missed skill"]
    E -->|"After: enriched descriptions\nwith 'Use when...' clauses"| G["✅ Skill correctly triggered\n→ accurate tool invocation"]
```

<sub>Last reviewed commit: 1476c1b</sub>

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->