### PR TITLE
fix(ci): prevent npm version collision and verify dist-tag after publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -307,6 +307,7 @@ jobs:
                   --no-git-tag-version \
                   --no-push
                 VERSION=$(node -p "require('./lerna.json').version")
+                sleep 1  # Brief delay for npm registry consistency
               else
                 echo "✅ Version ${VERSION} is available on npm"
                 break
@@ -540,6 +541,7 @@ jobs:
             for PKG in $PACKAGES; do
               if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
                 if npm dist-tag add "${PKG}@${VERSION}" "${DIST_TAG}" 2>/dev/null; then
+                  echo "  ✅ Updated dist-tag for ${PKG}"
                   FIXED=$((FIXED + 1))
                 else
                   echo "  ⚠️ Failed to update dist-tag for ${PKG}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -288,8 +288,38 @@ jobs:
             exit 1
           fi
 
-          # Get the new version
+          # Get the new version and verify it doesn't already exist on npm.
+          # lerna publish from-package silently skips already-published versions,
+          # so we must detect collisions here and bump again if needed.
           VERSION=$(node -p "require('./lerna.json').version")
+
+          if [[ "${RELEASE_TYPE}" == "alpha" || "${RELEASE_TYPE}" == "beta" ]]; then
+            MAX_RETRIES=3
+            for i in $(seq 1 $MAX_RETRIES); do
+              # Check if this version already exists on npm
+              if npm view "@elizaos/core@${VERSION}" version >/dev/null 2>&1; then
+                echo "⚠️ Version ${VERSION} already exists on npm — bumping again (attempt ${i}/${MAX_RETRIES})"
+                bunx lerna version prerelease \
+                  --preid "${RELEASE_TYPE}" \
+                  --force-publish \
+                  --yes \
+                  --no-private \
+                  --no-git-tag-version \
+                  --no-push
+                VERSION=$(node -p "require('./lerna.json').version")
+              else
+                echo "✅ Version ${VERSION} is available on npm"
+                break
+              fi
+            done
+
+            # Final check — if still colliding after retries, fail loudly
+            if npm view "@elizaos/core@${VERSION}" version >/dev/null 2>&1; then
+              echo "❌ Version ${VERSION} still exists on npm after ${MAX_RETRIES} bumps — aborting"
+              exit 1
+            fi
+          fi
+
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       # Update lockfile after version changes
@@ -478,6 +508,57 @@ jobs:
           fi
 
           echo "✅ Successfully published to NPM with dist-tag: ${DIST_TAG}"
