### PR TITLE
fix: adapter usage, turbo outputs, and build/type fixes

### DIFF
--- a/examples/app/electron/backend/src/runtimeManager.ts
+++ b/examples/app/electron/backend/src/runtimeManager.ts
@@ -140,8 +140,15 @@ export async function getOrCreateRuntime(
       currentMode = null;
     }
 
+    const agentId = stringToUuid(CHAT_CHARACTER.name ?? "Eliza");
+    if (!localdbPlugin.adapter) throw new Error("plugin-localdb adapter factory required");
+    const adapterOrPromise = localdbPlugin.adapter(agentId, { LOCALDB_DATA_DIR: dataDir });
+    const adapter = adapterOrPromise instanceof Promise ? await adapterOrPromise : adapterOrPromise;
+    await adapter.initialize();
+
     const runtime = new AgentRuntime({
       character: CHAT_CHARACTER,
+      adapter,
       plugins: await buildPlugins(effectiveMode),
       actionPlanning: false,
       llmMode: LLMMode.SMALL,

--- a/examples/aws/typescript/handler.ts
+++ b/examples/aws/typescript/handler.ts
@@ -18,7 +18,7 @@ import {
   type UUID,
 } from "@elizaos/core";
 import { openaiPlugin } from "@elizaos/plugin-openai";
-import sqlPlugin, { createDatabaseAdapter } from "@elizaos/plugin-sql";
+import sqlPlugin from "@elizaos/plugin-sql";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResultV2,
@@ -86,17 +86,24 @@ async function initializeRuntime(): Promise<AgentRuntime> {
 
     const character = getCharacter();
     const agentId = stringToUuid(character.name ?? "Eliza");
-    const adapter = process.env.POSTGRES_URL
-      ? createDatabaseAdapter(
-          { postgresUrl: process.env.POSTGRES_URL },
-          agentId,
-        )
-      : new InMemoryDatabaseAdapter();
+    let resolvedAdapter: Awaited<ReturnType<NonNullable<typeof sqlPlugin.adapter>>> | InMemoryDatabaseAdapter;
+    if (process.env.POSTGRES_URL) {
+      if (!sqlPlugin.adapter) throw new Error("plugin-sql adapter factory required");
+      const out = sqlPlugin.adapter(agentId, {
+        POSTGRES_URL: process.env.POSTGRES_URL,
+        DATABASE_URL: process.env.POSTGRES_URL,
+      });
+      resolvedAdapter = out instanceof Promise ? await out : out;
+    } else {
+      resolvedAdapter = new InMemoryDatabaseAdapter();
+    }
+
+    await resolvedAdapter.initialize();
 
     runtime = new AgentRuntime({
       character,
       plugins: [sqlPlugin, openaiPlugin],
-      adapter,
+      adapter: resolvedAdapter,
     });
 
     await runtime.initialize();

--- a/examples/next/app/api/chat/route.ts
+++ b/examples/next/app/api/chat/route.ts
@@ -25,8 +25,8 @@ import sqlPlugin from "@elizaos/plugin-sql";
 
 import { v4 as uuidv4 } from "uuid";
 
-// Type assertion needed due to namespace import inference
-const typedSqlPlugin = sqlPlugin as Plugin;
+// Type assertion: plugin-sql's schema type can be inferred as {} which doesn't satisfy Plugin's Record<string, ...>
+const typedSqlPlugin = sqlPlugin as unknown as Plugin;
 
 // Character configuration
 const character: Character = createCharacter({

--- a/examples/react/src/eliza-runtime.ts
+++ b/examples/react/src/eliza-runtime.ts
@@ -157,8 +157,15 @@ async function initializeRuntime(): Promise<AgentRuntime> {
   // Pre-initialize PGlite before the SQL plugin runs
   await preinitializePGlite();
 
+  const agentId = stringToUuid(elizaCharacter.name ?? "ELIZA");
+  if (!sqlPlugin.adapter) throw new Error("plugin-sql adapter factory required");
+  const adapterOrPromise = sqlPlugin.adapter(agentId, {});
+  const adapter = adapterOrPromise instanceof Promise ? await adapterOrPromise : adapterOrPromise;
+  await adapter.initialize();
+
   const runtime = new AgentRuntime({
     character: elizaCharacter,
+    adapter,
     plugins: [
       sqlPlugin, // PGlite database for browser (uses our pre-initialized instance)
       elizaClassicPlugin, // Classic ELIZA pattern matching

--- a/examples/vercel/api/chat.ts
+++ b/examples/vercel/api/chat.ts
@@ -39,14 +39,12 @@ function getCharacter(): Character {
   if (typeof process !== "undefined" && process.env?.OPENAI_API_KEY) {
     secrets.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
   }
+  const env = typeof process !== "undefined" ? process.env : undefined;
   return createCharacter({
-    name:
-      (typeof process !== "undefined" && process.env?.CHARACTER_NAME) ?? "Eliza",
-    bio:
-      (typeof process !== "undefined" && process.env?.CHARACTER_BIO) ??
-      "A helpful AI assistant.",
+    name: (env?.CHARACTER_NAME as string | undefined) ?? "Eliza",
+    bio: (env?.CHARACTER_BIO as string | undefined) ?? "A helpful AI assistant.",
     system:
-      (typeof process !== "undefined" && process.env?.CHARACTER_SYSTEM) ??
+      (env?.CHARACTER_SYSTEM as string | undefined) ??
       "You are a helpful, concise AI assistant. Respond thoughtfully to user messages.",
     secrets,
   });

--- a/packages/elizaos/examples-manifest.json
+++ b/packages/elizaos/examples-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-03-13T02:55:37.361Z",
+  "generatedAt": "2026-03-17T04:29:55.798Z",
   "repoUrl": "https://github.com/elizaos/eliza",
   "examples": [
     {

--- a/plugins/plugin-copilot-proxy/typescript/build.ts
+++ b/plugins/plugin-copilot-proxy/typescript/build.ts
@@ -35,7 +35,7 @@ async function build(): Promise<void> {
   console.log("📝 Generating TypeScript declarations...");
 
   const { $ } = await import("bun");
-  await $`tsc --project tsconfig.build.json`.nothrow();
+  await $`tsc --project tsconfig.json`.nothrow();
 
   const totalTime = ((Date.now() - totalStart) / 1000).toFixed(2);
   console.log(`🎉 All builds finished in ${totalTime}s`);

--- a/plugins/plugin-openai/typescript/build.ts
+++ b/plugins/plugin-openai/typescript/build.ts
@@ -75,8 +75,21 @@ async function build(): Promise<void> {
     throw new Error("Node CJS build failed");
   }
 
+  // Fix Bun bundler bug: it emits "default2 as default" when re-exporting default from index.node.ts
+  const { readFile, writeFile, rename, access } = await import("node:fs/promises");
+  for (const file of ["dist/node/index.node.js", "dist/cjs/index.node.js"]) {
+    try {
+      let code = await readFile(file, "utf-8");
+      if (code.includes("default2 as default")) {
+        code = code.replace("default2 as default", "openaiPlugin as default");
+        await writeFile(file, code);
+      }
+    } catch (e) {
+      console.warn("Post-process default export warning:", e);
+    }
+  }
+
   // Rename .js to .cjs for correct module resolution
-  const { rename, access } = await import("node:fs/promises");
   try {
     await access("dist/cjs/index.node.js");
     await rename("dist/cjs/index.node.js", "dist/cjs/index.node.cjs");
@@ -90,7 +103,7 @@ async function build(): Promise<void> {
   const dtsStart = Date.now();
   console.log("📝 Generating TypeScript declarations...");
 
-  const { mkdir, writeFile } = await import("node:fs/promises");
+  const { mkdir } = await import("node:fs/promises");
   const { $ } = await import("bun");
 
   await $`tsc --project tsconfig.build.json`;

--- a/plugins/plugin-openai/typescript/index.ts
+++ b/plugins/plugin-openai/typescript/index.ts
@@ -372,4 +372,4 @@ export const openaiPlugin: Plugin = {
   ],
 };
 
-export default openaiPlugin;
+export { openaiPlugin as default };

--- a/turbo.json
+++ b/turbo.json
@@ -168,6 +168,11 @@
       "env": ["LOG_LEVEL"],
       "outputs": ["typescript/dist/**", "rust/pkg/**", "python/dist/**"]
     },
+    "@elizaos/plugin-feishu-root#build": {
+      "dependsOn": ["^build"],
+      "env": ["LOG_LEVEL"],
+      "outputs": ["typescript/dist/**", "rust/pkg/**", "python/dist/**"]
+    },
     "@elizaos/plugin-browser-root#build": {
       "dependsOn": ["^build"],
       "env": ["LOG_LEVEL"],
@@ -315,6 +320,14 @@
       "outputs": ["rust/target/release/**"]
     },
     "ai-town#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "eliza-vrm-demo#build": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "@mediar-ai/workflow#build": {
       "dependsOn": ["^build"],
       "outputs": []
     },


### PR DESCRIPTION
probably more test fixes but just making sure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches runtime initialization paths across multiple examples and adjusts plugin build scripts/exports, which could impact startup and packaging if adapter factories or bundler assumptions differ across environments.
> 
> **Overview**
> **Standardizes database adapter initialization across examples.** Electron (LocalDB), React (SQL/PGlite), and AWS Lambda (SQL/Postgres or in-memory) now resolve adapters via each plugin’s `.adapter` factory (handling async factories) and explicitly call `adapter.initialize()` before creating `AgentRuntime`.
> 
> **Fixes build/type issues and turborepo config.** `plugin-openai` now re-exports default as `openaiPlugin` and post-processes Bun output to work around a default-export bundling bug; `plugin-copilot-proxy` uses `tsconfig.json` for declaration generation; `turbo.json` adds missing build tasks/outputs; minor env handling/type assertions are tightened in Next/Vercel examples, and `examples-manifest.json` is regenerated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce28beafe9501b4bf8dee6dc0f73aaa654c10b6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a collection of build, type, and adapter usage fixes across several example apps and plugins. The primary theme is standardizing how database adapters are created and initialized — explicitly invoking the plugin's `adapter()` factory and calling `adapter.initialize()` before passing the adapter to `AgentRuntime`, instead of relying on `createDatabaseAdapter()` or deferred initialization.

Key changes:
- **Adapter pattern fix** (`examples/aws`, `examples/react`, `examples/app/electron`): Adapter is now explicitly created via `plugin.adapter(agentId, settings)`, awaited, and initialized before constructing `AgentRuntime`. This ensures adapters are fully ready before the runtime starts.
- **Bun bundler workaround** (`plugin-openai`): Changed `export default openaiPlugin` to `export { openaiPlugin as default }` to prevent Bun from emitting `default2 as default` in bundled output. A post-processing step in `build.ts` patches any remaining occurrences.
- **tsconfig fix** (`plugin-copilot-proxy`): Corrected a reference from the non-existent `tsconfig.build.json` to the actual `tsconfig.json`.
- **Turbo outputs** (`turbo.json`): Added missing build task entries for `@elizaos/plugin-feishu-root`, `eliza-vrm-demo`, and `@mediar-ai/workflow`.
- **Type assertion fix** (`examples/next`): Widened cast from `as Plugin` to `as unknown as Plugin` to satisfy TypeScript's strict schema type inference.


<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; all changes are build/type fixes and example code consistency improvements with no core runtime changes.
- All changes are confined to example code, build scripts, and Turborepo configuration. The adapter pattern fixes align with the `plugin-sql` and `plugin-localdb` factory APIs. Minor concerns: the Next.js example was not fully migrated to the new adapter pattern (inconsistency with other examples), and the Bun bundler post-processing fix relies on a hardcoded identifier name. Neither is a blocking issue.
- plugins/plugin-openai/typescript/build.ts — hardcoded Bun bundler string fix; examples/next/app/api/chat/route.ts — adapter pattern not migrated unlike all other examples in this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/app/electron/backend/src/runtimeManager.ts | Adds explicit adapter creation via localdbPlugin.adapter() factory and initialization before constructing AgentRuntime. Pattern is consistent with the PR's broader goal. |
| examples/aws/typescript/handler.ts | Migrated from createDatabaseAdapter to sqlPlugin.adapter factory pattern; passes both POSTGRES_URL and DATABASE_URL keys to the settings object (redundantly); adapter initialized explicitly before runtime creation. |
| examples/next/app/api/chat/route.ts | Only the type assertion was updated (as Plugin → as unknown as Plugin). The adapter is still created via the old createDatabaseAdapter dynamic import, inconsistent with other examples migrated in this PR. |
| examples/react/src/eliza-runtime.ts | Adds adapter creation via sqlPlugin.adapter({}) before AgentRuntime construction, consistent with the browser version of plugin-sql that uses the pre-initialized PGliteClientManager singleton. |
| plugins/plugin-openai/typescript/build.ts | Adds a post-processing step to fix a Bun bundler bug where re-exported default is emitted as "default2 as default". The fix uses a hardcoded string replace tied to Bun's internal variable naming convention. |
| plugins/plugin-openai/typescript/index.ts | Changed export default openaiPlugin to export { openaiPlugin as default } to work around a Bun bundler re-export issue; functionally equivalent. |
| plugins/plugin-copilot-proxy/typescript/build.ts | Fixed incorrect tsconfig reference: tsconfig.build.json does not exist in this package; changed to tsconfig.json which is the only tsconfig present. |
| turbo.json | Adds missing build task configurations for @elizaos/plugin-feishu-root, eliza-vrm-demo, and @mediar-ai/workflow to ensure correct dependency resolution and output caching in Turborepo. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Example App
    participant Plugin as plugin.adapter()
    participant Adapter as IDatabaseAdapter
    participant Runtime as AgentRuntime

    App->>Plugin: plugin.adapter(agentId, settings)
    Plugin-->>App: adapter (sync or Promise)
    App->>App: await adapter if Promise
    App->>Adapter: adapter.initialize()
    Adapter-->>App: initialized
    App->>Runtime: new AgentRuntime({ adapter, plugins })
    Runtime->>Runtime: runtime.initialize()
    Note over Runtime: Adapter already ready, plugin.init() skips re-initialization
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `examples/next/app/api/chat/route.ts`, line 62-66 ([link](https://github.com/elizaos/eliza/blob/ce28beafe9501b4bf8dee6dc0f73aaa654c10b6d/examples/next/app/api/chat/route.ts#L62-L66)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Inconsistent adapter pattern with other examples**

   All other examples updated in this PR (AWS, React, Electron) now use the `sqlPlugin.adapter()` factory, but this file still uses the old `createDatabaseAdapter` dynamic import pattern. While `createDatabaseAdapter` is still a public API and this works correctly, adopting the same pattern would keep the examples consistent.

   

   
   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ce28bea</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->