### PR TITLE
fix: resolve build failures in core and autonomous packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -459,9 +459,18 @@ jobs:
           SKIP_PYTHON_BUILD: "1"
         run: |
           echo "Building packages with version v${{ steps.version.outputs.version }}..."
-          # Use --continue so build failures in root packages (Rust/Python) don't block NPM release
-          # Some -root packages may fail due to platform-specific Rust builds - this is expected
-          bunx turbo run build --continue || echo "Some packages had build errors - continuing with publish for successfully built packages"
+          # Use --continue so platform-specific build failures (Rust/Python) don't block the release.
+          # But verify critical packages built successfully afterward.
+          bunx turbo run build --continue || echo "Some packages had build errors — checking critical packages..."
+
+          # Fail if critical packages didn't produce dist/
+          for pkg in packages/typescript packages/autonomous packages/app-core; do
+            if [ ! -d "${pkg}/dist" ]; then
+              echo "❌ Critical package ${pkg} failed to build (no dist/ directory)"
+              exit 1
+            fi
+          done
+          echo "✅ All critical packages built successfully"
 
       # Replace workspace:* references with actual versions before publishing
       # This is required because Bun workspaces use workspace:* protocol

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -464,6 +464,7 @@ jobs:
           bunx turbo run build --continue || echo "Some packages had build errors — checking critical packages..."
 
           # Fail if critical packages didn't produce dist/
+          # packages/typescript is published as @elizaos/core
           for pkg in packages/typescript packages/autonomous packages/app-core; do
             if [ ! -d "${pkg}/dist" ]; then
               echo "❌ Critical package ${pkg} failed to build (no dist/ directory)"

--- a/packages/autonomous/src/api/server.ts
+++ b/packages/autonomous/src/api/server.ts
@@ -9475,7 +9475,7 @@ async function handleRequest(
     // Plugin internal names vary wildly (e.g. "local-ai" for plugin-local-embedding,
     // "eliza-coder" for plugin-code), so we check loaded names against multiple
     // derived forms of the npm package name.
-    const loadedNames = state.runtime
+    const loadedNames: Set<string> = state.runtime
       ? new Set(state.runtime.plugins.map((p: { name: string }) => p.name))
       : new Set<string>();
 

--- a/packages/autonomous/src/onboarding-presets.test.ts
+++ b/packages/autonomous/src/onboarding-presets.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHARACTER_PRESET_META,
+  STYLE_PRESETS,
+  getPresetByName,
+  getStylePresets,
+} from "./onboarding-presets";
+
+describe("getStylePresets", () => {
+  it("returns the STYLE_PRESETS array", () => {
+    expect(getStylePresets()).toBe(STYLE_PRESETS);
+  });
+
+  it("returns a non-empty array of presets with required fields", () => {
+    const presets = getStylePresets();
+    expect(presets.length).toBeGreaterThan(0);
+    for (const preset of presets) {
+      expect(preset).toHaveProperty("catchphrase");
+      expect(preset).toHaveProperty("hint");
+      expect(preset).toHaveProperty("bio");
+      expect(preset).toHaveProperty("system");
+    }
+  });
+});
+
+describe("getPresetByName", () => {
+  it("returns a name → catchphrase mapping", () => {
+    const map = getPresetByName();
+    expect(typeof map).toBe("object");
+    for (const [name, catchphrase] of Object.entries(map)) {
+      expect(typeof name).toBe("string");
+      expect(typeof catchphrase).toBe("string");
+      expect(name.length).toBeGreaterThan(0);
+      expect(catchphrase.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains one entry per CHARACTER_PRESET_META value", () => {
+    const map = getPresetByName();
+    const metaValues = Object.values(CHARACTER_PRESET_META);
+    expect(Object.keys(map).length).toBe(metaValues.length);
+    for (const meta of metaValues) {
+      expect(map[meta.name]).toBe(meta.catchphrase);
+    }
+  });
+
+  it("maps are consistent with STYLE_PRESETS catchphrases", () => {
+    const map = getPresetByName();
+    const validCatchphrases = new Set(
+      getStylePresets().map((p) => p.catchphrase),
+    );
+    for (const catchphrase of Object.values(map)) {
+      expect(validCatchphrases.has(catchphrase)).toBe(true);
+    }
+  });
+});

--- a/packages/autonomous/src/onboarding-presets.test.ts
+++ b/packages/autonomous/src/onboarding-presets.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CHARACTER_PRESET_META,
   STYLE_PRESETS,
-  getPresetByName,
+  getPresetNameMap,
   getStylePresets,
 } from "./onboarding-presets";
 
@@ -23,9 +23,9 @@ describe("getStylePresets", () => {
   });
 });
 
