### PR TITLE
fix(autonomous): add missing dotenv dependency

### DIFF
--- a/packages/autonomous/package.json
+++ b/packages/autonomous/package.json
@@ -222,6 +222,7 @@
   "dependencies": {
     "@clack/prompts": "^1.0.0",
     "@elizaos/core": "workspace:*",
+    "dotenv": "^17.2.3",
     "@elizaos/plugin-agent-orchestrator": "0.3.15",
     "@elizaos/plugin-agent-skills": "alpha",
     "@elizaos/plugin-anthropic": "alpha",


### PR DESCRIPTION
## Summary
- `benchmark-server.ts` imports `dotenv` but it wasn't declared in `package.json`, causing the autonomous build to fail in CI.

## Context
This was the last remaining build error after #6629 fixed the core protobuf codegen and other TS errors.

## Test plan
- [ ] Verify CI release builds all critical packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the missing `dotenv` dependency (`^17.2.3`) to `packages/autonomous/package.json`, fixing a CI build failure where `benchmark-server.ts` imported `dotenv` without it being declared. The fix is minimal, targeted, and consistent with the same version already used in `packages/typescript/package.json`.

**Key changes:**
- `packages/autonomous/package.json`: adds `"dotenv": "^17.2.3"` to `dependencies`

**Notes:**
- The declared minimum version (`17.2.3`) is valid and released; the latest in the `^17` range is `17.3.1`, which the caret range will resolve to on fresh installs.
- `dotenv` 17.x introduced a behaviour change: informational log messages (file loaded + key count) are now printed to `stdout` by default (`quiet` defaults to `false`). The call in `benchmark-server.ts` (`dotenv.config({ path: ... })`) does not pass `quiet: true`, so the server will emit a startup log line. This is cosmetic and unlikely to be a problem in a benchmark context, but worth being aware of.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single-line dependency addition that directly fixes a documented build failure with no functional risk.
- The change is a one-line dependency declaration that exactly matches the import already present in `benchmark-server.ts`. The version is valid, already used elsewhere in the monorepo, and has no known vulnerabilities. No logic is modified.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/autonomous/package.json | Adds missing `dotenv` ^17.2.3 dependency that `benchmark-server.ts` imports at runtime; version is valid, released, and consistent with the same pin in `packages/typescript/package.json`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Build
    participant pkg as package.json
    participant bm as benchmark-server.ts
    participant env as .env file

    CI->>pkg: install dependencies
    pkg-->>CI: dotenv resolved ✅ (previously missing ❌)
    CI->>bm: compile / run
    bm->>env: dotenv.config({ path: ".env" })
    env-->>bm: process.env populated
    bm-->>CI: server starts successfully
```

<sub>Last reviewed commit: ["fix(autonomous): add..."](https://github.com/elizaos/eliza/commit/7184d03a1e2a95417371adb97f722ee69b32d24a)</sub>

<!-- /greptile_comment -->