### PR TITLE
fix: implement component storage in InMemoryDatabaseAdapter

### DIFF
--- a/packages/typescript/src/__tests__/inMemoryAdapter-components.test.ts
+++ b/packages/typescript/src/__tests__/inMemoryAdapter-components.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import type { Component, UUID } from "../types";
+
+function uuid(): UUID {
+  return crypto.randomUUID() as UUID;
+}
+
+function makeComponent(overrides: Partial<Component> = {}): Component {
+  return {
+    id: uuid(),
+    entityId: uuid(),
+    agentId: uuid(),
+    roomId: uuid(),
+    type: "test",
+    data: {},
+    createdAt: Date.now(),
+    ...overrides,
+  } as Component;
+}
+
+describe("InMemoryDatabaseAdapter — components", () => {
+  let adapter: InMemoryDatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryDatabaseAdapter();
+    await adapter.init();
+  });
+
+  // ─── createComponents / getComponentsByIds ───
+
+  it("creates and retrieves components by ID", async () => {
+    const c1 = makeComponent();
+    const c2 = makeComponent();
+    const ids = await adapter.createComponents([c1, c2]);
+    expect(ids).toEqual([c1.id, c2.id]);
+
+    const fetched = await adapter.getComponentsByIds([c1.id, c2.id]);
+    expect(fetched).toHaveLength(2);
+    expect(fetched[0].id).toBe(c1.id);
+    expect(fetched[1].id).toBe(c2.id);
+  });
+
+  it("getComponentsByIds ignores unknown IDs", async () => {
+    const c = makeComponent();
+    await adapter.createComponents([c]);
+    const fetched = await adapter.getComponentsByIds([c.id, uuid()]);
+    expect(fetched).toHaveLength(1);
+  });
+
+  it("sets createdAt to Date.now() when missing", async () => {
+    const c = makeComponent({ createdAt: undefined as unknown as number });
+    const before = Date.now();
+    await adapter.createComponents([c]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect(typeof fetched.createdAt).toBe("number");
+    expect(fetched.createdAt).toBeGreaterThanOrEqual(before);
+  });
+
+  // ─── getComponent (single-item, filtered) ───
+
+  it("getComponent filters by entityId + type", async () => {
+    const entityId = uuid();
+    const c1 = makeComponent({ entityId, type: "profile" });
+    const c2 = makeComponent({ entityId, type: "settings" });
+    const c3 = makeComponent({ type: "profile" }); // different entity
+    await adapter.createComponents([c1, c2, c3]);
+
+    const found = await adapter.getComponent(entityId, "profile");
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(c1.id);
+
+    const notFound = await adapter.getComponent(entityId, "nonexistent");
+    expect(notFound).toBeNull();
+  });
+
+  it("getComponent filters by optional worldId", async () => {
+    const entityId = uuid();
+    const worldA = uuid();
+    const worldB = uuid();
+    const c1 = makeComponent({ entityId, type: "x", worldId: worldA });
+    const c2 = makeComponent({ entityId, type: "x", worldId: worldB });
+    await adapter.createComponents([c1, c2]);
+
+    const found = await adapter.getComponent(entityId, "x", worldA);
+    expect(found!.id).toBe(c1.id);
+  });
+
+  it("getComponent filters by optional sourceEntityId", async () => {
+    const entityId = uuid();
+    const src = uuid();
+    const c = makeComponent({ entityId, type: "x", sourceEntityId: src });
+    await adapter.createComponents([c]);
+
+    const found = await adapter.getComponent(entityId, "x", undefined, src);
+    expect(found!.id).toBe(c.id);
+
+    const miss = await adapter.getComponent(entityId, "x", undefined, uuid());
+    expect(miss).toBeNull();
+  });
+
+  // ─── getComponents (multi-item, filtered) ───
+
+  it("getComponents returns all components for an entity", async () => {
+    const entityId = uuid();
+    const c1 = makeComponent({ entityId, type: "a" });
+    const c2 = makeComponent({ entityId, type: "b" });
+    const c3 = makeComponent(); // different entity
+    await adapter.createComponents([c1, c2, c3]);
+
+    const result = await adapter.getComponents(entityId);
+    expect(result).toHaveLength(2);
+  });
+
+  // ─── updateComponents ───
+
+  it("updateComponents overwrites stored data", async () => {
+    const c = makeComponent({ data: { score: 10 } });
+    await adapter.createComponents([c]);
+
+    await adapter.updateComponents([{ ...c, data: { score: 99 } }]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect((fetched.data as Record<string, unknown>).score).toBe(99);
+  });
+
+  // ─── deleteComponents ───
+
+  it("deleteComponents removes components", async () => {
+    const c1 = makeComponent();
+    const c2 = makeComponent();
+    await adapter.createComponents([c1, c2]);
+
+    await adapter.deleteComponents([c1.id]);
+    const remaining = await adapter.getComponentsByIds([c1.id, c2.id]);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(c2.id);
+  });
+
+  // ─── upsertComponents ───
+
+  it("upsertComponents inserts new components", async () => {
+    const c = makeComponent();
+    await adapter.upsertComponents([c]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect(fetched.id).toBe(c.id);
+  });
+
+  it("upsertComponents merges on natural key conflict", async () => {
+    const entityId = uuid();
+    const c1 = makeComponent({
+      entityId,
+      type: "profile",
+      data: { name: "old" },
+    });
+    await adapter.createComponents([c1]);
+
+    const c2 = makeComponent({
+      entityId,
+      type: "profile",
+      data: { name: "new" },
+    });
+    await adapter.upsertComponents([c2]);
+
+    // Should still have 1 component (upserted, not duplicated)
+    const all = await adapter.getComponents(entityId);
+    expect(all).toHaveLength(1);
+    // Data should be updated
+    expect((all[0].data as Record<string, unknown>).name).toBe("new");
+    // ID should be preserved from original
+    expect(all[0].id).toBe(c1.id);
+  });
+
+  it("upsertComponents dedupes within batch by natural key", async () => {
+    const entityId = uuid();
+    const first = makeComponent({
+      entityId,
+      type: "x",
+      data: { v: 1 },
+    });
+    const second = makeComponent({
+      entityId,
+      type: "x",
+      data: { v: 2 },
+    });
+    await adapter.upsertComponents([first, second]);
+
+    const all = await adapter.getComponents(entityId);
+    expect(all).toHaveLength(1);
+    expect((all[0].data as Record<string, unknown>).v).toBe(2);
+  });
+
+  // ─── patchComponent ───
+
+  it("patchComponent set: sets a nested value", async () => {
+    const c = makeComponent({ data: { wallet: { balance: 100 } } });
+    await adapter.createComponents([c]);
+
+    await adapter.patchComponent(c.id, [
+      { op: "set", path: "wallet.balance", value: 200 },
+    ]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect(
+      (
+        fetched.data as Record<string, unknown> & {
+          wallet: { balance: number };
+        }
+      ).wallet.balance,
+    ).toBe(200);
+  });
+
+  it("patchComponent push: appends to array", async () => {
+    const c = makeComponent({ data: { tags: ["a"] } });
+    await adapter.createComponents([c]);
+
+    await adapter.patchComponent(c.id, [
+      { op: "push", path: "tags", value: "b" },
+    ]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect((fetched.data as Record<string, unknown>).tags).toEqual(["a", "b"]);
+  });
+
+  it("patchComponent push: creates array if not present", async () => {
+    const c = makeComponent({ data: {} });
+    await adapter.createComponents([c]);
+
+    await adapter.patchComponent(c.id, [
+      { op: "push", path: "items", value: "first" },
+    ]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect((fetched.data as Record<string, unknown>).items).toEqual(["first"]);
+  });
+
+  it("patchComponent remove: deletes a key", async () => {
+    const c = makeComponent({ data: { a: 1, b: 2 } });
+    await adapter.createComponents([c]);
+
+    await adapter.patchComponent(c.id, [{ op: "remove", path: "a" }]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect(fetched.data).toEqual({ b: 2 });
+  });
+
+  it("patchComponent increment: adds to numeric value", async () => {
+    const c = makeComponent({ data: { count: 5 } });
+    await adapter.createComponents([c]);
+
+    await adapter.patchComponent(c.id, [
+      { op: "increment", path: "count", value: 3 },
+    ]);
+    const [fetched] = await adapter.getComponentsByIds([c.id]);
+    expect((fetched.data as Record<string, unknown>).count).toBe(8);
+  });
+
+  it("patchComponent throws on unknown component", async () => {
+    await expect(
+      adapter.patchComponent(uuid(), [{ op: "set", path: "x", value: 1 }]),
+    ).rejects.toThrow("Component not found");
+  });
+
+  it("patchComponent throws on invalid path", async () => {
+    const c = makeComponent();
+    await adapter.createComponents([c]);
+
+    await expect(
+      adapter.patchComponent(c.id, [
+        { op: "set", path: "foo.bar-baz", value: 1 },
+      ]),
+    ).rejects.toThrow("Invalid patch path");
+  });
+});

--- a/packages/typescript/src/database/inMemoryAdapter.ts
+++ b/packages/typescript/src/database/inMemoryAdapter.ts
@@ -217,9 +217,12 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
 
     if (includeComponents) {
-      for (const entity of entities) {
-        entity.components = await this.getComponents(entity.id!);
-      }
+      return Promise.all(
+        entities.map(async (entity) => ({
+          ...entity,
+          components: await this.getComponents(entity.id!),
+        })),
+      );
     }
 
     return entities;
@@ -349,7 +352,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     for (const c of components) {
       this.components.set(String(c.id), {
         ...c,
-        createdAt: c.createdAt ?? new Date(),
+        createdAt: c.createdAt ?? Date.now(),
       });
       ids.push(c.id);
     }
@@ -413,7 +416,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
       } else {
         this.components.set(String(c.id), {
           ...c,
-          createdAt: c.createdAt ?? new Date(),
+          createdAt: c.createdAt ?? Date.now(),
         });
       }
     }
@@ -426,11 +429,20 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
   ): Promise<void> {
     if (ops.length === 0) return;
     const c = this.components.get(String(componentId));
-    if (!c) return;
+    if (!c) throw new Error(`Component not found: ${componentId}`);
     const data = (c.data ?? {}) as Metadata;
 
     for (const op of ops) {
       const segments = op.path.split(".");
+      if (
+        segments.some(
+          (seg) => !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(seg) && !/^\d+$/.test(seg),
+        )
+      ) {
+        throw new Error(
+          `Invalid patch path: "${op.path}". Only alphanumeric, underscore, and numeric indices allowed.`,
+        );
+      }
       const last = segments.pop()!;
       // Walk to parent object, creating intermediate objects as needed
       let target = data as Record<string, unknown>;

--- a/packages/typescript/src/database/inMemoryAdapter.ts
+++ b/packages/typescript/src/database/inMemoryAdapter.ts
@@ -72,6 +72,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
   private roomsByParticipant = new Map<string, Set<string>>();
   private participantUserState = new Map<string, "FOLLOWED" | "MUTED" | null>();
 
+  private components = new Map<string, Component>();
+
   // Pairing storage
   private pairingRequests = new Map<string, PairingRequest>();
   private pairingAllowlist = new Map<string, PairingAllowlistEntry>();
@@ -126,7 +128,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
     return ids;
   }
-  
+
   async upsertAgents(agents: Partial<Agent>[]): Promise<void> {
     // WHY simple set: Map.set() overwrites if key exists, inserts if not.
     // This is the InMemory equivalent of ON CONFLICT DO UPDATE.
@@ -137,7 +139,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
   }
 
-  async updateAgents(updates: Array<{ agentId: UUID; agent: Partial<Agent> }>): Promise<boolean> {
+  async updateAgents(
+    updates: Array<{ agentId: UUID; agent: Partial<Agent> }>,
+  ): Promise<boolean> {
     for (const { agentId, agent } of updates) {
       const existing = this.agents.get(String(agentId)) ?? {};
       this.agents.set(String(agentId), { ...existing, ...agent, id: agentId });
@@ -151,11 +155,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
     return true;
   }
-  
+
   async countAgents(): Promise<number> {
     return this.agents.size;
   }
-  
+
   async cleanupAgents(): Promise<void> {
     // WHY no-op: InMemory adapter has no persistent storage, so no cleanup needed.
     // Agents are automatically cleared when process restarts.
@@ -193,7 +197,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return [];
   }
 
-  async getEntitiesForRoom(roomId: UUID, includeComponents?: boolean): Promise<Entity[]> {
+  async getEntitiesForRoom(
+    roomId: UUID,
+    includeComponents?: boolean,
+  ): Promise<Entity[]> {
     // Get participant entity IDs for the given roomId from participantsByRoom
     const participantSet = this.participantsByRoom.get(String(roomId));
     if (!participantSet || participantSet.size === 0) {
@@ -209,12 +216,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
       }
     }
 
-    // If includeComponents is requested, include component data
-    // Note: For in-memory adapter, components are not tracked per entity,
-    // so this is effectively a no-op, but we maintain the interface contract
     if (includeComponents) {
-      // Components would be attached here if we tracked them
-      // For now, entities are returned as-is
+      for (const entity of entities) {
+        entity.components = await this.getComponents(entity.id!);
+      }
     }
 
     return entities;
@@ -229,7 +234,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
     return ids;
   }
-  
+
   async upsertEntities(entities: Entity[]): Promise<void> {
     // WHY simple set: For InMemory, upsert is just Map.set() which naturally
     // handles both insert (new key) and update (existing key) cases.
@@ -237,7 +242,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
       this.entities.set(String(entity.id), entity);
     }
   }
-  
+
   async searchEntitiesByName(params: {
     query: string;
     agentId: UUID;
@@ -248,56 +253,72 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     const lowerQuery = params.query.toLowerCase();
     const limit = params.limit ?? 10;
     const matches: Entity[] = [];
-    
+
     for (const entity of this.entities.values()) {
       if (entity.agentId !== params.agentId) continue;
-      
-      const hasMatch = entity.names?.some(name => 
-        name.toLowerCase().includes(lowerQuery)
+
+      const hasMatch = entity.names?.some((name) =>
+        name.toLowerCase().includes(lowerQuery),
       );
-      
+
       if (hasMatch) {
         matches.push(entity);
         if (matches.length >= limit) break;
       }
     }
-    
+
     return matches;
   }
-  
-  async getEntitiesByNames(params: { names: string[]; agentId: UUID }): Promise<Entity[]> {
+
+  async getEntitiesByNames(params: {
+    names: string[];
+    agentId: UUID;
+  }): Promise<Entity[]> {
     // WHY O(N) scan: InMemory has no indexing. Match ANY name in entity.names.
     // Case-sensitive exact match (consistent with SQL implementations).
     const nameSet = new Set(params.names);
     const matches: Entity[] = [];
-    
+
     for (const entity of this.entities.values()) {
       if (entity.agentId !== params.agentId) continue;
-      
-      const hasMatch = entity.names?.some(name => nameSet.has(name));
+
+      const hasMatch = entity.names?.some((name) => nameSet.has(name));
       if (hasMatch) {
         matches.push(entity);
       }
     }
-    
+
     return matches;
   }
 
   async getComponent(
-    _entityId: UUID,
-    _type: string,
-    _worldId?: UUID,
-    _sourceEntityId?: UUID,
+    entityId: UUID,
+    type: string,
+    worldId?: UUID,
+    sourceEntityId?: UUID,
   ): Promise<Component | null> {
+    for (const c of this.components.values()) {
+      if (c.entityId !== entityId || c.type !== type) continue;
+      if (worldId && c.worldId !== worldId) continue;
+      if (sourceEntityId && c.sourceEntityId !== sourceEntityId) continue;
+      return c;
+    }
     return null;
   }
 
   async getComponents(
-    _entityId: UUID,
-    _worldId?: UUID,
-    _sourceEntityId?: UUID,
+    entityId: UUID,
+    worldId?: UUID,
+    sourceEntityId?: UUID,
   ): Promise<Component[]> {
-    return [];
+    const out: Component[] = [];
+    for (const c of this.components.values()) {
+      if (c.entityId !== entityId) continue;
+      if (worldId && c.worldId !== worldId) continue;
+      if (sourceEntityId && c.sourceEntityId !== sourceEntityId) continue;
+      out.push(c);
+    }
+    return out;
   }
 
   // Batch entity methods
@@ -324,34 +345,124 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
   // Batch component methods
   async createComponents(components: Component[]): Promise<UUID[]> {
-    return components.map(c => c.id);
+    const ids: UUID[] = [];
+    for (const c of components) {
+      this.components.set(String(c.id), {
+        ...c,
+        createdAt: c.createdAt ?? new Date(),
+      });
+      ids.push(c.id);
+    }
+    return ids;
   }
 
-  async getComponentsByIds(_componentIds: UUID[]): Promise<Component[]> {
-    return [];
+  async getComponentsByIds(componentIds: UUID[]): Promise<Component[]> {
+    const out: Component[] = [];
+    for (const id of componentIds) {
+      const c = this.components.get(String(id));
+      if (c) out.push(c);
+    }
+    return out;
   }
 
-  async updateComponents(_components: Component[]): Promise<void> {
-    // no-op
+  async updateComponents(components: Component[]): Promise<void> {
+    for (const c of components) {
+      this.components.set(String(c.id), c);
+    }
   }
 
-  async deleteComponents(_componentIds: UUID[]): Promise<void> {
-    // no-op
+  async deleteComponents(componentIds: UUID[]): Promise<void> {
+    for (const id of componentIds) {
+      this.components.delete(String(id));
+    }
   }
 
   async upsertComponents(
-    _components: Component[],
+    components: Component[],
     _options?: { entityContext?: UUID },
   ): Promise<void> {
-    // InMemory does not persist components; no-op for compatibility.
+    // Dedupe by natural key (entityId + type + worldId + sourceEntityId), last wins
+    const deduped = new Map<string, Component>();
+    for (const c of components) {
+      const key = `${c.entityId}:${c.type}:${c.worldId ?? ""}:${c.sourceEntityId ?? ""}`;
+      deduped.set(key, c);
+    }
+    for (const c of deduped.values()) {
+      // Find existing by natural key, preserve its id if present
+      let existingId: string | undefined;
+      for (const [id, existing] of this.components.entries()) {
+        if (
+          existing.entityId === c.entityId &&
+          existing.type === c.type &&
+          (existing.worldId ?? null) === (c.worldId ?? null) &&
+          (existing.sourceEntityId ?? null) === (c.sourceEntityId ?? null)
+        ) {
+          existingId = id;
+          break;
+        }
+      }
+      if (existingId) {
+        // Update mutable fields, keep original id and createdAt
+        const prev = this.components.get(existingId)!;
+        this.components.set(existingId, {
+          ...prev,
+          data: c.data ?? prev.data,
+          agentId: c.agentId ?? prev.agentId,
+          roomId: c.roomId ?? prev.roomId,
+        });
+      } else {
+        this.components.set(String(c.id), {
+          ...c,
+          createdAt: c.createdAt ?? new Date(),
+        });
+      }
+    }
   }
 
   async patchComponent(
-    _componentId: UUID,
-    _ops: PatchOp[],
+    componentId: UUID,
+    ops: PatchOp[],
     _options?: { entityContext?: UUID },
   ): Promise<void> {
-    // InMemory does not persist components; no-op for compatibility.
+    if (ops.length === 0) return;
+    const c = this.components.get(String(componentId));
+    if (!c) return;
+    const data = (c.data ?? {}) as Metadata;
+
+    for (const op of ops) {
+      const segments = op.path.split(".");
+      const last = segments.pop()!;
+      // Walk to parent object, creating intermediate objects as needed
+      let target = data as Record<string, unknown>;
+      for (const seg of segments) {
+        if (target[seg] === undefined || target[seg] === null) {
+          target[seg] = {};
+        }
+        target = target[seg] as Record<string, unknown>;
+      }
+
+      switch (op.op) {
+        case "set":
+          target[last] = op.value;
+          break;
+        case "push": {
+          const arr = Array.isArray(target[last])
+            ? (target[last] as unknown[])
+            : [];
+          arr.push(op.value);
+          target[last] = arr;
+          break;
+        }
+        case "remove":
+          delete target[last];
+          break;
+        case "increment":
+          target[last] = (Number(target[last]) || 0) + Number(op.value);
+          break;
+      }
+    }
+
+    c.data = data;
   }
 
   async getMemories(params: {
@@ -410,7 +521,10 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
 
     const offset = params.offset ?? 0;
-    return all.slice(offset, offset + (effectiveLimit === Infinity ? all.length : effectiveLimit));
+    return all.slice(
+      offset,
+      offset + (effectiveLimit === Infinity ? all.length : effectiveLimit),
+    );
   }
 
   async getMemoriesByIds(ids: UUID[]): Promise<Memory[]> {
@@ -489,7 +603,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return this.logs.filter((l) => idSet.has(String(l.id)));
   }
 
-  async createLogs(params: Array<{ body: LogBody; entityId: UUID; roomId: UUID; type: string }>): Promise<void> {
+  async createLogs(
+    params: Array<{
+      body: LogBody;
+      entityId: UUID;
+      roomId: UUID;
+      type: string;
+    }>,
+  ): Promise<void> {
     for (const param of params) {
       const id =
         typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
@@ -506,7 +627,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
   }
 
-  async updateLogs(logs: Array<{ id: UUID; updates: Partial<Log> }>): Promise<void> {
+  async updateLogs(
+    logs: Array<{ id: UUID; updates: Partial<Log> }>,
+  ): Promise<void> {
     for (const { id, updates } of logs) {
       const log = this.logs.find((l) => String(l.id) === String(id));
       if (log) {
@@ -525,7 +648,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
   }
 
   // Batch memory methods
-  async createMemories(memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>): Promise<UUID[]> {
+  async createMemories(
+    memories: Array<{ memory: Memory; tableName: string; unique?: boolean }>,
+  ): Promise<UUID[]> {
     const ids: UUID[] = [];
     for (const { memory, tableName } of memories) {
       const gen =
@@ -630,11 +755,23 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     tableName?: string,
   ): Promise<number> {
     const roomId: UUID | undefined =
-      typeof roomIdOrParams === "object" && roomIdOrParams !== null && "roomId" in roomIdOrParams
+      typeof roomIdOrParams === "object" &&
+      roomIdOrParams !== null &&
+      "roomId" in roomIdOrParams
         ? roomIdOrParams.roomId
         : (roomIdOrParams as UUID);
-    const u = typeof roomIdOrParams === "object" && roomIdOrParams !== null && "unique" in roomIdOrParams ? roomIdOrParams.unique : unique;
-    const tbl = typeof roomIdOrParams === "object" && roomIdOrParams !== null && "tableName" in roomIdOrParams ? roomIdOrParams.tableName : tableName;
+    const u =
+      typeof roomIdOrParams === "object" &&
+      roomIdOrParams !== null &&
+      "unique" in roomIdOrParams
+        ? roomIdOrParams.unique
+        : unique;
+    const tbl =
+      typeof roomIdOrParams === "object" &&
+      roomIdOrParams !== null &&
+      "tableName" in roomIdOrParams
+        ? roomIdOrParams.tableName
+        : tableName;
     if (roomId == null) return 0;
     const key = roomTableKey(tbl ?? "messages", roomId);
     const memories = this.memoriesByRoom.get(key) ?? [];
@@ -664,7 +801,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
     return ids;
   }
-  
+
   async upsertWorlds(worlds: World[]): Promise<void> {
     // WHY simple set: Map.set() handles both insert and update atomically.
     for (const world of worlds) {
@@ -718,7 +855,7 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     }
     return ids;
   }
-  
+
   async upsertRooms(rooms: Room[]): Promise<void> {
     // WHY simple set: InMemory upsert is just Map.set() - idempotent by nature.
     for (const room of rooms) {
@@ -742,7 +879,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return Array.from(out.values()).map(asUuid);
   }
 
-  async getRoomsByWorld(worldId: UUID, limit?: number, offset?: number): Promise<Room[]> {
+  async getRoomsByWorld(
+    worldId: UUID,
+    limit?: number,
+    offset?: number,
+  ): Promise<Room[]> {
     let out: Room[] = [];
     for (const room of this.rooms.values()) {
       if (room.worldId && room.worldId === worldId) {
@@ -772,14 +913,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return Array.from(set.values()).map(asUuid);
   }
 
-  async createRoomParticipants(entityIds: UUID[], roomId: UUID): Promise<UUID[]> {
+  async createRoomParticipants(
+    entityIds: UUID[],
+    roomId: UUID,
+  ): Promise<UUID[]> {
     // WHY: InMemory doesn't have real participant record IDs (it's just a set).
     // We generate UUIDs to match the interface contract, even though they're not stored.
     const roomKey = String(roomId);
     const participants =
       this.participantsByRoom.get(roomKey) ?? new Set<string>();
     const ids: UUID[] = [];
-    
+
     for (const eid of entityIds) {
       const entityKey = String(eid);
       participants.add(entityKey);
@@ -794,14 +938,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
   }
 
   // Batch participant methods
-  async deleteParticipants(participants: Array<{ entityId: UUID; roomId: UUID }>): Promise<boolean> {
+  async deleteParticipants(
+    participants: Array<{ entityId: UUID; roomId: UUID }>,
+  ): Promise<boolean> {
     for (const { entityId, roomId } of participants) {
       const roomKey = String(roomId);
       const entityKey = String(entityId);
       const roomParticipants = this.participantsByRoom.get(roomKey);
       if (roomParticipants) {
         roomParticipants.delete(entityKey);
-        if (roomParticipants.size === 0) this.participantsByRoom.delete(roomKey);
+        if (roomParticipants.size === 0)
+          this.participantsByRoom.delete(roomKey);
       }
       const rooms = this.roomsByParticipant.get(entityKey);
       if (rooms) {
@@ -813,11 +960,13 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return true;
   }
 
-  async updateParticipants(participants: Array<{
-    entityId: UUID;
-    roomId: UUID;
-    updates: Partial<Participant>;
-  }>): Promise<void> {
+  async updateParticipants(
+    participants: Array<{
+      entityId: UUID;
+      roomId: UUID;
+      updates: Partial<Participant>;
+    }>,
+  ): Promise<void> {
     // InMemory adapter stores participants as just sets of IDs, so we can only
     // update roomState (which is stored separately in participantUserState).
     // Metadata updates are not supported in this simple adapter.
@@ -867,12 +1016,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
   }
 
   // Batch relationship methods
-  async createRelationships(relationships: Array<{
-    sourceEntityId: UUID;
-    targetEntityId: UUID;
-    tags?: string[];
-    metadata?: Metadata;
-  }>): Promise<UUID[]> {
+  async createRelationships(
+    relationships: Array<{
+      sourceEntityId: UUID;
+      targetEntityId: UUID;
+      tags?: string[];
+      metadata?: Metadata;
+    }>,
+  ): Promise<UUID[]> {
     // WHY: InMemory adapter doesn't actually store relationships, but we return
     // placeholder IDs to match the interface contract.
     return relationships.map(() => {
@@ -884,7 +1035,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     });
   }
 
-  async getRelationshipsByIds(_relationshipIds: UUID[]): Promise<Relationship[]> {
+  async getRelationshipsByIds(
+    _relationshipIds: UUID[],
+  ): Promise<Relationship[]> {
     return [];
   }
 
@@ -907,7 +1060,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return result;
   }
 
-  async setCaches<T>(entries: Array<{ key: string; value: T }>): Promise<boolean> {
+  async setCaches<T>(
+    entries: Array<{ key: string; value: T }>,
+  ): Promise<boolean> {
     for (const entry of entries) {
       this.cache.set(entry.key, JSON.stringify(entry.value));
     }
@@ -980,7 +1135,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return tasks;
   }
 
-  async updateTasks(updates: Array<{ id: UUID; task: Partial<Task> }>): Promise<void> {
+  async updateTasks(
+    updates: Array<{ id: UUID; task: Partial<Task> }>,
+  ): Promise<void> {
     for (const update of updates) {
       const existing = this.tasks.get(String(update.id));
       if (!existing) continue;
@@ -1146,7 +1303,9 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
     return ids;
   }
 
-  async updatePairingAllowlistEntries(entries: PairingAllowlistEntry[]): Promise<void> {
+  async updatePairingAllowlistEntries(
+    entries: PairingAllowlistEntry[],
+  ): Promise<void> {
     for (const entry of entries) {
       if (!entry.id) continue;
       const id = String(entry.id);


### PR DESCRIPTION
## Summary

- All 8 component methods in `InMemoryDatabaseAdapter` were stubs (`getComponent → null`, `createComponents → return ids without storing`, batch methods → no-op)
- Any plugin storing state in components couldn't be tested without PostgreSQL or PGlite
- Now uses `Map<string, Component>` storage matching the SQL adapter contract from `plugin-sql/typescript/stores/component.store.ts`

## Changes

**Storage**: Added `private components = new Map<string, Component>()`

**2 single-item methods** (used by AgentRuntime deprecated wrappers):
- `getComponent(entityId, type, worldId?, sourceEntityId?)` — O(N) scan with same AND filters as SQL adapter
- `getComponents(entityId, worldId?, sourceEntityId?)` — filters by entityId + optional worldId/sourceEntityId

**6 batch methods**:
- `createComponents` — stores with `createdAt` default
- `getComponentsByIds` — O(1) Map lookup per ID
- `updateComponents` — overwrites by component ID
- `deleteComponents` — removes by component ID
- `upsertComponents` — dedupes by natural key (`entityId+type+worldId+sourceEntityId`), merges mutable fields on conflict (matches SQL `ON CONFLICT DO UPDATE`)
- `patchComponent` — dot-path walking with `set`/`push`/`remove`/`increment` ops (matches SQL `jsonb_set`/`jsonb_insert` behavior)

**Bonus**: `getEntitiesForRoom` now attaches components when `includeComponents=true` (was a documented no-op)

## Test plan

- [x] `bun test packages/typescript/src/__tests__/` — 1379 pass, 0 new failures (30 pre-existing failures unrelated to components)
- [x] `bun test packages/typescript/src/__tests__/entities.test.ts` — 20/20 pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR correctly implements the previously stub-only component storage methods in `InMemoryDatabaseAdapter`, enabling plugins to store and query component state without a PostgreSQL/PGlite database. The overall approach — a `Map<string, Component>` with O(N) scans for filtered lookups and dot-path walking for patch ops — is a reasonable and faithful in-memory equivalent of the SQL adapter contract.

Two issues require attention before merging:

- **`createdAt` type mismatch (P1):** Both `createComponents` (line 352) and `upsertComponents` (line 416) fall back to `new Date()` when `createdAt` is absent, but `Component.createdAt` is typed as `TimestampValue = number`. `new Date()` produces a `Date` object, which will silently break any consumer that performs numeric comparison, arithmetic, or serialization on the timestamp. The fix is `Date.now()`.
- **Stored entity mutation (P1):** `getEntitiesForRoom` with `includeComponents=true` assigns `entity.components` directly onto the object reference retrieved from `this.entities`. Because `this.entities` stores objects by reference, this permanently attaches the component snapshot to the Map-stored entity. Later reads of those entities (via `getEntitiesByIds`, a second `getEntitiesForRoom` without the flag, etc.) will carry a stale `components` array. A shallow copy (`{ ...entity, components }`) before assignment is the minimal fix.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — two correctness bugs exist: a type mismatch for `createdAt` and a stored-entity mutation that will surface as stale data in long-running or multi-call scenarios.
- The core Map-based implementation is architecturally sound and the business logic for deduplication, patching, and filtering is correct. However, the `new Date()` vs `Date.now()` mismatch is a real type violation that can cause silent runtime failures, and the in-place entity mutation in `getEntitiesForRoom` is a genuine data-integrity bug. Both are easy one-line fixes but both need to land before this is merged.
- packages/typescript/src/database/inMemoryAdapter.ts — specifically lines 352, 416 (createdAt type), and 219-223 (entity mutation).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/database/inMemoryAdapter.ts | Implements full component storage for InMemoryDatabaseAdapter using a Map, but contains two type-mismatch bugs (`new Date()` instead of `Date.now()` for `createdAt: number`) and a mutation bug where `getEntitiesForRoom` with `includeComponents=true` permanently modifies stored entity objects in the Map. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[createComponents] -->|stores with createdAt fallback| B[(components Map)]
    B2[upsertComponents] -->|dedupes by natural key then merges| B
    C[getComponent] -->|scan with AND filters| B
    D[getComponents] -->|scan with AND filters| B
    E[getComponentsByIds] -->|direct lookup| B
    F[updateComponents] -->|overwrites by id| B
    G[deleteComponents] -->|removes by id| B
    H[patchComponent] -->|dot-path walk plus ops| B

    J[getEntitiesForRoom] -->|includeComponents=true calls getComponents| D
    D -->|result assigned to entity ref| K["⚠️ Mutates stored Entity in entities Map"]

    style K fill:#ff9999,stroke:#cc0000
    style A fill:#ffeecc
    style B2 fill:#ffeecc
```

<sub>Last reviewed commit: c157be5</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced full component lifecycle management with create, read, update, delete, and merge operations.
  * Added support for atomic patching of component data including nested field updates and array operations.
  * Enhanced component querying with improved filtering capabilities.

* **Tests**
  * Added comprehensive test coverage for component operations and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->