### PR TITLE
fix: dedupe identical action invocations + defer simple-mode reply

### DIFF
--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -1744,6 +1744,15 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 
 		let actionIndex = 0;
+		// Track which action names have already been executed in this
+		// processActions invocation. The LLM sometimes emits the same action
+		// twice in `actions` (e.g. ["GMAIL_ACTION", "CALENDAR_ACTION",
+		// "CALENDAR_ACTION"] when the user has multiple sub-intents the LLM
+		// can't split into per-action params). Without dedupe the second run
+		// uses the same params as the first → identical output → discord
+		// dedup layer rejects it as a duplicate callback. Two identical
+		// action+params runs in one turn is never useful, so collapse them.
+		const executedActionKeys = new Set<string>();
 
 		for (const response of responsesToProcess) {
 			if (!response.content?.actions || response.content.actions.length === 0) {
@@ -1950,6 +1959,31 @@ export class AgentRuntime implements IAgentRuntime {
 
 					if (validation.params) options.parameters = validation.params;
 				}
+
+				// Dedupe: same action name + identical params bucket means
+				// repeating the run would emit identical output. Skip the
+				// repeat instead of letting the discord callback layer reject
+				// it as a duplicate. Key includes the JSON of params so that
+				// distinct invocations with different params still go through.
+				const actionDedupeKey = `${action.name.trim().toUpperCase()}::${
+					options.parameters
+						? JSON.stringify(options.parameters)
+						: "<no-params>"
+				}`;
+				if (executedActionKeys.has(actionDedupeKey)) {
+					this.logger.debug(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							action: action.name,
+							dedupeKey: actionDedupeKey,
+						},
+						"Skipping duplicate action invocation in same turn",
+					);
+					actionIndex++;
+					continue;
+				}
+				executedActionKeys.add(actionDedupeKey);
 
 				const actionId = uuidv4() as UUID;
 				// Separate ID for streamed response message (independent from action badge)

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -1885,6 +1885,11 @@ export class DefaultMessageService implements IMessageService {
 		let responseContent: Content | null = null;
 		let responseMessages: Memory[] = [];
 		let mode: StrategyMode = "none";
+		// Holds a deferred simple-mode reply that will be flushed after
+		// evaluators + reflection have had a chance to override it. Declared
+		// out here so the post-evaluation flush at the bottom of handleMessage
+		// can see the same variable that the simple-mode branch sets.
+		let pendingSimpleEmit: Content | null = null;
 
 		if (shouldRespondToMessage) {
 			const resolvedRouting = mergeContextRouting(state, message);
@@ -2011,7 +2016,7 @@ export class DefaultMessageService implements IMessageService {
 								responseContent.text,
 							);
 						}
-						await callback(responseContent);
+						pendingSimpleEmit = responseContent;
 					}
 				} else if (mode === "actions") {
 					// Pass onStreamChunk to processActions so each action can manage its own streaming context
@@ -2188,7 +2193,18 @@ export class DefaultMessageService implements IMessageService {
 			);
 			await runtime.deleteCache(getTaskCompletionCacheKey(message.id));
 
-			if (taskCompletion?.assessed && !taskCompletion.completed) {
+			if (
+				taskCompletion?.assessed &&
+				!taskCompletion.completed &&
+				// Honor `suppressPostActionContinuation` here too. The flag's
+				// contract per Action.suppressPostActionContinuation is "stop after
+				// this action — don't run any continuation LLM turn." Without this
+				// guard, an action that already emitted a complete user-facing
+				// reply (e.g. CALENDAR_ACTION) will get a second visible callback
+				// when the reflection evaluator marks the task as incomplete and
+				// triggers another LLM/processActions pass.
+				!suppressesPostActionContinuation(runtime, responseContent)
+			) {
 				const continuation = await this.runReflectionTaskContinuation(
 					runtime,
 					message,
@@ -2206,9 +2222,22 @@ export class DefaultMessageService implements IMessageService {
 				if (continuation.responseContent) {
 					responseContent = continuation.responseContent;
 					mode = continuation.mode;
+					// Reflection produced a real follow-up response (likely an
+					// action result). Drop the deferred chatty REPLY that
+					// preceded it — emitting both would show two contradictory
+					// messages to the user (the original "i can delete and
+					// recreate" plus the action's "updated X").
+					pendingSimpleEmit = null;
 				}
 				state = continuation.state;
 			}
+		}
+
+		// Flush the deferred simple-mode reply now that reflection has had its
+		// chance to override. If reflection produced its own response, this is
+		// already null and the original chatty REPLY is dropped.
+		if (pendingSimpleEmit && callback) {
+			await callback(pendingSimpleEmit);
 		}
 
 		const didRespond =


### PR DESCRIPTION
# Risks

Low. Both changes are scoped to the message service / runtime action dispatch path. They make existing behavior more consistent rather than introducing new pathways. Existing single-action turns and simple REPLY responses are unaffected.

# Background

## What does this PR do?

Two related fixes to the action dispatch + reply emit path in \`packages/typescript/src\`. Both surfaced from real production usage where a chat-LLM-driven agent runs multiple actions per turn and the user sees duplicated or contradictory replies.

### 1. \`runtime.processActions\`: dedupe identical action invocations within a single turn

When the planner emits the same action twice in one response (e.g. \`actions: ["GMAIL_ACTION", "CALENDAR_ACTION", "CALENDAR_ACTION"]\` because the user message had multiple sub-intents the LLM couldn't split into per-action params), the runtime currently runs the action twice with the same params bucket. The second invocation produces identical output, which the discord plugin's callback dedup layer flags as a real bug.

Fix: track \`(action.name, JSON.stringify(options.parameters))\` keys in an \`executedActionKeys\` Set per processActions call, skip the repeat with a debug log. Two identical action+params runs in a single turn is never useful.

### 2. \`services/message.ts\`: defer simple-mode reply emit until reflection has had a chance to override

When the chat LLM picks REPLY mode with a chatty text (e.g. "I think calendar is broken, but I could try X or Y") and the reflection evaluator subsequently marks the task as incomplete, the existing \`runReflectionTaskContinuation\` path runs another LLM turn that produces a real action result. The user sees two messages: the chatty preamble AND the action result that supersedes it.

Fix: hold simple-mode \`callback(responseContent)\` in a \`pendingSimpleEmit\` slot, declared at \`handleMessage\` scope. Flush it at the end of the function, but **drop it** if reflection produced a continuation that already emitted its own response. Net effect: a chatty REPLY that gets corrected by reflection produces only the corrected message, not both.

Also extends the existing \`suppressesPostActionContinuation\` check to gate the reflection-continuation entry point too. Previously an action with that flag could still get re-fired by reflection's processActions invocation, defeating the flag's contract ("stop after this action, don't run any continuation LLM turn").

## What kind of change is this?

Bug fixes. Two non-breaking improvements that tighten existing semantics around action callbacks and reply emission.

# Documentation changes needed?

No. The behavioral changes preserve the existing public contracts:
- \`runtime.processActions\` still calls handlers with the same args and returns the same shape
- \`Action.suppressPostActionContinuation\` semantics are now actually honored in both continuation paths (the docstring already says "stop after executing this action instead of running a post-action continuation LLM turn")
- \`HandlerCallback\` invocation order is unchanged for any single-action or true-multi-action turn

# Testing

## Where should a reviewer start?

\`packages/typescript/src/runtime.ts\` line ~1746 (the new \`executedActionKeys\` Set declaration) and the dedupe check that follows the action resolution.

\`packages/typescript/src/services/message.ts\` line ~1885 (the \`pendingSimpleEmit\` declaration at \`handleMessage\` scope), then line ~2000+ where the simple-mode branch sets it instead of calling callback directly, then the bottom of \`handleMessage\` where it's flushed if not overridden by reflection.

## Detailed testing steps

Verified end-to-end in a downstream consumer (a self-hosted milady-style bot wired to discord, gmail, and google calendar) under real user usage:

- Multi-intent turn that previously produced duplicate identical callbacks: the planner emitted \`["GMAIL_ACTION", "CALENDAR_ACTION", "CALENDAR_ACTION"]\` for "check my inbox then create an event for april 15 2027". Before this PR: 3 visible callbacks (2 calendar runs with identical text → discord plugin throws duplicate-callback error). After: 2 visible callbacks, no errors.

- Chatty REPLY that gets reflection-corrected: the chat LLM picks REPLY with "I think calendar is broken, you'd need to..." after seeing prior failures in conversation memory, then reflection marks the task incomplete and re-runs as CALENDAR_ACTION which actually succeeds. Before: user sees both the chatty REPLY and the action result, contradicting each other. After: user sees only the action result.

- \`Action.suppressPostActionContinuation\` flag now actually suppresses both \`runPostActionContinuation\` AND \`runReflectionTaskContinuation\` for actions that set it.

- All existing message-service tests pass (\`vitest run packages/typescript/src/__tests__/message-service.test.ts\`).

- Single-action turns and simple REPLY-only turns are unchanged: \`pendingSimpleEmit\` flushes normally if reflection doesn't run or doesn't override, and the dedupe Set is empty for single-action runs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two behavioral fixes to the message/action dispatch path: a Set-based deduplication of identical action invocations within a single `processActions` call (in `runtime.ts`), and a deferred-emit pattern for simple-mode REPLY responses that lets the reflection evaluator override them before they are delivered via callback (in `message.ts`).

- **Memory persisted before drop decision**: in the simple-mode path the response memory is written to DB via `createMemory` (line 1987) and `emitMessageSent` fires (line 1989) *before* `pendingSimpleEmit` is set. When reflection later sets `pendingSimpleEmit = null`, the chatty REPLY is already in the database; future LLM turns will include it in context as if it was delivered, silently corrupting the agent's self-model of what the user actually saw.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge, but the simple-mode memory-persistence-before-drop issue is a correctness concern that should be addressed.

The dedup fix in runtime.ts is clean and well-scoped. The deferred-emit approach in message.ts solves the duplicate-message UX problem, but the memory and MESSAGE_SENT event for the simple-mode reply are committed to the DB before the drop decision is made. In the reflection-override scenario, the chatty REPLY sits in the DB as a sent message the user never saw, which will silently pollute the LLM's future conversation context. This is a P1 correctness issue that warrants a small follow-up fix before the PR is widely deployed.

packages/typescript/src/services/message.ts — specifically the ordering of createMemory/emitMessageSent relative to the pendingSimpleEmit drop at line 2230.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/runtime.ts | Adds `executedActionKeys` Set to deduplicate identical (action name + serialized params) invocations within a single `processActions` call; logic is correctly placed after parameter validation and scoped per-invocation. |
| packages/typescript/src/services/message.ts | Introduces `pendingSimpleEmit` to defer simple-mode callback until after reflection; however, `createMemory` + `emitMessageSent` fire before the defer/drop decision, leaving orphaned DB memory entries when reflection overrides the simple reply. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MS as message.ts handleMessage
    participant RT as runtime.ts processActions
    participant DB as Database
    participant CB as Callback (UI)

    Note over MS: mode = "simple"
    MS->>DB: createMemory(simpleReply) ← runs before dedup decision
    MS->>MS: emitMessageSent() ← event fires
    MS->>MS: pendingSimpleEmit = responseContent

    MS->>MS: runEvaluate() → reflection marks task incomplete

    alt reflection produces continuation
        MS->>RT: runReflectionTaskContinuation()
        RT->>DB: createMemory(actionResult)
        RT->>CB: callback(actionResult) → user sees action result
        MS->>MS: pendingSimpleEmit = null
        Note over DB: simpleReply in DB but user never saw it
    else no continuation
        MS->>CB: callback(pendingSimpleEmit) → user sees simple reply
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/typescript/src/services/message.ts`, line 1976-1994 ([link](https://github.com/elizaos/eliza/blob/c21048b887512c1de1819bfff796a0e9e48b406e/packages/typescript/src/services/message.ts#L1976-L1994)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Simple-mode memory saved before drop decision**

   `createMemory` and `emitMessageSent` both execute here — before `pendingSimpleEmit` is set. When reflection later sets `pendingSimpleEmit = null` at line 2230, the chatty REPLY is already persisted to the DB and its `MESSAGE_SENT` event has already fired. Future turns then include that response in the LLM's conversation context as if it was delivered, silently corrupting the agent's self-model of what the user actually saw.

   To fix this, either move the simple-mode `createMemory` / `emitMessageSent` calls to after the reflection gate (alongside the `pendingSimpleEmit` flush), or delete the orphaned memory entry when `pendingSimpleEmit` is set to `null`:

   ```typescript
   // After line 2230 where pendingSimpleEmit is set null:
   if (pendingSimpleEmit === null && responseMessages.length > 0) {
       // Remove the simple-mode memory that was persisted before reflection ran
       for (const mem of responseMessages) {
           await runtime.deleteMemory(mem.id);
       }
   }
   ```


2. `packages/typescript/src/services/message.ts`, line 2216-2231 ([link](https://github.com/elizaos/eliza/blob/c21048b887512c1de1819bfff796a0e9e48b406e/packages/typescript/src/services/message.ts#L2216-L2231)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`pendingSimpleEmit` dropped only when `continuation.responseContent` is non-null**

   `pendingSimpleEmit` is set to `null` only when `continuation.responseContent` is truthy. If `runReflectionTaskContinuation` returns `responseMessages` but `responseContent` is `null` (e.g. the continuation ran actions that set action-results but the helper returned early at line 2994–3001), the messages array is updated but `pendingSimpleEmit` is NOT cleared — so the chatty REPLY is still flushed to the user on top of whatever the actions emitted.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: dedupe identical action invocations..."](https://github.com/elizaos/eliza/commit/c21048b887512c1de1819bfff796a0e9e48b406e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28066268)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->