-describe("getPresetByName", () => {
+describe("getPresetNameMap", () => {
   it("returns a name → catchphrase mapping", () => {
-    const map = getPresetByName();
+    const map = getPresetNameMap();
     expect(typeof map).toBe("object");
     for (const [name, catchphrase] of Object.entries(map)) {
       expect(typeof name).toBe("string");
@@ -36,7 +36,7 @@ describe("getPresetByName", () => {
   });
 
   it("contains one entry per CHARACTER_PRESET_META value", () => {
-    const map = getPresetByName();
+    const map = getPresetNameMap();
     const metaValues = Object.values(CHARACTER_PRESET_META);
     expect(Object.keys(map).length).toBe(metaValues.length);
     for (const meta of metaValues) {
@@ -45,7 +45,7 @@ describe("getPresetByName", () => {
   });
 
   it("maps are consistent with STYLE_PRESETS catchphrases", () => {
-    const map = getPresetByName();
+    const map = getPresetNameMap();
     const validCatchphrases = new Set(
       getStylePresets().map((p) => p.catchphrase),
     );

--- a/packages/autonomous/src/onboarding-presets.ts
+++ b/packages/autonomous/src/onboarding-presets.ts
@@ -1315,4 +1315,18 @@ export const CHARACTER_PRESET_META: Record<
   "Show me what we're building.": { name: "Satoshi", avatarIndex: 7, voicePresetId: "callum", catchphrase: "Show me what we're building." },
 };
 
+/** Return the full list of style presets. */
+export function getStylePresets() {
+  return STYLE_PRESETS;
+}
+
+/** Return a name → catchphrase mapping derived from CHARACTER_PRESET_META. */
+export function getPresetByName(): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const meta of Object.values(CHARACTER_PRESET_META)) {
+    result[meta.name] = meta.catchphrase;
+  }
+  return result;
+}
+
 //#endregion

--- a/packages/autonomous/src/onboarding-presets.ts
+++ b/packages/autonomous/src/onboarding-presets.ts
@@ -1316,15 +1316,15 @@ export const CHARACTER_PRESET_META: Record<
 };
 
 /** Return the full list of style presets. */
-export function getStylePresets() {
+export function getStylePresets(): typeof STYLE_PRESETS {
   return STYLE_PRESETS;
 }
 
 /** Return a name → catchphrase mapping derived from CHARACTER_PRESET_META. */
 export function getPresetByName(): Record<string, string> {
   const result: Record<string, string> = {};
-  for (const meta of Object.values(CHARACTER_PRESET_META)) {
-    result[meta.name] = meta.catchphrase;
+  for (const entry of Object.values(CHARACTER_PRESET_META)) {
+    result[entry.name] = entry.catchphrase;
   }
   return result;
 }

--- a/packages/autonomous/src/onboarding-presets.ts
+++ b/packages/autonomous/src/onboarding-presets.ts
@@ -1321,7 +1321,7 @@ export function getStylePresets(): typeof STYLE_PRESETS {
 }
 
 /** Return a name → catchphrase mapping derived from CHARACTER_PRESET_META. */
-export function getPresetByName(): Record<string, string> {
+export function getPresetNameMap(): Record<string, string> {
   const result: Record<string, string> = {};
   for (const entry of Object.values(CHARACTER_PRESET_META)) {
     result[entry.name] = entry.catchphrase;

--- a/packages/autonomous/src/runtime/eliza.ts
+++ b/packages/autonomous/src/runtime/eliza.ts
@@ -2822,7 +2822,7 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
       Remilia: "...",
       Reisen: "locked in",
     };
-    const presetByName = getPresetByName() ?? defaultPresetByName;
+    const presetByName = getPresetNameMap() ?? defaultPresetByName;
     const presetCatchphrase = presetByName[name.trim()];
     if (!presetCatchphrase) return undefined;
     return getStylePresets().find(
@@ -3001,7 +3001,7 @@ import { pickRandomNames } from "./onboarding-names";
 // Style presets — shared between CLI and GUI onboarding
 // ---------------------------------------------------------------------------
 
-import { getStylePresets, getPresetByName } from "../onboarding-presets";
+import { getStylePresets, getPresetNameMap } from "../onboarding-presets";
 
 /**
  * Detect whether this is the first run (no agent name configured)

--- a/packages/autonomous/src/runtime/eliza.ts
+++ b/packages/autonomous/src/runtime/eliza.ts
@@ -730,8 +730,10 @@ export function findRuntimePluginExport(mod: PluginModuleShape): Plugin | null {
 
   // 6. Legacy CJS compatibility for modules that export only { name, description }.
   if (looksLikePluginBasic(mod)) return mod as unknown as Plugin;
-  if (looksLikePluginBasic(mod.default)) return mod.default as Plugin;
-  if (looksLikePluginBasic(mod.plugin)) return mod.plugin as Plugin;
+  const modDefault = (mod as Record<string, unknown>).default;
+  const modPlugin = (mod as Record<string, unknown>).plugin;
+  if (looksLikePluginBasic(modDefault)) return modDefault as Plugin;
+  if (looksLikePluginBasic(modPlugin)) return modPlugin as Plugin;
 
   return null;
 }
@@ -2999,7 +3001,7 @@ import { pickRandomNames } from "./onboarding-names";
 // Style presets — shared between CLI and GUI onboarding
 // ---------------------------------------------------------------------------
 
-import { STYLE_PRESETS, getStylePresets, getPresetByName } from "../onboarding-presets";
+import { getStylePresets, getPresetByName } from "../onboarding-presets";
 
 /**
  * Detect whether this is the first run (no agent name configured)

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -47,6 +47,7 @@
     "dist"
   ],
   "scripts": {
+    "prebuild": "cd ../schemas && bunx buf generate",
     "build": "bun run build.ts",
     "build:watch": "bun run build.ts --watch",
     "dev": "bun run build:watch",
@@ -76,7 +77,8 @@
     "esbuild": "^0.25.0",
     "sharp": "^0.33.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "@elizaos/schemas": "workspace:*"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.1",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "scripts": {
-    "prebuild": "cd ../schemas && bunx buf generate",
+    "prebuild": "[ -d src/types/generated ] || (cd ../schemas && bunx buf generate)",
     "build": "bun run build.ts",
     "build:watch": "bun run build.ts --watch",
     "dev": "bun run build:watch",


### PR DESCRIPTION
## Summary
- **Core protobuf codegen**: Added `prebuild` script to `@elizaos/core` that runs `buf generate` from `packages/schemas` before building. The generated `*_pb.ts` files are gitignored (`src/**/*.js` rule) and were missing in CI, causing all downstream `@elizaos/core` imports to fail.
- **Autonomous missing exports**: Added `getStylePresets()` and `getPresetByName()` to `onboarding-presets.ts` — removed in a previous refactor but still imported by `eliza.ts` and `server.ts`.
- **Type fixes**: Explicit `Set<string>` annotation in server.ts, safer property access cast in eliza.ts `findRuntimePluginExport`.
- **CI safety net**: After `turbo build --continue`, verify that critical packages (core, autonomous, app-core) produced `dist/` — fail the release if they didn't.

## Root cause
`proto.ts` re-exports from `./generated/eliza/v1/*_pb.js` which are produced by `buf generate` in `packages/schemas`. These files exist locally but are gitignored, so they're absent in CI. Without them, `@elizaos/core` fails to build, which cascades to every package that depends on it.

## Test plan
- [ ] Merge and verify CI release succeeds
- [ ] Verify `@elizaos/core`, `@elizaos/autonomous`, and `@elizaos/app-core` all publish with current source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cascade of build failures caused by protobuf-generated files being gitignored and therefore absent in CI. The three-part fix is: (1) add a `prebuild` hook to `@elizaos/core` (`packages/typescript`) that runs `buf generate` before compilation, (2) restore two missing named exports (`getStylePresets`, `getPresetByName`) in `onboarding-presets.ts` that `eliza.ts` and `server.ts` were already importing, and (3) add a post-build gate in the release workflow that aborts the release if any critical package failed to produce a `dist/` directory.

**Key changes:**
- `packages/typescript/package.json`: `prebuild` script and `@elizaos/schemas: workspace:*` devDependency — the workspace dep gives Turbo the correct build order while the `prebuild` acts as a local safety net to regenerate proto files immediately before compilation.
- `packages/autonomous/src/onboarding-presets.ts`: Adds the two previously-missing exports; the `getPresetByName()` implementation is correct but its name is misleading (see inline comment).
- `packages/autonomous/src/runtime/eliza.ts`: Removes the now-unused direct `STYLE_PRESETS` import and tightens property access casts via `Record<string, unknown>` to silence TypeScript errors without losing type safety.
- `.github/workflows/release.yaml`: The `dist/` existence check is a pragmatic improvement over the previous all-or-nothing approach, though it only validates the presence of `dist/` rather than its content integrity. `packages/typescript` (the checked directory) maps to `@elizaos/core` — this is non-obvious and worth a comment (see inline).

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fixes are targeted and correct; the remaining concerns are style/resilience improvements, not correctness blockers.
- All three root causes are properly addressed: generated files will now be present at build time, the missing exports are restored, and the release gate will catch future regressions. No logic bugs were found. Score reduced by one point because the `prebuild` introduces a live network dependency on `buf.build` in the critical path, and the CI `dist/` check uses `packages/typescript` without clarifying it is `@elizaos/core`, which could cause confusion during incident triage.
- `.github/workflows/release.yaml` (confusing package directory alias) and `packages/typescript/package.json` (external BSR network dependency in `prebuild`).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/package.json | Adds `prebuild` script to run `buf generate` before building `@elizaos/core`, and adds `@elizaos/schemas` as a devDependency to establish Turbo's dependency order. The prebuild relies on a remote BSR call, which is an external network dependency in the critical build path. |
| packages/autonomous/src/onboarding-presets.ts | Adds `getStylePresets()` and `getPresetByName()` as named exports to restore functions that were imported by `eliza.ts` and `server.ts` but missing after a prior refactor. Logic is correct. |
| packages/autonomous/src/runtime/eliza.ts | Removes unused `STYLE_PRESETS` direct import and adds safer `Record<string, unknown>` type casts when accessing `.default` and `.plugin` on the loosely-typed `PluginModuleShape`. |
| packages/autonomous/src/api/server.ts | Single-line type annotation change: adds an explicit `Set<string>` generic to the `loadedNames` variable to satisfy the TypeScript compiler. |
| .github/workflows/release.yaml | Adds a post-build check that verifies critical packages produced a `dist/` directory, failing the release job if any are absent. Correct in intent but only checks for `dist/` existence (not content integrity), and the listed directory `packages/typescript` is actually `@elizaos/core`, which could confuse readers. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI (release.yaml)
    participant Turbo as turbo build
    participant Schemas as packages/schemas<br/>(buf generate)
    participant Core as packages/typescript<br/>(@elizaos/core)
    participant Autonomous as packages/autonomous
    participant AppCore as packages/app-core

    CI->>Turbo: bunx turbo run build --continue
    Note over Turbo: Resolves workspace dep order
    Turbo->>Schemas: build (buf lint + buf generate)
    Schemas-->>Core: writes src/types/generated/*_pb.ts
    Turbo->>Core: prebuild → cd ../schemas && bunx buf generate
    Note over Core: second buf generate (safety net)
    Core-->>Core: bun run build.ts → dist/
    Turbo->>Autonomous: build
    Autonomous-->>Autonomous: dist/
    Turbo->>AppCore: build
    AppCore-->>AppCore: dist/
    Turbo-->>CI: exit (--continue, may be non-zero)
    CI->>CI: check packages/typescript/dist ✅
    CI->>CI: check packages/autonomous/dist ✅
    CI->>CI: check packages/app-core/dist ✅
    CI->>CI: proceed to publish
```

<sub>Last reviewed commit: ["fix: add return type..."](https://github.com/elizaos/eliza/commit/d3bf2ce389f5f92d87ecd5dbc4b87080c85cba34)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->