### PR TITLE
fix(ci): remove stale packages/agent dist check from release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -465,7 +465,7 @@ jobs:
 
           # Fail if critical packages didn't produce dist/
           # packages/typescript is published as @elizaos/core
-          for pkg in packages/typescript packages/agent; do
+          for pkg in packages/typescript; do
             if [ ! -d "${pkg}/dist" ]; then
               echo "❌ Critical package ${pkg} failed to build (no dist/ directory)"
               exit 1


### PR DESCRIPTION
packages/agent no longer exists — was deleted during the app-core/autonomous merge. Release fails with "Critical package packages/agent failed to build (no dist/ directory)" even though all 15 turbo tasks succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted, one-line CI fix that removes the stale `packages/agent` entry from the critical-package dist-check loop in the release workflow. `packages/agent` was deleted during the app-core/autonomous merge but was never cleaned up from the release gate, causing every release job to fail with `"Critical package packages/agent failed to build (no dist/ directory)"` despite all 15 turbo build tasks succeeding.

**Key change:**
- `.github/workflows/release.yaml`: `packages/agent` removed from the `for pkg in ...` loop that asserts a `dist/` directory exists after the build step. `packages/typescript` (published as `@elizaos/core`) remains as the sole critical-package check.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — the deleted directory is confirmed absent from the repo; removing it from the CI gate unblocks releases with no side-effects.
- Single-line removal of a reference to a non-existent directory. The remaining check (`packages/typescript`) is unaffected. No logic changes, no new risk introduced.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Removes stale `packages/agent` from the post-build dist/ check loop; the directory was deleted during the app-core/autonomous merge and no longer exists in the repo, causing every release run to fail. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[turbo run build --continue] --> B{Critical package dist/ check}
    B -->|BEFORE: packages/typescript AND packages/agent| C{packages/agent exists?}
    C -->|No — deleted| D[❌ exit 1 — release fails]
    B -->|AFTER: packages/typescript only| E{packages/typescript dist/ exists?}
    E -->|Yes| F[✅ All critical packages built]
    F --> G[Replace workspace references]
    G --> H[Publish to NPM]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): remove packages/agent from dist..."](https://github.com/elizaos/eliza/commit/5d4b26b777cd78bf5643f00f859dbcbe7c8f223c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26265983)</sub>

<!-- /greptile_comment -->