### PR TITLE
fix(core): remove redundant action params example (~500 chars/prompt)

### DIFF
--- a/packages/typescript/src/prompts.ts
+++ b/packages/typescript/src/prompts.ts
@@ -59,23 +59,6 @@ IMPORTANT ACTION PARAMETERS:
 - Required parameters MUST be provided; optional parameters can be omitted if not mentioned
 - If you cannot determine a required parameter value, ask the user for clarification in your <text>
 
-EXAMPLE (action parameters):
-User message: "Send a message to @dev_guru on telegram saying Hello!"
-<actions>
-  <action>
-    <name>REPLY</name>
-  </action>
-  <action>
-    <name>SEND_MESSAGE</name>
-    <params>
-      <targetType>user</targetType>
-      <source>telegram</source>
-      <target>dev_guru</target>
-      <text>Hello!</text>
-    </params>
-  </action>
-</actions>
-
 IMPORTANT PROVIDER SELECTION RULES:
 - Only include providers if they are needed to respond accurately.
 - If the message mentions images, photos, pictures, attachments, or visual content, OR if you see "(Attachments:" in the conversation, you MUST include "ATTACHMENTS" in your providers list


### PR DESCRIPTION
The instructions section includes a 15-line SEND_MESSAGE example showing action params format. Redundant with the output section XML example and keys section. Saves ~500 chars per prompt.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a 15-line plugin-specific `SEND_MESSAGE`/Telegram example from the `instructions` section of `messageHandlerTemplate` in `packages/typescript/src/prompts.ts`. The removed block illustrated how to populate `<params>` for an action, but this format is already fully described in two remaining sections:\n\n- The `<keys>` section (line 80) states that each action requiring parameters should include a `<params>` child element.\n- The `<output>` section already contains an abstract XML example showing `ACTION1`/`ACTION2` with `<params>` blocks and generic `<paramName>/<value>` children (lines 89–114), plus an explicit note that `<params>` is optional and should be omitted when an action has no parameters.\n\nBecause the removed example used `SEND_MESSAGE` — a telegram-plugin-specific action — it was not generically applicable to all agent deployments, making the removal correct both for accuracy and brevity. The ~500-character saving per prompt call is a meaningful reduction in token usage at production scale.\n\n**Key changes:**\n- Removes the `EXAMPLE (action parameters)` block (the `SEND_MESSAGE`/Telegram illustration) from `messageHandlerTemplate`\n- No other logic, types, or exports are modified

<h3>Confidence Score: 5/5</h3>

Safe to merge — the removed example is fully redundant and the remaining sections already cover the same information

Single-file, pure-deletion change with no logic alterations. The information conveyed by the removed example is covered in full by the abstract XML format in the output section and the keys section description. No tests, types, or other consumers are affected.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/prompts.ts | Removes the plugin-specific SEND_MESSAGE/Telegram example block from the instructions section of messageHandlerTemplate; the abstract XML format in the output section and the keys section together cover the same information |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[messageHandlerTemplate prompt] --> B[instructions section]
    A --> C[keys section]
    A --> D[output section]

    B --> B1[Action ordering rules]
    B --> B2[Action parameter rules]
    B2 -. removed .-> B3["❌ SEND_MESSAGE concrete example\n(plugin-specific / ~500 chars)"]
    B --> B4[Provider selection rules]
    B --> B5[Code block formatting rules]

    C --> C1["'actions': list of action elements\n with optional params child"]

    D --> D1["Abstract XML schema\n(ACTION1/ACTION2, paramName1/value1)"]
    D --> D2["Note: params block is optional –\nomit when action has no params"]

    B2 -- "fully covered by" --> C1
    B2 -- "fully covered by" --> D1
    B2 -- "fully covered by" --> D2

    style B3 fill:#ffcccc,stroke:#cc0000
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): remove redundant action param..."](https://github.com/elizaos/eliza/commit/c6a3206b60ce59f8e38ae40b45c5c24b92d2466e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26473096)</sub>

<!-- /greptile_comment -->