### PR TITLE
fix(app-core): skip loading flicker on coding agent settings re-mount

### DIFF
--- a/packages/app-core/src/components/CodingAgentSettingsSection.test.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.test.tsx
@@ -1,5 +1,106 @@
-import { describe, expect, it } from "vitest";
-import { ADAPTER_NAME_TO_TAB } from "./CodingAgentSettingsSection";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ADAPTER_NAME_TO_TAB,
+  CodingAgentSettingsSection,
+  _clearSettingsCache,
+} from "./CodingAgentSettingsSection";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetConfig = vi.fn();
+const mockFetchModels = vi.fn();
+
+vi.mock("../api", () => ({
+  client: {
+    getConfig: (...args: unknown[]) => mockGetConfig(...args),
+    fetchModels: (...args: unknown[]) => mockFetchModels(...args),
+  },
+}));
+
+vi.mock("../state", () => ({
+  useApp: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../hooks", () => ({
+  useTimeout: () => ({ setTimeout: globalThis.setTimeout }),
+}));
+
+vi.mock("./ConfigSaveFooter", () => ({
+  ConfigSaveFooter: () => null,
+}));
+
+vi.mock("@elizaos/ui", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode; [k: string]: unknown }) => (
+    <button {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}>
+      {children}
+    </button>
+  ),
+}));
+
+// Stub global fetch for the preflight endpoint
+const mockFetch = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default API stubs that resolve successfully with minimal data. */
+function stubSuccessfulApis() {
+  mockGetConfig.mockResolvedValue({ env: {} });
+  mockFetchModels.mockResolvedValue({ models: [] });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve([
+        { adapter: "claude code", installed: true },
+        { adapter: "aider", installed: true },
+      ]),
+  });
+}
+
+/** Flush all microtasks / pending promises so useEffect callbacks complete. */
+async function flushPromises() {
+  await act(async () => {
+    // Let pending promises resolve
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
+  });
+}
+
+/**
+ * Recursively search the rendered tree for a node whose props or children
+ * match a predicate. Returns true if found.
+ */
+function treeContainsText(
+  node: ReactTestRenderer,
+  text: string,
+): boolean {
+  const json = node.toJSON();
+  return jsonContainsText(json, text);
+}
+
+function jsonContainsText(
+  node: unknown,
+  text: string,
+): boolean {
+  if (node === null || node === undefined) return false;
+  if (typeof node === "string") return node.includes(text);
+  if (Array.isArray(node)) return node.some((n) => jsonContainsText(n, text));
+  if (typeof node === "object" && node !== null) {
+    const obj = node as { children?: unknown };
+    if (obj.children) return jsonContainsText(obj.children, text);
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — ADAPTER_NAME_TO_TAB (existing)
+// ---------------------------------------------------------------------------
 
 describe("ADAPTER_NAME_TO_TAB", () => {
   it("maps full adapter names from preflight API to tab keys", () => {
@@ -30,5 +131,160 @@ describe("ADAPTER_NAME_TO_TAB", () => {
     expect(simulatePreflight("Google Gemini")).toBe("gemini");
     expect(simulatePreflight("OpenAI Codex")).toBe("codex");
     expect(simulatePreflight("Aider")).toBe("aider");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Loading / caching behavior
+// ---------------------------------------------------------------------------
+
+describe("CodingAgentSettingsSection loading and cache", () => {
+  beforeEach(() => {
+    _clearSettingsCache();
+    vi.restoreAllMocks();
+    // Replace global fetch with our mock
+    vi.stubGlobal("fetch", mockFetch);
+    stubSuccessfulApis();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows loading text on first mount before data loads", () => {
+    // Make APIs hang so loading state is captured
+    mockGetConfig.mockReturnValue(new Promise(() => {}));
+
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+
+    // Should show the loading i18n key
+    expect(
+      treeContainsText(
+        renderer!,
+        "codingagentsettingssection.LoadingCodingAgent",
+      ),
+    ).toBe(true);
+  });
+
+  it("shows content after data loads", async () => {
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+
+    await flushPromises();
+
+    // Loading text should be gone; settings content should be present.
+    // The settings section renders i18n keys like "AgentSelectionStra"
+    expect(
+      treeContainsText(
+        renderer!,
+        "codingagentsettingssection.LoadingCodingAgent",
+      ),
+    ).toBe(false);
+    expect(
+      treeContainsText(
+        renderer!,
+        "codingagentsettingssection.AgentSelectionStra",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT show loading skeleton on re-mount when cache exists", async () => {
+    // First mount — populates the cache
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+    await flushPromises();
+
+    // Unmount
+    act(() => {
+      renderer!.unmount();
+    });
+
+    // Re-mount — cache should prevent loading skeleton
+    let renderer2: ReactTestRenderer;
+    act(() => {
+      renderer2 = create(<CodingAgentSettingsSection />);
+    });
+
+    // Immediately after mount (before background fetch resolves),
+    // should NOT show loading — should show cached content instead.
+    expect(
+      treeContainsText(
+        renderer2!,
+        "codingagentsettingssection.LoadingCodingAgent",
+      ),
+    ).toBe(false);
+    expect(
+      treeContainsText(
+        renderer2!,
+        "codingagentsettingssection.AgentSelectionStra",
+      ),
+    ).toBe(true);
+
+    // Clean up
+    await flushPromises();
+  });
+
+  it("still fetches fresh data in background on re-mount", async () => {
+    // First mount
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+    await flushPromises();
+
+    const callCountAfterFirst = mockGetConfig.mock.calls.length;
+
+    // Unmount and re-mount
+    act(() => {
+      renderer!.unmount();
+    });
+
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+    await flushPromises();
+
+    // getConfig should have been called again for the background refresh
+    expect(mockGetConfig.mock.calls.length).toBeGreaterThan(
+      callCountAfterFirst,
+    );
+  });
+
+  it("_clearSettingsCache resets the cache so next mount shows loading", async () => {
+    // First mount — populates cache
+    let renderer: ReactTestRenderer;
+    act(() => {
+      renderer = create(<CodingAgentSettingsSection />);
+    });
+    await flushPromises();
+    act(() => {
+      renderer!.unmount();
+    });
+
+    // Clear the cache
+    _clearSettingsCache();
+
+    // Make APIs hang so we can observe loading state
+    mockGetConfig.mockReturnValue(new Promise(() => {}));
+
+    let renderer2: ReactTestRenderer;
+    act(() => {
+      renderer2 = create(<CodingAgentSettingsSection />);
+    });
+
+    // Should show loading again since cache was cleared
+    expect(
+      treeContainsText(
+        renderer2!,
+        "codingagentsettingssection.LoadingCodingAgent",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@elizaos/ui";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AgentPreflightResult } from "../api";
 import { client } from "../api";
 import { useTimeout } from "../hooks";
@@ -100,29 +100,49 @@ const ENV_PREFIX: Record<AgentTab, string> = {
   aider: "PARALLAX_AIDER",
 };
 
+/** Module-level cache so re-mounts skip the loading skeleton. */
+interface SettingsCache {
+  prefs: Record<string, string>;
+  providerModels: Record<string, ModelOption[]>;
+  preflightByAgent: Partial<Record<AgentTab, AgentPreflightResult>>;
+  preflightLoaded: boolean;
+}
+
+let _settingsCache: SettingsCache | null = null;
+
+/** Visible for testing — clears the module-level settings cache. */
+export function _clearSettingsCache(): void {
+  _settingsCache = null;
+}
+
 export function CodingAgentSettingsSection() {
   const { setTimeout } = useTimeout();
   const { t } = useApp();
 
   const [activeTab, setActiveTab] = useState<AgentTab>("claude");
-  const hasLoadedOnce = useRef(false);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!_settingsCache);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [prefs, setPrefs] = useState<Record<string, string>>({});
+  const [prefs, setPrefs] = useState<Record<string, string>>(
+    _settingsCache?.prefs ?? {},
+  );
   const [providerModels, setProviderModels] = useState<
     Record<string, ModelOption[]>
-  >({});
-  const [preflightLoaded, setPreflightLoaded] = useState(false);
+  >(_settingsCache?.providerModels ?? {});
+  const [preflightLoaded, setPreflightLoaded] = useState(
+    _settingsCache?.preflightLoaded ?? false,
+  );
   const [preflightByAgent, setPreflightByAgent] = useState<
     Partial<Record<AgentTab, AgentPreflightResult>>
-  >({});
+  >(_settingsCache?.preflightByAgent ?? {});
 
   useEffect(() => {
     void (async () => {
-      if (!hasLoadedOnce.current) {
+      // Only show loading skeleton on very first fetch (no cache yet).
+      // When cache exists, we still fetch fresh data but don't block the UI.
+      if (!_settingsCache) {
         setLoading(true);
       }
       try {
@@ -195,6 +215,10 @@ export function CodingAgentSettingsSection() {
         }
         setProviderModels(models);
 
+        let newPreflightByAgent: Partial<
+          Record<AgentTab, AgentPreflightResult>
+        > = {};
+        let newPreflightLoaded = false;
         if (Array.isArray(preflightRes)) {
           const mapped: Partial<Record<AgentTab, AgentPreflightResult>> = {};
           for (const item of preflightRes as AgentPreflightResult[]) {
@@ -206,12 +230,21 @@ export function CodingAgentSettingsSection() {
           }
           setPreflightByAgent(mapped);
           setPreflightLoaded(true);
+          newPreflightByAgent = mapped;
+          newPreflightLoaded = true;
         }
+
+        // Persist to module-level cache so re-mounts are instant.
+        _settingsCache = {
+          prefs: loaded,
+          providerModels: models,
+          preflightByAgent: newPreflightByAgent,
+          preflightLoaded: newPreflightLoaded,
+        };
       } catch {
         // Fall back to built-in defaults when config or model fetches fail.
       }
       setLoading(false);
-      hasLoadedOnce.current = true;
     })();
   }, []);
 

--- a/packages/app-core/src/components/CodingAgentSettingsSection.tsx
+++ b/packages/app-core/src/components/CodingAgentSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@elizaos/ui";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { AgentPreflightResult } from "../api";
 import { client } from "../api";
 import { useTimeout } from "../hooks";
@@ -105,6 +105,7 @@ export function CodingAgentSettingsSection() {
   const { t } = useApp();
 
   const [activeTab, setActiveTab] = useState<AgentTab>("claude");
+  const hasLoadedOnce = useRef(false);
   const [loading, setLoading] = useState(true);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -121,7 +122,9 @@ export function CodingAgentSettingsSection() {
 
   useEffect(() => {
     void (async () => {
-      setLoading(true);
+      if (!hasLoadedOnce.current) {
+        setLoading(true);
+      }
       try {
         const [cfg, anthropicRes, googleRes, openaiRes, preflightRes] =
           await Promise.all([
@@ -208,6 +211,7 @@ export function CodingAgentSettingsSection() {
         // Fall back to built-in defaults when config or model fetches fail.
       }
       setLoading(false);
+      hasLoadedOnce.current = true;
     })();
   }, []);
 


### PR DESCRIPTION
## Summary
- CodingAgentSettingsSection showed a loading skeleton every time the settings page was navigated to, causing a visible flicker
- The preflight/config data doesn't change between visits, so subsequent mounts should render immediately with existing data
- Added a `useRef` to track first load — only the initial mount shows the loading state, re-mounts silently refresh in the background

## Test plan
- [ ] Navigate to settings page — coding agents section loads normally on first visit
- [ ] Navigate away and back — section renders immediately without flicker
- [ ] Data still refreshes correctly in the background on re-mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to eliminate the loading-skeleton flicker in `CodingAgentSettingsSection` by tracking whether data has been fetched at least once and skipping `setLoading(true)` on subsequent mounts. The approach is well-intentioned but the chosen mechanism — `useRef` — does not achieve the goal.

**Key issues:**
- **`useRef` is instance-scoped**: When the user navigates away from the settings page, the component unmounts and the ref is destroyed. On the next visit a new instance is created with `hasLoadedOnce.current === false`, so `setLoading(true)` is called anyway — the flicker is identical to before.
- **`useState(true)` initial value**: `loading` is initialised to `true`, meaning the component renders the skeleton on its very first paint of each new mount, *before* the `useEffect` even runs. Even if the ref were preserved, the skeleton would still flash for at least one render frame during the async data fetch.
- **No stale-data concern**: Because the fetch is still triggered on every mount (`useEffect(fn, [])`), data correctness is maintained — this is good — but it also means the background refresh delays `setLoading(false)`, extending the visible skeleton on re-mounts.

To properly fix the flicker, `hasLoadedOnce` should be lifted outside the component (module-level variable or React context) **and** `loading` should be initialised conditionally based on that flag (e.g. `useState(!hasLoadedOnce)`).

<h3>Confidence Score: 2/5</h3>

- The fix is logically incorrect — `useRef` resets on remount, so the flicker this PR aims to eliminate still occurs on every re-navigation.
- The change introduces no crashes or regressions (the component behaves identically to before), but it also does not fix the stated problem. The `useRef` is destroyed on unmount, and `loading` initialised to `true` means the skeleton still shows on every fresh mount. The fix needs a module-level (or context-level) persistence mechanism plus a conditional `useState` initialiser to work correctly.
- packages/app-core/src/components/CodingAgentSettingsSection.tsx — the core logic of the fix is incorrect

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/CodingAgentSettingsSection.tsx | Adds a `useRef` to skip showing the loading skeleton on re-mounts, but `useRef` is instance-scoped and resets to `false` on every remount, making the fix a no-op for the described navigation scenario. Additionally, `loading` is still initialised to `true` via `useState(true)`, so the skeleton flashes on every new mount regardless. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Router
    participant Component as CodingAgentSettingsSection
    participant API

    Note over Component: First visit
    User->>Router: Navigate to Settings
    Router->>Component: Mount (new instance)
    Note over Component: loading=true (useState init)<br/>hasLoadedOnce.current=false (new ref)
    Component-->>User: Renders loading skeleton
    Component->>API: fetch config, models, preflight
    API-->>Component: Data returned
    Component->>Component: setLoading(false)<br/>hasLoadedOnce.current=true

    Note over Component: Navigate away
    User->>Router: Navigate elsewhere
    Router->>Component: Unmount
    Note over Component: Ref destroyed, hasLoadedOnce lost

    Note over Component: Re-visit (current PR behaviour = same as before)
    User->>Router: Navigate back to Settings
    Router->>Component: Mount (NEW instance)
    Note over Component: loading=true (useState init)<br/>hasLoadedOnce.current=false (fresh ref!)
    Component-->>User: ⚠️ Still renders loading skeleton
    Component->>API: fetch config, models, preflight
    API-->>Component: Data returned
    Component->>Component: setLoading(false)
```

<sub>Last reviewed commit: ["fix(app-core): skip ..."](https://github.com/elizaos/eliza/commit/c9683b1a9fc2c36d930487bd77e52db1f20fa66f)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->