### PR TITLE
fix(ci): add libgbm/xcb/ssl system deps, suppress dead_code warnings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev libpipewire-0.3-dev libegl-dev
+          sudo apt-get install -y libpq-dev postgresql-client protobuf-compiler libwayland-dev libpipewire-0.3-dev libegl-dev libgbm-dev libxcb1-dev libssl-dev
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs
+++ b/packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs
@@ -68,6 +68,7 @@ impl fmt::Debug for StubElement {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 struct LinuxUIElement {
     object_id: usize,
     id: Option<String>,
@@ -695,6 +696,7 @@ struct ATSPIElementInfo {
 
 /// Wrapper around an AT-SPI2 accessible object reference
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct LinuxATSPIElement {
     info: ATSPIElementInfo,
     connection: Arc<ZbusConnection>,


### PR DESCRIPTION
Release CI linker fails: `unable to find library -lgbm`. Adds `libgbm-dev`, `libxcb1-dev`, `libssl-dev` to the release workflow apt-get install. Also suppresses dead_code warnings on two Linux structs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken release CI pipeline by adding three missing system libraries (`libgbm-dev`, `libxcb1-dev`, `libssl-dev`) to the apt-get install step in `release.yaml`, and suppresses spurious `dead_code` Rust compiler warnings on two Linux-specific structs (`LinuxUIElement`, `LinuxATSPIElement`) in the `computeruse` crate.

- **`release.yaml`**: Appends `libgbm-dev`, `libxcb1-dev`, and `libssl-dev` to the existing `apt-get install` line. These are required link-time dependencies for the `computeruse` crate on Ubuntu runners (`libgbm` for GPU buffer management, `libxcb1` for X11 client bindings, `libssl` for OpenSSL-based crates).
- **`linux/mod.rs`**: Adds `#[allow(dead_code)]` to `LinuxUIElement` and `LinuxATSPIElement`. These structs have fields that are defined but not yet consumed by all code paths; the attribute is a well-scoped, struct-level suppression rather than a crate-wide lint disable.

Both changes are minimal, targeted, and address the stated CI failure. No logic or API changes are included.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure CI / build-fix with no runtime logic changes.
- Both changes are narrowly scoped infrastructure fixes: adding well-known Ubuntu system libraries to an apt install line and adding struct-level dead_code suppressions. There is no new business logic, no API surface changes, and no risk of regression. The fixes directly match the stated failure mode.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Adds three missing system libraries (libgbm-dev, libxcb1-dev, libssl-dev) to apt-get install in the release job, directly fixing the reported `-lgbm` linker error. |
| packages/computeruse/crates/computeruse/src/platforms/linux/mod.rs | Adds #[allow(dead_code)] to LinuxUIElement (line 71) and LinuxATSPIElement (line 699) structs to suppress Rust dead_code warnings that were likely causing CI noise or hard warnings. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant APT as apt-get
    participant Rust as Rust Compiler
    participant NPM as NPM Registry

    GH->>APT: sudo apt-get install -y ...<br/>libgbm-dev libxcb1-dev libssl-dev (NEW)
    APT-->>GH: System deps installed
    GH->>Rust: cargo build (computeruse crate)
    Note over Rust: #[allow(dead_code)] suppresses<br/>LinuxUIElement / LinuxATSPIElement warnings
    Rust-->>GH: Build succeeds (no -lgbm linker error)
    GH->>NPM: lerna publish
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add libgbm-dev, libxcb1-dev, li..."](https://github.com/elizaos/eliza/commit/21f09184dd880efd29cd2b68646b084b2ceccf95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26263108)</sub>

<!-- /greptile_comment -->