### PR TITLE
fix(core): initialize trajectory AsyncLocalStorage synchronously

### DIFF
--- a/packages/typescript/src/__tests__/trajectory-context.test.ts
+++ b/packages/typescript/src/__tests__/trajectory-context.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+	getTrajectoryContext,
+	runWithTrajectoryContext,
+} from "../trajectory-context";
+
+describe("Trajectory Context", () => {
+	it("context is available immediately on first access (no async init race)", () => {
+		// This is the bug this fix addresses: the old lazy async init meant
+		// the first few calls used StackContextManager which doesn't propagate
+		// through async/await. With synchronous init, AsyncLocalStorage is
+		// available immediately.
+		let captured: { trajectoryStepId?: string } | undefined;
+
+		runWithTrajectoryContext({ trajectoryStepId: "test-step-1" }, () => {
+			captured = getTrajectoryContext();
+		});
+
+		expect(captured).toBeDefined();
+		expect(captured?.trajectoryStepId).toBe("test-step-1");
+	});
+
+	it("propagates context through async/await", async () => {
+		let captured: { trajectoryStepId?: string } | undefined;
+
+		await runWithTrajectoryContext(
+			{ trajectoryStepId: "async-step" },
+			async () => {
+				// Simulate async work (provider loading, state composition, etc.)
+				await new Promise((r) => setTimeout(r, 10));
+				captured = getTrajectoryContext();
+			},
+		);
+
+		expect(captured).toBeDefined();
+		expect(captured?.trajectoryStepId).toBe("async-step");
+	});
+
+	it("propagates through nested async calls", async () => {
+		let innerCapture: { trajectoryStepId?: string } | undefined;
+
+		await runWithTrajectoryContext(
+			{ trajectoryStepId: "outer-step" },
+			async () => {
+				await new Promise((r) => setTimeout(r, 5));
+				// Simulates useModel being called after several awaits
+				const doInnerWork = async () => {
+					await new Promise((r) => setTimeout(r, 5));
+					innerCapture = getTrajectoryContext();
+				};
+				await doInnerWork();
+			},
+		);
+
+		expect(innerCapture).toBeDefined();
+		expect(innerCapture?.trajectoryStepId).toBe("outer-step");
+	});
+
+	it("returns undefined when no context is set", () => {
+		expect(getTrajectoryContext()).toBeUndefined();
+	});
+
+	it("isolates contexts between concurrent calls", async () => {
+		const results: string[] = [];
+
+		await Promise.all([
+			runWithTrajectoryContext(
+				{ trajectoryStepId: "call-A" },
+				async () => {
+					await new Promise((r) => setTimeout(r, 20));
+					const ctx = getTrajectoryContext();
+					results.push(ctx?.trajectoryStepId ?? "missing");
+				},
+			),
+			runWithTrajectoryContext(
+				{ trajectoryStepId: "call-B" },
+				async () => {
+					await new Promise((r) => setTimeout(r, 10));
+					const ctx = getTrajectoryContext();
+					results.push(ctx?.trajectoryStepId ?? "missing");
+				},
+			),
+		]);
+
+		expect(results).toContain("call-A");
+		expect(results).toContain("call-B");
+		expect(results).not.toContain("missing");
+	});
+});

