### PR TITLE
fix(ui): replace rimraf with rm -rf to unblock CI publish

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,9 +18,9 @@
     "components"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "build": "bun run build:dist",
-    "build:dist": "rimraf dist && tsc -p tsconfig.build.json && node ../../scripts/copy-package-assets.mjs packages/ui src/styles && node ../../scripts/prepare-package-dist.mjs packages/ui",
+    "build:dist": "rm -rf dist && tsc -p tsconfig.build.json && node ../../scripts/copy-package-assets.mjs packages/ui src/styles && node ../../scripts/prepare-package-dist.mjs packages/ui",
     "pack:dry-run": "cd dist && npm pack --dry-run"
   },
   "exports": {


### PR DESCRIPTION
## Summary

- CI release workflow runs `bun install --ignore-scripts`, so `rimraf` binary is not available on PATH
- `@elizaos/ui` build fails with `rimraf: command not found`, blocking all npm releases
- Replace `rimraf dist` with `rm -rf dist` — no need for a cross-platform npm package to delete a build output folder in CI

Root cause: Shaw added a `"build"` alias to `@elizaos/ui` today (`e2567f5e`), which made turbo pick it up for the first time. The `rimraf` usage was always there but never ran in CI before.

## Test plan

- [ ] Merge and verify NPM Release workflow passes the `@elizaos/ui:build` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI release-blocking issue in `@elizaos/ui` by replacing `rimraf dist` with `rm -rf dist` in the `clean` and `build:dist` npm scripts. Because the CI publish workflow runs `bun install --ignore-scripts`, the `rimraf` binary is never installed into `node_modules/.bin` and therefore is not on `PATH`, causing `rimraf: command not found` to fail the build step.

**Key changes:**
- `packages/ui/package.json`: Both `clean` and `build:dist` scripts updated from `rimraf dist` → `rm -rf dist`

**Notes:**
- The fix is minimal, correct, and directly addresses the root cause
- `rm -rf` is a POSIX command; it works on Linux CI but will fail on native Windows `cmd.exe`. For a monorepo primarily targeting CI/Linux this is acceptable, but developers on Windows outside of WSL/Git Bash may encounter issues running these scripts locally
- `rimraf` was not listed in `dependencies` or `devDependencies` in `package.json`, so no dependency cleanup is needed

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line targeted fix with no logic changes, no new dependencies, and directly resolves a proven CI breakage.
- The change is extremely narrow (two script strings in one file), the root cause is well-understood and documented, and the fix is the standard approach used across the rest of the monorepo. The only trade-off (Windows compatibility) is a non-critical, pre-existing concern unrelated to this PR's purpose.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/package.json | Replaces `rimraf dist` with `rm -rf dist` in both `clean` and `build:dist` scripts to fix a CI failure caused by `rimraf` not being on PATH when `bun install --ignore-scripts` is used. Change is minimal, targeted, and correct for Linux CI. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Workflow
    participant Turbo as Turbo Build
    participant UI as @elizaos/ui
    participant Shell as Shell

    CI->>CI: bun install --ignore-scripts
    Note over CI: rimraf binary NOT available in PATH
    CI->>Turbo: Run build pipeline
    Turbo->>UI: Execute "build" script (newly picked up)
    UI->>UI: bun run build:dist

    alt Before fix (rimraf)
        UI->>Shell: rimraf dist
        Shell-->>UI: ❌ rimraf: command not found
        UI-->>Turbo: Build failure
        Turbo-->>CI: ❌ Blocks NPM release
    else After fix (rm -rf)
        UI->>Shell: rm -rf dist
        Shell-->>UI: ✅ dist deleted
        UI->>Shell: tsc -p tsconfig.build.json
        Shell-->>UI: ✅ Compile complete
        UI->>Shell: copy-package-assets.mjs + prepare-package-dist.mjs
        Shell-->>UI: ✅ Dist ready
        UI-->>Turbo: ✅ Build success
        Turbo-->>CI: ✅ NPM release proceeds
    end
```

<sub>Last reviewed commit: ["fix(ui): replace rim..."](https://github.com/elizaos/eliza/commit/0c9eb4e76f32aa3920285f7efbe00c9d7ff1e2ca)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->