### PR TITLE
fix(ci): add libpipewire-0.3-dev to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev
+          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev libpipewire-0.3-dev
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Release CI fails on computeruse Rust build: `Cannot find libraries: libpipewire-0.3`
- `libwayland-dev` was added in #6631 but `libpipewire-0.3-dev` (required by `libspa-sys` crate) was missed

## Test plan
- [ ] Release workflow completes without `libpipewire` build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `libpipewire-0.3-dev` to the system-dependency installation step in `release.yaml`, fixing a build failure where the `libspa-sys` Rust crate (pulled in by the `computeruse` plugin) could not locate the `libpipewire-0.3` library. The companion `publish-next-prerelease.yaml` already contained this package, so this change brings the release workflow to parity for this dependency.

- `libpipewire-0.3-dev` is appended to the existing `apt-get install` line alongside `libwayland-dev`, which was added for the same reason in PR #6631.
- The fix is minimal and targeted; it does not alter any build logic, versioning steps, or publishing steps.
- **Note for follow-up**: `publish-next-prerelease.yaml` installs a broader set of libraries (`libatspi2.0-dev`, `libgtk-3-dev`, `libx11-dev`, `libxcb1-dev`, `libxcb-randr0-dev`, `libxkbcommon-dev`, `libgbm-dev`, `libdrm-dev`, `libegl1-mesa-dev`) that `release.yaml` currently lacks. If `bunx turbo run build` in the release workflow tries to build more computeruse native code in the future, additional library gaps may surface — but that is beyond the scope of this fix.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line, targeted CI fix with no risk to application logic or publishing behaviour.
- The change adds one missing system library to an `apt-get install` call, directly mirroring what the sibling `publish-next-prerelease.yaml` already does. It resolves an identified build failure without touching any versioning, build, or publishing logic.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | One-line CI fix: adds `libpipewire-0.3-dev` to the `apt-get install` step to unblock the computeruse Rust build that depends on the `libspa-sys` crate. The change is minimal, targeted, and consistent with how `publish-next-prerelease.yaml` already handles this dependency. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release.yaml triggered] --> B[Checkout code]
    B --> C[Setup Git]
    C --> D["Install system dependencies\napt-get install -y\nlibpq-dev postgresql-client\nprotobuf-compiler libwayland-dev\n✅ libpipewire-0.3-dev  ← added by this PR"]
    D --> E[Setup Node + Bun]
    E --> F[Install dependencies]
    F --> G[Determine release type]
    G --> H[Version packages]
    H --> I[Install Rust toolchain]
    I --> J["Build WASM packages\n(packages/rust, plugins/plugin-sql/rust)"]
    J --> K["bunx turbo run build --continue\n(builds all packages incl. computeruse)"]
    K --> L[Publish to NPM]

    style D fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add libpipewire-0.3-dev to rele..."](https://github.com/elizaos/eliza/commit/e98ddad9b15455062e7f22e96028fa799d78be53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26259178)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system dependencies in the build pipeline to improve compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->