--- a/packages/typescript/src/streaming-context.ts
+++ b/packages/typescript/src/streaming-context.ts
@@ -87,16 +87,11 @@ function initContextManagerSync(): IStreamingContextManager {
 				StreamingContext | undefined
 			>();
 			return {
-				storage,
 				run<T>(context: StreamingContext | undefined, fn: () => T): T {
-					return (
-						this as unknown as { storage: typeof storage }
-					).storage.run(context, fn);
+					return storage.run(context, fn);
 				},
 				active(): StreamingContext | undefined {
-					return (
-						this as unknown as { storage: typeof storage }
-					).storage.getStore();
+					return storage.getStore();
 				},
 			} as IStreamingContextManager;
 		} catch {

--- a/packages/typescript/src/streaming-context.ts
+++ b/packages/typescript/src/streaming-context.ts
@@ -66,11 +66,7 @@ class StackContextManager implements IStreamingContextManager {
 
 // Global singleton - auto-configured on first access
 let globalContextManager: IStreamingContextManager | null = null;
-let contextManagerInitialized = false;
 
-/**
- * Detect if running in Node.js environment
- */
 function isNodeEnvironment(): boolean {
 	return (
 		typeof process !== "undefined" &&
@@ -79,68 +75,40 @@ function isNodeEnvironment(): boolean {
 	);
 }
 
-/**
- * Create the appropriate context manager for the current environment.
- * Uses AsyncLocalStorage in Node.js, Stack-based in browser.
- */
-async function createContextManager(): Promise<IStreamingContextManager> {
+// Initialize synchronously to avoid the race where early calls use the
+// StackContextManager fallback (which doesn't propagate through async/await).
+function initContextManagerSync(): IStreamingContextManager {
 	if (isNodeEnvironment()) {
 		try {
-			// Dynamic import to avoid bundling Node.js code in browser builds
-			const { AsyncLocalStorage } = await import("node:async_hooks");
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const { AsyncLocalStorage } =
+				require("node:async_hooks") as typeof import("node:async_hooks");
+			const storage = new AsyncLocalStorage<
+				StreamingContext | undefined
+			>();
 			return {
-				storage: new AsyncLocalStorage<StreamingContext | undefined>(),
+				storage,
 				run<T>(context: StreamingContext | undefined, fn: () => T): T {
 					return (
-						this as {
-							storage: InstanceType<
-								typeof AsyncLocalStorage<StreamingContext | undefined>
-							>;
-						}
+						this as unknown as { storage: typeof storage }
 					).storage.run(context, fn);
 				},
 				active(): StreamingContext | undefined {
 					return (
-						this as {
-							storage: InstanceType<
-								typeof AsyncLocalStorage<StreamingContext | undefined>
-							>;
-						}
+						this as unknown as { storage: typeof storage }
 					).storage.getStore();
 				},
-			} as IStreamingContextManager & {
-				storage: InstanceType<
-					typeof AsyncLocalStorage<StreamingContext | undefined>
-				>;
-			};
+			} as IStreamingContextManager;
 		} catch {
-			// Fallback to stack-based if async_hooks not available
-			return new StackContextManager();
+			// AsyncLocalStorage unavailable — fall back to stack
 		}
 	}
 	return new StackContextManager();
 }
 
-/**
- * Get or create the global context manager.
- * Lazily initializes on first access.
- */
 function getOrCreateContextManager(): IStreamingContextManager {
 	if (!globalContextManager) {
-		// Synchronous fallback - use Stack until async init completes
-		globalContextManager = new StackContextManager();
-
-		// Async upgrade to AsyncLocalStorage in Node.js
-		if (isNodeEnvironment() && !contextManagerInitialized) {
-			contextManagerInitialized = true;
-			createContextManager()
-				.then((manager) => {
-					globalContextManager = manager;
-				})
-				.catch(() => {
-					// Keep using StackContextManager
-				});
-		}
+		globalContextManager = initContextManagerSync();
 	}
 	return globalContextManager;
 }
@@ -155,7 +123,6 @@ export function setStreamingContextManager(
 	manager: IStreamingContextManager,
 ): void {
 	globalContextManager = manager;
-	contextManagerInitialized = true;
 }
 
 /**

--- a/packages/typescript/src/trajectory-context.ts
+++ b/packages/typescript/src/trajectory-context.ts
@@ -64,19 +64,14 @@ function initContextManagerSync(): ITrajectoryContextManager {
 				TrajectoryContext | undefined
 			>();
 			return {
-				storage,
 				run<T>(
 					context: TrajectoryContext | undefined,
 					fn: () => T | Promise<T>,
 				): T | Promise<T> {
-					return (
-						this as unknown as { storage: typeof storage }
-					).storage.run(context, fn);
+					return storage.run(context, fn);
 				},
 				active(): TrajectoryContext | undefined {
-					return (
-						this as unknown as { storage: typeof storage }
-					).storage.getStore();
+					return storage.getStore();
 				},
 			} as ITrajectoryContextManager;
 		} catch {

--- a/packages/typescript/src/trajectory-context.ts
+++ b/packages/typescript/src/trajectory-context.ts
@@ -1,9 +1,9 @@
 /**
  * Trajectory context management for benchmark/training traces.
  *
- * Mirrors the streaming context design:
- * - Node.js: AsyncLocalStorage for async-safe propagation
- * - Browser: stack-based fallback
+ * Node.js: AsyncLocalStorage for async-safe propagation (initialized
+ * synchronously to avoid race with first message processing).
+ * Browser: stack-based fallback.
  */
 export interface TrajectoryContext {
 	trajectoryStepId?: string;
@@ -39,6 +39,11 @@ class StackContextManager implements ITrajectoryContextManager {
 	}
 }
 
+// Initialize the context manager synchronously in Node.js so that
+// AsyncLocalStorage is available before the first message is processed.
+// The previous lazy async init (.then()) caused a race: the stack-based
+// fallback was used for early messages, which doesn't propagate context
+// through async/await — so logLlmCall never saw the trajectory step ID.
 let globalContextManager: ITrajectoryContextManager | null = null;
 let contextManagerInitialized = false;
 
@@ -50,41 +55,33 @@ function isNodeEnvironment(): boolean {
 	);
 }
 
-async function createContextManager(): Promise<ITrajectoryContextManager> {
+function initContextManagerSync(): ITrajectoryContextManager {
 	if (isNodeEnvironment()) {
 		try {
-			// Dynamic import to avoid bundling Node.js code in browser builds
-			const { AsyncLocalStorage } = await import("node:async_hooks");
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const { AsyncLocalStorage } =
+				require("node:async_hooks") as typeof import("node:async_hooks");
+			const storage = new AsyncLocalStorage<
+				TrajectoryContext | undefined
+			>();
 			return {
-				storage: new AsyncLocalStorage<TrajectoryContext | undefined>(),
+				storage,
 				run<T>(
 					context: TrajectoryContext | undefined,
 					fn: () => T | Promise<T>,
 				): T | Promise<T> {
 					return (
-						this as {
-							storage: InstanceType<
-								typeof AsyncLocalStorage<TrajectoryContext | undefined>
-							>;
-						}
+						this as unknown as { storage: typeof storage }
 					).storage.run(context, fn);
 				},
 				active(): TrajectoryContext | undefined {
 					return (
-						this as {
-							storage: InstanceType<
-								typeof AsyncLocalStorage<TrajectoryContext | undefined>
-							>;
-						}
+						this as unknown as { storage: typeof storage }
 					).storage.getStore();
 				},
-			} as ITrajectoryContextManager & {
-				storage: InstanceType<
-					typeof AsyncLocalStorage<TrajectoryContext | undefined>
-				>;
-			};
+			} as ITrajectoryContextManager;
 		} catch {
-			return new StackContextManager();
+			// AsyncLocalStorage unavailable — fall back to stack
 		}
 	}
 	return new StackContextManager();
@@ -92,18 +89,8 @@ async function createContextManager(): Promise<ITrajectoryContextManager> {
 
 function getOrCreateContextManager(): ITrajectoryContextManager {
 	if (!globalContextManager) {
-		globalContextManager = new StackContextManager();
-
-		if (isNodeEnvironment() && !contextManagerInitialized) {
-			contextManagerInitialized = true;
-			createContextManager()
-				.then((manager) => {
-					globalContextManager = manager;
-				})
-				.catch(() => {
-					// Keep using StackContextManager
-				});
-		}
+		globalContextManager = initContextManagerSync();
+		contextManagerInitialized = true;
 	}
 	return globalContextManager;
 }

--- a/packages/typescript/src/trajectory-context.ts
+++ b/packages/typescript/src/trajectory-context.ts
@@ -45,7 +45,6 @@ class StackContextManager implements ITrajectoryContextManager {
 // fallback was used for early messages, which doesn't propagate context
 // through async/await — so logLlmCall never saw the trajectory step ID.
 let globalContextManager: ITrajectoryContextManager | null = null;
-let contextManagerInitialized = false;
 
 function isNodeEnvironment(): boolean {
 	return (
@@ -90,7 +89,6 @@ function initContextManagerSync(): ITrajectoryContextManager {
 function getOrCreateContextManager(): ITrajectoryContextManager {
 	if (!globalContextManager) {
 		globalContextManager = initContextManagerSync();
-		contextManagerInitialized = true;
 	}
 	return globalContextManager;
 }
@@ -99,7 +97,6 @@ export function setTrajectoryContextManager(
 	manager: ITrajectoryContextManager,
 ): void {
 	globalContextManager = manager;
-	contextManagerInitialized = true;
 }
 
 export function getTrajectoryContextManager(): ITrajectoryContextManager {


### PR DESCRIPTION
Trajectory context was initialized lazily via async dynamic import, causing early messages to use the StackContextManager fallback which doesn't propagate through async/await. LLM calls weren't captured — trajectories only had synthetic backfilled data. Fix: synchronous require in Node.js.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a genuine race condition in `trajectory-context.ts` where `AsyncLocalStorage` was wired up via a `.then()` callback on a dynamic `import()`. Because the callback ran asynchronously, the very first call to `getOrCreateContextManager()` always returned the synchronous `StackContextManager` fallback — and that manager does not propagate context through `async`/`await` boundaries, so `logLlmCall` never saw the `trajectoryStepId` during the critical early-message window.\n\nThe fix is correct: switching to a synchronous `require("node:async_hooks")` ensures `AsyncLocalStorage` is created inline during the first call to `getOrCreateContextManager()`, with no window where the fallback can "win."\n\n**Changes reviewed:**\n- **Root cause correctly identified and fixed** — synchronous `require()` eliminates the async scheduling gap.\n- **`contextManagerInitialized` is now a dead variable** — it is assigned but never read; the `!globalContextManager` guard alone is sufficient.\n- **`this`-cast pattern is unnecessarily complex** — the `run` and `active` methods can close over the `storage` local variable directly instead of casting `this`.\n- **Bundler implications** — switching from dynamic `import()` to `require()` weakens the original \"avoid bundling Node.js code in browser builds\" protection; worth confirming build tooling handles `node:async_hooks` externals correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct and focused; remaining feedback is non-blocking cleanup.

The change addresses a real, well-described race condition with a straightforward and correct synchronous fix. No new logic paths are introduced; the try/catch and isNodeEnvironment() guard preserve existing fallback behaviour. All remaining comments are P2 style/cleanup items that do not affect correctness or runtime safety.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/trajectory-context.ts | Replaces async/lazy AsyncLocalStorage initialization with synchronous require(), correctly fixing the race condition that caused early messages to miss trajectory context; leaves a now-dead `contextManagerInitialized` variable and an unnecessary `this`-cast pattern. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant getOrCreate as getOrCreateContextManager()
    participant init as initContextManagerSync()
    participant ALS as AsyncLocalStorage (node:async_hooks)
    participant Stack as StackContextManager

    Note over Caller,Stack: NEW behaviour (synchronous init)
    Caller->>getOrCreate: first call
    getOrCreate->>init: globalContextManager is null
    init->>ALS: require("node:async_hooks") [synchronous]
    ALS-->>init: AsyncLocalStorage class
    init-->>getOrCreate: returns ALS-based manager immediately
    getOrCreate-->>Caller: returns ALS-based manager

    Note over Caller,Stack: OLD behaviour (async init — race condition)
    Caller->>getOrCreate: first call
    getOrCreate-->>Caller: returns StackContextManager (fallback)
    getOrCreate->>init: createContextManager() .then(...)
    Note right of init: import() resolves later
    init->>ALS: dynamic import("node:async_hooks")
    ALS-->>init: AsyncLocalStorage class
    init-->>getOrCreate: globalContextManager swapped to ALS manager
    Note over Caller,Stack: Too late — early LLM calls already used StackContextManager
    Note over Stack: StackContextManager doesn't propagate context through async/await
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): initialize AsyncLocalStorage ..."](https://github.com/elizaos/eliza/commit/21ac09eb1dd5872117c8b40e1fa3c1cbfd1f6455) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26494101)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->