+
+      # Verify the dist-tag actually points to the new version.
+      # lerna publish silently skips already-published versions, so the
+      # dist-tag may not have moved even though lerna reported success.
+      - name: Verify dist-tag
+        if: steps.publish.outcome == 'success'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DIST_TAG="${{ steps.release_type.outputs.dist_tag }}"
+
+          echo "Verifying dist-tag '${DIST_TAG}' points to ${VERSION}..."
+
+          # Check a representative package (@elizaos/core)
+          ACTUAL=$(npm view "@elizaos/core@${DIST_TAG}" version 2>/dev/null || echo "unknown")
+
+          if [[ "$ACTUAL" != "$VERSION" ]]; then
+            echo "⚠️ dist-tag '${DIST_TAG}' points to ${ACTUAL}, expected ${VERSION}"
+            echo "Forcing dist-tag update for all published packages..."
+
+            # Get list of public packages from lerna
+            PACKAGES=$(bunx lerna ls --json --no-private 2>/dev/null | node -e "
+              const pkgs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+              pkgs.forEach(p => console.log(p.name));
+            ")
+
+            FIXED=0
+            FAILED=0
+            for PKG in $PACKAGES; do
+              if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
+                if npm dist-tag add "${PKG}@${VERSION}" "${DIST_TAG}" 2>/dev/null; then
+                  FIXED=$((FIXED + 1))
+                else
+                  echo "  ⚠️ Failed to update dist-tag for ${PKG}"
+                  FAILED=$((FAILED + 1))
+                fi
+              fi
+            done
+
+            echo "✅ Updated dist-tag for ${FIXED} packages (${FAILED} failures)"
+
+            # Re-verify
+            ACTUAL2=$(npm view "@elizaos/core@${DIST_TAG}" version 2>/dev/null || echo "unknown")
+            if [[ "$ACTUAL2" != "$VERSION" ]]; then
+              echo "❌ dist-tag still not pointing to ${VERSION} after fix attempt"
+              exit 1
+            fi
+          else
+            echo "✅ dist-tag '${DIST_TAG}' correctly points to ${VERSION}"
+          fi
 
       # Always restore workspace:* references after publish (success or failure)
       # This keeps the repository clean for development


### PR DESCRIPTION
## Summary
- **Pre-publish version check**: After version bump, checks if the version already exists on npm. If it does, bumps again (up to 3 retries) before committing. Prevents `lerna publish from-package` from silently skipping the upload.
- **Post-publish dist-tag verification**: After publish, verifies the dist-tag (`alpha`/`beta`) actually points to the new version. If not, force-updates it with `npm dist-tag add` for all packages.

## Problem
`lerna publish from-package` silently skips already-published versions and reports success. When a version number collides with a previous run (e.g., two CI runs both compute `alpha.77`), the publish step "succeeds" but nothing is actually uploaded, and the dist-tag stays stuck on the old version.

This caused alpha.77 to contain stale build artifacts — the source had fixes but the dist-tag never moved from alpha.76.

## Test plan
- [ ] Merge and verify next alpha release publishes successfully
- [ ] Verify `npm view @elizaos/core@alpha version` returns the new version after CI completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves CI release reliability by adding two safeguards: a pre-publish npm version collision check (with up to 3 auto-bump retries) in the `Version packages` step, and a post-publish dist-tag verification step that force-updates stale dist-tags across all public packages when `lerna publish from-package` silently skips already-published versions.

**Key changes:**
- Pre-publish loop in `Version packages` checks `@elizaos/core@${VERSION}` against npm; if already published, runs `lerna version prerelease` again (up to 3 retries) before committing and tagging
- New `Verify dist-tag` step (runs on `steps.publish.outcome == 'success'`) confirms the dist-tag (e.g. `alpha`) points to the newly published version; if not, iterates all public packages and runs `npm dist-tag add` to force-correct them

**Issues found:**
- The `FAILED` counter in the dist-tag recovery loop is tracked and logged but never used to fail the step — if `@elizaos/core` gets its tag corrected but other packages fail, the workflow reports success with stale dist-tags across those packages
- If `bunx lerna ls --json --no-private` fails or produces empty output, the piped `node` JSON parsing throws silently to stderr, leaving `PACKAGES` empty; the recovery loop runs zero iterations and the re-verify then fails with a misleading error message about the dist-tag rather than about the empty package list
- The collision check relies solely on `@elizaos/core` as a representative package, with no fallback for transient registry errors or cases where `@elizaos/core` is newly introduced

<h3>Confidence Score: 3/5</h3>

- Safe to merge with caveats — the core logic is sound but partial dist-tag update failures are silently treated as success, and the lerna ls JSON parsing has an unhandled failure path
- The pre-publish collision detection and post-publish verification are valuable additions that address a real production issue. However, two logic gaps reduce confidence: (1) the `FAILED` counter in the dist-tag recovery loop is never used to halt the workflow, meaning a partial update (e.g. 40/50 packages fixed) still exits 0, and (2) the `lerna ls` JSON parsing can silently produce an empty package list, causing the recovery to do nothing and the re-verify to fail with a misleading error. These are non-blocking for the happy path but create blind spots in error recovery.
- .github/workflows/release.yaml — specifically the `Verify dist-tag` step's recovery loop (lines 533–558)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Adds pre-publish npm version collision detection with up to 3 auto-bumps, and a post-publish dist-tag verification step that force-updates stale tags. The approach is sound, but the dist-tag recovery loop has a logic gap where `FAILED` packages are never surfaced as an error, the `lerna ls` JSON parsing can silently produce an empty package list, and the representative-package heuristic (`@elizaos/core`) could miss or give false negatives for collision detection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Version packages step] --> B[Read VERSION from lerna.json]
    B --> C{alpha or beta release?}
    C -- No --> G[Write version output]
    C -- Yes --> D{npm view @elizaos/core@VERSION exists?}
    D -- No --> F[✅ Version available — break]
    F --> G
    D -- Yes --> E[lerna version prerelease --preid RELEASE_TYPE]
    E --> E2[Update VERSION from lerna.json]
    E2 --> D2{Retry i ≤ MAX_RETRIES=3?}
    D2 -- Yes --> D
    D2 -- No --> FAIL1[❌ Exit 1: still colliding after 3 bumps]

    G --> H[Update lockfile]
    H --> I[Commit version changes]
    I --> J[Create git tag]
    J --> K[Push to git]
    K --> L[Build + Publish to NPM via lerna publish from-package]

    L --> M{publish.outcome == success?}
    M -- No --> N[❌ Exit 1: publish failed]
    M -- Yes --> O[Verify dist-tag step]
    O --> P{npm view @elizaos/core@DIST_TAG == VERSION?}
    P -- Yes --> Q[✅ dist-tag correct]
    P -- No --> R[bunx lerna ls --json ➜ PACKAGES list]
    R --> S{PACKAGES empty or lerna failed?}
    S -- Yes --> T[⚠️ Silent: loop runs 0 times]
    S -- No --> U[For each PKG: npm dist-tag add PKG@VERSION DIST_TAG]
    U --> V{npm view @elizaos/core@DIST_TAG == VERSION?}
    T --> V
    V -- Yes --> W[✅ Re-verify passed]
    V -- No --> X[❌ Exit 1: dist-tag still wrong]
```

<sub>Last reviewed commit: ["fix(ci): add retry d..."](https://github.com/elizaos/eliza/commit/fee9fb125660e33551f2c39cd733cd96b451ff86)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->