### PR TITLE
fix(app-core): match full adapter names in coding agent preflight

### DIFF
--- a/packages/app-core/src/components/CodingAgentSettingsSection.test.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { ADAPTER_NAME_TO_TAB } from "./CodingAgentSettingsSection";
+
+describe("ADAPTER_NAME_TO_TAB", () => {
+  it("maps full adapter names from preflight API to tab keys", () => {
+    expect(ADAPTER_NAME_TO_TAB["claude code"]).toBe("claude");
+    expect(ADAPTER_NAME_TO_TAB["google gemini"]).toBe("gemini");
+    expect(ADAPTER_NAME_TO_TAB["openai codex"]).toBe("codex");
+    expect(ADAPTER_NAME_TO_TAB["aider"]).toBe("aider");
+  });
+
+  it("maps short adapter names for backwards compatibility", () => {
+    expect(ADAPTER_NAME_TO_TAB["claude"]).toBe("claude");
+    expect(ADAPTER_NAME_TO_TAB["gemini"]).toBe("gemini");
+    expect(ADAPTER_NAME_TO_TAB["codex"]).toBe("codex");
+  });
+
+  it("returns undefined for unknown adapter names", () => {
+    expect(ADAPTER_NAME_TO_TAB["unknown-agent"]).toBeUndefined();
+    expect(ADAPTER_NAME_TO_TAB[""]).toBeUndefined();
+  });
+
+  it("handles the lowercase normalization used at the call site", () => {
+    // The call site does `item.adapter?.toLowerCase()` before lookup,
+    // so the map only needs lowercase keys
+    const simulatePreflight = (adapterName: string) =>
+      ADAPTER_NAME_TO_TAB[adapterName.toLowerCase()];
+
+    expect(simulatePreflight("Claude Code")).toBe("claude");
+    expect(simulatePreflight("Google Gemini")).toBe("gemini");
+    expect(simulatePreflight("OpenAI Codex")).toBe("codex");
+    expect(simulatePreflight("Aider")).toBe("aider");
+  });
+});

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -83,7 +83,7 @@ const AGENT_LABELS: Record<AgentTab, string> = {
 };
 
 /** Map full adapter names from the preflight API to short tab keys. */
