### PR TITLE
feat(core): group addressee routing and anti-loop prompt guidance

### DIFF
--- a/docs/CORE_CONCEPTS.md
+++ b/docs/CORE_CONCEPTS.md
@@ -152,6 +152,11 @@ Core prompt templates live in `packages/prompts/prompts/` and are used by the ru
 
 In TypeScript, prompt assembly is typically done by `composePromptFromState(...)` (used in `packages/typescript/src/services/message.ts`).
 
+### Reply and addressee metadata
+
+- **`Content.inReplyTo`** is the UUID of the **parent message** in the thread, not an entity or agent id.
+- **Optional (platform adapters):** `replyToEntityId` or `inReplyToEntityId` on message `Content` or `MessageMetadata` can carry the UUID of the **entity** the user is replying to. Core uses this together with room participant names for non-LLM addressee checks in group channels (`NameVariationRegistry` / `evaluateGroupAddresseeOverride` in `packages/typescript/src/utils/`).
+
 ## Multi-language runtimes
 
 This repo contains:

--- a/packages/docs/runtime/providers.mdx
+++ b/packages/docs/runtime/providers.mdx
@@ -61,7 +61,6 @@ interface ProviderResult {
 | ------------------- | ------- | -------- | ---------------- | -------------------------- |
 | **ACTIONS**         | No      | -1       | Yes              | Lists available actions    |
 | **ACTION_STATE**    | No      | 150      | Yes              | Action execution state     |
-| **ANXIETY**         | No      | Default  | Yes              | Response style guidelines  |
 | **ATTACHMENTS**     | Yes     | Default  | No               | File/media attachments     |
 | **CAPABILITIES**    | No      | Default  | Yes              | Service capabilities       |
 | **CHARACTER**       | No      | Default  | Yes              | Agent personality          |

--- a/packages/prompts/prompts/message_handler.txt
+++ b/packages/prompts/prompts/message_handler.txt
@@ -3,15 +3,24 @@ task: Generate dialog and actions for {{agentName}}.
 context:
 {{providers}}
 
-rules[8]:
+rules[10]:
 - think briefly, then respond
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments from the user (ok, yes, thanks) often mean the turn is done -> prefer IGNORE over another acknowledgment
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
 - if a required param is unknown, ask for clarification in text
+
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep replies short; do not over-explain or monologue
+- Do not take over threads or replies that are clearly meant for another agent or user when context shows that
+- If unsure whether to speak in a busy channel, prefer IGNORE over adding low-value noise
+- Watch for ping-pong: only brief acknowledgments between you and another agent -> use IGNORE or STOP, not another acknowledgment
+- Brief ok / yes / thanks / yep from the user often means the exchange is done -> IGNORE unless there is an open question
 
 control_actions:
 - STOP means the task is done and the agent should end the run without executing more actions
@@ -30,7 +39,7 @@ formatting:
 - use inline backticks for short code identifiers
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 thought: Reply briefly. No extra providers needed.

--- a/packages/prompts/prompts/post_action_decision.txt
+++ b/packages/prompts/prompts/post_action_decision.txt
@@ -9,11 +9,13 @@ recent conversation:
 recent action results:
 {{actionResults}}
 
-rules[9]:
+rules[11]:
 - think briefly, then continue the task from the latest action results
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments often mean closure -> prefer IGNORE over ping-pong acknowledgments
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
@@ -21,8 +23,15 @@ rules[9]:
 - if the task is complete, either reply to the user or use STOP to end the run
 - STOP is a terminal control action even if it is not listed in available actions
 
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep follow-up replies short
+- Do not hijack threads clearly addressed to someone else when context indicates that
+- If unsure whether to speak in a busy channel, prefer IGNORE
+- Ping-pong acknowledgments with another agent -> IGNORE or STOP, not another hollow reply
+- Brief closure signals from the user -> prefer IGNORE unless something is still open
+
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 thought: Your thought here
 actions[1]: ACTION

--- a/packages/prompts/prompts/should_respond.txt
+++ b/packages/prompts/prompts/should_respond.txt
@@ -3,7 +3,29 @@ task: Decide whether {{agentName}} should respond, ignore, or stop.
 context:
 {{providers}}
 
-rules[6]:
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
 - direct mention of {{agentName}} -> RESPOND
 - different assistant name -> IGNORE
 - continuing an active thread with {{agentName}} -> RESPOND
@@ -11,25 +33,30 @@ rules[6]:
 - talking to someone else -> IGNORE
 - if unsure, prefer IGNORE over hallucinating relevance
 
-available_contexts:
-{{availableContexts}}
-
 context_routing:
 - primaryContext: choose one context from available_contexts, or "general" if none apply
 - secondaryContexts: optional comma-separated list of additional relevant contexts
-- evidenceTurnIds: optional comma-separated list of message IDs supporting the decision
+- evidenceTurnIds: optional comma-separated list of memory or message IDs supporting the decision
 
 decision_note:
 - talking TO {{agentName}} means name mention, reply chain, or direct continuation
 - talking ABOUT {{agentName}} is not enough
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 name: {{agentName}}
 reasoning: Direct mention and clear follow-up.
 action: RESPOND
+primaryContext: wallet
+secondaryContexts:
+evidenceTurnIds:
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention but no relevant action.
+action: IGNORE
 primaryContext: general
 secondaryContexts:
 evidenceTurnIds:

--- a/packages/prompts/prompts/should_respond_with_context.txt
+++ b/packages/prompts/prompts/should_respond_with_context.txt
@@ -6,7 +6,26 @@ context:
 available_contexts:
 {{availableContexts}}
 
-rules[6]:
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
 - direct mention of {{agentName}} -> RESPOND
 - different assistant name -> IGNORE
 - continuing an active thread with {{agentName}} -> RESPOND
@@ -26,7 +45,7 @@ decision_note:
 - context routing always applies, even for IGNORE/STOP decisions
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 name: {{agentName}}

--- a/packages/python/elizaos/prompts.py
+++ b/packages/python/elizaos/prompts.py
@@ -161,15 +161,24 @@ MESSAGE_HANDLER_TEMPLATE = """task: Generate dialog and actions for {{agentName}
 context:
 {{providers}}
 
-rules[8]:
+rules[10]:
 - think briefly, then respond
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments from the user (ok, yes, thanks) often mean the turn is done -> prefer IGNORE over another acknowledgment
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
 - if a required param is unknown, ask for clarification in text
+
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep replies short; do not over-explain or monologue
+- Do not take over threads or replies that are clearly meant for another agent or user when context shows that
+- If unsure whether to speak in a busy channel, prefer IGNORE over adding low-value noise
+- Watch for ping-pong: only brief acknowledgments between you and another agent -> use IGNORE or STOP, not another acknowledgment
+- Brief ok / yes / thanks / yep from the user often means the exchange is done -> IGNORE unless there is an open question
 
 control_actions:
 - STOP means the task is done and the agent should end the run without executing more actions
@@ -188,7 +197,7 @@ formatting:
 - use inline backticks for short code identifiers
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 thought: Reply briefly. No extra providers needed.
@@ -302,11 +311,13 @@ recent conversation:
 recent action results:
 {{actionResults}}
 
-rules[9]:
+rules[11]:
 - think briefly, then continue the task from the latest action results
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments often mean closure -> prefer IGNORE over ping-pong acknowledgments
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
@@ -314,8 +325,15 @@ rules[9]:
 - if the task is complete, either reply to the user or use STOP to end the run
 - STOP is a terminal control action even if it is not listed in available actions
 
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep follow-up replies short
+- Do not hijack threads clearly addressed to someone else when context indicates that
+- If unsure whether to speak in a busy channel, prefer IGNORE
+- Ping-pong acknowledgments with another agent -> IGNORE or STOP, not another hollow reply
+- Brief closure signals from the user -> prefer IGNORE unless something is still open
+
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 thought: Your thought here
 actions[1]: ACTION
@@ -563,7 +581,29 @@ SHOULD_RESPOND_TEMPLATE = """task: Decide whether {{agentName}} should respond, 
 context:
 {{providers}}
 
-rules[6]:
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
 - direct mention of {{agentName}} -> RESPOND
 - different assistant name -> IGNORE
 - continuing an active thread with {{agentName}} -> RESPOND
@@ -571,17 +611,89 @@ rules[6]:
 - talking to someone else -> IGNORE
 - if unsure, prefer IGNORE over hallucinating relevance
 
+context_routing:
+- primaryContext: choose one context from available_contexts, or "general" if none apply
+- secondaryContexts: optional comma-separated list of additional relevant contexts
+- evidenceTurnIds: optional comma-separated list of memory or message IDs supporting the decision
+
 decision_note:
 - talking TO {{agentName}} means name mention, reply chain, or direct continuation
 - talking ABOUT {{agentName}} is not enough
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 name: {{agentName}}
 reasoning: Direct mention and clear follow-up.
-action: RESPOND"""
+action: RESPOND
+primaryContext: wallet
+secondaryContexts:
+evidenceTurnIds:
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention but no relevant action.
+action: IGNORE
+primaryContext: general
+secondaryContexts:
+evidenceTurnIds:"""
+
+SHOULD_RESPOND_WITH_CONTEXT_TEMPLATE = """task: Decide whether {{agentName}} should respond and which domain context applies.
+
+context:
+{{providers}}
+
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
+- direct mention of {{agentName}} -> RESPOND
+- different assistant name -> IGNORE
+- continuing an active thread with {{agentName}} -> RESPOND
+- request to stop or be quiet -> STOP
+- talking to someone else -> IGNORE
+- if unsure, prefer IGNORE over hallucinating relevance
+
+context_routing:
+- primaryContext: the single best-matching domain from available_contexts
+- secondaryContexts: zero or more additional domains that are relevant
+- action intent does not only come from the last message; consider the full recent conversation
+- if no specific domain applies, use "general"
+
+decision_note:
+- talking TO {{agentName}} means name mention, reply chain, or direct continuation
+- talking ABOUT {{agentName}} is not enough
+- context routing always applies, even for IGNORE/STOP decisions
+
+output:
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention asking about token balance.
+action: RESPOND
+primaryContext: wallet
+secondaryContexts: []"""
 
 SHOULD_UNFOLLOW_ROOM_TEMPLATE = """task: Decide whether {{agentName}} should unfollow this room.
 
@@ -712,6 +824,7 @@ __all__ = [
     "SHOULD_FOLLOW_ROOM_TEMPLATE",
     "SHOULD_MUTE_ROOM_TEMPLATE",
     "SHOULD_RESPOND_TEMPLATE",
+    "SHOULD_RESPOND_WITH_CONTEXT_TEMPLATE",
     "SHOULD_UNFOLLOW_ROOM_TEMPLATE",
     "SHOULD_UNMUTE_ROOM_TEMPLATE",
     "UPDATE_CONTACT_TEMPLATE",

--- a/packages/rust/src/prompts.rs
+++ b/packages/rust/src/prompts.rs
@@ -157,15 +157,24 @@ pub const MESSAGE_HANDLER_TEMPLATE: &str = r#"task: Generate dialog and actions 
 context:
 {{providers}}
 
-rules[8]:
+rules[10]:
 - think briefly, then respond
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments from the user (ok, yes, thanks) often mean the turn is done -> prefer IGNORE over another acknowledgment
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
 - if a required param is unknown, ask for clarification in text
+
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep replies short; do not over-explain or monologue
+- Do not take over threads or replies that are clearly meant for another agent or user when context shows that
+- If unsure whether to speak in a busy channel, prefer IGNORE over adding low-value noise
+- Watch for ping-pong: only brief acknowledgments between you and another agent -> use IGNORE or STOP, not another acknowledgment
+- Brief ok / yes / thanks / yep from the user often means the exchange is done -> IGNORE unless there is an open question
 
 control_actions:
 - STOP means the task is done and the agent should end the run without executing more actions
@@ -184,7 +193,7 @@ formatting:
 - use inline backticks for short code identifiers
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 thought: Reply briefly. No extra providers needed.
@@ -298,11 +307,13 @@ recent conversation:
 recent action results:
 {{actionResults}}
 
-rules[9]:
+rules[11]:
 - think briefly, then continue the task from the latest action results
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments often mean closure -> prefer IGNORE over ping-pong acknowledgments
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
@@ -310,8 +321,15 @@ rules[9]:
 - if the task is complete, either reply to the user or use STOP to end the run
 - STOP is a terminal control action even if it is not listed in available actions
 
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep follow-up replies short
+- Do not hijack threads clearly addressed to someone else when context indicates that
+- If unsure whether to speak in a busy channel, prefer IGNORE
+- Ping-pong acknowledgments with another agent -> IGNORE or STOP, not another hollow reply
+- Brief closure signals from the user -> prefer IGNORE unless something is still open
+
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 thought: Your thought here
 actions[1]: ACTION
@@ -559,7 +577,29 @@ pub const SHOULD_RESPOND_TEMPLATE: &str = r#"task: Decide whether {{agentName}} 
 context:
 {{providers}}
 
-rules[6]:
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
 - direct mention of {{agentName}} -> RESPOND
 - different assistant name -> IGNORE
 - continuing an active thread with {{agentName}} -> RESPOND
@@ -567,17 +607,89 @@ rules[6]:
 - talking to someone else -> IGNORE
 - if unsure, prefer IGNORE over hallucinating relevance
 
+context_routing:
+- primaryContext: choose one context from available_contexts, or "general" if none apply
+- secondaryContexts: optional comma-separated list of additional relevant contexts
+- evidenceTurnIds: optional comma-separated list of memory or message IDs supporting the decision
+
 decision_note:
 - talking TO {{agentName}} means name mention, reply chain, or direct continuation
 - talking ABOUT {{agentName}} is not enough
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 name: {{agentName}}
 reasoning: Direct mention and clear follow-up.
-action: RESPOND"#;
+action: RESPOND
+primaryContext: wallet
+secondaryContexts:
+evidenceTurnIds:
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention but no relevant action.
+action: IGNORE
+primaryContext: general
+secondaryContexts:
+evidenceTurnIds:"#;
+
+pub const SHOULD_RESPOND_WITH_CONTEXT_TEMPLATE: &str = r#"task: Decide whether {{agentName}} should respond and which domain context applies.
+
+context:
+{{providers}}
+
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
+- direct mention of {{agentName}} -> RESPOND
+- different assistant name -> IGNORE
+- continuing an active thread with {{agentName}} -> RESPOND
+- request to stop or be quiet -> STOP
+- talking to someone else -> IGNORE
+- if unsure, prefer IGNORE over hallucinating relevance
+
+context_routing:
+- primaryContext: the single best-matching domain from available_contexts
+- secondaryContexts: zero or more additional domains that are relevant
+- action intent does not only come from the last message; consider the full recent conversation
+- if no specific domain applies, use "general"
+
+decision_note:
+- talking TO {{agentName}} means name mention, reply chain, or direct continuation
+- talking ABOUT {{agentName}} is not enough
+- context routing always applies, even for IGNORE/STOP decisions
+
+output:
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention asking about token balance.
+action: RESPOND
+primaryContext: wallet
+secondaryContexts: []"#;
 
 pub const SHOULD_UNFOLLOW_ROOM_TEMPLATE: &str = r#"task: Decide whether {{agentName}} should unfollow this room.
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -95,7 +95,7 @@ SENTRY_SEND_DEFAULT_PII=true
 
 Key behaviors and APIs are documented with their **reasons** so future changes stay consistent with intent:
 
-- **[docs/DESIGN.md](docs/DESIGN.md)** — Design decisions: message races, provider timeout, keepExistingResponses, JSON5, formatPosts fallbacks, HandlerCallback actionName, anxiety provider, file logging, and what we don’t do.
+- **[docs/DESIGN.md](docs/DESIGN.md)** — Design decisions: message races, provider timeout, keepExistingResponses, JSON5, formatPosts fallbacks, HandlerCallback actionName, multi-party prompt guidance, file logging, and what we don’t do.
 - **[CHANGELOG.md](CHANGELOG.md)** — Per-change notes with WHY for each addition or fix.
 - **[ROADMAP.md](ROADMAP.md)** — Planned work and rationale (observability, robustness, API consistency, performance).
 

--- a/packages/typescript/docs/DESIGN.md
+++ b/packages/typescript/docs/DESIGN.md
@@ -128,13 +128,9 @@ The runtime is the only place that knows which action produced the content. Pass
 
 ## Basic-capabilities and plugins
 
-### Why an ANXIETY provider?
+### Multi-party / “social” guidance without a separate provider
 
-The message service already requested `ANXIETY` in the initial state composition. Without a provider registered under that name, the request was a no-op. Adding the provider makes that intent effective: we can give the model channel-specific guidance (e.g. be brief in groups, more natural in DMs) to reduce verbosity and over-eagerness. **Why channel-specific?** Group channels benefit from “don’t over-explain; use IGNORE when unsure”; DMs can be more conversational; voice channels need very short replies.
-
-### Why randomize anxiety examples?
-
-So the model sees variety across turns and doesn’t overfit to a single phrasing. We pick three per run to keep the prompt size small while still varying the guidance.
+Group-style behavior (brevity, don’t hijack threads, closure and anti–ping-pong, prefer IGNORE when unsure in busy channels) lives in **shared prompt templates** under `packages/prompts/prompts/` — notably `multi_party_behavior` / `multi_party_rules` blocks in `should_respond`, `message_handler`, and `post_action_decision`. That keeps one source of truth and avoids a dedicated `ANXIETY` provider slot in initial state.
 
 ---
 

--- a/packages/typescript/src/__tests__/message-service.test.ts
+++ b/packages/typescript/src/__tests__/message-service.test.ts
@@ -249,6 +249,83 @@ describe("DefaultMessageService", () => {
 			expect(result.reason).toContain("platform reply");
 		});
 
+		it("group reply to this agent's message skips LLM when parent author matches", () => {
+			const message: Memory = {
+				id: "123e4567-e89b-12d3-a456-426614174012" as UUID,
+				content: { text: "Thanks!", channelType: ChannelType.GROUP } as Content,
+				entityId: "123e4567-e89b-12d3-a456-426614174005" as UUID,
+				roomId: "123e4567-e89b-12d3-a456-426614174002" as UUID,
+				agentId: runtime.agentId,
+				createdAt: Date.now(),
+			};
+
+			const room = {
+				id: "123e4567-e89b-12d3-a456-426614174002" as UUID,
+				type: ChannelType.GROUP,
+				name: "Group",
+				worldId: "123e4567-e89b-12d3-a456-426614174003" as UUID,
+				source: "test",
+			};
+
+			const mentionContext = {
+				isMention: false,
+				isReply: true,
+				isThread: false,
+				mentionedUserIds: [],
+			};
+
+			const result = messageService.shouldRespond(
+				runtime,
+				message,
+				room,
+				mentionContext,
+				{ parentMessageAuthorEntityId: runtime.agentId },
+			);
+
+			expect(result.shouldRespond).toBe(true);
+			expect(result.skipEvaluation).toBe(true);
+			expect(result.reason).toContain("reply to this agent");
+		});
+
+		it("group reply to another user's message defers to LLM when options passed", () => {
+			const other =
+				"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+			const message: Memory = {
+				id: "123e4567-e89b-12d3-a456-426614174012" as UUID,
+				content: { text: "Thanks!", channelType: ChannelType.GROUP } as Content,
+				entityId: "123e4567-e89b-12d3-a456-426614174005" as UUID,
+				roomId: "123e4567-e89b-12d3-a456-426614174002" as UUID,
+				agentId: runtime.agentId,
+				createdAt: Date.now(),
+			};
+
+			const room = {
+				id: "123e4567-e89b-12d3-a456-426614174002" as UUID,
+				type: ChannelType.GROUP,
+				name: "Group",
+				worldId: "123e4567-e89b-12d3-a456-426614174003" as UUID,
+				source: "test",
+			};
+
+			const mentionContext = {
+				isMention: false,
+				isReply: true,
+				isThread: false,
+				mentionedUserIds: [],
+			};
+
+			const result = messageService.shouldRespond(
+				runtime,
+				message,
+				room,
+				mentionContext,
+				{ parentMessageAuthorEntityId: other },
+			);
+
+			expect(result.shouldRespond).toBe(false);
+			expect(result.skipEvaluation).toBe(false);
+		});
+
 		it("should always respond in VOICE_DM channels", () => {
 			const message: Memory = {
 				id: "123e4567-e89b-12d3-a456-426614174013" as UUID,

--- a/packages/typescript/src/__tests__/name-variation-registry.test.ts
+++ b/packages/typescript/src/__tests__/name-variation-registry.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { UUID } from "../types/primitives.ts";
+import {
+	detectAddressees,
+	NameVariationRegistry,
+} from "../utils/name-variation-registry.ts";
+
+describe("NameVariationRegistry", () => {
+	const alice = "11111111-1111-4111-8111-111111111111" as UUID;
+	const bob = "22222222-2222-4222-8222-222222222222" as UUID;
+
+	it("checkAddressedTo resolves @mention to a unique entity", () => {
+		const r = new NameVariationRegistry();
+		r.registerEntity(alice, ["Alice"]);
+		r.registerEntity(bob, ["Bob"]);
+		expect(r.checkAddressedTo("@Alice help", {})).toBe(alice);
+		expect(r.checkAddressedTo("@Bob hi", {})).toBe(bob);
+	});
+
+	it("isAddressedToOther when metadata replyToEntityId points elsewhere", () => {
+		const r = new NameVariationRegistry();
+		r.registerEntity(alice, ["Alice"]);
+		r.registerEntity(bob, ["Bob"]);
+		expect(
+			r.isAddressedToOther("anything", alice, { replyToEntityId: bob }),
+		).toBe(true);
+		expect(
+			r.isAddressedToOther("anything", alice, { replyToEntityId: alice }),
+		).toBe(false);
+	});
+
+	it("detectAddressees finds @handles among known names", () => {
+		const d = detectAddressees("Hey @Alice and @Bob", ["alice", "carol"]);
+		expect(d.explicitMentions).toContain("Alice");
+		expect(d.explicitMentions).not.toContain("Bob");
+	});
+});

--- a/packages/typescript/src/__tests__/prompts.test.ts
+++ b/packages/typescript/src/__tests__/prompts.test.ts
@@ -24,7 +24,10 @@ describe("Prompts", () => {
 				"request to stop or be quiet -> STOP",
 			);
 
-			expect(shouldRespondTemplate).toContain("rules[6]:");
+			expect(shouldRespondTemplate).toContain("closure_rules[6]:");
+			expect(shouldRespondTemplate).toContain("routing_rules[6]:");
+			expect(shouldRespondTemplate).toContain("addressee_alignment[3]:");
+			expect(shouldRespondTemplate).toContain("multi_party_behavior[4]:");
 			expect(shouldRespondTemplate).toContain(
 				"direct mention of {{agentName}}",
 			);
@@ -41,7 +44,11 @@ describe("Prompts", () => {
 			expect(messageHandlerTemplate).toContain("text:");
 			expect(messageHandlerTemplate).toContain("simple: true");
 
-			expect(messageHandlerTemplate).toContain("rules[8]:");
+			expect(messageHandlerTemplate).toContain("rules[10]:");
+			expect(messageHandlerTemplate).toContain(
+				"use IGNORE only when you should not respond",
+			);
+			expect(messageHandlerTemplate).toContain("multi_party_rules[5]:");
 			expect(messageHandlerTemplate).toContain(
 				"actions execute in listed order",
 			);
@@ -101,7 +108,7 @@ describe("Prompts", () => {
 		it("all templates should have concise output-only instructions", () => {
 			templates.forEach((template) => {
 				expect(template).toMatch(
-					/No <think>|Do NOT include any thinking|Do not include any text, thinking, or reasoning before or after it/,
+					/No <redacted_thinking>|Do NOT include any thinking|Do not include any text, thinking, or reasoning before or after it/,
 				);
 				expect(template.includes("TOON")).toBe(true);
 			});

--- a/packages/typescript/src/basic-capabilities/index.ts
+++ b/packages/typescript/src/basic-capabilities/index.ts
@@ -51,6 +51,7 @@ import type {
 } from "../types/index.ts";
 import { MemoryType } from "../types/memory.ts";
 import { ModelType } from "../types/model.ts";
+import type { ShouldRespondOptions } from "../types/message-service.ts";
 import type { ServiceClass } from "../types/plugin.ts";
 import { ChannelType, ContentType } from "../types/primitives.ts";
 import {
@@ -358,6 +359,7 @@ export function shouldRespond(
 	message: Memory,
 	room?: Room,
 	mentionContext?: MentionContext,
+	options?: ShouldRespondOptions,
 ): { shouldRespond: boolean; skipEvaluation: boolean; reason: string } {
 	if (!room) {
 		return {
@@ -388,10 +390,12 @@ export function shouldRespond(
 	const alwaysRespondSources = ["client_chat"];
 
 	const customChannels = normalizeEnvList(
-		runtime.getSetting("ALWAYS_RESPOND_CHANNELS"),
+		runtime.getSetting("ALWAYS_RESPOND_CHANNELS") ||
+			runtime.getSetting("SHOULD_RESPOND_BYPASS_TYPES"),
 	);
 	const customSources = normalizeEnvList(
-		runtime.getSetting("ALWAYS_RESPOND_SOURCES"),
+		runtime.getSetting("ALWAYS_RESPOND_SOURCES") ||
+			runtime.getSetting("SHOULD_RESPOND_BYPASS_SOURCES"),
 	);
 
 	const respondChannels = new Set(
@@ -426,23 +430,40 @@ export function shouldRespond(
 		};
 	}
 
-	// 3. Platform mentions and replies: always respond
-	// This is the key feature from mentionContext - platform-detected mentions/replies
-	const mentionContextIsMention = mentionContext?.isMention;
-	const mentionContextIsReply = mentionContext?.isReply;
-	const hasPlatformMention = !!(
-		mentionContextIsMention || mentionContextIsReply
-	);
-	if (hasPlatformMention) {
-		const mentionType = mentionContextIsMention ? "mention" : "reply";
+	// 3. Platform mention: always respond
+	if (mentionContext?.isMention) {
 		return {
 			shouldRespond: true,
 			skipEvaluation: true,
-			reason: `platform ${mentionType}`,
+			reason: "platform mention",
 		};
 	}
 
-	// 4. All other cases: let the LLM decide
+	// 4. Platform reply: match MessageService (group disambiguation when options passed)
+	if (mentionContext?.isReply) {
+		const parentAuthor = options?.parentMessageAuthorEntityId;
+		if (parentAuthor === runtime.agentId) {
+			return {
+				shouldRespond: true,
+				skipEvaluation: true,
+				reason: "reply to this agent's message",
+			};
+		}
+		if (options && "parentMessageAuthorEntityId" in options) {
+			return {
+				shouldRespond: false,
+				skipEvaluation: false,
+				reason: "reply thread; needs classifier or addressee check",
+			};
+		}
+		return {
+			shouldRespond: true,
+			skipEvaluation: true,
+			reason: "platform reply",
+		};
+	}
+
+	// 5. All other cases: let the LLM decide
 	// The LLM will handle: text-based name detection, indirect questions, conversation context, etc.
 	return {
 		shouldRespond: false,

--- a/packages/typescript/src/prompts.ts
+++ b/packages/typescript/src/prompts.ts
@@ -1,7 +1,7 @@
 /**
  * Auto-generated prompt templates for elizaOS
  * DO NOT EDIT - Generated from packages/prompts/prompts/*.txt
- *
+ * 
  * These prompts use Handlebars-style template syntax:
  * - {{variableName}} for simple substitution
  * - {{#each items}}...{{/each}} for iteration
@@ -56,8 +56,7 @@ Your last autonomous note: "{{lastThought}}"
 
 Continue from that note. Output <thought> and take action if needed.`;
 
-export const AUTONOMY_CONTINUOUS_CONTINUE_TEMPLATE =
-	autonomyContinuousContinueTemplate;
+export const AUTONOMY_CONTINUOUS_CONTINUE_TEMPLATE = autonomyContinuousContinueTemplate;
 
 export const autonomyContinuousFirstTemplate = `Your job: reflect on context, decide what you want to do next, and act if appropriate.
 - Use available actions/tools when they can advance the goal.
@@ -73,8 +72,7 @@ USER CONTEXT (most recent last):
 
 Think briefly, then output <thought> and take action if needed.`;
 
-export const AUTONOMY_CONTINUOUS_FIRST_TEMPLATE =
-	autonomyContinuousFirstTemplate;
+export const AUTONOMY_CONTINUOUS_FIRST_TEMPLATE = autonomyContinuousFirstTemplate;
 
 export const autonomyTaskContinueTemplate = `You are running in AUTONOMOUS TASK MODE.
 
@@ -177,15 +175,24 @@ export const messageHandlerTemplate = `task: Generate dialog and actions for {{a
 context:
 {{providers}}
 
-rules[8]:
+rules[10]:
 - think briefly, then respond
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments from the user (ok, yes, thanks) often mean the turn is done -> prefer IGNORE over another acknowledgment
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
 - if a required param is unknown, ask for clarification in text
+
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep replies short; do not over-explain or monologue
+- Do not take over threads or replies that are clearly meant for another agent or user when context shows that
+- If unsure whether to speak in a busy channel, prefer IGNORE over adding low-value noise
+- Watch for ping-pong: only brief acknowledgments between you and another agent -> use IGNORE or STOP, not another acknowledgment
+- Brief ok / yes / thanks / yep from the user often means the exchange is done -> IGNORE unless there is an open question
 
 control_actions:
 - STOP means the task is done and the agent should end the run without executing more actions
@@ -204,7 +211,7 @@ formatting:
 - use inline backticks for short code identifiers
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 thought: Reply briefly. No extra providers needed.
@@ -326,11 +333,13 @@ recent conversation:
 recent action results:
 {{actionResults}}
 
-rules[9]:
+rules[11]:
 - think briefly, then continue the task from the latest action results
 - actions execute in listed order
 - if replying, REPLY goes first
 - use IGNORE or STOP only by themselves
+- use IGNORE only when you should not respond or take any actions at all; if you use IGNORE, do not include any other actions in the same turn
+- brief acknowledgments often mean closure -> prefer IGNORE over ping-pong acknowledgments
 - include providers only when needed
 - use provider_hints from context when present instead of restating the same rules
 - if an action needs inputs, include them under params keyed by action name
@@ -338,8 +347,15 @@ rules[9]:
 - if the task is complete, either reply to the user or use STOP to end the run
 - STOP is a terminal control action even if it is not listed in available actions
 
+multi_party_rules[5]:
+- When context indicates multiple participants or a group/public-style channel: keep follow-up replies short
+- Do not hijack threads clearly addressed to someone else when context indicates that
+- If unsure whether to speak in a busy channel, prefer IGNORE
+- Ping-pong acknowledgments with another agent -> IGNORE or STOP, not another hollow reply
+- Brief closure signals from the user -> prefer IGNORE unless something is still open
+
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 thought: Your thought here
 actions[1]: ACTION
@@ -610,7 +626,26 @@ context:
 available_contexts:
 {{availableContexts}}
 
-rules[6]:
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
 - direct mention of {{agentName}} -> RESPOND
 - different assistant name -> IGNORE
 - continuing an active thread with {{agentName}} -> RESPOND
@@ -621,14 +656,14 @@ rules[6]:
 context_routing:
 - primaryContext: choose one context from available_contexts, or "general" if none apply
 - secondaryContexts: optional comma-separated list of additional relevant contexts
-- evidenceTurnIds: optional comma-separated list of memory IDs supporting the decision
+- evidenceTurnIds: optional comma-separated list of memory or message IDs supporting the decision
 
 decision_note:
 - talking TO {{agentName}} means name mention, reply chain, or direct continuation
 - talking ABOUT {{agentName}} is not enough
 
 output:
-TOON only. Return exactly one TOON document. No prose before or after it. No <think>.
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
 
 Example:
 name: {{agentName}}
@@ -647,6 +682,64 @@ secondaryContexts:
 evidenceTurnIds:`;
 
 export const SHOULD_RESPOND_TEMPLATE = shouldRespondTemplate;
+
+export const shouldRespondWithContextTemplate = `task: Decide whether {{agentName}} should respond and which domain context applies.
+
+context:
+{{providers}}
+
+available_contexts:
+{{availableContexts}}
+
+closure_rules[6]:
+- If the message is only a brief acknowledgment (ok, yes, good, right, yep, sure, got it, makes sense, etc.) with NO question or request -> IGNORE (natural closure)
+- If you notice short back-and-forth exchanges with another bot/agent that are only brief acknowledgments -> STOP (anti ping-pong)
+- If the last few messages are only acknowledgments going back and forth -> IGNORE
+- If the last 2-3 messages are farewells, exits (I'm out), acknowledgments, or meta (we're going in circles) -> IGNORE
+- Conversational closure (affirmations, no new content, no ask) -> IGNORE
+- Explicit request to stop or be quiet -> STOP
+
+addressee_alignment[3]:
+- If context or providers show the user addressed a different named agent (not {{agentName}}) and not a general room message -> IGNORE
+- Align with any deterministic addressee or mention signals already reflected in context; do not contradict them
+- When unclear who the message is for in a multi-party setting, prefer IGNORE
+
+multi_party_behavior[4]:
+- In rooms with multiple participants (or when context reads like a public/group channel), if you RESPOND, be concise; avoid long monologues and over-explaining
+- Do not hijack threads or replies that are clearly addressed to another participant when context indicates that
+- If you are uncertain whether speaking adds value in a busy multi-party channel, prefer IGNORE over noise
+- When someone only says ok, yes, good, yep, etc. with no new ask, that is closure — do not answer with another empty acknowledgment (IGNORE)
+
+routing_rules[6]:
+- direct mention of {{agentName}} -> RESPOND
+- different assistant name -> IGNORE
+- continuing an active thread with {{agentName}} -> RESPOND
+- request to stop or be quiet -> STOP
+- talking to someone else -> IGNORE
+- if unsure, prefer IGNORE over hallucinating relevance
+
+context_routing:
+- primaryContext: the single best-matching domain from available_contexts
+- secondaryContexts: zero or more additional domains that are relevant
+- action intent does not only come from the last message; consider the full recent conversation
+- if no specific domain applies, use "general"
+
+decision_note:
+- talking TO {{agentName}} means name mention, reply chain, or direct continuation
+- talking ABOUT {{agentName}} is not enough
+- context routing always applies, even for IGNORE/STOP decisions
+
+output:
+TOON only. Return exactly one TOON document. No prose before or after it. No <redacted_thinking>.
+
+Example:
+name: {{agentName}}
+reasoning: Direct mention asking about token balance.
+action: RESPOND
+primaryContext: wallet
+secondaryContexts: []`;
+
+export const SHOULD_RESPOND_WITH_CONTEXT_TEMPLATE = shouldRespondWithContextTemplate;
 
 export const shouldUnfollowRoomTemplate = `task: Decide whether {{agentName}} should unfollow this room.
 

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -4361,9 +4361,9 @@ ${section_end}`;
 
 			let response: string;
 			try {
-				response = await this.useModel<typeof resolvedModelType, string>(
-					resolvedModelType,
-					modelParams,
+				response = await this.useModel(
+					resolvedModelType as keyof ModelParamsMap,
+					modelParams as ModelParamsMap[keyof ModelParamsMap],
 					options.model,
 				);
 			} catch (modelError) {

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -10,6 +10,7 @@ import {
 	postActionDecisionTemplate,
 	shouldRespondTemplate,
 } from "../prompts";
+import { runWithStreamingContext } from "../streaming-context.ts";
 import { runWithTrajectoryContext } from "../trajectory-context";
 import type {
 	Action,
@@ -27,6 +28,7 @@ import type {
 	MessageProcessingOptions,
 	MessageProcessingResult,
 	ShouldRespondModelType,
+	ShouldRespondOptions,
 } from "../types/message-service";
 import type {
 	GenerateTextAttachment,
@@ -38,6 +40,11 @@ import type { Content, Media, MentionContext, UUID } from "../types/primitives";
 import { asUUID, ChannelType, ContentType } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
 import type { State } from "../types/state";
+import {
+	evaluateGroupAddresseeOverride,
+	fetchParentMessageAuthorEntityId,
+	isPrivateChannelRoom,
+} from "../utils/addressee-resolution.ts";
 import {
 	composePromptFromState,
 	getLocalServerUrl,
@@ -207,7 +214,7 @@ type ResolvedMessageOptions = {
 	useMultiStep: boolean;
 	maxMultiStepIterations: number;
 	continueAfterActions: boolean;
-	onStreamChunk?: (chunk: string, messageId?: string) => Promise<void>;
+	onStreamChunk?: StreamChunkCallback;
 	shouldRespondModel: ShouldRespondModelType;
 };
 
@@ -1036,7 +1043,7 @@ export class DefaultMessageService implements IMessageService {
 		// Compose initial state
 		let state = await runtime.composeState(
 			message,
-			["ANXIETY", "ENTITIES", "CHARACTER", "RECENT_MESSAGES", "ACTIONS"],
+			["ENTITIES", "CHARACTER", "RECENT_MESSAGES", "ACTIONS"],
 			true,
 			false,
 		);
@@ -1091,13 +1098,42 @@ export class DefaultMessageService implements IMessageService {
 			// Check if shouldRespond evaluation is enabled
 			const checkShouldRespondEnabled = runtime.isCheckShouldRespondEnabled();
 
-			// Determine if we should respond
-			const responseDecision = this.shouldRespond(
+			let shouldRespondOptions: ShouldRespondOptions | undefined;
+			if (
+				room &&
+				!isPrivateChannelRoom(room) &&
+				mentionContext?.isReply
+			) {
+				shouldRespondOptions = {
+					parentMessageAuthorEntityId: message.content.inReplyTo
+						? await fetchParentMessageAuthorEntityId(
+								runtime,
+								message.content.inReplyTo,
+							)
+						: null,
+				};
+			}
+
+			let responseDecision = this.shouldRespond(
 				runtime,
 				message,
 				room ?? undefined,
 				mentionContext,
+				shouldRespondOptions,
 			);
+
+			if (room && !isPrivateChannelRoom(room)) {
+				const addresseeOverride = await evaluateGroupAddresseeOverride(
+					runtime,
+					message,
+					room,
+					mentionContext,
+					shouldRespondOptions?.parentMessageAuthorEntityId,
+				);
+				if (addresseeOverride) {
+					responseDecision = addresseeOverride;
+				}
+			}
 
 			runtime.logger.debug(
 				{ src: "service:message", responseDecision, checkShouldRespondEnabled },
@@ -1633,6 +1669,7 @@ export class DefaultMessageService implements IMessageService {
 		message: Memory,
 		room?: Room,
 		mentionContext?: MentionContext,
+		options?: ShouldRespondOptions,
 	): ContextRoutedResponseDecision {
 		if (!room) {
 			return {
@@ -1707,21 +1744,44 @@ export class DefaultMessageService implements IMessageService {
 			};
 		}
 
-		// 3. Platform mentions and replies: always respond
-		const hasPlatformMention = !!(
-			mentionContext?.isMention || mentionContext?.isReply
-		);
-		if (hasPlatformMention) {
-			const mentionType = mentionContext?.isMention ? "mention" : "reply";
+		// 3. Platform mention: always respond
+		if (mentionContext?.isMention) {
 			return {
 				shouldRespond: true,
 				skipEvaluation: true,
-				reason: `platform ${mentionType}`,
+				reason: "platform mention",
 				primaryContext: "general",
 			};
 		}
 
-		// 4. All other cases: let the LLM decide
+		// 4. Platform reply: disambiguate in group rooms when parent author is known
+		if (mentionContext?.isReply) {
+			const parentAuthor = options?.parentMessageAuthorEntityId;
+			if (parentAuthor === runtime.agentId) {
+				return {
+					shouldRespond: true,
+					skipEvaluation: true,
+					reason: "reply to this agent's message",
+					primaryContext: "general",
+				};
+			}
+			if (options && "parentMessageAuthorEntityId" in options) {
+				return {
+					shouldRespond: false,
+					skipEvaluation: false,
+					reason: "reply thread; needs classifier or addressee check",
+					primaryContext: "general",
+				};
+			}
+			return {
+				shouldRespond: true,
+				skipEvaluation: true,
+				reason: "platform reply",
+				primaryContext: "general",
+			};
+		}
+
+		// 5. All other cases: let the LLM decide
 		return {
 			shouldRespond: false,
 			skipEvaluation: false,

--- a/packages/typescript/src/types/message-service.ts
+++ b/packages/typescript/src/types/message-service.ts
@@ -1,4 +1,4 @@
-import type { AgentContext, HandlerCallback } from "./components";
+import type { AgentContext, HandlerCallback, StreamChunkCallback } from "./components";
 import type { Room } from "./environment";
 import type { Memory } from "./memory";
 import { ModelType } from "./model";
@@ -30,7 +30,7 @@ export interface MessageProcessingOptions
 	useMultiStep?: boolean;
 	maxMultiStepIterations?: number;
 	shouldRespondModel?: ShouldRespondModelType;
-	onStreamChunk?: (chunk: string, messageId?: string) => Promise<void>;
+	onStreamChunk?: StreamChunkCallback;
 	/**
 	 * When true, run a follow-up reasoning pass after actions complete so the
 	 * agent can decide whether to share results, run another action, or stop.
@@ -81,6 +81,12 @@ export interface ContextRoutedResponseDecision extends ResponseDecision {
 	secondaryContexts?: AgentContext[];
 	/** Turn IDs that contributed to the intent (for multi-turn extraction) */
 	evidenceTurnIds?: string[];
+}
+
+/** Optional inputs for {@link IMessageService.shouldRespond} (group reply-thread disambiguation). */
+export interface ShouldRespondOptions {
+	/** Author entity id of the message referenced by `Content.inReplyTo`, when resolved. */
+	parentMessageAuthorEntityId?: UUID | null;
 }
 
 export type ShouldRespondModelType =
@@ -173,6 +179,7 @@ export interface IMessageService {
 		message: Memory,
 		room?: Room,
 		mentionContext?: MentionContext,
+		options?: ShouldRespondOptions,
 	): ResponseDecision;
 
 	/**

--- a/packages/typescript/src/utils/addressee-resolution.ts
+++ b/packages/typescript/src/utils/addressee-resolution.ts
@@ -1,0 +1,136 @@
+import type { Room } from "../types/environment.ts";
+import type { Memory } from "../types/memory.ts";
+import type { ContextRoutedResponseDecision } from "../types/message-service.ts";
+import type { MentionContext, UUID } from "../types/primitives.ts";
+import { ChannelType } from "../types/primitives.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+import {
+	buildNameRegistryForRoom,
+	NameVariationRegistry,
+} from "./name-variation-registry.ts";
+
+export function isPrivateChannelRoom(room: Room): boolean {
+	const t = room.type;
+	return (
+		t === ChannelType.DM ||
+		t === ChannelType.VOICE_DM ||
+		t === ChannelType.SELF ||
+		t === ChannelType.API
+	);
+}
+
+/** Merge optional routing hints from content and message metadata (documented adapter fields). */
+export function mergeMessageRoutingMetadata(
+	message: Memory,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	const content = message.content as Record<string, unknown>;
+	for (const key of [
+		"replyToEntityId",
+		"inReplyToEntityId",
+		"replyTo",
+		"inReplyTo",
+	] as const) {
+		if (content[key] !== undefined && content[key] !== null) {
+			out[key] = content[key];
+		}
+	}
+	const meta = message.metadata as Record<string, unknown> | undefined;
+	if (meta) {
+		for (const key of [
+			"replyToEntityId",
+			"inReplyToEntityId",
+			"replyTo",
+			"inReplyTo",
+		] as const) {
+			if (meta[key] !== undefined && meta[key] !== null) {
+				out[key] = meta[key];
+			}
+		}
+	}
+	return out;
+}
+
+export async function fetchParentMessageAuthorEntityId(
+	runtime: IAgentRuntime,
+	parentMessageId: UUID | undefined,
+): Promise<UUID | null> {
+	if (!parentMessageId) return null;
+	const parent = await runtime.getMemoryById(parentMessageId);
+	if (!parent?.entityId) return null;
+	return parent.entityId;
+}
+
+/**
+ * Non-LLM overrides for group rooms: explicit addressee to another agent, or text that addresses this agent in a reply-to-other thread.
+ */
+export async function evaluateGroupAddresseeOverride(
+	runtime: IAgentRuntime,
+	message: Memory,
+	room: Room,
+	mentionContext: MentionContext | undefined,
+	parentMessageAuthorEntityId: UUID | null | undefined,
+): Promise<ContextRoutedResponseDecision | null> {
+	if (isPrivateChannelRoom(room)) return null;
+	if (mentionContext?.isMention) return null;
+
+	const myId = runtime.agentId;
+	const text = message.content.text ?? "";
+	const routingMeta = mergeMessageRoutingMetadata(message);
+	const roomId = room.id;
+	if (!roomId) return null;
+
+	let registry: NameVariationRegistry | null = null;
+	const loadRegistry = async () => {
+		if (!registry) {
+			try {
+				registry = await buildNameRegistryForRoom(runtime, roomId);
+			} catch {
+				registry = new NameVariationRegistry();
+			}
+		}
+		return registry;
+	};
+
+	if (mentionContext?.isReply) {
+		if (parentMessageAuthorEntityId === myId) {
+			return null;
+		}
+		if (
+			parentMessageAuthorEntityId != null &&
+			parentMessageAuthorEntityId !== myId
+		) {
+			const reg = await loadRegistry();
+			if (reg.isAddressedToSelf(text, myId, routingMeta)) {
+				return {
+					shouldRespond: true,
+					skipEvaluation: true,
+					reason: "reply thread; text addresses this agent",
+					primaryContext: "general",
+				};
+			}
+			if (reg.isAddressedToOther(text, myId, routingMeta)) {
+				return {
+					shouldRespond: false,
+					skipEvaluation: true,
+					reason: "addressed to other agent (reply thread)",
+					primaryContext: "general",
+				};
+			}
+			return null;
+		}
+		return null;
+	}
+
+	if (!text.trim()) return null;
+	const reg = await loadRegistry();
+	if (reg.isAddressedToOther(text, myId, routingMeta)) {
+		return {
+			shouldRespond: false,
+			skipEvaluation: true,
+			reason: "addressed to other agent",
+			primaryContext: "general",
+		};
+	}
+	return null;
+}

--- a/packages/typescript/src/utils/name-variation-registry.ts
+++ b/packages/typescript/src/utils/name-variation-registry.ts
@@ -1,0 +1,224 @@
+import type { UUID } from "../types/primitives.ts";
+import type { IAgentRuntime } from "../types/runtime.ts";
+
+const UUID_RE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function normToken(s: string): string {
+	return s.trim().toLowerCase().replace(/^@+/, "");
+}
+
+function splitNameTokens(raw: string): string[] {
+	const n = normToken(raw);
+	if (!n) return [];
+	const out = new Set<string>([n]);
+	const first = n.split(/\s+/)[0];
+	if (first) out.add(first);
+	return [...out];
+}
+
+/**
+ * Fast addressee / mention resolution without an LLM (plugin-autonomous–style).
+ * Maps entity (and optional agent) ids to normalized name tokens for @mentions and lead-in patterns.
+ */
+export class NameVariationRegistry {
+	private readonly entityToTokens = new Map<UUID, Set<string>>();
+	private readonly tokenToEntities = new Map<string, Set<UUID>>();
+
+	registerEntity(entityId: UUID, rawNames: readonly string[]): void {
+		const tokens = new Set<string>();
+		for (const raw of rawNames) {
+			for (const t of splitNameTokens(raw)) {
+				if (t.length > 0) tokens.add(t);
+			}
+		}
+		if (tokens.size === 0) return;
+		this.entityToTokens.set(entityId, tokens);
+		for (const t of tokens) {
+			let set = this.tokenToEntities.get(t);
+			if (!set) {
+				set = new Set();
+				this.tokenToEntities.set(t, set);
+			}
+			set.add(entityId);
+		}
+	}
+
+	/** Register the same token set under another id (e.g. agentId vs entity id). */
+	aliasEntity(alternateId: UUID, canonicalEntityId: UUID): void {
+		const tokens = this.entityToTokens.get(canonicalEntityId);
+		if (!tokens) return;
+		this.entityToTokens.set(alternateId, tokens);
+		for (const t of tokens) {
+			let set = this.tokenToEntities.get(t);
+			if (!set) {
+				set = new Set();
+				this.tokenToEntities.set(t, set);
+			}
+			set.add(alternateId);
+		}
+	}
+
+	hasEntity(id: UUID): boolean {
+		return this.entityToTokens.has(id);
+	}
+
+	private resolveUuid(value: unknown): UUID | null {
+		if (typeof value !== "string") return null;
+		const t = value.trim();
+		if (!UUID_RE.test(t)) return null;
+		return t as UUID;
+	}
+
+	/**
+	 * Primary addressee: explicit metadata first (replyToEntityId, inReplyToEntityId, replyTo, inReplyTo as UUID),
+	 * then leading @Name, "Name,", "Name:".
+	 */
+	checkAddressedTo(
+		messageText: string,
+		metadata?: Record<string, unknown>,
+	): UUID | null {
+		if (metadata) {
+			for (const key of [
+				"replyToEntityId",
+				"inReplyToEntityId",
+				"replyTo",
+				"inReplyTo",
+			] as const) {
+				const id = this.resolveUuid(metadata[key]);
+				if (id && this.entityToTokens.has(id)) return id;
+			}
+		}
+
+		const text = messageText.trim();
+		if (!text) return null;
+
+		const at = text.match(/^@([\w.-]+)\b/);
+		if (at) {
+			const id = this.resolveSingleToken(at[1]);
+			if (id) return id;
+		}
+
+		const comma = text.match(/^([^,:\n]{1,80}),\s/);
+		if (comma) {
+			const id = this.resolveSingleToken(comma[1]);
+			if (id) return id;
+		}
+
+		const colon = text.match(/^([^,:\n]{1,80}):\s/);
+		if (colon) {
+			const id = this.resolveSingleToken(colon[1]);
+			if (id) return id;
+		}
+
+		const hey = text.match(/^(?:hey|hi|hello)\s+([\w.-]+)\b/i);
+		if (hey) {
+			const id = this.resolveSingleToken(hey[1]);
+			if (id) return id;
+		}
+
+		return null;
+	}
+
+	private resolveSingleToken(fragment: string): UUID | null {
+		const t = normToken(fragment);
+		if (!t) return null;
+		const set = this.tokenToEntities.get(t);
+		if (!set || set.size === 0) return null;
+		if (set.size === 1) return [...set][0];
+		return null;
+	}
+
+	/** All entities whose names appear as @mentions in the text. */
+	getMentionedAgents(messageText: string): UUID[] {
+		const found = new Set<UUID>();
+		const re = /@([\w.-]+)\b/g;
+		for (;;) {
+			const m = re.exec(messageText);
+			if (m === null) break;
+			const id = this.resolveSingleToken(m[1]);
+			if (id) found.add(id);
+		}
+		return [...found];
+	}
+
+	isAddressedToOther(
+		messageText: string,
+		myEntityId: UUID,
+		metadata?: Record<string, unknown>,
+	): boolean {
+		const to = this.checkAddressedTo(messageText, metadata);
+		return to !== null && to !== myEntityId;
+	}
+
+	isAddressedToSelf(
+		messageText: string,
+		myEntityId: UUID,
+		metadata?: Record<string, unknown>,
+	): boolean {
+		const to = this.checkAddressedTo(messageText, metadata);
+		return to === myEntityId;
+	}
+}
+
+export interface AddresseeDetection {
+	explicitMentions: string[];
+	namedAgents: string[];
+}
+
+/**
+ * Parse @mentions and simple "Name," / "Hey Name" / "Name and" patterns against known agent display names.
+ */
+export function detectAddressees(
+	text: string,
+	agentDisplayNames: string[],
+): AddresseeDetection {
+	const explicitMentions: string[] = [];
+	const namedAgents: string[] = [];
+	const lowerNames = new Set(agentDisplayNames.map((n) => normToken(n)));
+
+	const mentionMatches = text.matchAll(/@([\w.-]+)\b/g);
+	for (const m of mentionMatches) {
+		const name = m[1];
+		if (lowerNames.has(normToken(name))) explicitMentions.push(name);
+	}
+
+	const comma = text.match(/^([^,:\n]{1,80}),\s/);
+	if (comma && lowerNames.has(normToken(comma[1]))) {
+		namedAgents.push(comma[1].trim());
+	}
+
+	const hey = text.match(/^(?:hey|hi|hello)\s+([\w.-]+)\b/i);
+	if (hey && lowerNames.has(normToken(hey[1]))) {
+		namedAgents.push(hey[1].trim());
+	}
+
+	const andPat = text.match(/^([\w.-]+)\s+and\s+/i);
+	if (andPat && lowerNames.has(normToken(andPat[1]))) {
+		namedAgents.push(andPat[1].trim());
+	}
+
+	return { explicitMentions, namedAgents };
+}
+
+/** Build a registry from current room participants (entity + optional agent id aliases). */
+export async function buildNameRegistryForRoom(
+	runtime: IAgentRuntime,
+	roomId: UUID,
+): Promise<NameVariationRegistry> {
+	const registry = new NameVariationRegistry();
+	const participants = await runtime.getParticipantsForRoom(roomId);
+	if (participants.length === 0) return registry;
+	const entities = await runtime.getEntitiesByIds(participants);
+	for (const e of entities) {
+		const id = e.id;
+		if (!id) continue;
+		const names = [...(e.names ?? [])];
+		registry.registerEntity(id, names);
+		const agentId = e.agentId;
+		if (agentId && agentId !== id) {
+			registry.aliasEntity(agentId as UUID, id);
+		}
+	}
+	return registry;
+}


### PR DESCRIPTION
Add NameVariationRegistry and evaluateGroupAddresseeOverride for non-LLM disambiguation in group rooms (reply threads and addressed-to-other).

Extend shouldRespond flow with parent message author for replies, merge routing metadata from content, and sync basic-capabilities shouldRespond with the same options shape.

Tighten should_respond, should_respond_with_context, message_handler, and post_action_decision prompts for closure, IGNORE-only replies, and multi-party behavior; regenerate bundled prompts for TypeScript, Python, and Rust.

Update DESIGN, README, CORE_CONCEPTS, and providers docs; add tests for registry utilities and message-service addressee paths.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `shouldRespond` decision path and adds deterministic addressee resolution for group replies, which can alter when agents speak or stay silent in multi-party rooms. Prompt-template updates are broad (TS/Python/Rust) and may shift runtime behavior across deployments.
> 
> **Overview**
> Improves group-room addressee routing by adding a deterministic, non-LLM layer (`NameVariationRegistry` + `evaluateGroupAddresseeOverride`) that uses participant names plus optional adapter metadata (e.g. `replyToEntityId`) and parent-message author lookup to decide when to respond in reply threads or ignore messages aimed at other agents.
> 
> Refactors `shouldRespond` to accept `ShouldRespondOptions` (including `parentMessageAuthorEntityId`), updates both the message service and `basic-capabilities` to disambiguate platform replies in group channels, and adds tests covering the new reply-thread and name-resolution behavior.
> 
> Tightens shared prompt templates (`should_respond*`, `message_handler`, `post_action_decision`) with explicit closure/anti–ping-pong and multi-party brevity rules, updates the “no thinking” instruction wording, regenerates bundled prompts for TypeScript/Python/Rust, and updates docs to document reply/addressee metadata and remove the prior `ANXIETY` provider guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed5b1ec094bc27f7c202e06ac3c72039a7ef365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds non-LLM group-room addressee routing via a new `NameVariationRegistry` and `evaluateGroupAddresseeOverride`, extends the `shouldRespond` flow with parent-message-author disambiguation for reply threads, and tightens all four decision prompts with closure, anti-loop, and multi-party guidance.

- **P1 — `aliasEntity` breaks address resolution for agents with separate `entityId`/`agentId`**: `buildNameRegistryForRoom` calls `aliasEntity(agentId, entityId)` for each such agent, which adds `agentId` to every token's entry in `tokenToEntities`. Because `resolveSingleToken` returns `null` when `set.size > 1`, `checkAddressedTo` can never resolve a name for those agents, silently making `isAddressedToSelf` and `isAddressedToOther` both return `false` — the core feature this PR ships.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the aliasEntity ambiguity bug; all other changes are additive prompt and type improvements.

One P1 logic bug: aliasEntity corrupts tokenToEntities for agents whose entityId ≠ agentId, silently disabling the primary feature this PR ships (non-LLM group addressee routing). The remaining findings are P2 (dead code). Score is 4 pending that fix.

packages/typescript/src/utils/name-variation-registry.ts (aliasEntity + tokenToEntities logic)

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The new routing logic performs read-only entity lookups and string matching; no user-supplied input is executed or used in privileged operations. Metadata fields used for routing (`replyToEntityId`, `inReplyTo`, etc.) are validated as UUIDs before any lookup is attempted via `resolveUuid`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/utils/name-variation-registry.ts | New utility for fast addressee resolution; contains a P1 logic bug where aliasEntity adds alternateId to tokenToEntities, causing resolveSingleToken to return null for all agents with a separate entityId/agentId pair. |
| packages/typescript/src/utils/addressee-resolution.ts | New group-room routing helpers; logic is sound but inherits the aliasEntity bug from the registry when agentId ≠ entityId; mergeMessageRoutingMetadata correctly guards against null values. |
| packages/typescript/src/services/message.ts | Extends shouldRespond with parent-author disambiguation and evaluateGroupAddresseeOverride; ANXIETY provider removal and reply-to-other deferral to LLM are correct intentional changes. |
| packages/typescript/src/prompts.ts | Adds closure/addressee/multi-party rules to shouldRespond templates and a new shouldRespondWithContextTemplate that is currently unused dead code. |
| packages/typescript/src/basic-capabilities/index.ts | Syncs shouldRespond signature with MessageService (adds ShouldRespondOptions, group disambiguation) and adds SHOULD_RESPOND_BYPASS_TYPES/SOURCES as setting aliases. |
| packages/typescript/src/types/message-service.ts | Adds ShouldRespondOptions interface and updates shouldRespond signature in IMessageService; clean, well-typed additions. |
| packages/typescript/src/__tests__/name-variation-registry.test.ts | Tests basic registry operations but doesn't cover aliasEntity behaviour — the P1 bug would not be caught by the existing suite. |
| packages/typescript/src/__tests__/message-service.test.ts | Adds two well-structured unit tests for group-reply disambiguation paths in shouldRespond; covers the happy paths correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming message] --> B{Private channel?}
    B -- yes --> C[shouldRespond original path]
    B -- no --> D{mentionContext isReply?}

    D -- yes --> E[fetchParentMessageAuthorEntityId]
    E --> F[shouldRespondOptions set]
    F --> G[shouldRespond]

    D -- no --> G2[shouldRespond no options]

    G --> H{parentAuthor == agentId?}
    H -- yes --> I[skipEval=true respond=true]
    H -- no key present --> J[skipEval=false respond=false]
    H -- no options --> K[skipEval=true respond=true]

    J --> L[evaluateGroupAddresseeOverride]
    G2 --> L

    L --> M[buildNameRegistryForRoom]
    M --> N{isAddressedToSelf?}
    N -- yes --> O[override respond=true]
    N -- no --> P{isAddressedToOther?}
    P -- yes --> Q[override respond=false]
    P -- no --> R[no override]

    R --> S{skipEval=false?}
    S -- yes --> T[LLM evaluation]
    S -- no --> U[Use decision directly]
```

<sub>Reviews (1): Last reviewed commit: ["feat(core): group addressee routing and ..."](https://github.com/elizaos/eliza/commit/5ed5b1ec094bc27f7c202e06ac3c72039a7ef365) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27810423)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->