### PR TITLE
fix(build): replace rimraf with rm -rf in app-core and autonomous

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -18,10 +18,10 @@
   ],
   "main": "src/index.ts",
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "build": "bun run build:dist",
     "typecheck": "test -f ../ui/dist/index.d.ts || (cd ../ui && bun run build) && tsc --noEmit -p tsconfig.json",
-    "build:dist": "test -f ../ui/dist/index.d.ts || (cd ../ui && bun run build) && rimraf dist && tsc -p tsconfig.build.json && node ../../scripts/copy-package-assets.mjs packages/app-core src/styles src/i18n/locales && node ../../scripts/prepare-package-dist.mjs packages/app-core",
+    "build:dist": "test -f ../ui/dist/index.d.ts || (cd ../ui && bun run build) && rm -rf dist && tsc -p tsconfig.build.json && node ../../scripts/copy-package-assets.mjs packages/app-core src/styles src/i18n/locales && node ../../scripts/prepare-package-dist.mjs packages/app-core",
     "pack:dry-run": "cd dist && npm pack --dry-run"
   },
   "exports": {

--- a/packages/autonomous/package.json
+++ b/packages/autonomous/package.json
@@ -22,10 +22,10 @@
     "milady-autonomous": "./src/bin.ts"
   },
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "build": "bun run build:dist",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "build:dist": "rimraf dist && tsc -p tsconfig.build.json && node ../../scripts/prepare-package-dist.mjs packages/autonomous --compiled-prefix=packages/autonomous/src",
+    "build:dist": "rm -rf dist && tsc -p tsconfig.build.json && node ../../scripts/prepare-package-dist.mjs packages/autonomous --compiled-prefix=packages/autonomous/src",
     "lint:check": "bunx @biomejs/biome check ./src/actions ./src/api ./src/auth ./src/awareness ./src/bin.ts ./src/cli ./src/cloud ./src/config ./src/contracts ./src/diagnostics ./src/emotes ./src/hooks ./src/index.ts ./src/onboarding-presets.ts ./src/plugins ./src/providers ./src/runtime ./src/security ./src/server ./src/services ./src/shared ./src/testing ./src/triggers ./src/utils ./src/version-resolver.ts",
     "pack:dry-run": "cd dist && npm pack --dry-run",
     "test": "cd ../.. && vitest run packages/autonomous/src/hooks/discovery.test.ts packages/autonomous/src/hooks/hooks.test.ts packages/autonomous/src/hooks/loader.test.ts packages/autonomous/src/hooks/registry.test.ts packages/autonomous/src/cloud/*.test.ts packages/autonomous/src/runtime/cloud-onboarding.test.ts packages/autonomous/test/api/wallet-routes.test.ts packages/autonomous/test/api/wallet-routes.observability.test.ts"


### PR DESCRIPTION
## Summary

- Same issue as #6620 — `rimraf` not on PATH in CI because `bun install --ignore-scripts` skips bin linking
- Applies the same `rm -rf dist` fix to `@elizaos/app-core` and `@elizaos/autonomous`

## Test plan

- [ ] CI release workflow builds these packages without `rimraf: command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces `rimraf dist` with `rm -rf dist` in the `clean` and `build:dist` scripts of `@elizaos/app-core` and `@elizaos/autonomous`, mirroring the fix already applied in PR #6620. The root cause is that `bun install --ignore-scripts` skips bin linking, leaving `rimraf` unavailable on `PATH` in CI.

- Both changes are minimal, targeted, and logically equivalent on Unix-based CI runners (Linux/macOS).
- The `rm -rf` form is already used elsewhere in the monorepo; other scripts in these same files (e.g. `test -f ../ui/dist/index.d.ts || ...`) are also Bash-only, confirming the project does not target Windows build environments.
- After this change, the only remaining `rimraf` references in the repo are inside the vendored `packages/autonomous/test/contracts/lib/openzeppelin-contracts` third-party library, which is unrelated and intentionally left as-is.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — two-line config-only fix that unblocks CI with no functional risk.
- `rm -rf dist` is functionally identical to `rimraf dist` on all Unix CI runners. The project already uses other Bash-only constructs in the same scripts, so there is no cross-platform regression. The change is consistent with PR #6620 and leaves no unintended `rimraf` usages in the main build scripts.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/package.json | Replaces `rimraf dist` with `rm -rf dist` in `clean` and `build:dist` scripts — straightforward CI fix consistent with the rest of the monorepo's shell conventions. |
| packages/autonomous/package.json | Same `rimraf` → `rm -rf` replacement in `clean` and `build:dist` scripts. No other concerns; remaining `rimraf` references in the repo are inside a vendored OpenZeppelin test library and are unrelated. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: bun install --ignore-scripts] --> B[bin linking skipped]
    B --> C{rimraf on PATH?}
    C -- Before PR --> D[❌ rimraf: command not found]
    C -- After PR --> E[✅ rm -rf dist]
    E --> F[dist/ removed]
    F --> G[tsc build proceeds]
    G --> H[Package published]
```

<sub>Last reviewed commit: ["fix(app-core,autonom..."](https://github.com/elizaos/eliza/commit/e81e0a5cd1a9f3829063518777117d76e7c361a7)</sub>

<!-- /greptile_comment -->