-const ADAPTER_NAME_TO_TAB: Record<string, AgentTab> = {
+export const ADAPTER_NAME_TO_TAB: Record<string, AgentTab> = {
   "claude code": "claude",
   "google gemini": "gemini",
   "openai codex": "codex",

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -82,13 +82,6 @@ const AGENT_LABELS: Record<AgentTab, string> = {
   aider: "Aider",
 };
 
-const KNOWN_AGENT_ADAPTERS = new Set<AgentTab>([
-  "claude",
-  "gemini",
-  "codex",
-  "aider",
-]);
-
 /** Map full adapter names from the preflight API to short tab keys. */
 const ADAPTER_NAME_TO_TAB: Record<string, AgentTab> = {
   "claude code": "claude",

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -89,6 +89,17 @@ const KNOWN_AGENT_ADAPTERS = new Set<AgentTab>([
   "aider",
 ]);
 
+/** Map full adapter names from the preflight API to short tab keys. */
+const ADAPTER_NAME_TO_TAB: Record<string, AgentTab> = {
+  "claude code": "claude",
+  "google gemini": "gemini",
+  "openai codex": "codex",
+  aider: "aider",
+  claude: "claude",
+  gemini: "gemini",
+  codex: "codex",
+};
+
 const ENV_PREFIX: Record<AgentTab, string> = {
   claude: "PARALLAX_CLAUDE",
   gemini: "PARALLAX_GEMINI",
@@ -192,10 +203,7 @@ export function CodingAgentSettingsSection() {
           const mapped: Partial<Record<AgentTab, AgentPreflightResult>> = {};
           for (const item of preflightRes as AgentPreflightResult[]) {
             const raw = item.adapter?.toLowerCase();
-            const key =
-              raw && KNOWN_AGENT_ADAPTERS.has(raw as AgentTab)
-                ? (raw as AgentTab)
-                : undefined;
+            const key = raw ? ADAPTER_NAME_TO_TAB[raw] : undefined;
             if (key) {
               mapped[key] = item;
             }


### PR DESCRIPTION
## Summary
- The preflight API returns full adapter names like `"claude code"`, `"google gemini"`, `"openai codex"` but the settings UI was matching against short keys (`"claude"`, `"gemini"`, `"codex"`)
- Only Aider showed as available because its adapter name matches its short key
- Replaced `KNOWN_AGENT_ADAPTERS` Set with an `ADAPTER_NAME_TO_TAB` mapping that handles both full and short names

## Test plan
- [ ] Open Settings > Coding Agents — all installed agents (Claude, Gemini, Codex, Aider) should show as available
- [ ] Verify preflight status dots reflect actual CLI availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the Coding Agent settings UI where only Aider was showing as "installed" because the preflight API returns full adapter names (`"claude code"`, `"google gemini"`, `"openai codex"`) while the old code was doing a set membership check against the short tab keys (`"claude"`, `"gemini"`, `"codex"`). The fix introduces `ADAPTER_NAME_TO_TAB`, a flat lookup map that covers both the full API names and the short fallback names, and replaces the previous set-based check with a simple map lookup.

- **Root-cause fix is correct** — the new map covers all four known agents under both their full and short names, meaning the preflight status will now resolve correctly regardless of which form the API returns.
- **Short-name fallbacks are included** (`claude`, `gemini`, `codex`) which provides resilience if an older or variant API response uses only the short key.
- **Aider's entry is handled appropriately** — since its adapter name is already `"aider"` (full ≡ short), a single map entry is sufficient.
- **Minor edge case**: if the preflight API ever returns both forms for the same adapter in one response (e.g. an entry with `adapter: "claude code"` and another with `adapter: "claude"`), the second entry in the response array silently overwrites the first in `mapped`. This is low-risk given current API behaviour but worth noting.


<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix is narrowly scoped to a lookup-map substitution with no side-effects on the rest of the component.
- The change is a small, correct substitution that directly addresses the described bug. The only caveat is a theoretical last-write-wins edge case if the preflight API returns duplicate entries for the same adapter, which is low-risk given current API behaviour. No regressions to existing functionality are introduced.
- No files require special attention beyond the single changed file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/CodingAgentSettingsSection.tsx | Replaces the KNOWN_AGENT_ADAPTERS Set with ADAPTER_NAME_TO_TAB mapping to correctly resolve full preflight API adapter names (e.g. "claude code", "google gemini", "openai codex") to their AgentTab keys. The fix is accurate and minimal, though it silently drops adapters not in the map and could produce unexpected results if the API ever returns both a full and short name for the same adapter in one response (last-write-wins). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["/api/coding-agents/preflight response"] --> B["item.adapter?.toLowerCase()"]
    B --> C{"raw in ADAPTER_NAME_TO_TAB?"}
    C -- "yes\n(e.g. 'claude code' → 'claude')" --> D["mapped[key] = item"]
    C -- "no / undefined" --> E["skip entry"]
    D --> F["setPreflightByAgent(mapped)"]
    F --> G{"preflightLoaded &&\ninstalledAgents.length === 0?"}
    G -- "yes" --> H["Show 'no CLIs' error UI\nwith install instructions"]
    G -- "no" --> I["Render tab bar with\nInstalled / Unknown badges"]
    I --> J["availableAgents = installedAgents\n(or AGENT_TABS fallback)"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/components/CodingAgentSettingsSection.tsx`, line 196-203 ([link](https://github.com/elizaos/eliza/blob/2b5776511926528f7febaffc76a0fd4dcdea846d/packages/app-core/src/components/CodingAgentSettingsSection.tsx#L196-L203)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Last-write-wins when both full and short names appear in one response**

   Both `"claude code"` and `"claude"` map to the same `AgentTab` key. If the preflight API ever returns two separate entries for the same adapter (one under its full name and one under its short name), the second entry in the array silently overwrites the first in `mapped`. In practice the API likely returns exactly one entry per adapter, so this is low-risk — but it's worth being defensive:

   

   Alternatively, you could always prefer the `installed === true` entry:

   ```ts
   if (key && (!mapped[key] || item.installed)) {
     mapped[key] = item;
   }
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["chore: remove unused..."](https://github.com/elizaos/eliza/commit/2b5776511926528f7febaffc76a0fd4dcdea846d)</sub>

<!-- /greptile_comment -->