### PR TITLE
fix: extract action params from standalone XML blocks in comma-separated format

### DIFF
--- a/packages/typescript/src/__tests__/comma-separated-action-params.test.ts
+++ b/packages/typescript/src/__tests__/comma-separated-action-params.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test: action params must be extracted from standalone XML blocks
+ * when the LLM outputs actions as a comma-separated list.
+ *
+ * The LLM may respond with:
+ *   <actions>REPLY,START_CODING_TASK</actions>
+ *   <START_CODING_TASK>
+ *     <repo>https://github.com/org/repo</repo>
+ *     <agents>claude:Fix auth | codex:Write tests</agents>
+ *   </START_CODING_TASK>
+ *
+ * The XML parser puts "START_CODING_TASK" as a top-level key on parsedXml.
+ * extractStandaloneActionParams collects these into the legacy flat format
+ * that parseActionParams can consume downstream.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseActionParams } from "../actions";
+import {
+	extractStandaloneActionParams,
+	RESERVED_XML_KEYS,
+} from "../services/message";
+
+// ---------------------------------------------------------------------------
+// extractStandaloneActionParams
+// ---------------------------------------------------------------------------
+
+describe("extractStandaloneActionParams", () => {
+	it("extracts params from a matching parsedXml key", () => {
+		const parsedXml = {
+			actions: "REPLY,START_CODING_TASK",
+			thought: "Spawning agents",
+			START_CODING_TASK:
+				"<repo>https://github.com/org/repo</repo><task>Fix it</task>",
+		};
+		const result = extractStandaloneActionParams(
+			["REPLY", "START_CODING_TASK"],
+			parsedXml,
+		);
+		expect(result).toContain("<START_CODING_TASK>");
+		expect(result).toContain("<repo>https://github.com/org/repo</repo>");
+		expect(result).toContain("<task>Fix it</task>");
+	});
+
+	it("matches action names case-insensitively", () => {
+		const parsedXml = {
+			start_coding_task: "<task>Fix</task>",
+		};
+		const result = extractStandaloneActionParams(
+			["START_CODING_TASK"],
+			parsedXml,
+		);
+		expect(result).toContain("<START_CODING_TASK>");
+		expect(result).toContain("<task>Fix</task>");
+	});
+
+	it("skips reserved keys even if they match action names", () => {
+		const parsedXml = {
+			actions: "REPLY",
+			thought: "something",
+			text: "<bold>hello</bold>",
+		};
+		const result = extractStandaloneActionParams(
+			["actions", "thought", "text"],
+			parsedXml,
+		);
+		expect(result).toBe("");
+	});
+
+	it("skips keys that do not contain XML (plain text values)", () => {
+		const parsedXml = {
+			MY_ACTION: "just a plain string without XML",
+		};
+		const result = extractStandaloneActionParams(["MY_ACTION"], parsedXml);
+		expect(result).toBe("");
+	});
+
+	it("handles multiple actions with params", () => {
+		const parsedXml = {
+			START_CODING_TASK: "<repo>https://github.com/org/repo</repo>",
+			FINALIZE_WORKSPACE: "<workspaceId>ws-123</workspaceId>",
+		};
+		const result = extractStandaloneActionParams(
+			["START_CODING_TASK", "FINALIZE_WORKSPACE"],
+			parsedXml,
+		);
+		expect(result).toContain("<START_CODING_TASK>");
+		expect(result).toContain("<FINALIZE_WORKSPACE>");
+	});
+
+	it("returns empty string when no matches found", () => {
+		const result = extractStandaloneActionParams(["REPLY", "NONE"], {});
+		expect(result).toBe("");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// RESERVED_XML_KEYS
+// ---------------------------------------------------------------------------
+
+describe("RESERVED_XML_KEYS", () => {
+	it("includes standard response schema fields", () => {
+		expect(RESERVED_XML_KEYS.has("actions")).toBe(true);
+		expect(RESERVED_XML_KEYS.has("thought")).toBe(true);
+		expect(RESERVED_XML_KEYS.has("text")).toBe(true);
+		expect(RESERVED_XML_KEYS.has("simple")).toBe(true);
+		expect(RESERVED_XML_KEYS.has("providers")).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseActionParams integration (end-to-end with the assembled format)
+// ---------------------------------------------------------------------------
+
+describe("parseActionParams with standalone action block format", () => {
+	it("extracts params from assembled <ACTION_NAME>...</ACTION_NAME> format", () => {
+		// This is the format that extractStandaloneActionParams produces
+		const paramsXml = `<START_CODING_TASK>
+			<repo>https://github.com/org/repo</repo>
+			<agents>claude:Fix auth | codex:Write tests</agents>
+			<task>Fix the login bug</task>
+		</START_CODING_TASK>`;
+
+		const result = parseActionParams(paramsXml);
+		expect(result.has("START_CODING_TASK")).toBe(true);
+
+		const params = result.get("START_CODING_TASK");
+		expect(params).toBeTruthy();
+		expect(params?.repo).toBe("https://github.com/org/repo");
+		expect(params?.agents).toBe("claude:Fix auth | codex:Write tests");
+		expect(params?.task).toBe("Fix the login bug");
+	});
+
+	it("handles multiple action blocks", () => {
+		const paramsXml = `<START_CODING_TASK>
+			<repo>https://github.com/org/repo</repo>
+			<task>Fix bugs</task>
+		</START_CODING_TASK>
+		<FINALIZE_WORKSPACE>
+			<workspaceId>ws-123</workspaceId>
+		</FINALIZE_WORKSPACE>`;
+
+		const result = parseActionParams(paramsXml);
+		expect(result.has("START_CODING_TASK")).toBe(true);
+		expect(result.has("FINALIZE_WORKSPACE")).toBe(true);
+		expect(result.get("START_CODING_TASK")?.task).toBe("Fix bugs");
+		expect(result.get("FINALIZE_WORKSPACE")?.workspaceId).toBe("ws-123");
+	});
+
+	it("returns empty map for empty input", () => {
+		expect(parseActionParams("").size).toBe(0);
+		expect(parseActionParams(undefined).size).toBe(0);
+		expect(parseActionParams(null).size).toBe(0);
+	});
+});

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -50,6 +50,51 @@ import {
 } from "../utils/text-splitting";
 
 /**
+ * Reserved XML response keys that are NOT action names.
+ * Used when scanning parsedXml for standalone action param blocks.
+ */
+export const RESERVED_XML_KEYS = new Set([
+	"actions",
+	"thought",
+	"text",
+	"simple",
+	"providers",
+]);
+
+/**
+ * Extract action params from standalone XML blocks in a parsedXml object.
+ *
+ * When the LLM outputs `<actions>REPLY,START_CODING_TASK</actions>` alongside
+ * `<START_CODING_TASK><repo>...</repo></START_CODING_TASK>`, the XML parser
+ * puts the action block as a top-level key on parsedXml. This function finds
+ * those keys and assembles them into the legacy flat params format that
+ * `parseActionParams` consumes.
+ *
+ * Returns the assembled params string, or empty string if none found.
+ */
+export function extractStandaloneActionParams(
+	actionNames: string[],
+	parsedXml: Record<string, unknown>,
+): string {
+	const fragments: string[] = [];
+	for (const actionName of actionNames) {
+		const upperName = actionName.toUpperCase();
+		const matchingKey = Object.keys(parsedXml).find(
+			(k) => k.toUpperCase() === upperName,
+		);
+		if (
+			matchingKey &&
+			!RESERVED_XML_KEYS.has(matchingKey.toLowerCase()) &&
+			typeof parsedXml[matchingKey] === "string" &&
+			(parsedXml[matchingKey] as string).includes("<")
+		) {
+			fragments.push(`<${upperName}>${parsedXml[matchingKey]}</${upperName}>`);
+		}
+	}
+	return fragments.join("\n");
+}
+
+/**
  * Escape Handlebars syntax in a string to prevent template injection.
  *
  * WHY: When embedding LLM-generated text into continuation prompts, the text
@@ -332,35 +377,33 @@ export class DefaultMessageService implements IMessageService {
 														"nova";
 
 													let audioBuffer: Buffer | null = null;
-														const params: TextToSpeechParams & {
-															model?: string;
-														} = {
-															text: first,
-															voice: voiceId,
-															model: model,
-														};
-														const result = runtime.getModel(
-															ModelType.TEXT_TO_SPEECH,
-														)
-															? await runtime.useModel(
-																	ModelType.TEXT_TO_SPEECH,
-																	params,
-																)
-															: undefined;
+													const params: TextToSpeechParams & {
+														model?: string;
+													} = {
+														text: first,
+														voice: voiceId,
+														model: model,
+													};
+													const result = runtime.getModel(
+														ModelType.TEXT_TO_SPEECH,
+													)
+														? await runtime.useModel(
+																ModelType.TEXT_TO_SPEECH,
+																params,
+															)
+														: undefined;
 
-														if (
-															result instanceof ArrayBuffer ||
-															Object.prototype.toString.call(result) ===
-																"[object ArrayBuffer]"
-														) {
-															audioBuffer = Buffer.from(result as ArrayBuffer);
-														} else if (Buffer.isBuffer(result)) {
-															audioBuffer = result;
-														} else if (result instanceof Uint8Array) {
-															audioBuffer = Buffer.from(result);
-														}
-
-
+													if (
+														result instanceof ArrayBuffer ||
+														Object.prototype.toString.call(result) ===
+															"[object ArrayBuffer]"
+													) {
+														audioBuffer = Buffer.from(result as ArrayBuffer);
+													} else if (Buffer.isBuffer(result)) {
+														audioBuffer = result;
+													} else if (result instanceof Uint8Array) {
+														audioBuffer = Buffer.from(result);
+													}
 
 													if (audioBuffer && callback) {
 														const audioBase64 = audioBuffer.toString("base64");
@@ -1661,10 +1704,24 @@ export class DefaultMessageService implements IMessageService {
 						}
 					}
 					// Legacy comma-separated format
-					return actionsXml
+					const commaSplitActions = actionsXml
 						.split(",")
 						.map((action) => String(action).trim())
 						.filter((action) => action.length > 0);
+
+					// Extract params from standalone action blocks in parsedXml
+					// (e.g. <START_CODING_TASK><repo>...</repo></START_CODING_TASK>).
+					if (!parsedXml.params || parsedXml.params === "") {
+						const assembled = extractStandaloneActionParams(
+							commaSplitActions,
+							parsedXml as Record<string, unknown>,
+						);
+						if (assembled) {
+							parsedXml.params = assembled;
+						}
+					}
+
+					return commaSplitActions;
 				}
 				if (Array.isArray(parsedXml.actions)) {
 					return parsedXml.actions as string[];


### PR DESCRIPTION
## Summary
- When the LLM outputs actions as `<actions>REPLY,START_CODING_TASK</actions>` (comma-separated), the message service extracted action names but **dropped all parameters**
- The LLM outputs params in standalone sibling blocks like `<START_CODING_TASK><repo>...</repo></START_CODING_TASK>` — the XML parser puts these as top-level keys on `parsedXml`, but the comma-split path never collected them into `parsedXml.params`
- This caused `processActions` to call handlers with empty `options.parameters`, breaking any action that relies on params (e.g., coding agent spawning where `task`/`agents`/`repo` are needed)

## Fix
After comma-splitting action names, scan `parsedXml` for top-level keys matching those names. If found and they contain XML children, assemble them into `parsedXml.params` in the legacy flat format (`<ACTION_NAME>...</ACTION_NAME>`) that `parseActionParams` already consumes.

Guards:
- Only populates when `parsedXml.params` is not already set (structured `<action>` blocks take priority)
- Skips reserved keys (`actions`, `thought`, `text`, `simple`)
- Only matches string values containing `<` (actual XML, not plain text)

## Test plan
- [x] `comma-separated-action-params.test.ts` — 7 tests covering source verification + `parseActionParams` integration with the flat format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where action parameters were silently dropped when the LLM used the comma-separated `<actions>REPLY,START_CODING_TASK</actions>` format instead of the structured `<action>` block format. The fix scans `parsedXml` for top-level keys matching the comma-split action names and assembles them into the `parsedXml.params` string that `parseActionParams` already knows how to consume, mirroring what the structured-action path already did.\n\n**Changes:**\n- `message.ts` – After comma-splitting action names, iterates `parsedXml` for matching top-level keys (skipping reserved ones and non-XML values), wraps them into the legacy flat `<ACTION_NAME>…</ACTION_NAME>` format, and assigns the result to `parsedXml.params` (only when params is not already populated). Also cleans up excessive indentation in the TTS block.\n- New test file – 7 tests: 4 source-inspection assertions (variable names, patterns) and 3 proper `parseActionParams` integration tests covering single-action, multi-action, and empty-input cases.\n\n**Observations:**\n- The core logic is correct: `parsedXml[matchingKey]` holds inner XML content (the XML parser strips the outer wrapper), so re-wrapping with `<UPPER_NAME>` before joining produces exactly the legacy flat format expected by `parseActionParams`.\n- The `!parsedXml.params || parsedXml.params === \"\"` guard correctly prevents overwriting params already populated by the structured-action path.\n- The reserved-key exclusions (`actions`, `thought`, `text`, `simple`) use case-sensitive string comparisons against `matchingKey`, which could miss uppercase/mixed-case variants emitted by some XML parsers.\n- The source-inspection tests in the first `describe` block are brittle: they assert on internal variable names and will break on any rename, even safe ones.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix correctly addresses the parameter-loss bug and all remaining findings are P2 style/robustness suggestions.

The functional change is correct and well-guarded: it only activates when params are absent, skips reserved keys, validates for XML content, and the assembled string is in the exact format that the existing parseActionParams already handles. The two P2 findings (brittle source-inspection tests and case-sensitive reserved-key guards) are non-blocking quality improvements. No P0 or P1 issues found.

packages/typescript/src/__tests__/comma-separated-action-params.test.ts — the source-inspection test block should ideally be replaced with behavioural tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds standalone XML-block param extraction for comma-split action format; also cleans up TTS indentation. Logic is sound but reserved-key comparisons are case-sensitive. |
| packages/typescript/src/__tests__/comma-separated-action-params.test.ts | New regression tests covering the fix; the first describe block uses brittle source-inspection assertions (variable name checks) rather than behavioural tests. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM response parsed into parsedXml] --> B{parsedXml.actions type?}
    B -- "string containing action" --> C[Structured path: extract action entries and inline params]
    C --> D{actionEntries found?}
    D -- yes --> E[Build inlineParamsXml string if parsedXml.params is empty]
    E --> F[Return action names list]
    D -- no --> G[Fall through to comma-split path]
    B -- "plain comma-separated string" --> G
    G --> H[Split by comma → commaSplitActions]
    H --> I{parsedXml.params empty?}
    I -- yes --> J[For each action name: find matching top-level key in parsedXml]
    J --> K{Key found and not reserved and value contains '<'?}
    K -- yes --> L[Push ACTION_NAME inner content to standaloneParamsFragments]
    K -- no --> M[Skip]
    L --> N{Any fragments?}
    N -- yes --> O[Set parsedXml.params = joined fragments]
    O --> P[Return commaSplitActions]
    N -- no --> P
    I -- no --> P
    B -- "array" --> Q[Return parsedXml.actions directly]
    F --> R[responseContent = spread parsedXml + overrides]
    P --> R
    Q --> R
    R --> S[parseActionParams reads responseContent.params → Map of action to params]
```

<sub>Reviews (1): Last reviewed commit: ["fix: extract action params from standalo..."](https://github.com/elizaos/eliza/commit/268170e3dc32533e612a4d9c1032402093b1ddb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26585402)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->