### PR TITLE
fix(ci): break release version deadlock when lerna.json is ahead of tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,19 +191,26 @@ jobs:
               HIGHEST_VERSION=${HIGHEST_TAG#v}
               echo "Highest existing alpha tag: ${HIGHEST_VERSION}"
 
-              # If lerna.json is behind the tags, sync it first
-              if [[ "$CURRENT_VERSION" != "$HIGHEST_VERSION" ]]; then
-                echo "Syncing lerna.json from ${CURRENT_VERSION} to ${HIGHEST_VERSION}..."
+              # Only sync if lerna.json is BEHIND the tags (not ahead).
+              # If lerna.json is ahead, a previous run already bumped it
+              # but failed to create the tag — just increment from current.
+              HIGHEST_NUM=$(echo "$HIGHEST_VERSION" | grep -o '[0-9]*$')
+              CURRENT_NUM=$(echo "$CURRENT_VERSION" | grep -o '[0-9]*$')
+
+              if [[ "$CURRENT_NUM" -lt "$HIGHEST_NUM" ]]; then
+                echo "Syncing lerna.json from ${CURRENT_VERSION} to ${HIGHEST_VERSION} (behind tags)..."
                 bunx lerna version ${HIGHEST_VERSION} \
                   --force-publish \
                   --yes \
                   --no-private \
                   --no-git-tag-version \
                   --no-push
+              elif [[ "$CURRENT_NUM" -gt "$HIGHEST_NUM" ]]; then
+                echo "lerna.json (${CURRENT_VERSION}) is ahead of highest tag (${HIGHEST_VERSION}) — skipping sync"
               fi
 
               # Now increment to the next alpha
-              echo "Incrementing from ${HIGHEST_VERSION}..."
+              echo "Incrementing from $(node -p "require('./lerna.json').version")..."
               bunx lerna version prerelease \
                 --preid alpha \
                 --force-publish \
@@ -236,19 +243,24 @@ jobs:
               HIGHEST_VERSION=${HIGHEST_TAG#v}
               echo "Highest existing beta tag: ${HIGHEST_VERSION}"
 
-              # If lerna.json is behind the tags, sync it first
-              if [[ "$CURRENT_VERSION" != "$HIGHEST_VERSION" ]]; then
-                echo "Syncing lerna.json from ${CURRENT_VERSION} to ${HIGHEST_VERSION}..."
+              # Only sync if lerna.json is BEHIND the tags (not ahead).
+              HIGHEST_NUM=$(echo "$HIGHEST_VERSION" | grep -o '[0-9]*$')
+              CURRENT_NUM=$(echo "$CURRENT_VERSION" | grep -o '[0-9]*$')
+
+              if [[ "$CURRENT_NUM" -lt "$HIGHEST_NUM" ]]; then
+                echo "Syncing lerna.json from ${CURRENT_VERSION} to ${HIGHEST_VERSION} (behind tags)..."
                 bunx lerna version ${HIGHEST_VERSION} \
                   --force-publish \
                   --yes \
                   --no-private \
                   --no-git-tag-version \
                   --no-push
+              elif [[ "$CURRENT_NUM" -gt "$HIGHEST_NUM" ]]; then
+                echo "lerna.json (${CURRENT_VERSION}) is ahead of highest tag (${HIGHEST_VERSION}) — skipping sync"
               fi
 
               # Now increment to the next beta
-              echo "Incrementing from ${HIGHEST_VERSION}..."
+              echo "Incrementing from $(node -p "require('./lerna.json').version")..."
               bunx lerna version prerelease \
                 --preid beta \
                 --force-publish \


### PR DESCRIPTION
## Summary
- Release CI has been stuck re-publishing `alpha.75` for 5+ runs without incrementing
- Root cause: when `lerna.json` (alpha.75) is ahead of the highest git tag (alpha.74), the script syncs DOWN to alpha.74, bumps back to alpha.75, produces no git diff, skips tag creation, and the cycle repeats
- Fix: compare numeric suffixes before syncing — only sync down when `lerna.json` is actually behind the tags, skip sync when ahead
- Applied to both alpha and beta release paths

## How it got stuck
1. A run bumped `lerna.json` to alpha.75 and committed it
2. Tag creation or push failed (transient error)
3. Every subsequent run: tag=74 → sync down to 74 → bump to 75 → no diff → no tag → npm says "already published" → loop

## Test plan
- [ ] Merge this PR — the next push to develop triggers a release run
- [ ] Verify CI increments to alpha.76 and publishes successfully
- [ ] Check that `v2.0.0-alpha.76` git tag is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a recurring CI deadlock where the alpha release pipeline would loop forever re-publishing the same version. The root cause was that the sync logic ran whenever `lerna.json` and the highest git tag differed — even when `lerna.json` was already *ahead* — causing it to sync down, produce no diff, and skip tag creation indefinitely. The fix introduces a numeric comparison of prerelease suffixes so that the sync-down only fires when `lerna.json` is genuinely behind the tags; when ahead, it simply increments from the current version. The change is applied symmetrically to both the alpha and beta release paths.

- **Root cause addressed correctly**: comparing only the trailing numeric suffix via `grep -o '[0-9]*$'` is safe here because the tag query is already scoped to the same base version (`v${BASE_VERSION}-alpha.*`), so cross-base-version mismatches cannot occur.
- **Implicit equal case handled correctly**: when `CURRENT_NUM == HIGHEST_NUM` neither branch fires, and `lerna version prerelease` increments normally.
- **Log message improvement**: the "Incrementing from …" message now reads the live `lerna.json` value instead of `${HIGHEST_VERSION}`, which gives accurate output in the skip-sync path.
- **Minor robustness gap**: `grep -o '[0-9]*$'` returns an empty string for unusual version strings, and Bash integer comparisons silently coerce `""` to `0`, which could trigger an incorrect sync-down. Adding `${VAR:-0}` defaults would make this defensive.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fix directly resolves the described deadlock with sound logic and minimal blast radius.
- The change is small, well-scoped, and the comparison logic is correct for all realistic version formats. The one minor gap (no guard for empty grep output) is a theoretical edge case that won't occur with normal semver strings. Both alpha and beta paths are updated symmetrically.
- No files require special attention beyond the single changed workflow file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Fixes release deadlock by comparing numeric prerelease suffixes before deciding whether to sync lerna.json down to the highest git tag; logic is sound but a subtle edge case exists around empty CURRENT_NUM. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Alpha/Beta Release Triggered] --> B[Read CURRENT_VERSION from lerna.json]
    B --> C[Fetch tags\ngit fetch --tags]
    C --> D{Highest tag exists?}
    D -- No --> E[Start fresh at base-alpha.0\nor base-beta.0]
    D -- Yes --> F[Extract HIGHEST_NUM\nfrom tag suffix]
    F --> G[Extract CURRENT_NUM\nfrom lerna.json suffix]
    G --> H{Compare\nCURRENT_NUM vs HIGHEST_NUM}
    H -- CURRENT_NUM < HIGHEST_NUM --> I[Sync DOWN: lerna version\nHIGHEST_VERSION]
    H -- CURRENT_NUM > HIGHEST_NUM --> J[Skip sync — lerna.json\nalready ahead of tags]
    H -- CURRENT_NUM == HIGHEST_NUM --> K[No sync needed]
    I --> L[lerna version prerelease\nbump to next alpha/beta]
    J --> L
    K --> L
    E --> L
    L --> M[Commit version changes]
    M --> N{Any git diff?}
    N -- No --> O[has_changes=false\nskip tag + push]
    N -- Yes --> P[Create git tag vX.Y.Z-alpha.N]
    P --> Q[Push commit + tag]
    Q --> R[Publish to NPM]
```

<sub>Last reviewed commit: ["fix(ci): break relea..."](https://github.com/elizaos/eliza/commit/9c0e49679167d7c9eb03d636cd2c47803c91dbd8)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->