### PR TITLE
fix(ci): add libegl-dev for computeruse khronos-egl build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev libpipewire-0.3-dev
+          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev libpipewire-0.3-dev libegl-dev
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Release CI fails after #6662 — `libpipewire-0.3-dev` was added but `libegl-dev` (required by `khronos-egl` Rust crate) was missed.

```
The system library `egl` required by crate `khronos-egl` was not found.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a minimal, targeted CI fix that appends `libegl-dev` to the `apt-get install` step in `release.yaml`, resolving a build failure introduced by #6662 where `libpipewire-0.3-dev` was added without its transitive EGL dependency required by the `khronos-egl` Rust crate.

- Adds `libegl-dev` to the system dependency install step in `.github/workflows/release.yaml`
- The fix is consistent with `publish-next-prerelease.yaml`, which already installs an equivalent package (`libegl1-mesa-dev`) alongside `libpipewire-0.3-dev`
- No logic changes; purely a CI environment dependency correction

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a one-line CI dependency addition with no risk to application logic.
- The change is a single-package addition to an `apt-get install` command, directly addressing a known build error. The fix is validated by the fact that the equivalent package (`libegl1-mesa-dev`) already exists in the analogous `publish-next-prerelease.yaml` workflow, confirming this dependency is genuinely required.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Appends `libegl-dev` to the apt-get install step to resolve the missing `egl` system library required by the `khronos-egl` Rust crate during CI builds. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to develop/main or GitHub Release] --> B[NPM Release Job]
    B --> C[Checkout Code]
    C --> D[Setup Git]
    D --> E[Install System Dependencies\napt-get: libpq-dev, postgresql-client,\nprotobuf-compiler, libwayland-dev,\nlibpipewire-0.3-dev, libegl-dev ✅ NEW]
    E --> F[Setup Node + Bun]
    F --> G[Install JS Dependencies]
    G --> H[Build Rust Crates\nkhronos-egl links against libegl]
    H --> I{Release Type?}
    I -->|develop| J[Publish Alpha]
    I -->|main| K[Publish Beta]
    I -->|GitHub Release| L[Publish Latest]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add libegl-dev for computeruse ..."](https://github.com/elizaos/eliza/commit/06afd5e8a830b9271bd059d00583419fb81eb1e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26260722)</sub>

<!-- /greptile_comment -->