### PR TITLE
fix(ci): add libwayland-dev for computeruse build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler
+          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Adds `libwayland-dev` to CI system dependencies so `@elizaos/computeruse` (Rust/wayland-client) compiles successfully
- This was the last remaining build failure in the release pipeline

## Test plan
- [ ] Verify next alpha release builds all packages including computeruse without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a minimal CI fix that adds `libwayland-dev` to the `apt-get install` command in the `release.yaml` "Install system dependencies" step. The change is necessary because `@elizaos/computeruse` bundles the `computeruse-rs` Rust crate, which pulls in `xcap` (for cross-platform screen capture); on Linux, `xcap` links against `wayland-client`, which requires `libwayland-dev` to compile. Without it, the Rust build step in the release pipeline was failing.

- The single-line change in `release.yaml` is correct and well-placed — it installs the system library before the Rust toolchain setup and the `bunx turbo run build` step.
- The dedicated `release-computeruse-npm.yaml` workflow, which also builds the `computeruse-ts` napi-rs bindings on Linux (and therefore the same `computeruse-rs` → `xcap` dependency chain), still omits `libwayland-dev` from its Linux dependency list and may hit the same failure.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the change is a targeted, correct CI fix with no impact on application code or published artifacts beyond unblocking the build.
- The one-line change is exactly the right fix for the described root cause (`xcap` → `wayland-client` → `libwayland-dev`). No logic is changed, only a build-time system dependency is added. The minor concern is that the sibling `release-computeruse-npm.yaml` workflow appears to have the same missing dependency, which may be a latent failure in a separate workflow.
- `.github/workflows/release-computeruse-npm.yaml` (line 122) — the Linux dependency install step likely also needs `libwayland-dev` for the same reason.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Single-line fix adding `libwayland-dev` to the apt-get install command in the "Install system dependencies" step so the Rust `xcap`/wayland-client crate inside `@elizaos/computeruse` compiles on the Ubuntu runner. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Runner as ubuntu-latest Runner
    participant APT as apt-get
    participant Bun as Bun/Turbo
    participant Rust as Rust Compiler
    participant NPM as npm Registry

    GH->>Runner: Trigger release workflow (push to develop/main / GitHub release)
    Runner->>APT: sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev
    Note over APT: libwayland-dev now included ✅
    APT-->>Runner: System deps installed
    Runner->>Bun: bun install --ignore-scripts
    Bun-->>Runner: Node deps ready
    Runner->>Rust: Install Rust toolchain + wasm-pack
    Runner->>Bun: bunx turbo run build --continue
    Note over Bun,Rust: Builds @elizaos/computeruse<br/>(Rust crate using wayland-client / xcap)
    Bun->>Rust: cargo build (wayland-client links against libwayland-dev)
    Rust-->>Bun: ✅ Compile success
    Bun-->>Runner: All packages built
    Runner->>NPM: lerna publish from-package
    NPM-->>GH: ✅ Release complete
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release-computeruse-npm.yaml`, line 118-123 ([link](https://github.com/elizaos/eliza/blob/d6caf72325a35c19a5fdb79d5f1c4d1415e494ed/.github/workflows/release-computeruse-npm.yaml#L118-L123)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing `libwayland-dev` in Linux dependency step**

   The `computeruse-ts` napi-rs bindings crate depends on `computeruse-rs`, which in turn depends on `xcap = "0.6.0"` (workspace dependency in `packages/computeruse/Cargo.toml`). The `xcap` crate on Linux links against `wayland-client`, which requires `libwayland-dev` at compile time — the same root cause fixed by this PR in `release.yaml`.

   If this workflow runs against the same `computeruse-rs` crate, it will hit the same link failure on the `ubuntu-latest` runners. Consider adding `libwayland-dev` here as well:

</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ["fix(ci): add libwayl..."](https://github.com/elizaos/eliza/commit/d6caf72325a35c19a5fdb79d5f1c4d1415e494ed)</sub>

<!-- /greptile_comment -->