### PR TITLE
fix: computeruse Linux Rust build errors

### DIFF
--- a/packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs
+++ b/packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs
@@ -413,6 +413,11 @@ impl UIElementImpl for LinuxUIElement {
     fn is_selected(&self) -> Result<bool, AutomationError> {
         Ok(false)
     }
+    fn set_selected(&self, _state: bool) -> Result<(), AutomationError> {
+        Err(AutomationError::UnsupportedOperation(
+            "set_selected not implemented on Linux yet".to_string(),
+        ))
+    }
 }
 
 impl UIElementImpl for StubElement {
@@ -726,7 +731,7 @@ impl LinuxATSPIElement {
         // Get PID from application
         let pid = proxy.get_application().await
             .ok()
-            .and_then(|app_ref| {
+            .and_then(|_app_ref| {
                 // Try to get PID from the application accessible
                 // This is a best-effort approach
                 0u32.into()
@@ -738,9 +743,9 @@ impl LinuxATSPIElement {
         
         // Get states
         let states = proxy.get_state().await
-            .map(|state_set| {
+            .map(|_state_set| {
                 // Convert state set to HashSet of state names
-                let mut states = HashSet::new();
+                let states = HashSet::new();
                 // AT-SPI2 states are bit flags, convert to readable names
                 states
             })
@@ -786,10 +791,10 @@ impl LinuxATSPIElement {
         let extents = component.get_extents(atspi::CoordType::Screen).await.ok()?;
         
         Some((
-            extents.x as f64,
-            extents.y as f64,
-            extents.width as f64,
-            extents.height as f64,
+            extents.0 as f64,
+            extents.1 as f64,
+            extents.2 as f64,
+            extents.3 as f64,
         ))
     }
     
@@ -1632,7 +1637,7 @@ impl LinuxEngine {
             .await
             .map_err(|e| AutomationError::PlatformError(format!("Failed to connect to AT-SPI2: {e}")))?;
         
-        Ok(Arc::new(connection.into()))
+        Ok(Arc::new(connection.connection().clone()))
     }
     
     /// Get the desktop root accessible from AT-SPI2 registry


### PR DESCRIPTION
## Summary
Release CI fails on computeruse Rust build with 6 compilation errors:

1. Missing `set_selected` trait implementation on `LinuxUIElement`
2. Named field access on tuple type (`extents.x` → `extents.0`) — atspi returns `(i32, i32, i32, i32)` not a struct
3. `AccessibilityConnection` doesn't impl `Into<zbus::Connection>` — use `.connection().clone()` instead
4. Unused variable warnings (`app_ref`, `state_set`, `mut states`)

## Test plan
- [ ] Release CI `@elizaos/computeruse` Rust build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes 6 Rust compilation errors in the Linux AT-SPI2 accessibility backend (`packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs`) that were blocking CI for the `@elizaos/computeruse` package.

Key fixes:
- **Missing trait method**: Adds a `set_selected` stub to `LinuxUIElement` returning `UnsupportedOperation`, matching the existing pattern used by `StubElement` and other unimplemented methods on Linux.
- **Tuple index fix**: Corrects `extents.x/y/width/height` → `extents.0/1/2/3` since `atspi::ComponentProxy::get_extents` returns a plain `(i32, i32, i32, i32)` tuple, not a named struct.
- **`zbus::Connection` fix**: Replaces `connection.into()` (which `AccessibilityConnection` does not implement) with `connection.connection().clone()` to properly extract the underlying `ZbusConnection`.
- **Unused variable warnings**: Prefixes `app_ref` and `state_set` with `_` and removes `mut` from `states` (the `HashSet` is created empty and never mutated), silencing the four remaining compiler warnings.

All changes are mechanical correctness fixes with no behavioral change — the states and PID extraction were already stub/incomplete implementations before this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are targeted compiler error fixes with no behavioral regressions.
- Every change directly corresponds to a documented compilation error. The `set_selected` stub follows the established pattern for unimplemented Linux methods. The tuple index fix matches the atspi API signature. The `connection().clone()` pattern is the idiomatic way to extract a `ZbusConnection` from `AccessibilityConnection`. The unused variable fixes are trivially correct. No logic is changed beyond what was already a stub or incomplete implementation prior to this PR.
- No files require special attention — the single changed file has straightforward, targeted fixes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs | Fixes 6 Rust compilation errors: adds missing `set_selected` stub on `LinuxUIElement`, corrects tuple index access for atspi extents (`extents.0/1/2/3`), replaces invalid `connection.into()` with `connection.connection().clone()`, and silences unused variable warnings (`_app_ref`, `_state_set`, `mut states` → `states`). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AccessibilityConnection::new] --> B["connection.connection().clone()"]
    B --> C["Arc ZbusConnection"]
    C --> D["AccessibleProxy builder"]
    D --> E["get_extents CoordType::Screen"]
    E --> F["Tuple i32 i32 i32 i32"]
    F --> G["extents.0 x, extents.1 y, extents.2 width, extents.3 height"]
    G --> H["Some f64 f64 f64 f64"]

    I["UIElementImpl trait"] --> J["LinuxUIElement"]
    I --> K["StubElement"]
    J --> L["set_selected returns UnsupportedOperation"]
    K --> M["set_selected returns UnsupportedOperation"]
```

<sub>Reviews (1): Last reviewed commit: ["fix: computeruse Linux build errors"](https://github.com/elizaos/eliza/commit/eeef3d4eb220cb40f1ed0e8b7e1d39f027706c11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26262112)</sub>

<!-- /greptile_comment -->