### PR TITLE
fix: knowledge upload — image handling, .mdx support, bulk

### DIFF
--- a/packages/app-core/src/components/KnowledgeView.tsx
+++ b/packages/app-core/src/components/KnowledgeView.tsx
@@ -38,6 +38,7 @@ const LARGE_FILE_WARNING_BYTES = 8 * 1_048_576;
 const SUPPORTED_UPLOAD_EXTENSIONS = new Set([
   ".txt",
   ".md",
+  ".mdx",
   ".pdf",
   ".docx",
   ".json",
@@ -76,7 +77,9 @@ export function shouldReadKnowledgeFileAsText(
   ];
 
   return (
-    textTypes.some((t) => file.type.includes(t)) || file.name.endsWith(".md")
+    textTypes.some((t) => file.type.includes(t)) ||
+    file.name.endsWith(".md") ||
+    file.name.endsWith(".mdx")
   );
 }
 
@@ -162,7 +165,7 @@ function UploadZone({
         type="file"
         className="hidden"
         multiple
-        accept=".txt,.md,.pdf,.docx,.json,.csv,.xml,.html,.png,.jpg,.jpeg,.webp,.gif"
+        accept=".txt,.md,.mdx,.pdf,.docx,.json,.csv,.xml,.html,.png,.jpg,.jpeg,.webp,.gif"
         onChange={handleFileSelect}
       />
       <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-1">

--- a/packages/autonomous/src/api/knowledge-routes.ts
+++ b/packages/autonomous/src/api/knowledge-routes.ts
@@ -855,29 +855,67 @@ export async function handleKnowledgeRoutes(
     fragmentCount: number;
     warnings?: string[];
   }> {
+    let content = document.content;
+    let contentType = document.contentType || "text/plain";
+    const warnings: string[] = [];
+
+    // Image files: the content is base64-encoded binary which can't be
+    // text-extracted. Convert to a text description for embedding.
+    if (contentType.startsWith("image/")) {
+      const includeDescriptions = (document.metadata as Record<string, unknown>)?.includeImageDescriptions === true;
+      if (includeDescriptions && runtime) {
+        // Try to describe the image via the runtime's vision model
+        try {
+          const { ModelType } = await import("@elizaos/core");
+          const dataUri = `data:${contentType};base64,${content}`;
+          const description = await runtime.useModel(ModelType.TEXT_SMALL, {
+            prompt: `Describe this image in detail for a knowledge base. Focus on text content, data, charts, and key visual elements. Image filename: ${document.filename}`,
+            images: [dataUri],
+            maxTokens: 1000,
+          });
+          content = `[Image: ${document.filename}]\n\n${typeof description === "string" ? description : (description as { text?: string }).text || "Image uploaded"}`;
+          contentType = "text/plain";
+        } catch (err) {
+          // Vision failed — store as a reference entry
+          content = `[Image: ${document.filename}] — Image uploaded. Vision description unavailable.`;
+          contentType = "text/plain";
+          warnings.push(`Vision description failed for ${document.filename}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } else {
+        // No vision requested — store as a reference entry
+        content = `[Image: ${document.filename}] — Image uploaded without text extraction.`;
+        contentType = "text/plain";
+      }
+    }
+
+    // MDX files: treat as markdown
+    if (document.filename?.endsWith(".mdx")) {
+      contentType = "text/markdown";
+    }
+
     const result = await service.addKnowledge({
       agentId,
       worldId: agentId,
       roomId: agentId,
       entityId: agentId,
       clientDocumentId: "" as UUID, // Will be generated
-      contentType: document.contentType || "text/plain",
+      contentType,
       originalFilename: document.filename,
-      content: document.content,
+      content,
       metadata: document.metadata,
     });
 
     const warningsValue = (result as { warnings?: unknown }).warnings;
-    const warnings = Array.isArray(warningsValue)
-      ? warningsValue.filter(
-          (warning): warning is string => typeof warning === "string",
-        )
-      : undefined;
+    if (Array.isArray(warningsValue)) {
+      for (const w of warningsValue) {
+        if (typeof w === "string") warnings.push(w);
+      }
+    }
 
     return {
       documentId: result.clientDocumentId,
       fragmentCount: result.fragmentCount,
-      warnings,
+      warnings: warnings.length > 0 ? warnings : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

- **Image uploads no longer fail with "appears to be binary"** — when `contentType` starts with `image/`, the knowledge route now:
  1. If `includeImageDescriptions` is true: tries the runtime's vision model to describe the image, stores the description as text
  2. Falls back to a reference entry (`[Image: filename.png]`) if vision is unavailable
  3. No longer passes raw base64 to the text extractor

- **MDX files supported** — `.mdx` added to `SUPPORTED_UPLOAD_EXTENSIONS`, treated as `text/markdown`, file input accept attribute updated

- **Bulk upload already works** via `POST /api/knowledge/documents/bulk` — no changes needed

## Test plan
- [ ] Upload a PNG with "Process Images" enabled → should succeed (vision description or reference entry)
- [ ] Upload a .mdx file → should be processed as markdown
- [ ] Upload multiple files at once → bulk endpoint handles batching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `.mdx` file support to the knowledge upload UI and fixes raw-binary image uploads from crashing with "appears to be binary" by routing image content through a vision model (or falling back to a text reference). The UI changes are clean and correct. However, the vision path in `knowledge-routes.ts` contains a critical model-type mismatch that renders the image-description feature non-functional.

Key changes:
- `KnowledgeView.tsx`: `.mdx` added to `SUPPORTED_UPLOAD_EXTENSIONS`, `shouldReadKnowledgeFileAsText`, and the file-input `accept` attribute — all correct.
- `knowledge-routes.ts`: new `addKnowledgeDocument` pre-processing stage handles images and `.mdx` content-type overrides before calling `service.addKnowledge`. The image branch uses `ModelType.TEXT_SMALL` with an `images: [dataUri]` parameter, but the correct model type throughout the codebase is `ModelType.IMAGE_DESCRIPTION` with an `imageUrl` string parameter. Because `TEXT_SMALL` does not accept image data in this shape, every call to the vision path will throw, the catch block will fire, and the file will be stored as a plain `[Image: filename]` reference — even when the user explicitly enables "Process Images".

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the primary new feature (image vision description) is silently broken.
- The `.mdx` UI changes are safe, but the core image-handling logic uses the wrong model type (`TEXT_SMALL` instead of `IMAGE_DESCRIPTION`) and the wrong parameter name (`images` array vs `imageUrl` string), causing the vision path to always fail at runtime and fall back to a reference-only entry. This is a P0 logic bug in the only new server-side behavior introduced by this PR.
- packages/autonomous/src/api/knowledge-routes.ts — vision model call at lines 871–875 must be corrected before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autonomous/src/api/knowledge-routes.ts | Image vision path uses `ModelType.TEXT_SMALL` with an `images` array instead of the correct `ModelType.IMAGE_DESCRIPTION` with `imageUrl`; this will always throw and fall back to a reference-only entry, making the vision description feature non-functional. |
| packages/app-core/src/components/KnowledgeView.tsx | Straightforward additions: `.mdx` added to the extension allow-list, the `accept` attribute, and the `shouldReadKnowledgeFileAsText` check. No issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[POST /api/knowledge/documents] --> B{contentType starts with image/?}
    B -- No --> G{filename ends with .mdx?}
    G -- Yes --> H[Override contentType = text/markdown]
    G -- No --> I[service.addKnowledge]
    H --> I

    B -- Yes --> C{includeImageDescriptions AND runtime?}
    C -- No --> D[Fallback: store reference entry]
    D --> I

    C -- Yes --> E["runtime.useModel(TEXT_SMALL ⚠️,\n{ images: [dataUri] })"]
    E -- Success --> F[Store image + description as text/plain]
    E -- Throws / fails --> D2[Catch: store reference entry + warning]
    F --> I
    D2 --> I

    style E fill:#ff9999,stroke:#cc0000
    style D2 fill:#ffe0b2,stroke:#e65100
```

<sub>Last reviewed commit: ["fix: knowledge uploa..."](https://github.com/elizaos/eliza/commit/cce57d5abdf41a8deefc156269f30580e32dbad1)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->