### PR TITLE
fix(core): eagerly start plugin services during registration

### DIFF
--- a/packages/typescript/src/__tests__/services-by-type.test.ts
+++ b/packages/typescript/src/__tests__/services-by-type.test.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 import { beforeEach, describe, expect, it } from "vitest";
 import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
 import { AgentRuntime } from "../runtime";
-import { ServiceType, type UUID } from "../types";
+import { ServiceType, type ServiceTypeName, type UUID } from "../types";
 import type { IAgentRuntime } from "../types/runtime";
 import { Service } from "../types/service";
 
@@ -178,6 +178,73 @@ describe("Service Type System", () => {
 			expect(serviceTypes).toContain(ServiceType.WALLET);
 			expect(serviceTypes).toContain(ServiceType.PDF);
 			expect(serviceTypes).toHaveLength(2);
+		});
+	});
+
+	describe("Eager service start via registerPlugin", () => {
+		it("should start services eagerly when registered via plugin", async () => {
+			const plugin = {
+				name: "test-eager-plugin",
+				description: "Test plugin for eager service start",
+				services: [MockWalletService1],
+			};
+
+			await runtime.registerPlugin(plugin);
+
+			// Service should be available via sync getService immediately
+			// after registerPlugin resolves — no getServiceLoadPromise needed
+			const service = runtime.getService(ServiceType.WALLET);
+			expect(service).toBeInstanceOf(MockWalletService1);
+		});
+
+		it("should start multiple services eagerly via plugin", async () => {
+			const plugin = {
+				name: "test-multi-service-plugin",
+				description: "Test plugin with multiple services",
+				services: [MockWalletService1, MockPdfService],
+			};
+
+			await runtime.registerPlugin(plugin);
+
+			const walletService = runtime.getService(ServiceType.WALLET);
+			const pdfService = runtime.getService(ServiceType.PDF);
+			expect(walletService).toBeInstanceOf(MockWalletService1);
+			expect(pdfService).toBeInstanceOf(MockPdfService);
+		});
+
+		it("should not block registration when a service fails to start", async () => {
+			class FailingService extends Service {
+				static override readonly serviceType =
+					"FAILING_SERVICE" as ServiceTypeName;
+				readonly capabilityDescription = "Service that fails to start";
+
+				static async start(
+					_runtime: IAgentRuntime,
+				): Promise<FailingService> {
+					throw new Error("Intentional start failure");
+				}
+
+				async stop(): Promise<void> {}
+			}
+
+			const plugin = {
+				name: "test-failing-plugin",
+				description: "Test plugin with a failing and a working service",
+				services: [FailingService, MockWalletService1],
+			};
+
+			// Should not throw despite FailingService
+			await runtime.registerPlugin(plugin);
+
+			// The working service should still be available
+			const walletService = runtime.getService(ServiceType.WALLET);
+			expect(walletService).toBeInstanceOf(MockWalletService1);
+
+			// The failing service should not be available
+			const failingService = runtime.getService(
+				"FAILING_SERVICE" as ServiceTypeName,
+			);
+			expect(failingService).toBeNull();
 		});
 	});
 

--- a/packages/typescript/src/__tests__/services-by-type.test.ts
+++ b/packages/typescript/src/__tests__/services-by-type.test.ts
@@ -191,8 +191,12 @@ describe("Service Type System", () => {
 
 			await runtime.registerPlugin(plugin);
 
-			// Service should be available via sync getService immediately
-			// after registerPlugin resolves — no getServiceLoadPromise needed
+			// Service start is fire-and-forget (awaits initPromise internally),
+			// so wait for it to complete after init resolves.
+			await runtime.getServiceLoadPromise(ServiceType.WALLET);
+
+			// Service should be available via sync getService —
+			// no manual lazy-start trigger needed beyond the eager kick.
 			const service = runtime.getService(ServiceType.WALLET);
 			expect(service).toBeInstanceOf(MockWalletService1);
 		});
