### PR TITLE
fix(ci): ensure @elizaos/core dist-tag is updated in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -540,10 +540,14 @@ jobs:
             echo "⚠️ dist-tag '${DIST_TAG}' points to ${ACTUAL}, expected ${VERSION}"
             echo "Forcing dist-tag update for all published packages..."
 
-            # Get list of public packages from lerna
+            # Get list of public packages from lerna, plus @elizaos/core
+            # which is published from packages/typescript but may not appear
+            # in lerna ls if the workspace config changed.
             PACKAGES=$(bunx lerna ls --json --no-private 2>/dev/null | node -e "
               const pkgs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-              pkgs.forEach(p => console.log(p.name));
+              const names = new Set(pkgs.map(p => p.name));
+              names.add('@elizaos/core');
+              names.forEach(n => console.log(n));
             ")
 
             FIXED=0


### PR DESCRIPTION
Release publishes @elizaos/core successfully but the dist-tag fix loop skips it because lerna ls doesn't list it. The verification then fails: "dist-tag still not pointing to alpha.105".

Explicitly adds @elizaos/core to the package list used for dist-tag updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI release workflow bug where the dist-tag verification step would fail for `@elizaos/core` because `lerna ls` does not list it (since it is published from `packages/typescript` rather than a standard lerna-managed package directory).

**Key change:**
- In `.github/workflows/release.yaml`, the forced dist-tag fix loop now builds its package list using a `Set` seeded from `lerna ls` output and then explicitly inserts `@elizaos/core` before iterating. This ensures `@elizaos/core`'s dist-tag is always updated even when it is absent from `lerna ls`.

**Observations:**
- The use of `Set` correctly deduplicates in case `@elizaos/core` ever does appear in `lerna ls` output in the future.
- The fix is scoped only to the forced-update fallback path (i.e. it only runs when the dist-tag is already stale), so it does not affect normal publish flow.
- The rest of the workflow logic (re-verification, error exit) is unchanged and remains correct.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — minimal, targeted fix that correctly addresses the reported dist-tag update failure for `@elizaos/core`.
- The change is a single-file, three-line tweak in a fallback/recovery code path. It correctly uses a `Set` to deduplicate and explicitly adds the missing `@elizaos/core` package. No logic in the happy path is affected, and the deduplication ensures no regressions if package tracking changes in the future.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Targeted fix in the "Verify dist-tag" step: `@elizaos/core` (published from `packages/typescript`, not tracked by lerna) is now explicitly added to the package list used when forcing dist-tag updates, preventing the post-publish verification from failing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LR as lerna publish
    participant ND as NPM Registry
    participant VD as Verify dist-tag step
    participant FX as Fix loop

    LR->>ND: "publish all packages (from-package)"
    LR-->>VD: "publish outcome = success"

    VD->>ND: "npm view @elizaos/core@DIST_TAG version"
    alt dist-tag already correct
        ND-->>VD: "VERSION matches - done"
    else dist-tag stale
        ND-->>VD: "VERSION mismatch - forcing update"
        VD->>FX: "begin forced dist-tag update"

        FX->>FX: "bunx lerna ls --json --no-private"
        Note over FX: Before fix - @elizaos/core absent from lerna ls
        FX->>FX: "names = Set(lerna pkgs) + add('@elizaos/core')"
        loop for each PKG in names
            FX->>ND: "npm view PKG@VERSION"
            FX->>ND: "npm dist-tag add PKG@VERSION DIST_TAG"
        end

        FX->>ND: "npm view @elizaos/core@DIST_TAG version"
        alt re-verify passes
            ND-->>VD: "dist-tag updated successfully"
        else still wrong
            ND-->>VD: "exit 1 - dist-tag update failed"
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): ensure @elizaos/core dist-tag i..."](https://github.com/elizaos/eliza/commit/315b3735a45064e274c75f5b4173c08b79c9a7e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26301536)</sub>

<!-- /greptile_comment -->