### PR TITLE
fix(autonomous): add unique-names-generator as direct dependency

### DIFF
--- a/packages/autonomous/package.json
+++ b/packages/autonomous/package.json
@@ -265,6 +265,7 @@
     "pty-manager": "1.9.8",
     "puppeteer-core": "^24.37.5",
     "qrcode": "^1.5.4",
+    "unique-names-generator": "^4.7.1",
     "ws": "^8.19.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## Problem
When `@elizaos/autonomous` is consumed as a published npm package, `unique-names-generator` (a dependency of `@elizaos/core`) is not reliably hoisted, causing a startup failure:

```
Cannot find package 'unique-names-generator' from '.../packages/typescript/src/actions.ts'
```

## Fix
Add `unique-names-generator` as a direct dependency of `autonomous` to ensure it's always available regardless of hoisting behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `unique-names-generator` as a direct dependency of `@elizaos/autonomous` to resolve a runtime failure (`Cannot find package 'unique-names-generator'`) when the package is consumed as a published npm artifact rather than from a monorepo workspace.

Key observations:
- `unique-names-generator` is **not** imported anywhere in `packages/autonomous/src`; it is used exclusively inside `@elizaos/core` (`packages/typescript`), which already declares it as its own direct dependency at the same version.
- The added version constraint `^4.7.1` is consistent with the version already declared in `packages/typescript/package.json`.
- Adding the dependency is a valid defensive measure to eliminate hoisting-related resolution failures, but the root cause may be a mismatch between the `@elizaos/core` peer dependency pin (`2.0.0-alpha.22`) and the current release (`2.0.0-alpha.25`) — a consumer installing the older peer could receive a build that lacks the fix.
- No functional code changes are made; this is purely a package manifest update.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; a single dependency addition with no functional code changes and a consistent version constraint.
- The change is a one-line addition to a manifest file, the version `^4.7.1` is consistent with the already-declared version in `@elizaos/core`, and it directly addresses the reported startup failure. Minor deduction because the peer dependency version pin (`2.0.0-alpha.22` vs current `2.0.0-alpha.25`) may mean consumers still install an older core without the underlying fix, and the root cause (why `@elizaos/core`'s own direct dep isn't reliably visible) is not fully addressed.
- No files require special attention beyond the noted peer dependency version gap in `packages/autonomous/package.json`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autonomous/package.json | Adds `unique-names-generator@^4.7.1` as a direct dependency to solve an npm hoisting issue; the package is not directly imported in `autonomous/src`, but is needed transitively via `@elizaos/core` (packages/typescript). The version matches what `@elizaos/core` already declares, which is consistent. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@elizaos/autonomous\n(published npm package)"] -->|"peer dependency\n2.0.0-alpha.22"| B["@elizaos/core\n(packages/typescript)"]
    B -->|"direct dep\n^4.7.1"| C["unique-names-generator"]
    B -->|"imports"| D["packages/typescript/src/actions.ts\npackages/typescript/src/utils.ts\npackages/typescript/src/basic-capabilities/\nproviders/evaluators.ts"]
    A -->|"NEW direct dep\n^4.7.1 (this PR)"| C
    subgraph Problem["Without this PR (published context)"]
        E["Node/Bun module resolution\nfails to find\nunique-names-generator\nunder autonomous context"]
    end
    subgraph Fix["With this PR"]
        F["unique-names-generator\nalways installed under\nautonomous's node_modules"]
    end
```

<sub>Last reviewed commit: 9e79cc6</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->