@@ -205,6 +209,11 @@ describe("Service Type System", () => {
 			};
 
 			await runtime.registerPlugin(plugin);
+
+			await Promise.all([
+				runtime.getServiceLoadPromise(ServiceType.WALLET),
+				runtime.getServiceLoadPromise(ServiceType.PDF),
+			]);
 
 			const walletService = runtime.getService(ServiceType.WALLET);
 			const pdfService = runtime.getService(ServiceType.PDF);
@@ -235,6 +244,9 @@ describe("Service Type System", () => {
 
 			// Should not throw despite FailingService
 			await runtime.registerPlugin(plugin);
+
+			// Wait for the working service to finish starting
+			await runtime.getServiceLoadPromise(ServiceType.WALLET);
 
 			// The working service should still be available
 			const walletService = runtime.getService(ServiceType.WALLET);

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -586,7 +586,6 @@ export class AgentRuntime implements IAgentRuntime {
 					"Registering service",
 				);
 
-				// Lazy: store the ServiceClass only; start() is deferred until getService() is called.
 				if (!this.servicePromises.has(serviceType)) {
 					this._createServiceResolver(serviceType);
 				}
@@ -598,6 +597,23 @@ export class AgentRuntime implements IAgentRuntime {
 				if (services) {
 					services.push(service);
 				}
+
+				// Eagerly start the service so it is available via the sync
+				// getService() call by the time actions/routes need it.
+				// Errors are logged but do not block plugin registration.
+				this._ensureServiceStarted(serviceType).catch((err) => {
+					this.logger.error(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							plugin: pluginToRegister.name,
+							serviceType,
+							error:
+								err instanceof Error ? err.message : String(err),
+						},
+						"Eager service start failed",
+					);
+				});
 			}
 		}
 		if (pluginToRegister.adapter) {

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -573,6 +573,7 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		if (pluginToRegister.services) {
+			const serviceStartPromises: Promise<void>[] = [];
 			for (const service of pluginToRegister.services) {
 				const serviceType = service.serviceType as ServiceTypeName;
 
@@ -599,22 +600,29 @@ export class AgentRuntime implements IAgentRuntime {
 				}
 
 				// Eagerly start the service so it is available via the sync
-				// getService() call by the time actions/routes need it.
-				// Errors are logged but do not block plugin registration.
-				this._ensureServiceStarted(serviceType).catch((err) => {
-					this.logger.error(
-						{
-							src: "agent",
-							agentId: this.agentId,
-							plugin: pluginToRegister.name,
-							serviceType,
-							error:
-								err instanceof Error ? err.message : String(err),
-						},
-						"Eager service start failed",
-					);
-				});
+				// getService() call when registerPlugin() resolves.
+				serviceStartPromises.push(
+					this._ensureServiceStarted(serviceType).catch((err) => {
+						this.logger.error(
+							{
+								src: "agent",
+								agentId: this.agentId,
+								plugin: pluginToRegister.name,
+								serviceType,
+								error:
+									err instanceof Error
+										? err.message
+										: String(err),
+							},
+							"Service start failed",
+						);
+					}) as Promise<void>,
+				);
 			}
+			// Wait for all services to start (or fail) so getService() works
+			// immediately after registerPlugin() resolves. Individual failures
+			// are already caught above and do not reject here.
+			await Promise.allSettled(serviceStartPromises);
 		}
 		if (pluginToRegister.adapter) {
 			this.logger.debug(

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -573,7 +573,6 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		if (pluginToRegister.services) {
-			const serviceStartPromises: Promise<void>[] = [];
 			for (const service of pluginToRegister.services) {
 				const serviceType = service.serviceType as ServiceTypeName;
 
@@ -599,30 +598,25 @@ export class AgentRuntime implements IAgentRuntime {
 					services.push(service);
 				}
 
-				// Eagerly start the service so it is available via the sync
-				// getService() call when registerPlugin() resolves.
-				serviceStartPromises.push(
-					this._ensureServiceStarted(serviceType).catch((err) => {
-						this.logger.error(
-							{
-								src: "agent",
-								agentId: this.agentId,
-								plugin: pluginToRegister.name,
-								serviceType,
-								error:
-									err instanceof Error
-										? err.message
-										: String(err),
-							},
-							"Service start failed",
-						);
-					}) as Promise<void>,
-				);
+				// Eagerly kick off service start so it is available via the
+				// sync getService() by the time actions/routes need it.
+				// Fire-and-forget: cannot await here because _runServiceStart
+				// awaits initPromise which resolves after initialize() completes
+				// (after all registerPlugin calls finish). Awaiting would deadlock.
+				this._ensureServiceStarted(serviceType).catch((err) => {
+					this.logger.error(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							plugin: pluginToRegister.name,
+							serviceType,
+							error:
+								err instanceof Error ? err.message : String(err),
+						},
+						"Service start failed",
+					);
+				});
 			}
-			// Wait for all services to start (or fail) so getService() works
-			// immediately after registerPlugin() resolves. Individual failures
-			// are already caught above and do not reject here.
-			await Promise.allSettled(serviceStartPromises);
 		}
 		if (pluginToRegister.adapter) {
 			this.logger.debug(
@@ -720,6 +714,23 @@ export class AgentRuntime implements IAgentRuntime {
 	async initialize(options?: {
 		skipMigrations?: boolean;
 		/** Allow running without a persistent database adapter (benchmarks/tests). */
+		allowNoDatabase?: boolean;
+	}): Promise<void> {
+		try {
+			await this._initializeCore(options);
+		} catch (err) {
+			// Always resolve initPromise so eager service starts and stop()
+			// do not hang waiting on a promise that never settles.
+			if (this.initResolver) {
+				this.initResolver();
+				this.initResolver = undefined;
+			}
+			throw err;
+		}
+	}
+
+	private async _initializeCore(options?: {
+		skipMigrations?: boolean;
 		allowNoDatabase?: boolean;
 	}): Promise<void> {
 		const pluginRegistrationPromises: Promise<void>[] = [];


### PR DESCRIPTION
## Summary

- The Runtime Diet refactor (`eebc5649`) introduced lazy service start, intending `getService()` to become async and trigger start on first call
- However `getService()` remained **synchronous** — it only checks already-started services and returns `null` for pending ones
- This means any plugin that declares services (e.g. `plugin-agent-orchestrator` with `PTYService`) has those services registered in `serviceTypes` but never started, so `getService("PTY_SERVICE")` always returns `null`
- Fix: fire-and-forget `_ensureServiceStarted()` immediately after storing each service class, so services are started eagerly and available via the sync `getService()` by the time actions/routes need them
- Errors are caught and logged without blocking plugin registration

## Test plan

- [ ] Verify `runtime.getService("PTY_SERVICE")` returns the service instance after plugin registration
- [ ] Verify services that fail to start log errors but don't block other plugin registration
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability during plugin initialization with enhanced error logging and recovery.
  * Services now start eagerly during registration, reducing potential delays when accessing them later.
  * Plugin registration continues even if individual service startup fails, ensuring greater system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a regression introduced by the "Runtime Diet" refactor (`eebc5649`) where services declared in plugins were registered in `serviceTypes` but never actually started, causing `getService()` to always return `null`. The fix adds a fire-and-forget `_ensureServiceStarted()` call immediately after each service class is stored in `registerPlugin()`, so services begin starting asynchronously right after plugin registration rather than waiting for a (never-triggered) lazy-start on first `getService()` call.

**Key changes:**
- Removes the now-stale comment `"Lazy: store the ServiceClass only; start() is deferred until getService() is called."` from `registerPlugin()`
- Adds `this._ensureServiceStarted(serviceType).catch(...)` after each service is pushed to `serviceTypes`, making startup eager
- Existing deduplication via `startingServices` and `initPromise` gating in `_runServiceStart` ensure no double-starts or deadlocks

**Issues found:**
- `registerService()` (the standalone public method at line 2871) still retains the old lazy start model — its debug log even reads `"Registering service (lazy; start() on first getService)"`. This creates a public-API inconsistency: callers using `registerService()` directly will still see `null` from `getService()` unless they explicitly await `getServiceLoadPromise()`, while callers that go through `registerPlugin()` get the new eager behaviour.
- The `.catch()` handler added at line 604 (`"Eager service start failed"`) will never actually fire. `_ensureServiceStarted` is not expected to reject — `_runServiceStart` already catches all `serviceDef.start()` errors and logs `"Service start failed"` internally, resolving the promise to `null` instead of rejecting.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix is minimal and correct; two style-level inconsistencies don't affect the happy path.
- The change is a small, well-targeted fix. The existing `startingServices` deduplication, `initPromise` gating, and internal error handling in `_runServiceStart` all protect against the obvious failure modes (double-start, deadlock, unhandled rejection). The two flagged issues (`registerService()` inconsistency and dead `.catch()` handler) are cosmetic / P2 and do not introduce regressions.
- No files require special attention beyond the two style notes on `packages/typescript/src/runtime.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/runtime.ts | Single-line loop change in `registerPlugin()` that fires `_ensureServiceStarted` as fire-and-forget after each service class is pushed. The core mechanism is sound: deduplication via `startingServices`, `initPromise` gating, and existing error handling in `_runServiceStart` prevent double-starts, deadlocks, and unhandled rejections. Two style-level concerns: (1) `registerService()` retains lazy behaviour creating a public-API inconsistency, and (2) the new `.catch()` handler will never fire since `_ensureServiceStarted` catches all errors internally. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant AgentRuntime
    participant _ensureServiceStarted
    participant _runServiceStart
    participant initPromise

    Caller->>AgentRuntime: registerPlugin(plugin)
    loop for each service in plugin.services
        AgentRuntime->>AgentRuntime: serviceTypes.set(serviceType, [..., ServiceClass])
        AgentRuntime->>_ensureServiceStarted: fire-and-forget (no await)
        _ensureServiceStarted->>_ensureServiceStarted: check startingServices (dedup)
        _ensureServiceStarted->>_runServiceStart: start all classes for type
        _runServiceStart->>initPromise: await initPromise
        Note over _runServiceStart,initPromise: Suspends until initialize() finishes
    end
    AgentRuntime-->>Caller: registerPlugin() returns

    Note over Caller,initPromise: initialize() completes → initResolver()

    initPromise-->>_runServiceStart: resolved
    _runServiceStart->>_runServiceStart: serviceDef.start(runtime)
    _runServiceStart->>AgentRuntime: services.set(serviceType, [instance])
    _runServiceStart->>AgentRuntime: servicePromiseHandlers.resolve(instance)

    Caller->>AgentRuntime: getService("PTY_SERVICE")
    AgentRuntime-->>Caller: returns instance ✅
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/typescript/src/runtime.ts`, line 2871-2898 ([link](https://github.com/elizaos/eliza/blob/8b64bf1ecd0c17ee188266d2f96c710e9c5efef0/packages/typescript/src/runtime.ts#L2871-L2898)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`registerService()` still uses lazy startup — inconsistent with `registerPlugin()`**

   This PR eagerly starts services in `registerPlugin()` but the standalone `registerService()` method retains the old lazy model. Any caller using `runtime.registerService(SomeService)` directly (e.g. tests in `services-by-type.test.ts`, or the `CustomMessageService` example in `message-service.ts`) will still get `null` from `getService()` until they explicitly await `getServiceLoadPromise()`.

   The existing tests already paper over this by calling `await runtime.getServiceLoadPromise(ServiceType.WALLET)` before accessing services, but a developer consuming the public API who observes the eager behaviour from `registerPlugin` would reasonably expect `registerService` to behave the same way.

   Consider applying the same `_ensureServiceStarted(serviceType).catch(...)` pattern here, or at minimum updating the JSDoc/log message to make the asymmetry explicit.

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["fix(core): await ser..."](https://github.com/elizaos/eliza/commit/8b64bf1ecd0c17ee188266d2f96c710e9c5efef0)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->