### PR TITLE
feat(core): shared batch-queue drains and bounded knowledge embeddings

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -116,7 +116,8 @@
                   "runtime/core",
                   "runtime/memory",
                   "runtime/events",
-                  "runtime/providers"
+                  "runtime/providers",
+                  "runtime/batch-queue"
                 ]
               },
               {

--- a/packages/docs/guides/background-tasks.mdx
+++ b/packages/docs/guides/background-tasks.mdx
@@ -20,6 +20,12 @@ Blocking the main thread kills responsiveness. Polling wastes resources.
   scheduling.
 </Tip>
 
+## Core utilities: batch queue (WHY)
+
+`@elizaos/core` includes **`utils/batch-queue`**: composable **`PriorityQueue`**, **`BatchProcessor`** (bounded concurrency + retries), **`TaskDrain`** (repeat tasks with `tags: ["queue", "repeat"]`, optional `skipRegisterWorker` when a global worker already owns the name), and **`BatchQueue`** when a service needs all three. Embedding generation, action-filter index embedding, and prompt-batcher affinity drains build on this stack.
+
+**Why not only ad-hoc `createTask` per feature?** The goal is **consistency and fewer parallel “mini queues”** as the codebase grows—not because the whole runtime is batching-bound, but so drain metadata, retries, and worker registration do not diverge copy-paste by copy-paste. See [Batch queue subsystem](/runtime/batch-queue) (mirrors `packages/typescript/docs/BATCH_QUEUE.md` in the monorepo).
+
 ## Quick Start
 
 ### 1. Define a Task Worker

--- a/packages/docs/runtime/batch-queue.mdx
+++ b/packages/docs/runtime/batch-queue.mdx
@@ -1,0 +1,79 @@
+---
+title: "Batch queue subsystem"
+description: "Why @elizaos/core ships utils/batch-queue and how PriorityQueue, BatchProcessor, TaskDrain, and BatchQueue fit together"
+---
+
+This page mirrors the contributor-oriented markdown in the core package (`packages/typescript/docs/BATCH_QUEUE.md`) so the public docs stay aligned with source.
+
+<Tip>
+  **Why this exists:** the runtime is not globally “batching-bound,” but several subsystems share the same **ordering**, **bounded parallelism**, **retries**, and **repeat-task drain** patterns. One small composable stack avoids parallel one-off queues that drift apart over time.
+</Tip>
+
+## Problem statement
+
+Several subsystems need overlapping concerns:
+
+- **Ordering** — e.g. high / normal / low priority before processing.
+- **Bounded parallelism** — avoid unbounded `Promise.all` against model APIs.
+- **Retries and backoff** — align with the rest of the runtime (`utils/retry` in `@elizaos/core`).
+- **Scheduling** — repeat tasks with `tags: ["queue", "repeat"]`, stable metadata (`maxFailures: -1`, etc.).
+
+It is tempting to fix **only** the worst hot path (for example a three-line semaphore in one service). That is often correct for a **single** bottleneck. The risk is **proliferation**: each new feature copies a slightly different queue, drain loop, or `createTask` + `registerTaskWorker` pair. Those copies drift, disagree on edge cases (pause, dispose, retry), and make review harder (“is this the same pattern as embedding or a new one?”).
+
+## What we standardized
+
+| Piece | Role |
+| ----- | ---- |
+| **`PriorityQueue<T>`** | What runs next (three deques, optional `maxSize` / `onPressure`). |
+| **`BatchProcessor<T>`** | How a **slice** runs: semaphore-limited concurrency, retries, `onExhausted`. |
+| **`TaskDrain`** | When the task system ticks: find/create repeat task, optional worker registration. |
+| **`BatchQueue<T>`** | End-to-end “enqueue → drain on interval → process batch” when a service needs all three. |
+| **`Semaphore`** | Shared primitive; also re-exported from `prompt-batcher/shared` so existing imports keep working. |
+
+Callers **compose only what they need**:
+
+- **Embedding generation** — `BatchQueue` (queue + processor + drain).
+- **Action filter index build** — `BatchProcessor` only (synchronous batch job, no repeat task).
+- **Knowledge (documents + `generateTextEmbeddingsBatch`)** — `BatchProcessor` for capped parallel embedding calls when falling back to per-text requests.
+- **Prompt batcher per-affinity drains** — `TaskDrain` with **`skipRegisterWorker: true`** because a **single** global worker handles `BATCHER_DRAIN` and dispatches by `metadata.affinityKey`; per-affinity instances must not register duplicate workers with the same name.
+
+## Design choices (WHYs)
+
+### Why not push failed items back onto the priority queue?
+
+**BatchProcessor** retries **in place** for that item, then moves on. Re-queueing failures between ticks would complicate lifecycle (duplicate detection, ordering, partial batches) and could interact badly with concurrent drains. See the header comment in `batch-processor.ts` in the monorepo.
+
+### Why does `TaskDrain` support `skipRegisterWorker`?
+
+Registering a worker twice under the same task name would **overwrite** the previous handler. Batcher affinities share one logical worker in `TaskService`; each affinity only needs the **DB row** and interval updates. See `task-drain.ts` in the monorepo.
+
+### Why `maxFailures: -1` on drain tasks?
+
+`JSON.stringify(Infinity)` becomes `null`; metadata round-trips through storage. **`-1`** is stored reliably and means “do not auto-pause” for long-lived drains. See the core package changelog for batcher / task notes.
+
+### Why is the embedding queue unbounded by default?
+
+**Throughput** (embedding I/O) is usually the real limit, not in-memory queue length. A bounded queue with eviction is a **product policy**; it can be reintroduced via `maxSize` + `onPressure` on `BatchQueueOptions` if a deployment needs it.
+
+### Invalid `getPriority` values?
+
+Anything other than `high`, `normal`, or `low` is logged **once** per queue (via the core logger) and treated as **normal** so typos are visible and do not silently sort work into the low tier.
+
+## Limitations (current behavior)
+
+- **Cancellation:** `dispose` does not abort in-flight `process()` calls (for example an active embedding request). Shutdown is cooperative.
+- **High-priority flush on dispose:** Defaults to a dedicated `BatchProcessor` (serial, one attempt per item) for bounded concurrency and no long retry tail on stop; `disposeHighPriorityViaProcessor: false` restores the legacy direct loop.
+- **Queue size:** Unbounded unless you configure `maxSize` + `onPressure` on `BatchQueueOptions`.
+
+## Where to read code
+
+- Module rationale (reviewer-oriented): [`batch-queue.ts` (core source)](https://github.com/elizaos/eliza/blob/main/packages/typescript/src/utils/batch-queue.ts)
+- Composition and `BatchQueue` behavior: [`batch-queue/index.ts`](https://github.com/elizaos/eliza/blob/main/packages/typescript/src/utils/batch-queue/index.ts)
+- Canonical markdown (stays in sync with this page): [`BATCH_QUEUE.md`](https://github.com/elizaos/eliza/blob/main/packages/typescript/docs/BATCH_QUEUE.md)
+- Tests: `batch-queue.test.ts`, `task-drain.test.ts` under `packages/typescript/src/__tests__/`
+
+## Related docs
+
+- [Background tasks](/guides/background-tasks) — task workers, scheduling, and how batch-queue fits beside them
+- [Core runtime](/runtime/core) — embedding generation and runtime APIs
+- [Contribute to core](/guides/contribute-to-core) — monorepo layout and contribution flow

--- a/packages/docs/runtime/core.mdx
+++ b/packages/docs/runtime/core.mdx
@@ -817,6 +817,8 @@ addEmbeddingToMemory(memory: Memory): Promise<Memory>;
 - `normal` - Default priority (conversations)
 - `low` - Background processing (bulk imports)
 
+In `@elizaos/core`, the embedding-generation service drains that queue through a **shared batch-queue pipeline** (priority queue, bounded concurrency, retries, repeat `EMBEDDING_DRAIN` task) so this path does not diverge from other queue-and-drain workloads. **Why:** one composable subsystem instead of multiple bespoke queue implementations as features grow. See [Batch queue subsystem](/runtime/batch-queue) (also `packages/typescript/docs/BATCH_QUEUE.md` in the monorepo).
+
 ```typescript
 // Queue high-priority embedding for user query
 await runtime.queueEmbeddingGeneration(userMessage, "high");

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **Shared batch-queue subsystem (`utils/batch-queue`).** Composable building blocks: `PriorityQueue`, `BatchProcessor` (semaphore-limited concurrency + retries using `utils/retry`), `TaskDrain` (repeat `queue` tasks, optional `skipRegisterWorker` when a global worker already owns the task name), composed `BatchQueue`, and one shared `Semaphore` (re-exported from `prompt-batcher/shared.ts` for existing imports). Tests: `src/__tests__/batch-queue.test.ts`, `src/__tests__/task-drain.test.ts`.
+  - **Why (architecture, not a single hot path):** The runtime is not globally “batching-bound”; a minimal fix in one service could be a few lines. The goal here is **forward-looking consolidation** so embedding drains, action-index embedding, batcher affinity scheduling, and shared throttling do not each grow a bespoke queue + task + retry stack that drifts over time. One composable surface caps proliferation of incompatible queuing patterns. See `src/utils/batch-queue.ts` (module comment) and `docs/BATCH_QUEUE.md`.
 - **Prompt cache hints (PromptSegment, promptSegments).** The core can pass ordered segments with stability metadata so providers can use prompt-caching APIs. `GenerateTextParams` now has optional `promptSegments?: PromptSegment[]` where each segment is `{ content: string; stable: boolean }`. When set, `prompt` must equal `promptSegments.map(s => s.content).join("")`.
   - **Why:** Repeated calls often share the same instructions/format while only context changes; provider caches (Anthropic ephemeral, OpenAI/Gemini prefix) can reuse tokens for the stable part, reducing cost and latency. A single invariant lets providers opt in or ignore segments without breaking behavior.
 - **Runtime segment building in dynamicPromptExecFromState.** The runtime builds `promptSegments` from the dynamic prompt: variable block (unstable), format prefix (stable), validation/middle block (unstable), format suffix (stable), end block (unstable). Only content that is identical for the same schema/character is marked stable; validation instructions that contain per-call UUIDs are kept in an unstable segment.
@@ -42,6 +44,29 @@
 
 ### Changed
 
+- **Embedding generation service** uses `BatchQueue` for the drain pipeline (priority dequeue, bounded parallel `process`, repeat `EMBEDDING_DRAIN` task via `TaskDrain`). When no `TEXT_EMBEDDING` model is registered, start returns a **no-op** service after a warning instead of throwing.
+  - **Why:** Same drain/retry/task semantics as other batch workloads; optional embedding setups can boot without a hard failure.
+- **Action filter `buildIndex`** embeds actions via `BatchProcessor` (batch slices, retries, `onExhausted`) instead of raw `Promise.all` per slice only.
+  - **Why:** Shares backoff/concurrency policy with the rest of the batch stack; invalid vectors log and continue (BM25 still works) instead of failing the whole index on one bad response.
+- **Prompt batcher affinity tasks** are ensured/updated/disposed via shared `TaskDrain` (`skipRegisterWorker: true` for `BATCHER_DRAIN`) instead of ad-hoc `createTask` / `deleteTask` maps keyed by task id. `addSection` still syncs ideal interval after drain setup; **immediate / once** sections can drain after `runtime.initPromise` when the batcher is not yet enabled.
+  - **Why:** One implementation of repeat-task metadata (`maxFailures: -1`, intervals) and no duplicate worker registration for the same task name; early startup sections still get a drain path.
+
+### Changed (batch-queue polish)
+
+- **`TaskDrain`:** When a matching repeat task already exists, `start` now calls `updateInterval` so DB `updateInterval` / `baseInterval` match the configured drain (fixes stale metadata after restarts).
+  - **Why:** Avoids leaving an old tick interval in the store until the next explicit sync.
+- **`PriorityQueue`:** Unknown `getPriority` values log once (`logger.warn`) and enqueue as **normal** (previously fell into the low bucket silently).
+  - **Why:** Typos should not demote work to “low” without visibility.
+- **`BatchProcessor`:** Optional `maxAttemptsCap` to bound attempts per item (used by `BatchQueue` high-priority dispose flush).
+  - **Why:** Items with large per-item `maxRetries` should not retry many times during shutdown.
+- **`BatchQueue`:** Optional `onDrainBatchOutcomes`; high-priority dispose flush defaults to a serial `BatchProcessor` (`disposeHighPriorityViaProcessor`, default true); `clear()` is a no-op after `dispose`.
+  - **Why:** Observability, flush path parity with bounded concurrency, and safer lifecycle after shutdown.
+- **`Semaphore`:** Documented acquire/release pairing contract in the class header.
+  - **Why:** Future callers are less likely to leak permits.
+- **`Semaphore`:** Removed duplicate class from `runtime.ts`; package entry points (`index.node` / `index.browser` / `index.edge`) re-export `Semaphore` from `utils/batch-queue/semaphore.js` so `import { Semaphore } from "@elizaos/core"` stays valid with a single implementation.
+  - **Why:** One semaphore implementation avoids drift and conflicting behavior.
+- **Knowledge embeddings:** `document-processor` batch fallback (single vector for many texts) and `llm.generateTextEmbeddingsBatch` now use `BatchProcessor` with `maxParallel: 10` instead of unbounded `Promise.all` over texts.
+  - **Why:** Large document / batch sizes no longer open unbounded concurrent `TEXT_EMBEDDING` calls; retries on the document-processor fallback align with other batch paths (`maxRetriesAfterFailure: 2`).
 - **Prompt batcher section resolution.** Section promises now resolve with `{ fields, meta }` instead of raw `fields`. askOnce and askNow unwrap to `result?.fields ?? fallback` so their return type remains `Promise<Record<string, unknown>>`. Runtime pre-callback audit uses `addSectionResult?.fields` for audited fields.
   - **Why:** Consistent result shape across the batcher; consumers that only need fields (askOnce, askNow, audit) keep the same API.
 - **Reflection evaluator** now uses the thenable style: `const result = await onDrain<ReflectionFields>(...); if (result) { ... }` and no `onResult` callback. Processing logic is unchanged; it runs inside the `if (result)` block.

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -95,9 +95,10 @@ SENTRY_SEND_DEFAULT_PII=true
 
 Key behaviors and APIs are documented with their **reasons** so future changes stay consistent with intent:
 
-- **[docs/DESIGN.md](docs/DESIGN.md)** — Design decisions: message races, provider timeout, keepExistingResponses, JSON5, formatPosts fallbacks, HandlerCallback actionName, anxiety provider, file logging, and what we don’t do.
+- **[docs/DESIGN.md](docs/DESIGN.md)** — Design decisions: message races, provider timeout, keepExistingResponses, JSON5, formatPosts fallbacks, HandlerCallback actionName, anxiety provider, file logging, batch-queue consolidation, and what we don’t do.
+- **[docs/BATCH_QUEUE.md](docs/BATCH_QUEUE.md)** — Why `utils/batch-queue` exists (forward-looking consolidation vs one-line fixes), layer breakdown (`PriorityQueue` / `BatchProcessor` / `TaskDrain` / `BatchQueue`), and where each is used. Published copy: [docs.elizaos.ai/runtime/batch-queue](https://docs.elizaos.ai/runtime/batch-queue).
 - **[CHANGELOG.md](CHANGELOG.md)** — Per-change notes with WHY for each addition or fix.
-- **[ROADMAP.md](ROADMAP.md)** — Planned work and rationale (observability, robustness, API consistency, performance).
+- **[ROADMAP.md](ROADMAP.md)** — Planned work and rationale (observability, robustness, API consistency, performance). Shipped items remain documented in CHANGELOG and design docs.
 
 When adding or changing behavior, update these docs so the WHY stays accurate.
 
@@ -251,7 +252,7 @@ Relevant runtime knobs:
 - `PROMPT_MAX_PARALLEL_CALLS`
 - `PROMPT_MODEL_SEPARATION`
 
-For the deeper design rationale and rollout details, see `DESIGN.md`, `ROADMAP.md`, and `CHANGELOG.md` in this package.
+For the deeper design rationale and rollout details, see `DESIGN.md`, `docs/BATCH_QUEUE.md`, `ROADMAP.md`, and `CHANGELOG.md` in this package.
 
 ### Task system
 
@@ -264,6 +265,8 @@ The **task system** is the single place for *when* scheduled work runs. Only tas
 **Why queue + repeat:**
 
 - Tasks with `tags: ["queue"]` are fetched every tick. Non-repeat tasks run when `now >= dueAt` (or `metadata.scheduledAt`) then are deleted; repeat tasks use `updateInterval`/`baseInterval` and `metadata.updatedAt` as last-run time. **Why:** One-shot "run at time X" (e.g. follow-up) uses `dueAt`; interval-based scheduling covers batcher drains and recurring use.
+
+**Why `utils/batch-queue`’s `TaskDrain`:** several services create the same style of repeat drain task (`queue` + `repeat`, `maxFailures: -1`, interval metadata). Centralizing find/create/update/delete avoids each caller re-implementing JSON/metadata edge cases and keeps worker registration rules explicit (`skipRegisterWorker` when TaskService already owns the worker name). See `docs/BATCH_QUEUE.md`.
 
 **Cross-runtime scheduling (three modes):**
 

--- a/packages/typescript/ROADMAP.md
+++ b/packages/typescript/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap — `@elizaos/core`
+
+Forward-looking work and **rationale** for changes we have not made yet. Shipped behavior, including **why** it landed, lives in [CHANGELOG.md](./CHANGELOG.md). Subsystem-specific intent is in [docs/DESIGN.md](./docs/DESIGN.md); queue/drain composition is in [docs/BATCH_QUEUE.md](./docs/BATCH_QUEUE.md).
+
+---
+
+## Robustness and runtime UX
+
+- **Configurable provider timeout** — `composeState` uses a fixed per-provider timeout today so defaults stay predictable. Making it configurable (per agent or per provider) is deferred.
+  - **Why wait:** avoids a matrix of timeouts across plugins before we have concrete operator demand and tests.
+- **Circuit breaker or backoff for providers** — repeated failures still invoke failing providers each turn.
+  - **Why it matters:** reduces retry storms and noisy logs when an integration is down; needs clear semantics so we do not hide failures silently.
+
+## API and typing consistency
+
+- Continue aligning adapter and runtime types (see CHANGELOG for recent `Promise<boolean>` batch mutations, etc.).
+  - **Why:** keeps `tsc` and plugin authors aligned with one contract.
+
+## Observability
+
+- Expand structured logging where operators routinely debug (tasks, batcher drains, embedding queue depth) without spamming default logs.
+  - **Why:** production triage should not require reproducing locally.
+
+---
+
+When you ship a roadmap item, add a **CHANGELOG** entry with a **Why** bullet (see existing Unreleased style) and update or remove the item here so this file stays honest.

--- a/packages/typescript/docs/BATCH_QUEUE.md
+++ b/packages/typescript/docs/BATCH_QUEUE.md
@@ -1,0 +1,80 @@
+# Batch queue subsystem (`utils/batch-queue`)
+
+This document explains **why** `@elizaos/core` ships a small shared stack for prioritized queues, bounded-concurrency batch execution, repeat-task drains, and (when needed) the composed **`BatchQueue`**. It complements inline code comments and [CHANGELOG.md](../CHANGELOG.md).
+
+---
+
+## Problem statement
+
+Several subsystems need overlapping concerns:
+
+- **Ordering** — e.g. high / normal / low priority before processing.
+- **Bounded parallelism** — avoid unbounded `Promise.all` against model APIs.
+- **Retries and backoff** — align with the rest of the runtime ([`utils/retry.ts`](../src/utils/retry.ts)).
+- **Scheduling** — repeat tasks with `tags: ["queue", "repeat"]`, stable metadata (`maxFailures: -1`, etc.).
+
+It is tempting to fix **only** the worst hot path (for example a three-line semaphore in one service). That is often correct for a **single** bottleneck. The risk is **proliferation**: each new feature copies a slightly different queue, drain loop, or `createTask` + `registerTaskWorker` pair. Those copies drift, disagree on edge cases (pause, dispose, retry), and make review harder (“is this the same pattern as embedding or a new one?”).
+
+---
+
+## What we standardized
+
+| Piece | Role |
+|--------|------|
+| **`PriorityQueue<T>`** | What runs next (three deques, optional `maxSize` / `onPressure`). |
+| **`BatchProcessor<T>`** | How a **slice** runs: semaphore-limited concurrency, retries, `onExhausted`. |
+| **`TaskDrain`** | When the task system ticks: find/create repeat task, optional worker registration. |
+| **`BatchQueue<T>`** | End-to-end “enqueue → drain on interval → process batch” when a service needs all three. |
+| **`Semaphore`** | Shared primitive; also re-exported from `prompt-batcher/shared.ts` so existing imports keep working. |
+
+Callers **compose only what they need**:
+
+- **Embedding generation** — `BatchQueue` (queue + processor + drain).
+- **Action filter index build** — `BatchProcessor` only (synchronous batch job, no repeat task).
+- **Knowledge** — `BatchProcessor` for document embedding fallback and `generateTextEmbeddingsBatch` (bounded parallel `TEXT_EMBEDDING` calls).
+- **Prompt batcher per-affinity drains** — `TaskDrain` with **`skipRegisterWorker: true`** because a **single** global worker handles `BATCHER_DRAIN` and dispatches by `metadata.affinityKey`; per-affinity instances must not register duplicate workers with the same name.
+
+---
+
+## Design choices (WHYs)
+
+### Why not push failed items back onto the priority queue?
+
+**BatchProcessor** retries **in place** for that item, then moves on. Re-queueing failures between ticks would complicate lifecycle (duplicate detection, ordering, partial batches) and could interact badly with concurrent drains. See `batch-processor.ts` header.
+
+### Why `TaskDrain` supports `skipRegisterWorker`?
+
+Registering a worker twice under the same task name would **overwrite** the previous handler. Batcher affinities share one logical worker in `TaskService`; each affinity only needs the **DB row** and interval updates. See `task-drain.ts` header.
+
+### Why `maxFailures: -1` on drain tasks?
+
+`JSON.stringify(Infinity)` becomes `null`; metadata round-trips through storage. **`-1`** is stored reliably and means “do not auto-pause” for long-lived drains. Documented in CHANGELOG under batcher / task fixes.
+
+### Why is the embedding queue unbounded by default?
+
+**Throughput** (embedding I/O) is usually the real limit, not in-memory queue length. A bounded queue with eviction is a **product policy**; it can be reintroduced via `maxSize` + `onPressure` on `BatchQueueOptions` if a deployment needs it.
+
+---
+
+## Where to read code
+
+- Module rationale (reviewer-oriented): [`src/utils/batch-queue.ts`](../src/utils/batch-queue.ts) (top-of-file comment).
+- Composition and `BatchQueue` behavior: [`src/utils/batch-queue/index.ts`](../src/utils/batch-queue/index.ts).
+- Tests: `src/__tests__/batch-queue.test.ts`, `src/__tests__/task-drain.test.ts`.
+
+---
+
+## Limitations (current behavior)
+
+- **Cancellation:** `dispose` does not abort in-flight `process()` calls (for example an active `useModel` request). Shutdown is cooperative; long-running work may finish after the repeat task row is deleted.
+- **High-priority flush on dispose:** By default uses a dedicated `BatchProcessor` (serial, `maxAttemptsCap: 1`) so shutdown matches bounded concurrency and avoids long retry tails; set `disposeHighPriorityViaProcessor: false` on `BatchQueueOptions` only if you need the legacy direct `process` loop.
+- **Default queue length:** `BatchQueue` / `PriorityQueue` are unbounded unless you set `maxSize` + `onPressure`; memory is bounded by deployment policy, not by this module alone.
+
+---
+
+## Related docs
+
+- **Public docs (same content):** [Batch queue subsystem](https://docs.elizaos.ai/runtime/batch-queue) on docs.elizaos.ai — source: `packages/docs/runtime/batch-queue.mdx` in the monorepo.
+- [DESIGN.md](./DESIGN.md) — Broader core design decisions.
+- [CHANGELOG.md](../CHANGELOG.md) — What shipped and when, with per-item WHYs.
+- [ROADMAP.md](../ROADMAP.md) — Forward-looking work (this subsystem is **shipped**; roadmap points here for rationale).

--- a/packages/typescript/docs/DESIGN.md
+++ b/packages/typescript/docs/DESIGN.md
@@ -151,6 +151,30 @@ Console logs use colors (ANSI codes). Writing them raw to a file makes the file 
 
 ---
 
+## Shared batch queue (`utils/batch-queue`)
+
+### Why a subsystem instead of only fixing embedding parallelism?
+
+A small **semaphore** (or capped `Promise.all`) can fix unbounded concurrency in **one** service. We still added **`PriorityQueue`**, **`BatchProcessor`**, **`TaskDrain`**, optional **`BatchQueue`**, and a single **`Semaphore`** because several core paths already needed the **same combination** of ideas: priority ordering, bounded parallel I/O, retry/backoff aligned with `utils/retry`, and repeat **queue** tasks with consistent metadata (`maxFailures: -1`, intervals, dispose).
+
+**Why consolidate:** without a shared layer, each new feature tends to copy a slightly different queue, drain loop, or `createTask` + `registerTaskWorker` pair. Those copies drift and are harder to review (“is this the same as embedding or a new pattern?”). The trade is a **small shared surface** so we do not keep growing incompatible queuing systems. The runtime as a whole is not assumed to be “batching-bound”; this is **architecture to prevent proliferation**, not a claim that every agent spends most of its time in these queues.
+
+### Where it shows up
+
+- **Embedding generation** — full `BatchQueue` (see service comments).
+- **Action filter index build** — `BatchProcessor` only (no repeat task).
+- **Knowledge** — `BatchProcessor` for document / batch embedding paths that previously used unbounded `Promise.all`.
+- **Prompt batcher** — per-affinity **`TaskDrain`** with `skipRegisterWorker` so we do not register multiple workers named `BATCHER_DRAIN`.
+
+Longer tables and FAQs: [BATCH_QUEUE.md](./BATCH_QUEUE.md).
+
+### Operational notes
+
+- **Invalid priority strings:** `PriorityQueue` expects `high` | `normal` | `low`. Anything else logs **once** per queue instance (via `logger.warn`) and is treated as **normal** so typos do not silently sink work to the back of the queue.
+- **Shutdown flush:** `BatchQueue.dispose` high-priority work runs through a dedicated `BatchProcessor` (serial, `maxAttemptsCap: 1`) by default so stop path matches bounded concurrency; `dispose` still does not cancel in-flight async work (see BATCH_QUEUE limitations).
+
+---
+
 ## What we don’t do (and why)
 
 - **No legacy generateObject API:** Structured generation is handled by the dynamic execution path and related evolution. We don’t re-add the old generateObject surface.

--- a/packages/typescript/src/__tests__/batch-queue.test.ts
+++ b/packages/typescript/src/__tests__/batch-queue.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+import { logger } from "../logger.js";
+import type { IAgentRuntime } from "../types/runtime";
+import { BatchQueue } from "../utils/batch-queue/index";
+import { BatchProcessor } from "../utils/batch-queue/batch-processor";
+import type { QueuePriority } from "../utils/batch-queue/priority-queue";
+import { PriorityQueue } from "../utils/batch-queue/priority-queue";
+import { Semaphore } from "../utils/batch-queue/semaphore";
+
+describe("PriorityQueue", () => {
+	it("orders high before normal before low", () => {
+		const q = new PriorityQueue<{ id: number; p: "high" | "normal" | "low" }>({
+			getPriority: (x) => x.p,
+		});
+		q.enqueue({ id: 1, p: "low" });
+		q.enqueue({ id: 2, p: "high" });
+		q.enqueue({ id: 3, p: "normal" });
+		const batch = q.dequeueBatch(10);
+		expect(batch.map((x) => x.id)).toEqual([2, 3, 1]);
+	});
+
+	it("rejects enqueue when onPressure returns false", () => {
+		const q = new PriorityQueue<{ id: number; p: "high" | "normal" | "low" }>({
+			getPriority: (x) => x.p,
+			maxSize: 1,
+			onPressure: () => false,
+		});
+		expect(q.enqueue({ id: 1, p: "high" })).toBe(true);
+		expect(q.enqueue({ id: 2, p: "high" })).toBe(false);
+		expect(q.size).toBe(1);
+	});
+
+	it("stats counts priorities", () => {
+		const q = new PriorityQueue<{ id: number; p: "high" | "normal" | "low" }>({
+			getPriority: (x) => x.p,
+		});
+		q.enqueue({ id: 1, p: "high" });
+		q.enqueue({ id: 2, p: "normal" });
+		q.enqueue({ id: 3, p: "low" });
+		expect(q.stats()).toEqual({ high: 1, normal: 1, low: 1, total: 3 });
+	});
+
+	it("warns once and treats unknown priority labels as normal", () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const q = new PriorityQueue<{ id: number; tag: string }>({
+			getPriority: (x) => x.tag as QueuePriority,
+		});
+		q.enqueue({ id: 1, tag: "urgent" });
+		q.enqueue({ id: 2, tag: "high" });
+		const batch = q.dequeueBatch(10);
+		expect(batch.map((x) => x.id)).toEqual([2, 1]);
+		expect(warn).toHaveBeenCalledTimes(1);
+		warn.mockRestore();
+	});
+});
+
+describe("BatchProcessor", () => {
+	it("processes batch with concurrency limit", async () => {
+		let concurrent = 0;
+		let maxConcurrent = 0;
+		const processor = new BatchProcessor<number>({
+			maxParallel: 2,
+			maxRetriesAfterFailure: 0,
+			process: async (_n) => {
+				concurrent++;
+				maxConcurrent = Math.max(maxConcurrent, concurrent);
+				await new Promise((r) => setTimeout(r, 5));
+				concurrent--;
+			},
+		});
+		await processor.processBatch([1, 2, 3, 4, 5]);
+		expect(maxConcurrent).toBeLessThanOrEqual(2);
+	});
+
+	it("retries then succeeds", async () => {
+		let calls = 0;
+		const processor = new BatchProcessor<number>({
+			maxParallel: 1,
+			maxRetriesAfterFailure: 2,
+			process: async (_n) => {
+				calls++;
+				if (calls < 2) {
+					throw new Error("fail");
+				}
+			},
+		});
+		const out = await processor.processBatch([1]);
+		expect(out[0]?.success).toBe(true);
+		expect(calls).toBe(2);
+	});
+
+	it("calls onExhausted after max retries", async () => {
+		const onExhausted = vi.fn();
+		const processor = new BatchProcessor<number>({
+			maxParallel: 1,
+			maxRetriesAfterFailure: 1,
+			process: async () => {
+				throw new Error("always");
+			},
+			onExhausted,
+		});
+		const out = await processor.processBatch([42]);
+		expect(out[0]?.success).toBe(false);
+		expect(onExhausted).toHaveBeenCalled();
+	});
+
+	it("uses per-item maxRetries", async () => {
+		type Item = { maxRetries: number };
+		let attempts = 0;
+		const processor = new BatchProcessor<Item>({
+			maxParallel: 1,
+			maxRetriesAfterFailure: 0,
+			process: async () => {
+				attempts++;
+				throw new Error("x");
+			},
+		});
+		await processor.processBatch([{ maxRetries: 2 }]);
+		expect(attempts).toBe(3);
+	});
+
+	it("maxAttemptsCap overrides per-item maxRetries", async () => {
+		type Item = { maxRetries: number };
+		let attempts = 0;
+		const processor = new BatchProcessor<Item>({
+			maxParallel: 1,
+			maxRetriesAfterFailure: 5,
+			maxAttemptsCap: 1,
+			process: async () => {
+				attempts++;
+				throw new Error("x");
+			},
+		});
+		await processor.processBatch([{ maxRetries: 99 }]);
+		expect(attempts).toBe(1);
+	});
+
+	it("respects maxParallel under load", async () => {
+		let concurrent = 0;
+		let maxConcurrent = 0;
+		const processor = new BatchProcessor<number>({
+			maxParallel: 3,
+			maxRetriesAfterFailure: 0,
+			process: async () => {
+				concurrent++;
+				maxConcurrent = Math.max(maxConcurrent, concurrent);
+				await new Promise((r) => setTimeout(r, 3));
+				concurrent--;
+			},
+		});
+		await processor.processBatch(Array.from({ length: 30 }, (_, i) => i));
+		expect(maxConcurrent).toBeLessThanOrEqual(3);
+	});
+});
+
+describe("BatchQueue", () => {
+	it("calls onDrainBatchOutcomes after a non-empty drain", async () => {
+		const batches: unknown[] = [];
+		const bq = new BatchQueue<number>({
+			name: "TEST_BATCH_QUEUE_DRAIN",
+			batchSize: 5,
+			drainIntervalMs: 60_000,
+			getPriority: () => "normal",
+			process: async () => {},
+			onDrainBatchOutcomes: (o) => batches.push(o),
+		});
+		bq.enqueue(7);
+		await bq.drain();
+		expect(batches).toHaveLength(1);
+		const first = batches[0] as { length: number; 0: { success: boolean } };
+		expect(first.length).toBe(1);
+		expect(first[0].success).toBe(true);
+	});
+
+	it("dispose flush invokes onDrainBatchOutcomes via processor by default", async () => {
+		const batches: unknown[] = [];
+		const runtime = {
+			agentId: "agent-1",
+			deleteTask: vi.fn().mockResolvedValue(undefined),
+		} as unknown as IAgentRuntime;
+		const bq = new BatchQueue<number>({
+			name: "TEST_FLUSH",
+			batchSize: 2,
+			drainIntervalMs: 60_000,
+			getPriority: (n) => (n === 1 ? "high" : "normal"),
+			process: async () => {},
+			onDrainBatchOutcomes: (o) => batches.push(o),
+		});
+		bq.enqueue(1);
+		bq.enqueue(2);
+		await bq.dispose(runtime, { flushHighPriority: true });
+		expect(batches).toHaveLength(1);
+		expect((batches[0] as unknown[]).length).toBe(1);
+	});
+});
+
+describe("Semaphore", () => {
+	it("limits concurrency", async () => {
+		const s = new Semaphore(2);
+		let n = 0;
+		await Promise.all(
+			[1, 2, 3, 4].map(async () => {
+				await s.acquire();
+				n++;
+				expect(n).toBeLessThanOrEqual(2);
+				await new Promise((r) => setTimeout(r, 2));
+				n--;
+				s.release();
+			}),
+		);
+	});
+});

--- a/packages/typescript/src/__tests__/task-drain.test.ts
+++ b/packages/typescript/src/__tests__/task-drain.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UUID } from "../types/primitives";
+import type { IAgentRuntime } from "../types/runtime";
+import { TaskDrain } from "../utils/batch-queue/task-drain";
+
+describe("TaskDrain", () => {
+	it("creates task when none exists", async () => {
+		const createTask = vi.fn().mockResolvedValue("task-id-1" as UUID);
+		const getTasksByName = vi.fn().mockResolvedValue([]);
+		const registerTaskWorker = vi.fn();
+		const runtime = {
+			agentId: "agent-1",
+			getTasksByName,
+			createTask,
+			registerTaskWorker,
+		} as unknown as IAgentRuntime;
+
+		const drain = new TaskDrain(
+			{
+				taskName: "TEST_DRAIN",
+				intervalMs: 500,
+				onDrain: async () => {},
+			},
+			500,
+		);
+		await drain.start(runtime);
+
+		expect(registerTaskWorker).toHaveBeenCalledWith(
+			expect.objectContaining({ name: "TEST_DRAIN" }),
+		);
+		expect(createTask).toHaveBeenCalledWith(
+			expect.objectContaining({
+				name: "TEST_DRAIN",
+				tags: ["queue", "repeat"],
+				metadata: expect.objectContaining({
+					updateInterval: 500,
+					maxFailures: -1,
+				}),
+			}),
+		);
+		expect(drain.id).toBe("task-id-1");
+	});
+
+	it("skipRegisterWorker does not register worker", async () => {
+		const createTask = vi.fn().mockResolvedValue("t2" as UUID);
+		const getTasksByName = vi.fn().mockResolvedValue([]);
+		const registerTaskWorker = vi.fn();
+		const runtime = {
+			agentId: "agent-1",
+			getTasksByName,
+			createTask,
+			registerTaskWorker,
+		} as unknown as IAgentRuntime;
+
+		const drain = new TaskDrain({
+			taskName: "BATCHER_DRAIN",
+			intervalMs: 1000,
+			taskMetadata: { affinityKey: "room:x" },
+			skipRegisterWorker: true,
+		});
+		await drain.start(runtime);
+
+		expect(registerTaskWorker).not.toHaveBeenCalled();
+		expect(createTask).toHaveBeenCalled();
+	});
+
+	it("reconciles interval when matching repeat task already exists", async () => {
+		const existing = {
+			id: "existing-uuid",
+			agentId: "agent-1",
+			metadata: {
+				affinityKey: "room:a",
+				updateInterval: 5000,
+				baseInterval: 5000,
+			},
+		};
+		const getTasksByName = vi.fn().mockResolvedValue([existing]);
+		const getTask = vi.fn().mockResolvedValue(existing);
+		const updateTask = vi.fn().mockResolvedValue(undefined);
+		const createTask = vi.fn();
+		const registerTaskWorker = vi.fn();
+		const runtime = {
+			agentId: "agent-1",
+			getTasksByName,
+			createTask,
+			getTask,
+			updateTask,
+			registerTaskWorker,
+		} as unknown as IAgentRuntime;
+
+		const drain = new TaskDrain(
+			{
+				taskName: "BATCHER_DRAIN",
+				intervalMs: 250,
+				taskMetadata: { affinityKey: "room:a" },
+				skipRegisterWorker: true,
+			},
+			250,
+		);
+		await drain.start(runtime);
+
+		expect(createTask).not.toHaveBeenCalled();
+		expect(getTask).toHaveBeenCalledWith("existing-uuid");
+		expect(updateTask).toHaveBeenCalledWith(
+			"existing-uuid",
+			expect.objectContaining({
+				metadata: expect.objectContaining({
+					updateInterval: 250,
+					baseInterval: 250,
+				}),
+			}),
+		);
+	});
+});

--- a/packages/typescript/src/features/knowledge/document-processor.ts
+++ b/packages/typescript/src/features/knowledge/document-processor.ts
@@ -9,6 +9,7 @@ import {
 	ModelType,
 	type UUID,
 } from "../../types";
+import { BatchProcessor } from "../../utils/batch-queue";
 import { splitChunks } from "../../utils";
 import { getProviderRateLimits, validateModelConfig } from "./config.ts";
 import {
@@ -549,19 +550,34 @@ async function generateBatchEmbeddingsViaRuntime(
 	}
 
 	if (isEmbeddingVector(batchResult)) {
-		const embeddings: number[][] = await Promise.all(
-			texts.map(async (text) => {
+		// Provider returned one vector for many texts — fall back to per-text calls with bounded
+		// concurrency (same stack as action-filter / embedding batch paths).
+		const slots: number[][] = new Array(texts.length);
+		const processor = new BatchProcessor<number>({
+			maxParallel: 10,
+			maxRetriesAfterFailure: 2,
+			process: async (idx) => {
+				const text = texts[idx];
+				if (text === undefined) {
+					return;
+				}
 				const result = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
 					text,
 				});
 				if (isEmbeddingVector(result)) {
-					return result;
+					slots[idx] = result;
+				} else {
+					const embeddingResult = result as { embedding?: number[] } | undefined;
+					slots[idx] = embeddingResult?.embedding ?? [];
 				}
-				const embeddingResult = result as { embedding?: number[] } | undefined;
-				return embeddingResult?.embedding ?? [];
-			}),
-		);
-		return embeddings;
+			},
+			onExhausted: (idx) => {
+				slots[idx] = [];
+			},
+		});
+		const indices = texts.map((_, idx) => idx);
+		await processor.processBatch(indices);
+		return slots;
 	}
 
 	throw new Error("Unexpected batch embedding result format");

--- a/packages/typescript/src/features/knowledge/llm.ts
+++ b/packages/typescript/src/features/knowledge/llm.ts
@@ -156,6 +156,8 @@ export async function generateTextEmbeddingsBatch(
 			index: number;
 		} | null> = batch.map(() => null);
 
+		// Note: BatchProcessor is used here purely as a concurrency limiter (semaphore).
+		// Errors are caught internally and written to `slot`, so retries and onExhausted are bypassed.
 		const processor = new BatchProcessor<BatchItem>({
 			maxParallel: 10,
 			maxRetriesAfterFailure: 0,

--- a/packages/typescript/src/features/knowledge/llm.ts
+++ b/packages/typescript/src/features/knowledge/llm.ts
@@ -4,6 +4,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateText as aiGenerateText, embed, type ModelMessage } from "ai";
 import { logger } from "../../logger";
+import { BatchProcessor } from "../../utils/batch-queue";
 import {
 	logActiveTrajectoryLlmCall,
 	withStandaloneTrajectory,
@@ -142,28 +143,51 @@ export async function generateTextEmbeddingsBatch(
 		const batch = texts.slice(i, i + batchSize);
 		const batchStartIndex = i;
 
-		const batchPromises = batch.map(async (text, batchIndex) => {
-			const globalIndex = batchStartIndex + batchIndex;
-			try {
-				const result = await generateTextEmbedding(runtime, text);
-				return {
-					embedding: result.embedding,
-					success: true,
-					index: globalIndex,
-				};
-			} catch (error) {
-				logger.error({ error }, `Embedding error for item ${globalIndex}`);
-				return {
-					embedding: null,
-					success: false,
-					error,
-					index: globalIndex,
-				};
-			}
-		});
+		type BatchItem = { text: string; globalIndex: number; batchPos: number };
+		const items: BatchItem[] = batch.map((text, batchIndex) => ({
+			text,
+			globalIndex: batchStartIndex + batchIndex,
+			batchPos: batchIndex,
+		}));
+		const slot: Array<{
+			embedding: number[] | null;
+			success: boolean;
+			error?: unknown;
+			index: number;
+		} | null> = batch.map(() => null);
 
-		const batchResults = await Promise.all(batchPromises);
-		results.push(...batchResults);
+		const processor = new BatchProcessor<BatchItem>({
+			maxParallel: 10,
+			maxRetriesAfterFailure: 0,
+			process: async (item) => {
+				try {
+					const result = await generateTextEmbedding(runtime, item.text);
+					slot[item.batchPos] = {
+						embedding: result.embedding,
+						success: true,
+						index: item.globalIndex,
+					};
+				} catch (error) {
+					logger.error(
+						{ error },
+						`Embedding error for item ${item.globalIndex}`,
+					);
+					slot[item.batchPos] = {
+						embedding: null,
+						success: false,
+						error,
+						index: item.globalIndex,
+					};
+				}
+			},
+		});
+		await processor.processBatch(items);
+		for (let j = 0; j < slot.length; j++) {
+			const row = slot[j];
+			if (row) {
+				results.push(row);
+			}
+		}
 
 		if (i + batchSize < texts.length) {
 			await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/typescript/src/index.browser.ts
+++ b/packages/typescript/src/index.browser.ts
@@ -18,6 +18,7 @@ export * from "./memory";
 export * from "./prompts";
 export * from "./roles";
 export * from "./runtime";
+export { Semaphore } from "./utils/batch-queue/semaphore.js";
 // Export schemas (including buildBaseTables for plugin-sql browser/PGLite builds)
 export * from "./schemas/character";
 export { type BaseTables, buildBaseTables } from "./schemas/index";

--- a/packages/typescript/src/index.edge.ts
+++ b/packages/typescript/src/index.edge.ts
@@ -39,6 +39,7 @@ export * from "./providers/onboarding-progress";
 export * from "./providers/skill-eligibility";
 export * from "./roles";
 export * from "./runtime";
+export { Semaphore } from "./utils/batch-queue/semaphore.js";
 export * from "./schemas/character";
 export * from "./schemas/index";
 export { type BaseTables, buildBaseTables } from "./schemas/index";

--- a/packages/typescript/src/index.node.ts
+++ b/packages/typescript/src/index.node.ts
@@ -56,6 +56,8 @@ export * from "./providers/skill-eligibility";
 export * from "./provisioning";
 export * from "./roles";
 export * from "./runtime";
+/** Single implementation — see `utils/batch-queue/semaphore.ts` (was duplicated on `runtime.ts`). */
+export { Semaphore } from "./utils/batch-queue/semaphore.js";
 // Runtime composition (loadCharacters, createRuntimes, getBasicCapabilitiesSettings, mergeSettingsInto) - node only
 export * from "./runtime-composition";
 // Export character schemas

--- a/packages/typescript/src/runtime.ts
+++ b/packages/typescript/src/runtime.ts
@@ -202,31 +202,6 @@ function resolveDynamicPromptModelType(
 	}
 }
 
-export class Semaphore {
-	private permits: number;
-	private waiting: Array<() => void> = [];
-	constructor(count: number) {
-		this.permits = count;
-	}
-	async acquire(): Promise<void> {
-		if (this.permits > 0) {
-			this.permits -= 1;
-			return Promise.resolve();
-		}
-		return new Promise<void>((resolve) => {
-			this.waiting.push(resolve);
-		});
-	}
-	release(): void {
-		this.permits += 1;
-		const nextResolve = this.waiting.shift();
-		if (nextResolve && this.permits > 0) {
-			this.permits -= 1;
-			nextResolve();
-		}
-	}
-}
-
 type ServiceResolver = (service: Service) => void;
 type ServiceRejecter = (reason: Error | string) => void;
 type ServicePromiseHandler = {

--- a/packages/typescript/src/services/action-filter.ts
+++ b/packages/typescript/src/services/action-filter.ts
@@ -25,6 +25,7 @@ import type {
 import { ModelType } from "../types/model.ts";
 import { Service } from "../types/service.ts";
 import type { State } from "../types/state.ts";
+import { BatchProcessor } from "../utils/batch-queue.ts";
 import { BM25Index } from "./bm25.ts";
 import { cosineSimilarity } from "./cosine-similarity.ts";
 
@@ -331,39 +332,46 @@ export class ActionFilterService extends Service {
 			}
 
 			if (this.embeddingAvailable) {
-				// Embed in batches to avoid flooding the model
+				// `utils/batch-queue` BatchProcessor only (no TaskDrain): index build is synchronous;
+				// shares retry/concurrency primitives with embedding + batcher drains (see `batch-queue.ts`).
 				const batchSize = 10;
-				for (let i = 0; i < actions.length; i += batchSize) {
-					const batch = actions.slice(i, i + batchSize);
-					const embedPromises = batch.map(async (action) => {
-						try {
-							const text = getActionEmbeddingText(action);
-							const embedding: number[] = await runtime.useModel(
-								ModelType.TEXT_EMBEDDING,
-								{ text },
-							);
-							if (isValidEmbedding(embedding)) {
-								this.actionEmbeddings.set(action.name, embedding);
-							} else {
-								this.metrics.embedFailureCount++;
-								throw new Error(
-									`Embedding model returned an invalid vector for action ${action.name}`,
-								);
-							}
-						} catch (err) {
-							logger.error(
+				const processor = new BatchProcessor<Action>({
+					maxParallel: 10,
+					maxRetriesAfterFailure: 2,
+					process: async (action) => {
+						const text = getActionEmbeddingText(action);
+						const embedding: number[] = await runtime.useModel(
+							ModelType.TEXT_EMBEDDING,
+							{ text },
+						);
+						if (isValidEmbedding(embedding)) {
+							this.actionEmbeddings.set(action.name, embedding);
+						} else {
+							logger.warn(
 								{
 									src: "service:action-filter",
 									action: action.name,
-									error: err instanceof Error ? err.message : String(err),
 								},
-								"Failed to embed action",
+								"Embedding model returned invalid vector (NaN/empty) — action available via BM25 only",
 							);
 							this.metrics.embedFailureCount++;
-							throw err;
 						}
-					});
-					await Promise.all(embedPromises);
+					},
+					onExhausted: (action, err) => {
+						logger.warn(
+							{
+								src: "service:action-filter",
+								action: action.name,
+								error: err.message,
+							},
+							"Failed to embed action after retries — it will still be available via BM25",
+						);
+						this.metrics.embedFailureCount++;
+					},
+				});
+				for (let i = 0; i < actions.length; i += batchSize) {
+					const batch = actions.slice(i, i + batchSize);
+					await processor.processBatch(batch);
 				}
 			}
 		}

--- a/packages/typescript/src/services/embedding.ts
+++ b/packages/typescript/src/services/embedding.ts
@@ -9,9 +9,6 @@ import { BatchQueue } from "../utils/batch-queue";
 interface EmbeddingQueueItem {
 	memory: Memory;
 	priority: "high" | "normal" | "low";
-	retryCount: number;
-	maxRetries: number;
-	addedAt: number;
 	runId?: string;
 }
 
@@ -166,9 +163,6 @@ export class EmbeddingGenerationService extends Service {
 		const queueItem: EmbeddingQueueItem = {
 			memory,
 			priority,
-			retryCount,
-			maxRetries,
-			addedAt: Date.now(),
 			runId,
 		};
 

--- a/packages/typescript/src/services/embedding.ts
+++ b/packages/typescript/src/services/embedding.ts
@@ -2,9 +2,9 @@ import type { EmbeddingGenerationPayload } from "../types/events";
 import { EventType } from "../types/events";
 import type { Memory } from "../types/memory";
 import { ModelType } from "../types/model";
-import type { UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
 import { Service } from "../types/service";
+import { BatchQueue } from "../utils/batch-queue";
 
 interface EmbeddingQueueItem {
 	memory: Memory;
@@ -25,13 +25,8 @@ export class EmbeddingGenerationService extends Service {
 	capabilityDescription =
 		"Handles asynchronous embedding generation for memories";
 
-	private queue: EmbeddingQueueItem[] = [];
-	private isProcessing = false;
-	private drainTaskId: UUID | null = null;
-	private maxQueueSize = 1000;
-	private batchSize = 10; // Process up to 10 embeddings at a time
-	private processingIntervalMs = 100; // Interval for drain task (effective rate is scheduler tick, typically 1/s)
-	private isDisabled = false; // Flag to indicate if service is disabled due to missing embedding model
+	private batchQueue: BatchQueue<EmbeddingQueueItem> | null = null;
+	private isDisabled = false;
 
 	private static readonly EMBEDDING_DRAIN_TASK = "EMBEDDING_DRAIN";
 
@@ -44,19 +39,18 @@ export class EmbeddingGenerationService extends Service {
 			"Starting embedding generation service",
 		);
 
-		// Check if TEXT_EMBEDDING model is registered
 		const embeddingModel = runtime.getModel(ModelType.TEXT_EMBEDDING);
 		if (!embeddingModel) {
-			runtime.logger.error(
+			runtime.logger.warn(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
 					agentId: runtime.agentId,
 				},
-				"No TEXT_EMBEDDING model registered - embedding generation cannot start",
+				"No TEXT_EMBEDDING model registered - service will not be initialized",
 			);
-			throw new Error(
-				"EmbeddingGenerationService requires a registered TEXT_EMBEDDING model",
-			);
+			const noOpService = new EmbeddingGenerationService(runtime);
+			noOpService.isDisabled = true;
+			return noOpService;
 		}
 
 		const service = new EmbeddingGenerationService(runtime);
@@ -84,57 +78,48 @@ export class EmbeddingGenerationService extends Service {
 			"Initializing embedding generation service",
 		);
 
-		// Register event handlers
 		this.runtime.registerEvent(
 			EventType.EMBEDDING_GENERATION_REQUESTED,
 			this.handleEmbeddingRequest.bind(this),
 		);
 
-		this.registerDrainWorker();
-		await this.ensureDrainTask();
-	}
-
-	private registerDrainWorker(): void {
-		this.runtime.registerTaskWorker({
+		// Uses shared `utils/batch-queue` (see `batch-queue.ts` header): same drain/retry/priority
+		// model as other services so we do not maintain another bespoke queue + task stack here.
+		// Task system owns WHEN (repeat EMBEDDING_DRAIN tick); we own WHAT (dequeue, embed, persist).
+		// No maxSize — bottleneck is embedding I/O, not queue length.
+		this.batchQueue = new BatchQueue<EmbeddingQueueItem>({
 			name: EmbeddingGenerationService.EMBEDDING_DRAIN_TASK,
-			execute: async () => {
-				if (!this.isProcessing && this.queue.length > 0) {
-					await this.processQueue();
-				}
-				return undefined;
+			taskDescription: "Embedding generation drain",
+			batchSize: 10,
+			drainIntervalMs: 100,
+			getPriority: (item) => item.priority,
+			maxParallel: 10,
+			maxRetriesAfterFailure: 3,
+			process: (item) => this.generateEmbedding(item),
+			onExhausted: async (item, error) => {
+				await this.runtime.log({
+					entityId: this.runtime.agentId,
+					roomId: item.memory.roomId || this.runtime.agentId,
+					type: "embedding_event",
+					body: {
+						runId: item.runId,
+						memoryId: item.memory.id,
+						status: "failed",
+						error: error.message,
+						source: "embeddingService",
+					},
+				});
+				await this.runtime.emitEvent(EventType.EMBEDDING_GENERATION_FAILED, {
+					runtime: this.runtime,
+					memory: item.memory,
+					error: error.message,
+					source: "embeddingService",
+				});
 			},
 		});
-	}
 
-	private async ensureDrainTask(): Promise<void> {
-		const rt = this.runtime;
-		if (
-			typeof rt.getTasksByName !== "function" ||
-			typeof rt.createTask !== "function"
-		) {
-			return;
-		}
-		const agentId = rt.agentId;
-		const existing = await rt.getTasksByName(
-			EmbeddingGenerationService.EMBEDDING_DRAIN_TASK,
-		);
-		const mine = existing.find(
-			(t) => t.agentId != null && String(t.agentId) === String(agentId),
-		);
-		if (mine?.id) {
-			this.drainTaskId = mine.id;
-			return;
-		}
-		this.drainTaskId = await rt.createTask({
-			name: EmbeddingGenerationService.EMBEDDING_DRAIN_TASK,
-			tags: ["queue", "repeat"],
-			worldId: agentId,
-			metadata: {
-				updateInterval: this.processingIntervalMs,
-				baseInterval: this.processingIntervalMs,
-				updatedAt: Date.now(),
-			},
-		});
+		await this.batchQueue.start(this.runtime);
+
 		this.runtime.logger.info(
 			{
 				src: "plugin:basic-capabilities:service:embedding",
@@ -147,14 +132,13 @@ export class EmbeddingGenerationService extends Service {
 	private async handleEmbeddingRequest(
 		payload: EmbeddingGenerationPayload,
 	): Promise<void> {
-		// Skip if service is disabled
-		if (this.isDisabled) {
+		if (this.isDisabled || !this.batchQueue) {
 			this.runtime.logger.debug(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
 					agentId: this.runtime.agentId,
 				},
-				"Service is disabled, skipping embedding request",
+				"Service is disabled or queue missing, skipping embedding request",
 			);
 			return;
 		}
@@ -167,7 +151,6 @@ export class EmbeddingGenerationService extends Service {
 			runId,
 		} = payload;
 
-		// Skip if memory already has embeddings
 		if (memory.embedding) {
 			this.runtime.logger.debug(
 				{
@@ -180,21 +163,6 @@ export class EmbeddingGenerationService extends Service {
 			return;
 		}
 
-		// Check queue size and make room if needed
-		if (this.queue.length >= this.maxQueueSize) {
-			this.runtime.logger.warn(
-				{
-					src: "plugin:basic-capabilities:service:embedding",
-					agentId: this.runtime.agentId,
-					queueSize: this.queue.length,
-					maxSize: this.maxQueueSize,
-				},
-				"Queue is full, making room",
-			);
-			this.makeRoomInQueue();
-		}
-
-		// Add to queue
 		const queueItem: EmbeddingQueueItem = {
 			memory,
 			priority,
@@ -204,190 +172,16 @@ export class EmbeddingGenerationService extends Service {
 			runId,
 		};
 
-		// Insert based on priority
-		this.insertItemByPriority(queueItem);
+		this.batchQueue.enqueue(queueItem);
 
 		this.runtime.logger.debug(
 			{
 				src: "plugin:basic-capabilities:service:embedding",
 				agentId: this.runtime.agentId,
-				queueSize: this.queue.length,
+				queueSize: this.batchQueue.size,
 			},
 			"Added memory to queue",
 		);
-	}
-
-	/**
-	 * Make room in the queue by removing items based on priority and age
-	 * Removes 10% of the queue (minimum 1, maximum 10 items)
-	 */
-	private makeRoomInQueue(): void {
-		// Remove 10% of queue, but at least 1 and at most 10 items
-		const tenPercent = Math.floor(this.maxQueueSize * 0.1);
-		const itemsToRemove = Math.min(10, Math.max(1, tenPercent));
-
-		// Create array with items and their original indices
-		const itemsWithIndex = this.queue.map((item, index) => ({
-			item,
-			originalIndex: index,
-		}));
-
-		// Sort by priority (low first for removal) and age (oldest first)
-		itemsWithIndex.sort((a, b) => {
-			// Priority order for removal: low > normal > high
-			const priorityOrder = { low: 0, normal: 1, high: 2 };
-			const priorityDiff =
-				priorityOrder[a.item.priority] - priorityOrder[b.item.priority];
-
-			if (priorityDiff !== 0) {
-				return priorityDiff;
-			}
-
-			// Within same priority, remove older items first
-			return a.item.addedAt - b.item.addedAt;
-		});
-
-		// Get the original indices of items to remove (first N items after sorting)
-		const indicesToRemove = new Set(
-			itemsWithIndex
-				.slice(0, Math.min(itemsToRemove, itemsWithIndex.length))
-				.map(({ originalIndex }) => originalIndex),
-		);
-
-		// Keep items that are not in the removal set
-		const newQueue = this.queue.filter(
-			(_, index) => !indicesToRemove.has(index),
-		);
-		const removedCount = this.queue.length - newQueue.length;
-
-		this.queue = newQueue;
-
-		this.runtime.logger.info(
-			{
-				src: "plugin:basic-capabilities:service:embedding",
-				agentId: this.runtime.agentId,
-				removedCount,
-				newSize: this.queue.length,
-			},
-			"Removed items from queue",
-		);
-	}
-
-	/**
-	 * Insert an item into the queue based on its priority
-	 * High priority items go to the front, normal in the middle, low at the end
-	 */
-	private insertItemByPriority(queueItem: EmbeddingQueueItem): void {
-		if (queueItem.priority === "low" || this.queue.length === 0) {
-			// Add to end of queue
-			this.queue.push(queueItem);
-			return;
-		}
-
-		let insertIndex = this.queue.length;
-		for (let i = 0; i < this.queue.length; i++) {
-			const priority = this.queue[i].priority;
-			if (queueItem.priority === "high") {
-				if (priority !== "high") {
-					insertIndex = i;
-					break;
-				}
-			} else if (priority === "low") {
-				// Normal priority - add after high priority items but before low priority items
-				insertIndex = i;
-				break;
-			}
-		}
-
-		this.queue.splice(insertIndex, 0, queueItem);
-	}
-
-	private async processQueue(): Promise<void> {
-		if (this.isProcessing || this.queue.length === 0) {
-			return;
-		}
-
-		this.isProcessing = true;
-
-		try {
-			// Process a batch of items
-			const batch = this.queue.splice(
-				0,
-				Math.min(this.batchSize, this.queue.length),
-			);
-
-			this.runtime.logger.debug(
-				{
-					src: "plugin:basic-capabilities:service:embedding",
-					agentId: this.runtime.agentId,
-					batchSize: batch.length,
-					remaining: this.queue.length,
-				},
-				"Processing batch",
-			);
-
-			// Process items in parallel
-			const promises = batch.map(async (item) => {
-				try {
-					await this.generateEmbedding(item);
-				} catch (error) {
-					this.runtime.logger.error(
-						{
-							src: "plugin:basic-capabilities:service:embedding",
-							agentId: this.runtime.agentId,
-							memoryId: item.memory.id,
-							error: error instanceof Error ? error.message : String(error),
-						},
-						"Error processing item",
-					);
-
-					// Retry if under max retries
-					if (item.retryCount < item.maxRetries) {
-						item.retryCount++;
-						// Re-add to queue with same priority using proper insertion
-						this.insertItemByPriority(item);
-						this.runtime.logger.debug(
-							{
-								src: "plugin:basic-capabilities:service:embedding",
-								agentId: this.runtime.agentId,
-								retryCount: item.retryCount,
-								maxRetries: item.maxRetries,
-							},
-							"Re-queued item for retry",
-						);
-					} else {
-						// Log embedding failure
-						await this.runtime.log({
-							entityId: this.runtime.agentId,
-							roomId: item.memory.roomId || this.runtime.agentId,
-							type: "embedding_event",
-							body: {
-								runId: item.runId,
-								memoryId: item.memory.id,
-								status: "failed",
-								error: error instanceof Error ? error.message : String(error),
-								source: "embeddingService",
-							},
-						});
-
-						// Emit failure event
-						await this.runtime.emitEvent(
-							EventType.EMBEDDING_GENERATION_FAILED,
-							{
-								runtime: this.runtime,
-								memory: item.memory,
-								error: error instanceof Error ? error.message : String(error),
-								source: "embeddingService",
-							},
-						);
-					}
-				}
-			});
-
-			await Promise.all(promises);
-		} finally {
-			this.isProcessing = false;
-		}
 	}
 
 	private async generateEmbedding(item: EmbeddingQueueItem): Promise<void> {
@@ -409,7 +203,6 @@ export class EmbeddingGenerationService extends Service {
 		try {
 			const startTime = Date.now();
 
-			// Generate embedding
 			const embedding = await this.runtime.useModel(ModelType.TEXT_EMBEDDING, {
 				text: memory.content.text ?? "",
 			});
@@ -425,14 +218,12 @@ export class EmbeddingGenerationService extends Service {
 				"Generated embedding",
 			);
 
-			// Update memory with embedding
 			if (memory.id) {
 				await this.runtime.updateMemory({
 					id: memory.id,
 					embedding,
 				});
 
-				// Log embedding completion
 				await this.runtime.log({
 					entityId: this.runtime.agentId,
 					roomId: memory.roomId || this.runtime.agentId,
@@ -446,7 +237,6 @@ export class EmbeddingGenerationService extends Service {
 					},
 				});
 
-				// Emit completion event
 				await this.runtime.emitEvent(EventType.EMBEDDING_GENERATION_COMPLETED, {
 					runtime: this.runtime,
 					memory: { ...memory, embedding },
@@ -463,7 +253,7 @@ export class EmbeddingGenerationService extends Service {
 				},
 				"Failed to generate embedding",
 			);
-			throw error; // Re-throw to trigger retry logic
+			throw error;
 		}
 	}
 
@@ -476,7 +266,7 @@ export class EmbeddingGenerationService extends Service {
 			"Stopping embedding generation service",
 		);
 
-		if (this.isDisabled) {
+		if (this.isDisabled || !this.batchQueue) {
 			this.runtime.logger.debug(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
@@ -487,53 +277,23 @@ export class EmbeddingGenerationService extends Service {
 			return;
 		}
 
-		if (this.drainTaskId && typeof this.runtime.deleteTask === "function") {
-			await this.runtime.deleteTask(this.drainTaskId).catch(() => {});
-			this.drainTaskId = null;
-		}
-
-		// Process remaining high priority items before shutdown
-		const highPriorityItems = this.queue.filter(
-			(item) => item.priority === "high",
-		);
-		if (highPriorityItems.length > 0) {
-			this.runtime.logger.info(
-				{
-					src: "plugin:basic-capabilities:service:embedding",
-					agentId: this.runtime.agentId,
-					count: highPriorityItems.length,
-				},
-				"Processing high priority items before shutdown",
-			);
-			for (const item of highPriorityItems) {
-				try {
-					await this.generateEmbedding(item);
-				} catch (error) {
-					this.runtime.logger.error(
-						{
-							src: "plugin:basic-capabilities:service:embedding",
-							agentId: this.runtime.agentId,
-							error: error instanceof Error ? error.message : String(error),
-						},
-						"Error during shutdown processing",
-					);
-				}
-			}
-		}
+		const remaining = this.batchQueue.size;
+		await this.batchQueue.dispose(this.runtime, { flushHighPriority: true });
 
 		this.runtime.logger.info(
 			{
 				src: "plugin:basic-capabilities:service:embedding",
 				agentId: this.runtime.agentId,
-				remainingItems: this.queue.length,
+				remainingItems: remaining,
 			},
 			"Stopped",
 		);
+
+		this.batchQueue = null;
 	}
 
-	// Public methods for monitoring
 	getQueueSize(): number {
-		return this.queue.length;
+		return this.batchQueue?.size ?? 0;
 	}
 
 	getQueueStats(): {
@@ -542,23 +302,12 @@ export class EmbeddingGenerationService extends Service {
 		low: number;
 		total: number;
 	} {
-		const stats = {
-			high: 0,
-			normal: 0,
-			low: 0,
-			total: this.queue.length,
-		};
-
-		for (const item of this.queue) {
-			stats[item.priority]++;
-		}
-
-		return stats;
+		return this.batchQueue?.stats() ?? { high: 0, normal: 0, low: 0, total: 0 };
 	}
 
 	clearQueue(): void {
-		const size = this.queue.length;
-		this.queue = [];
+		const size = this.batchQueue?.size ?? 0;
+		this.batchQueue?.clear();
 		this.runtime.logger.info(
 			{
 				src: "plugin:basic-capabilities:service:embedding",

--- a/packages/typescript/src/utils/batch-queue.ts
+++ b/packages/typescript/src/utils/batch-queue.ts
@@ -1,0 +1,32 @@
+/**
+ * **Why this module exists (architecture, not a single hot path).**
+ *
+ * The generic runtime is not “batching-bound”; fixing one hot spot with a few lines (for example
+ * a semaphore around `Promise.all` in one service) would be locally sufficient. This package is
+ * still **forward-looking consolidation**: today we already had separate ad-hoc patterns for
+ * priority queues, bounded concurrency, retry/backoff, and repeat-task / drain scheduling
+ * (embedding generation, action-index embedding, prompt-batcher affinity tasks, shared
+ * `Semaphore` in the batcher). Each new feature risked copying another half-queue or another
+ * `registerTaskWorker` + `createTask` pair.
+ *
+ * Here, **one composable stack** — {@link PriorityQueue}, {@link BatchProcessor}, {@link TaskDrain},
+ * and {@link BatchQueue} when a service needs all three — is the deliberate trade: a small shared
+ * surface so we do **not** keep growing incompatible “queuing systems” across the codebase. Callers
+ * use only the layers they need (for example `BatchProcessor` alone for a synchronous batch job).
+ *
+ * Re-exports below; implementation lives under `./batch-queue/`.
+ */
+export {
+	type BatchItemOutcome,
+	BatchProcessor,
+	BatchQueue,
+	type BatchQueueOptions,
+	type DrainStats,
+	PriorityQueue,
+	type PriorityQueueOptions,
+	type PriorityQueueStats,
+	type QueuePriority,
+	Semaphore,
+	TaskDrain,
+	type TaskDrainOptions,
+} from "./batch-queue/index.js";

--- a/packages/typescript/src/utils/batch-queue/batch-processor.ts
+++ b/packages/typescript/src/utils/batch-queue/batch-processor.ts
@@ -141,6 +141,7 @@ export class BatchProcessor<T> {
 		let lastError: Error = new Error("unknown");
 
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			let exhausted = false;
 			await this.semaphore.acquire();
 			try {
 				await this.process(item);
@@ -151,19 +152,27 @@ export class BatchProcessor<T> {
 					attempt >= maxAttempts ||
 					!this.shouldRetry(item, lastError, attempt)
 				) {
-					if (this.onExhausted) {
-						await this.onExhausted(item, lastError);
-					}
-					return {
-						item,
-						success: false,
-						error: lastError,
-						retryCount,
-					};
+					exhausted = true;
+				} else {
+					retryCount++;
 				}
-				retryCount++;
 			} finally {
 				this.semaphore.release();
+			}
+			if (exhausted) {
+				if (this.onExhausted) {
+					try {
+						await this.onExhausted(item, lastError);
+					} catch {
+						// Keep callback failures from aborting the whole batch
+					}
+				}
+				return {
+					item,
+					success: false,
+					error: lastError,
+					retryCount,
+				};
 			}
 			const delayMs = computeBackoff(this.policy, attempt);
 			if (delayMs > 0) {

--- a/packages/typescript/src/utils/batch-queue/batch-processor.ts
+++ b/packages/typescript/src/utils/batch-queue/batch-processor.ts
@@ -1,0 +1,177 @@
+/**
+ * Stateless execution of a **batch** of work items: each item runs through `process` with a
+ * {@link Semaphore} cap, exponential backoff between attempts, and optional `onExhausted`.
+ *
+ * **Why not push failed items back onto a queue:** Inline retries keep item lifecycle simple and
+ * avoid losing work between ticks; releasing the semaphore between attempts lets other items run.
+ *
+ * Reuses `resolveRetryConfig` / `computeBackoff` from `utils/retry.ts` so delay policy matches
+ * the rest of the runtime.
+ */
+import {
+	type BackoffPolicy,
+	computeBackoff,
+	type RetryConfig,
+	resolveRetryConfig,
+	sleep,
+} from "../retry.js";
+import { Semaphore } from "./semaphore.js";
+
+export interface BatchItemOutcome<T> {
+	item: T;
+	success: boolean;
+	error?: Error;
+	retryCount: number;
+}
+
+export interface BatchProcessorOptions<T> {
+	/** Max concurrent `process` calls across the batch. */
+	maxParallel: number;
+	/**
+	 * After a failed attempt, re-try up to this many times (embedding-style).
+	 * Total attempts = maxRetriesAfterFailure + 1. Default 3 → 4 total tries.
+	 *
+	 * **Interaction with per-item `maxRetries`:** If the item is an object with numeric `maxRetries`,
+	 * total attempts use `maxRetries + 1` instead of this default (unless `maxAttemptsCap` applies).
+	 * Prefer one source of truth per call site to avoid surprises.
+	 */
+	maxRetriesAfterFailure?: number;
+	retryPolicy?: RetryConfig;
+	/**
+	 * Upper bound on attempts per item after resolving per-item `maxRetries` and global retry config.
+	 * Use for shutdown-style paths where items may carry large `maxRetries` but only one try is wanted.
+	 */
+	maxAttemptsCap?: number;
+	process: (item: T) => Promise<void>;
+	onExhausted?: (item: T, error: Error) => void | Promise<void>;
+	shouldRetry?: (item: T, error: Error, attempt: number) => boolean;
+}
+
+function defaultShouldRetry(
+	_item: unknown,
+	_err: Error,
+	_attempt: number,
+): boolean {
+	return true;
+}
+
+function toBackoffPolicy(
+	resolved: ReturnType<typeof resolveRetryConfig>,
+): BackoffPolicy {
+	return {
+		initialMs: resolved.minDelayMs,
+		maxMs: resolved.maxDelayMs,
+		factor: 2,
+		jitter: resolved.jitter,
+	};
+}
+
+/**
+ * If the item carries `maxRetries` (e.g. embedding payload), total attempts = `maxRetries + 1`.
+ * **Why:** Aligns with “retryCount < maxRetries” style loops elsewhere in the codebase.
+ */
+function getPerItemMaxAttempts(item: unknown, fallback: number): number {
+	if (
+		item &&
+		typeof item === "object" &&
+		"maxRetries" in item &&
+		typeof (item as { maxRetries?: unknown }).maxRetries === "number"
+	) {
+		const mr = (item as { maxRetries: number }).maxRetries;
+		if (Number.isFinite(mr) && mr >= 0) {
+			return mr + 1;
+		}
+	}
+	return fallback;
+}
+
+export class BatchProcessor<T> {
+	private readonly maxParallel: number;
+	private readonly defaultMaxAttempts: number;
+	private readonly maxAttemptsCap?: number;
+	private readonly policy: BackoffPolicy;
+	private readonly process: (item: T) => Promise<void>;
+	private readonly onExhausted?: (
+		item: T,
+		error: Error,
+	) => void | Promise<void>;
+	private readonly shouldRetry: (
+		item: T,
+		error: Error,
+		attempt: number,
+	) => boolean;
+	private readonly semaphore: Semaphore;
+
+	constructor(options: BatchProcessorOptions<T>) {
+		this.maxParallel = Math.max(1, options.maxParallel);
+		// retriesAfter + 1 total attempts: first try + N failures that may retry.
+		const retriesAfter = options.maxRetriesAfterFailure ?? 3;
+		const resolved = resolveRetryConfig(
+			{
+				attempts: retriesAfter + 1,
+				minDelayMs: 300,
+				maxDelayMs: 30_000,
+				jitter: 0,
+			},
+			options.retryPolicy,
+		);
+		this.defaultMaxAttempts = resolved.attempts;
+		this.maxAttemptsCap = options.maxAttemptsCap;
+		// Factor 2 in toBackoffPolicy: matches classic exponential backoff between attempts.
+		this.policy = toBackoffPolicy(resolved);
+		this.process = options.process;
+		this.onExhausted = options.onExhausted;
+		this.shouldRetry = options.shouldRetry ?? defaultShouldRetry;
+		this.semaphore = new Semaphore(this.maxParallel);
+	}
+
+	async processBatch(items: T[]): Promise<BatchItemOutcome<T>[]> {
+		return Promise.all(items.map((item) => this.processOne(item)));
+	}
+
+	private async processOne(item: T): Promise<BatchItemOutcome<T>> {
+		const resolved = getPerItemMaxAttempts(item, this.defaultMaxAttempts);
+		const maxAttempts = Math.max(
+			1,
+			this.maxAttemptsCap !== undefined
+				? Math.min(resolved, this.maxAttemptsCap)
+				: resolved,
+		);
+		let retryCount = 0;
+		let lastError: Error = new Error("unknown");
+
+		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+			await this.semaphore.acquire();
+			try {
+				await this.process(item);
+				return { item, success: true, retryCount };
+			} catch (err) {
+				lastError = err instanceof Error ? err : new Error(String(err));
+				if (
+					attempt >= maxAttempts ||
+					!this.shouldRetry(item, lastError, attempt)
+				) {
+					if (this.onExhausted) {
+						await this.onExhausted(item, lastError);
+					}
+					return {
+						item,
+						success: false,
+						error: lastError,
+						retryCount,
+					};
+				}
+				retryCount++;
+			} finally {
+				this.semaphore.release();
+			}
+			const delayMs = computeBackoff(this.policy, attempt);
+			if (delayMs > 0) {
+				await sleep(delayMs);
+			}
+		}
+
+		// Unreachable when maxAttempts >= 1 (loop always returns), but satisfies the compiler.
+		return { item, success: false, error: lastError, retryCount };
+	}
+}

--- a/packages/typescript/src/utils/batch-queue/batch-processor.ts
+++ b/packages/typescript/src/utils/batch-queue/batch-processor.ts
@@ -69,17 +69,23 @@ function toBackoffPolicy(
 /**
  * If the item carries `maxRetries` (e.g. embedding payload), total attempts = `maxRetries + 1`.
  * **Why:** Aligns with “retryCount < maxRetries” style loops elsewhere in the codebase.
+/**
+ * Per-item attempt override via explicit `_batchMaxAttempts` property.
+ *
+ * Uses `_batchMaxAttempts` (not `maxRetries`) to avoid accidentally duck-typing payload fields
+ * that happen to carry `maxRetries` for other purposes. Items must explicitly opt-in to override
+ * the queue-level `maxRetriesAfterFailure` by setting `_batchMaxAttempts` (total attempts, not retries).
  */
 function getPerItemMaxAttempts(item: unknown, fallback: number): number {
 	if (
 		item &&
 		typeof item === "object" &&
-		"maxRetries" in item &&
-		typeof (item as { maxRetries?: unknown }).maxRetries === "number"
+		"_batchMaxAttempts" in item &&
+		typeof (item as { _batchMaxAttempts?: unknown })._batchMaxAttempts === "number"
 	) {
-		const mr = (item as { maxRetries: number }).maxRetries;
-		if (Number.isFinite(mr) && mr >= 0) {
-			return mr + 1;
+		const attempts = (item as { _batchMaxAttempts: number })._batchMaxAttempts;
+		if (Number.isFinite(attempts) && attempts >= 1) {
+			return attempts;
 		}
 	}
 	return fallback;

--- a/packages/typescript/src/utils/batch-queue/index.ts
+++ b/packages/typescript/src/utils/batch-queue/index.ts
@@ -57,8 +57,8 @@ export interface BatchQueueOptions<T> {
 	onDrainComplete?: (stats: DrainStats) => void;
 	shouldRetry?: (item: T, error: Error, attempt: number) => boolean;
 	/**
-	 * When false, only registers the repeat task — caller must register `name` with TaskService
-	 * (e.g. `BATCHER_DRAIN`). Default true.
+	 * When true, skips registering the task worker and only registers the repeat task — caller must
+	 * register `name` with TaskService (e.g. `BATCHER_DRAIN`). Default false.
 	 */
 	skipRegisterWorker?: boolean;
 	/** Merged into repeat task metadata (e.g. `{ affinityKey: "room:x" }`). */
@@ -139,13 +139,21 @@ export class BatchQueue<T> {
 				return;
 			}
 			const outcomes = await this.batchProcessor.processBatch(batch);
-			this.options.onDrainBatchOutcomes?.(outcomes);
+			try {
+				this.options.onDrainBatchOutcomes?.(outcomes);
+			} catch {
+				// Keep hook failures from failing a completed batch
+			}
 			const durationMs = Date.now() - started;
-			this.options.onDrainComplete?.({
-				batchSize: batch.length,
-				remaining: this.priorityQueue.size,
-				durationMs,
-			});
+			try {
+				this.options.onDrainComplete?.({
+					batchSize: batch.length,
+					remaining: this.priorityQueue.size,
+					durationMs,
+				});
+			} catch {
+				// Keep hook failures from failing a completed batch
+			}
 		} finally {
 			this.isDraining = false;
 		}
@@ -153,6 +161,12 @@ export class BatchQueue<T> {
 
 	/** Wire `TaskDrain` (worker + repeat task unless `skipRegisterWorker`). */
 	async start(runtime: IAgentRuntime): Promise<void> {
+		if (this.disposed) {
+			throw new Error(`BatchQueue "${this.options.name}" has already been disposed`);
+		}
+		if (this.taskDrain) {
+			return;
+		}
 		const skip = this.options.skipRegisterWorker ?? false;
 		this.taskDrain = new TaskDrain(
 			{

--- a/packages/typescript/src/utils/batch-queue/index.ts
+++ b/packages/typescript/src/utils/batch-queue/index.ts
@@ -1,0 +1,234 @@
+/**
+ * Composed batch pipeline: {@link PriorityQueue} (what to run next) +
+ * {@link BatchProcessor} (how to run a slice with concurrency + retries) +
+ * {@link TaskDrain} (when the task system ticks). Use {@link BatchQueue} for services that need
+ * all three; use layers alone when you only need ordering, or only batch execution, or only
+ * repeat-task CRUD.
+ *
+ * **Rationale:** avoid parallel one-off queue + drain + retry implementations as features grow;
+ * see the longer “why not just three lines?” note on the package re-export in `../batch-queue.ts`.
+ */
+
+import type { IAgentRuntime } from "../../types/runtime.js";
+import type { RetryConfig } from "../retry.js";
+import {
+	type BatchItemOutcome,
+	BatchProcessor,
+} from "./batch-processor.js";
+import {
+	PriorityQueue,
+	type PriorityQueueStats,
+	type QueuePriority,
+} from "./priority-queue.js";
+import { TaskDrain } from "./task-drain.js";
+
+export { type BatchItemOutcome, BatchProcessor } from "./batch-processor.js";
+export {
+	PriorityQueue,
+	type PriorityQueueOptions,
+	type PriorityQueueStats,
+	type QueuePriority,
+} from "./priority-queue.js";
+export { Semaphore } from "./semaphore.js";
+export { TaskDrain, type TaskDrainOptions } from "./task-drain.js";
+
+export interface DrainStats {
+	batchSize: number;
+	remaining: number;
+	durationMs: number;
+}
+
+export interface BatchQueueOptions<T> {
+	/** Task worker name and repeat task name (e.g. `EMBEDDING_DRAIN`). */
+	name: string;
+	batchSize: number;
+	drainIntervalMs: number;
+	getPriority: (item: T) => QueuePriority;
+	process: (item: T) => Promise<void>;
+	maxParallel?: number;
+	maxRetriesAfterFailure?: number;
+	retryPolicy?: RetryConfig;
+	maxSize?: number;
+	onPressure?: (queue: PriorityQueue<T>, item: T) => boolean;
+	onOverflowWarning?: (sizeAfter: number, maxSize: number) => void;
+	onExhausted?: (item: T, error: Error) => void | Promise<void>;
+	/** Called after a non-empty batch finishes `processBatch` (includes per-item success/failure). */
+	onDrainBatchOutcomes?: (outcomes: BatchItemOutcome<T>[]) => void;
+	onDrainComplete?: (stats: DrainStats) => void;
+	shouldRetry?: (item: T, error: Error, attempt: number) => boolean;
+	/**
+	 * When false, only registers the repeat task — caller must register `name` with TaskService
+	 * (e.g. `BATCHER_DRAIN`). Default true.
+	 */
+	skipRegisterWorker?: boolean;
+	/** Merged into repeat task metadata (e.g. `{ affinityKey: "room:x" }`). */
+	taskMetadata?: Record<string, unknown>;
+	/** Optional repeat task description in the task store. */
+	taskDescription?: string;
+	drainHighPriorityOnStop?: boolean;
+	/**
+	 * When true (default), high-priority flush on {@link BatchQueue.dispose} uses {@link BatchProcessor}
+	 * with `maxParallel: 1`, `maxAttemptsCap: 1`, and the same `process` / `onExhausted` / `shouldRetry`
+	 * as scheduled drains — bounded concurrency and a single attempt per item (no long retry tail on stop).
+	 * When false, uses a direct `process` loop (legacy best-effort; no semaphore).
+	 */
+	disposeHighPriorityViaProcessor?: boolean;
+}
+
+/**
+ * End-to-end queue for “enqueue work, drain on a schedule, process with backpressure.”
+ *
+ * **Why `isDraining`:** Repeat tasks can fire while a drain is still running; we skip re-entry so
+ * two batches don’t process the same logical slice or overlap `process` side effects.
+ *
+ * **Why `dispose` flushes high priority optionally:** Matches embedding shutdown: best-effort
+ * completion for urgent items before deleting the repeat task and clearing the queue.
+ *
+ * **Flush path:** By default the high-priority shutdown slice runs through a dedicated
+ * {@link BatchProcessor} (serial, one attempt per item) so behavior stays aligned with bounded
+ * concurrency; set `disposeHighPriorityViaProcessor: false` only if you need the old direct loop.
+ */
+export class BatchQueue<T> {
+	private readonly priorityQueue: PriorityQueue<T>;
+	private readonly batchProcessor: BatchProcessor<T>;
+	private taskDrain: TaskDrain | null = null;
+	private isDraining = false;
+	private disposed = false;
+	private readonly batchSize: number;
+	private readonly options: BatchQueueOptions<T>;
+
+	constructor(options: BatchQueueOptions<T>) {
+		this.options = options;
+		this.batchSize = Math.max(1, options.batchSize);
+		this.priorityQueue = new PriorityQueue<T>({
+			getPriority: options.getPriority,
+			maxSize: options.maxSize,
+			onPressure: options.onPressure,
+			onOverflowWarning: options.onOverflowWarning,
+		});
+		// Default maxParallel 10: matches prior embedding batch parallelism; callers can set 1 for strict serial.
+		this.batchProcessor = new BatchProcessor<T>({
+			maxParallel: options.maxParallel ?? 10,
+			maxRetriesAfterFailure: options.maxRetriesAfterFailure,
+			retryPolicy: options.retryPolicy,
+			process: options.process,
+			onExhausted: options.onExhausted,
+			shouldRetry: options.shouldRetry,
+		});
+	}
+
+	enqueue(item: T): boolean {
+		if (this.disposed) {
+			return false;
+		}
+		return this.priorityQueue.enqueue(item);
+	}
+
+	/**
+	 * Run one drain cycle (typically from the repeat task worker).
+	 */
+	async drain(): Promise<void> {
+		if (this.disposed || this.isDraining) {
+			return;
+		}
+		this.isDraining = true;
+		const started = Date.now();
+		try {
+			const batch = this.priorityQueue.dequeueBatch(this.batchSize);
+			if (batch.length === 0) {
+				return;
+			}
+			const outcomes = await this.batchProcessor.processBatch(batch);
+			this.options.onDrainBatchOutcomes?.(outcomes);
+			const durationMs = Date.now() - started;
+			this.options.onDrainComplete?.({
+				batchSize: batch.length,
+				remaining: this.priorityQueue.size,
+				durationMs,
+			});
+		} finally {
+			this.isDraining = false;
+		}
+	}
+
+	/** Wire `TaskDrain` (worker + repeat task unless `skipRegisterWorker`). */
+	async start(runtime: IAgentRuntime): Promise<void> {
+		const skip = this.options.skipRegisterWorker ?? false;
+		this.taskDrain = new TaskDrain(
+			{
+				taskName: this.options.name,
+				description: this.options.taskDescription,
+				intervalMs: this.options.drainIntervalMs,
+				taskMetadata: this.options.taskMetadata,
+				skipRegisterWorker: skip,
+				onDrain: skip
+					? undefined
+					: async () => {
+							await this.drain();
+						},
+			},
+			this.options.drainIntervalMs,
+		);
+		await this.taskDrain.start(runtime);
+	}
+
+	async updateDrainInterval(runtime: IAgentRuntime, ms: number): Promise<void> {
+		await this.taskDrain?.updateInterval(runtime, ms);
+	}
+
+	async dispose(
+		runtime: IAgentRuntime,
+		opts?: { flushHighPriority?: boolean },
+	): Promise<void> {
+		this.disposed = true;
+		const flush =
+			opts?.flushHighPriority ?? this.options.drainHighPriorityOnStop !== false;
+		if (flush) {
+			const high = this.priorityQueue.drain(
+				(item) => this.options.getPriority(item) === "high",
+			);
+			const viaProcessor = this.options.disposeHighPriorityViaProcessor !== false;
+			if (high.length > 0) {
+				if (viaProcessor) {
+					const flushProcessor = new BatchProcessor<T>({
+						maxParallel: 1,
+						maxRetriesAfterFailure: 0,
+						maxAttemptsCap: 1,
+						process: this.options.process,
+						onExhausted: this.options.onExhausted,
+						shouldRetry: this.options.shouldRetry,
+						retryPolicy: this.options.retryPolicy,
+					});
+					const flushOutcomes = await flushProcessor.processBatch(high);
+					this.options.onDrainBatchOutcomes?.(flushOutcomes);
+				} else {
+					for (const item of high) {
+						try {
+							await this.options.process(item);
+						} catch {
+							/* best effort on shutdown */
+						}
+					}
+				}
+			}
+		}
+		await this.taskDrain?.dispose(runtime);
+		this.taskDrain = null;
+		this.priorityQueue.clear();
+	}
+
+	get size(): number {
+		return this.priorityQueue.size;
+	}
+
+	stats(): PriorityQueueStats {
+		return this.priorityQueue.stats();
+	}
+
+	clear(): void {
+		if (this.disposed) {
+			return;
+		}
+		this.priorityQueue.clear();
+	}
+}

--- a/packages/typescript/src/utils/batch-queue/priority-queue.ts
+++ b/packages/typescript/src/utils/batch-queue/priority-queue.ts
@@ -1,0 +1,178 @@
+import { logger } from "../../logger.js";
+
+/**
+ * In-memory priority queue: **high** items dequeue before **normal**, before **low**.
+ *
+ * **Why unbounded by default:** Queue entries are cheap; workloads like embedding generation are
+ * bounded by API throughput, not array length. Use `maxSize` + `onPressure` only when you
+ * explicitly want a cap (e.g. sampling / stale buffers) and can define drop or reject policy.
+ *
+ * **Why `onPressure` returns boolean:** The caller decides whether to evict, reject the new
+ * item, or take other action — we do not silently drop work here.
+ */
+
+export type QueuePriority = "high" | "normal" | "low";
+
+export type PriorityQueueStats = {
+	high: number;
+	normal: number;
+	low: number;
+	total: number;
+};
+
+export interface PriorityQueueOptions<T> {
+	getPriority: (item: T) => QueuePriority;
+	/** When set and length >= maxSize before enqueue, see {@link onPressure} / overflow behavior. */
+	maxSize?: number;
+	/**
+	 * Called when maxSize is reached before adding `item`. Return true after making room (e.g. dequeue)
+	 * so the new item can be inserted; return false to reject `item` (not enqueued).
+	 */
+	onPressure?: (queue: PriorityQueue<T>, item: T) => boolean;
+	/** When maxSize exceeded and no onPressure: still enqueue but notify (queue grows past maxSize). */
+	onOverflowWarning?: (sizeAfter: number, maxSize: number) => void;
+}
+
+export class PriorityQueue<T> {
+	// Note: Three separate arrays avoid O(n) linear scan per insertion; enqueue is O(1).
+	private invalidPriorityWarned = false;
+	private readonly highItems: T[] = [];
+	private readonly normalItems: T[] = [];
+	private readonly lowItems: T[] = [];
+	private readonly getPriority: (item: T) => QueuePriority;
+	private readonly maxSize?: number;
+	private readonly onPressure?: (queue: PriorityQueue<T>, item: T) => boolean;
+	private readonly onOverflowWarning?: (
+		sizeAfter: number,
+		maxSize: number,
+	) => void;
+
+	constructor(options: PriorityQueueOptions<T>) {
+		this.getPriority = options.getPriority;
+		this.maxSize = options.maxSize;
+		this.onPressure = options.onPressure;
+		this.onOverflowWarning = options.onOverflowWarning;
+	}
+
+	/**
+	 * Insert by priority. Returns false if rejected (onPressure returned false).
+	 */
+	enqueue(item: T): boolean {
+		const max = this.maxSize;
+		if (max !== undefined && this.size >= max) {
+			if (this.onPressure) {
+				if (!this.onPressure(this, item)) {
+					return false;
+				}
+			} else {
+				this.onOverflowWarning?.(this.size + 1, max);
+			}
+		}
+
+		this.insertByPriority(item);
+		return true;
+	}
+
+	private insertByPriority(item: T): void {
+		const p = this.getPriority(item);
+		if (p === "high") {
+			this.highItems.push(item);
+		} else if (p === "normal") {
+			this.normalItems.push(item);
+		} else if (p === "low") {
+			this.lowItems.push(item);
+		} else {
+			if (!this.invalidPriorityWarned) {
+				this.invalidPriorityWarned = true;
+				logger.warn(
+					{ src: "utils:priority-queue", priority: String(p) },
+					'Invalid queue priority; expected "high" | "normal" | "low". Treating as normal.',
+				);
+			}
+			this.normalItems.push(item);
+		}
+		// Note: separates items by priority for efficient batch processing and avoids linear scans.
+	}
+
+	/** Remove up to `n` items from the front (highest priority first). */
+	dequeueBatch(n: number): T[] {
+		if (n <= 0 || this.size === 0) {
+			return [];
+		}
+		const result: T[] = [];
+		let remaining = n;
+
+		// Drain from high priority first
+		if (remaining > 0 && this.highItems.length > 0) {
+			const take = Math.min(remaining, this.highItems.length);
+			result.push(...this.highItems.splice(0, take));
+			remaining -= take;
+		}
+
+		// Then normal priority
+		if (remaining > 0 && this.normalItems.length > 0) {
+			const take = Math.min(remaining, this.normalItems.length);
+			result.push(...this.normalItems.splice(0, take));
+			remaining -= take;
+		}
+
+		// Then low priority
+		if (remaining > 0 && this.lowItems.length > 0) {
+			const take = Math.min(remaining, this.lowItems.length);
+			result.push(...this.lowItems.splice(0, take));
+		}
+
+		return result;
+	}
+
+	/** Remove and return all items matching `filter`. */
+	drain(filter?: (item: T) => boolean): T[] {
+		if (!filter) {
+			const all = [...this.highItems, ...this.normalItems, ...this.lowItems];
+			this.highItems.length = 0;
+			this.normalItems.length = 0;
+			this.lowItems.length = 0;
+			return all;
+		}
+
+		const drainArray = (arr: T[]): T[] => {
+			const kept: T[] = [];
+			const out: T[] = [];
+			for (const item of arr) {
+				if (filter(item)) {
+					out.push(item);
+				} else {
+					kept.push(item);
+				}
+			}
+			arr.length = 0;
+			arr.push(...kept);
+			return out;
+		};
+
+		return [
+			...drainArray(this.highItems),
+			...drainArray(this.normalItems),
+			...drainArray(this.lowItems),
+		];
+	}
+
+	get size(): number {
+		return this.highItems.length + this.normalItems.length + this.lowItems.length;
+	}
+
+	clear(): void {
+		this.highItems.length = 0;
+		this.normalItems.length = 0;
+		this.lowItems.length = 0;
+	}
+
+	stats(): PriorityQueueStats {
+		return {
+			high: this.highItems.length,
+			normal: this.normalItems.length,
+			low: this.lowItems.length,
+			total: this.size,
+		};
+	}
+}

--- a/packages/typescript/src/utils/batch-queue/semaphore.ts
+++ b/packages/typescript/src/utils/batch-queue/semaphore.ts
@@ -1,0 +1,38 @@
+/**
+ * Async semaphore: limits how many in-flight `process` calls run at once (true throttle for I/O).
+ *
+ * **Contract:** every `acquire()` must be paired with `release()` in a `finally` (or equivalent)
+ * so permits return even when the guarded work throws. {@link BatchProcessor} does this; ad-hoc
+ * callers must do the same.
+ *
+ * **Why shared with PromptDispatcher:** One implementation avoids drift; `prompt-batcher/shared`
+ * re-exports this module so existing `import { Semaphore } from "./shared"` keeps working.
+ */
+export class Semaphore {
+	private permits: number;
+	private waiters: Array<() => void> = [];
+
+	constructor(count: number) {
+		this.permits = Math.max(1, count);
+	}
+
+	async acquire(): Promise<void> {
+		if (this.permits > 0) {
+			this.permits -= 1;
+			return;
+		}
+
+		await new Promise<void>((resolve) => {
+			this.waiters.push(resolve);
+		});
+	}
+
+	release(): void {
+		this.permits += 1;
+		const next = this.waiters.shift();
+		if (next && this.permits > 0) {
+			this.permits -= 1;
+			next();
+		}
+	}
+}

--- a/packages/typescript/src/utils/batch-queue/task-drain.ts
+++ b/packages/typescript/src/utils/batch-queue/task-drain.ts
@@ -1,0 +1,194 @@
+/**
+ * Encapsulates **repeat task** lifecycle for drain workloads: find-or-create a row with
+ * `tags: ["queue", "repeat"]`, merge scheduling metadata, optionally register a task worker.
+ *
+ * **Why `skipRegisterWorker`:** `BATCHER_DRAIN` is executed by a **single** worker registered in
+ * `TaskService` that dispatches by `metadata.affinityKey`. Per-affinity `TaskDrain` instances only
+ * create/update/delete tasks; registering another worker with the same name would overwrite the
+ * global handler.
+ *
+ * **Why `maxFailures: -1`:** `JSON.stringify(Infinity)` is `null`; `-1` round-trips through JSON
+ * and is interpreted by TaskService as “do not auto-pause this drain” (see CHANGELOG).
+ */
+
+import type { UUID } from "../../types/primitives.js";
+import type { JsonValue } from "../../types/proto";
+import type { IAgentRuntime } from "../../types/runtime.js";
+import type { Task } from "../../types/task.js";
+
+export interface TaskDrainOptions {
+	taskName: string;
+	/** Initial interval for repeat task metadata. */
+	intervalMs: number;
+	/** Optional DB task description (e.g. affinity label). */
+	description?: string;
+	/** Extra metadata merged into the repeat task (e.g. `{ affinityKey: "default" }`). */
+	taskMetadata?: Record<string, unknown>;
+	/**
+	 * When true, does not call `runtime.registerTaskWorker` — use when a global worker
+	 * already handles this task name (e.g. `BATCHER_DRAIN` in TaskService).
+	 */
+	skipRegisterWorker?: boolean;
+	/** Required unless `skipRegisterWorker` is true. Invoked when the repeat task fires. */
+	onDrain?: (runtime: IAgentRuntime) => Promise<void>;
+}
+
+export class TaskDrain {
+	private readonly taskName: string;
+	private readonly taskMetadata: Record<string, unknown>;
+	private readonly skipRegisterWorker: boolean;
+	private readonly onDrain?: (runtime: IAgentRuntime) => Promise<void>;
+	private intervalMs: number;
+	private taskId: UUID | null = null;
+	private workerRegistered = false;
+	private disposed = false;
+
+	private readonly description: string;
+
+	constructor(options: TaskDrainOptions, initialIntervalMs?: number) {
+		this.taskName = options.taskName;
+		this.description =
+			options.description ?? `Repeat drain: ${options.taskName}`;
+		this.taskMetadata = { ...(options.taskMetadata ?? {}) };
+		this.skipRegisterWorker = options.skipRegisterWorker ?? false;
+		this.onDrain = options.onDrain;
+		this.intervalMs = initialIntervalMs ?? options.intervalMs;
+	}
+
+	get id(): UUID | null {
+		return this.taskId;
+	}
+
+	/**
+	 * Register worker (unless skipped) and ensure the repeat task exists for this agent.
+	 */
+	async start(runtime: IAgentRuntime): Promise<void> {
+		if (this.disposed) {
+			return;
+		}
+		if (!this.skipRegisterWorker) {
+			const onDrain = this.onDrain;
+			if (!onDrain) {
+				throw new Error(
+					"TaskDrain: onDrain is required when registerWorker is enabled",
+				);
+			}
+			runtime.registerTaskWorker({
+				name: this.taskName,
+				execute: async (
+					rt: IAgentRuntime,
+					_options: Record<string, JsonValue | object>,
+					_task: Task,
+				) => {
+					await onDrain(rt);
+					return undefined;
+				},
+			});
+			this.workerRegistered = true;
+		}
+
+		await this.ensureTask(runtime);
+	}
+
+	/** Match agent + every key in `taskMetadata` (e.g. affinityKey for batcher drains). */
+	private matchesTask(t: Task, agentId: string): boolean {
+		if (t.agentId == null || String(t.agentId) !== String(agentId)) {
+			return false;
+		}
+		const meta = (t.metadata ?? {}) as Record<string, unknown>;
+		for (const [key, value] of Object.entries(this.taskMetadata)) {
+			if (meta[key] !== value) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private async ensureTask(runtime: IAgentRuntime): Promise<void> {
+		if (
+			typeof runtime.getTasksByName !== "function" ||
+			typeof runtime.createTask !== "function"
+		) {
+			return;
+		}
+		const agentId = runtime.agentId;
+		const existing = await runtime.getTasksByName(this.taskName);
+		const mine = existing.find((t) => this.matchesTask(t, String(agentId)));
+		if (mine?.id) {
+			this.taskId = mine.id;
+			// Reconcile DB interval/metadata with this drain’s configured interval (stale rows after restart).
+			if (
+				typeof runtime.getTask === "function" &&
+				typeof runtime.updateTask === "function"
+			) {
+				await this.updateInterval(runtime, this.intervalMs);
+			}
+			return;
+		}
+		this.taskId = await runtime.createTask({
+			name: this.taskName,
+			description: this.description,
+			tags: ["queue", "repeat"],
+			agentId: agentId as UUID,
+			worldId: agentId as UUID,
+			metadata: {
+				...this.taskMetadata,
+				updateInterval: this.intervalMs,
+				baseInterval: this.intervalMs,
+				updatedAt: Date.now(),
+				maxFailures: -1,
+			},
+		});
+	}
+
+	/**
+	 * Update repeat interval in DB when scheduling changes (e.g. batcher ideal tick).
+	 */
+	async updateInterval(
+		runtime: IAgentRuntime,
+		newIntervalMs: number,
+	): Promise<void> {
+		this.intervalMs = newIntervalMs;
+		const taskId = this.taskId;
+		if (
+			!taskId ||
+			typeof runtime.getTask !== "function" ||
+			typeof runtime.updateTask !== "function"
+		) {
+			return;
+		}
+		const task = await runtime.getTask(taskId);
+		if (!task) {
+			this.taskId = null;
+			return;
+		}
+		const current = (task.metadata as Record<string, unknown>)
+			?.updateInterval as number | undefined;
+		if (current === newIntervalMs) {
+			return;
+		}
+		await runtime.updateTask(taskId, {
+			metadata: {
+				...task.metadata,
+				updateInterval: newIntervalMs,
+				baseInterval: newIntervalMs,
+			},
+		});
+	}
+
+	getIntervalMs(): number {
+		return this.intervalMs;
+	}
+
+	async dispose(runtime: IAgentRuntime): Promise<void> {
+		this.disposed = true;
+		if (this.taskId && typeof runtime.deleteTask === "function") {
+			await runtime.deleteTask(this.taskId).catch(() => {});
+			this.taskId = null;
+		}
+		// Runtime has no unregisterTaskWorker; a later service may call registerTaskWorker again.
+		if (this.workerRegistered) {
+			this.workerRegistered = false;
+		}
+	}
+}

--- a/packages/typescript/src/utils/batch-queue/task-drain.ts
+++ b/packages/typescript/src/utils/batch-queue/task-drain.ts
@@ -95,6 +95,10 @@ export class TaskDrain {
 		if (t.agentId == null || String(t.agentId) !== String(agentId)) {
 			return false;
 		}
+		const tags = Array.isArray(t.tags) ? t.tags : [];
+		if (!tags.includes("queue") || !tags.includes("repeat")) {
+			return false;
+		}
 		const meta = (t.metadata ?? {}) as Record<string, unknown>;
 		for (const [key, value] of Object.entries(this.taskMetadata)) {
 			if (meta[key] !== value) {

--- a/packages/typescript/src/utils/prompt-batcher/batcher.ts
+++ b/packages/typescript/src/utils/prompt-batcher/batcher.ts
@@ -1,6 +1,5 @@
 import type { Memory } from "../../types/memory";
 import type { GenerateTextParams } from "../../types/model";
-import type { UUID } from "../../types/primitives";
 import {
 	BatcherDisposedError,
 	type BatcherResult,
@@ -14,7 +13,7 @@ import {
 } from "../../types/prompt-batcher";
 import type { IAgentRuntime } from "../../types/runtime";
 import type { SchemaRow } from "../../types/state";
-import type { Task } from "../../types/task";
+import { TaskDrain } from "../batch-queue";
 import type { PromptDispatcher } from "./dispatcher";
 import {
 	buildCharacterContext,
@@ -53,7 +52,7 @@ export class PromptBatcher {
 
 	private enabled = false;
 	private disposed = false;
-	private readonly affinityTaskIds = new Map<string, UUID>();
+	private readonly affinityDrains = new Map<string, TaskDrain>();
 
 	constructor(
 		private readonly runtime: IAgentRuntime,
@@ -115,15 +114,32 @@ export class PromptBatcher {
 			resolved: false,
 		});
 
-		void this._ensureAffinityTask(normalized.affinityKey ?? "default");
+		const affinityKey = normalized.affinityKey ?? "default";
+		void this._ensureAffinityDrain(affinityKey).then(() =>
+			this._syncAffinityTask(affinityKey),
+		);
 
-		if (
-			this.enabled &&
-			(normalized.priority === "immediate" ||
-				normalized.frequency === "once" ||
-				normalized.frequency === "per-drain")
-		) {
-			void this.drainAffinityGroup(normalized.affinityKey ?? "default");
+		const shouldDrainNow =
+			normalized.priority === "immediate" ||
+			normalized.frequency === "once" ||
+			normalized.frequency === "per-drain";
+
+		if (shouldDrainNow) {
+			if (this.enabled) {
+				void this.drainAffinityGroup(normalized.affinityKey ?? "default");
+			} else if (
+				normalized.priority === "immediate" ||
+				normalized.frequency === "once"
+			) {
+				// WHY: `enabled` flips true only after initPromise; without this, askNow
+				// registered during early startup would never drain until a later global drain.
+				// Per-drain sections intentionally skip this path so they are not double-drained.
+				void this.runtime.initPromise.then(() => {
+					if (!this.disposed) {
+						void this.drainAffinityGroup(normalized.affinityKey ?? "default");
+					}
+				});
+			}
 		}
 
 		return promise;
@@ -239,14 +255,12 @@ export class PromptBatcher {
 	dispose(): void {
 		this.disposed = true;
 
-		if (typeof this.runtime.deleteTask === "function") {
-			for (const [, taskId] of this.affinityTaskIds) {
-				void this.runtime.deleteTask(taskId).catch(() => {
-					/* task may already be gone */
-				});
-			}
+		for (const [, drain] of this.affinityDrains) {
+			void drain.dispose(this.runtime).catch(() => {
+				/* task may already be gone */
+			});
 		}
-		this.affinityTaskIds.clear();
+		this.affinityDrains.clear();
 
 		for (const pending of this.pendingResults.values()) {
 			if (!pending.resolved) {
@@ -499,9 +513,13 @@ export class PromptBatcher {
 		).length;
 	}
 
-	/** WHY create a task per affinity: task system owns WHEN (interval, pause/resume); batcher owns WHAT runs during drain. One BATCHER_DRAIN task per affinity so each group has its own schedule. */
-	private async _ensureAffinityTask(affinityKey: string): Promise<void> {
-		if (this.affinityTaskIds.has(affinityKey)) {
+	/**
+	 * One repeat task per affinity — shared {@link TaskDrain} with `skipRegisterWorker`:
+	 * TaskService already registers `BATCHER_DRAIN`; we only ensure the DB row + interval updates.
+	 * Same subsystem as embedding drains (`utils/batch-queue.ts` rationale).
+	 */
+	private async _ensureAffinityDrain(affinityKey: string): Promise<void> {
+		if (this.affinityDrains.has(affinityKey)) {
 			return;
 		}
 		if (
@@ -510,73 +528,40 @@ export class PromptBatcher {
 		) {
 			return;
 		}
-		const existing = await this.runtime.getTasksByName("BATCHER_DRAIN");
-		const match = existing.find(
-			(t) =>
-				(t.metadata as Record<string, unknown>)?.affinityKey === affinityKey,
-		);
-		if (match?.id) {
-			this.affinityTaskIds.set(affinityKey, match.id);
-			return;
-		}
 		const interval = this.getIdealTickInterval(affinityKey);
-		// WHY queue+repeat: TaskService only runs tasks with tag "queue"; repeat uses updateInterval/updatedAt for scheduling.
-		// WHY maxFailures -1: JSON.stringify(Infinity) is null; -1 survives DB round-trip and means "never auto-pause" for drain tasks.
-		const task: Task = {
-			name: "BATCHER_DRAIN",
-			description: `Drain affinity group: ${affinityKey}`,
-			tags: ["queue", "repeat"],
-			metadata: {
-				affinityKey,
-				updateInterval: interval,
-				baseInterval: interval,
-				updatedAt: Date.now(),
-				maxFailures: -1,
+		const drain = new TaskDrain(
+			{
+				taskName: "BATCHER_DRAIN",
+				description: `Drain affinity group: ${affinityKey}`,
+				intervalMs: interval,
+				taskMetadata: { affinityKey },
+				skipRegisterWorker: true,
 			},
-		};
-		const id = await this.runtime.createTask(task);
-		this.affinityTaskIds.set(affinityKey, id);
+			interval,
+		);
+		await drain.start(this.runtime);
+		this.affinityDrains.set(affinityKey, drain);
 	}
 
 	private async _syncAffinityTask(affinityKey: string): Promise<void> {
-		const taskId = this.affinityTaskIds.get(affinityKey);
-		if (!taskId) return;
-		if (
-			typeof this.runtime.getTask !== "function" ||
-			typeof this.runtime.updateTask !== "function"
-		)
-			return;
+		const drain = this.affinityDrains.get(affinityKey);
+		if (!drain) return;
 		const count = this.getSectionCountForAffinity(affinityKey);
 		if (count === 0) {
 			await this._removeAffinityTask(affinityKey);
 			return;
 		}
-		const task = await this.runtime.getTask(taskId);
-		if (!task) {
-			this.affinityTaskIds.delete(affinityKey);
-			return;
-		}
 		const newInterval = this.getIdealTickInterval(affinityKey);
-		const current = (task.metadata as Record<string, unknown>)
-			?.updateInterval as number | undefined;
-		if (current !== newInterval) {
-			await this.runtime.updateTask(taskId, {
-				metadata: { ...task.metadata, updateInterval: newInterval },
-			});
-		}
+		await drain.updateInterval(this.runtime, newInterval);
 	}
 
 	private async _removeAffinityTask(affinityKey: string): Promise<void> {
-		const taskId = this.affinityTaskIds.get(affinityKey);
-		if (!taskId) return;
-		if (typeof this.runtime.deleteTask !== "function") {
-			this.affinityTaskIds.delete(affinityKey);
-			return;
-		}
+		const drain = this.affinityDrains.get(affinityKey);
+		if (!drain) return;
 		try {
-			await this.runtime.deleteTask(taskId);
+			await drain.dispose(this.runtime);
 		} finally {
-			this.affinityTaskIds.delete(affinityKey);
+			this.affinityDrains.delete(affinityKey);
 		}
 	}
 

--- a/packages/typescript/src/utils/prompt-batcher/batcher.ts
+++ b/packages/typescript/src/utils/prompt-batcher/batcher.ts
@@ -115,9 +115,19 @@ export class PromptBatcher {
 		});
 
 		const affinityKey = normalized.affinityKey ?? "default";
-		void this._ensureAffinityDrain(affinityKey).then(() =>
-			this._syncAffinityTask(affinityKey),
-		);
+		void this._ensureAffinityDrain(affinityKey)
+			.then(() => this._syncAffinityTask(affinityKey))
+			.catch((error) => {
+				this.runtime.logger.error(
+					{
+						src: "prompt-batcher",
+						agentId: this.runtime.agentId,
+						affinityKey,
+						error,
+					},
+					"Failed to ensure prompt batcher drain",
+				);
+			});
 
 		const shouldDrainNow =
 			normalized.priority === "immediate" ||

--- a/packages/typescript/src/utils/prompt-batcher/shared.ts
+++ b/packages/typescript/src/utils/prompt-batcher/shared.ts
@@ -64,34 +64,11 @@ export type PromptBatcherSettings = {
 	modelSeparation: number;
 };
 
-export class Semaphore {
-	private permits: number;
-	private queue: Array<() => void> = [];
-
-	constructor(count: number) {
-		this.permits = Math.max(1, count);
-	}
-
-	async acquire(): Promise<void> {
-		if (this.permits > 0) {
-			this.permits -= 1;
-			return;
-		}
-
-		await new Promise<void>((resolve) => {
-			this.queue.push(resolve);
-		});
-	}
-
-	release(): void {
-		this.permits += 1;
-		const next = this.queue.shift();
-		if (next && this.permits > 0) {
-			this.permits -= 1;
-			next();
-		}
-	}
-}
+/**
+ * Re-export so dispatcher keeps `import { Semaphore } from "./shared"`.
+ * Single `Semaphore` implementation under `utils/batch-queue` (see `batch-queue.ts` header).
+ */
+export { Semaphore } from "../batch-queue/semaphore.js";
 
 export function sanitizeIdentifier(value: string): string {
 	const normalized = value.replace(/[^a-zA-Z0-9_]/g, "_");


### PR DESCRIPTION
Introduce utils/batch-queue (PriorityQueue, BatchProcessor, TaskDrain, BatchQueue, Semaphore) so embedding drains, action-filter index build, prompt-batcher affinity tasks, and knowledge embedding paths share one concurrency/retry/task story.

- EmbeddingGenerationService uses BatchQueue; optional TEXT_EMBEDDING boots as no-op.
- ActionFilterService buildIndex uses BatchProcessor for action embeddings.
- PromptBatcher uses TaskDrain per affinity (skipRegisterWorker for BATCHER_DRAIN).
- Knowledge: document-processor fallback and generateTextEmbeddingsBatch use BatchProcessor.
- Remove duplicate Semaphore from runtime; re-export canonical Semaphore from package entries.
- Polish: invalid priority warn + normal tier, TaskDrain interval reconcile on existing task, dispose high-priority flush via BatchProcessor, onDrainBatchOutcomes, maxAttemptsCap, clear after dispose.

Docs: BATCH_QUEUE.md, DESIGN, ROADMAP, CHANGELOG, README, public runtime/batch-queue.mdx; tests for batch-queue and TaskDrain.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core background-processing paths (embedding drain scheduling, prompt-batcher affinity tasks, and knowledge/action embedding concurrency), so regressions could affect throughput and task execution behavior, though changes are additive and covered by new unit tests and docs.
> 
> **Overview**
> Introduces a new shared `utils/batch-queue` stack in `@elizaos/core` (**`PriorityQueue`**, **`BatchProcessor`**, **`TaskDrain`**, **`BatchQueue`**, and a single **`Semaphore`**) to standardize priority ordering, bounded parallelism, retries/backoff, and repeat-task drain lifecycle.
> 
> Refactors key runtime paths to use this shared pipeline: `EmbeddingGenerationService` now drains via `BatchQueue` (and becomes a **no-op** when no `TEXT_EMBEDDING` model is registered), action-filter index embedding uses `BatchProcessor` with retries and non-fatal handling of invalid vectors, prompt-batcher per-affinity scheduling uses `TaskDrain` with `skipRegisterWorker`, and knowledge embedding fallbacks replace unbounded `Promise.all` with bounded concurrency.
> 
> Updates exports to remove duplicate `Semaphore` implementations (now re-exported from `utils/batch-queue` across `index.node`/`index.browser`/`index.edge`), adds unit tests for the new queue/drain primitives, and expands public and contributor docs (new batch-queue docs page, `BATCH_QUEUE.md`, roadmap/design/changelog/README updates) and navigation to surface the subsystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62169a6da95fd375bf35472601cc0f1aacb2b78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a standardized batch queue subsystem for managing concurrent task processing, queue prioritization, and automatic retries with backoff.
  * Added prompt cache support via `promptSegments` parameter for text generation, enabling providers to optimize cache efficiency.
  * Enhanced embedding generation with bounded concurrency control and improved retry behavior.

* **Improvements**
  * Embedding service now gracefully handles missing models with a warning instead of throwing an error.
  * Refined error handling and recovery for batch processing workflows across embedding, knowledge, and action filtering.

* **Documentation**
  * New comprehensive guides on batch queue subsystem design and usage patterns.
  * Updated README and added ROADMAP documenting planned features and design rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `utils/batch-queue` stack (`PriorityQueue`, `BatchProcessor`, `TaskDrain`, `BatchQueue`, `Semaphore`) to consolidate previously ad-hoc concurrency/retry/task patterns across `EmbeddingGenerationService`, `ActionFilterService`, `PromptBatcher`, and knowledge-processing paths. The architecture is well-reasoned and the `skipRegisterWorker` / `BATCHER_DRAIN` delegation pattern is correctly grounded in `task.ts`.

- **P1 in `batch-processor.ts`:** `onExhausted` is `await`-ed inside the `catch` block without a try-catch guard. If `onExhausted` throws (e.g., `runtime.log()` or `runtime.emitEvent()` on a DB outage in `EmbeddingGenerationService`), the error escapes `processOne`, causes `Promise.all` in `processBatch` to reject, and propagates through `BatchQueue.drain()` — disrupting the drain task lifecycle and skipping `onDrainBatchOutcomes`/`onDrainComplete` callbacks.
- Two P2 style/consistency issues in `llm.ts` and `document-processor.ts` around error-swallowing inside `process` callbacks are noted inline.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the onExhausted error propagation in batch-processor; P2 findings are non-blocking style improvements.

One P1 issue: if onExhausted throws (possible in EmbeddingGenerationService on DB failure), the entire drain cycle errors and outcome callbacks are skipped. The fix is a one-line try-catch wrap. The rest of the architecture — PriorityQueue, TaskDrain, BatchQueue, BATCHER_DRAIN delegation — is correct.

packages/typescript/src/utils/batch-queue/batch-processor.ts (P1: onExhausted propagation). packages/typescript/src/features/knowledge/llm.ts and document-processor.ts (P2 style notes).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/utils/batch-queue/batch-processor.ts | New: stateless batch executor with semaphore, retries, backoff. P1 issue: onExhausted errors propagate through Promise.all, disrupting BatchQueue.drain() lifecycle and skipping outcome callbacks. |
| packages/typescript/src/utils/batch-queue/index.ts | New: composed BatchQueue (PriorityQueue + BatchProcessor + TaskDrain) with dispose, drain, and interval-update. Logic is sound; drain re-entry guard and disposed flag are correct. |
| packages/typescript/src/utils/batch-queue/task-drain.ts | New: repeat-task lifecycle manager (find-or-create, interval reconcile, dispose). skipRegisterWorker pattern for BATCHER_DRAIN is correct; maxFailures: -1 JSON-safe sentinel is well-reasoned. |
| packages/typescript/src/utils/batch-queue/priority-queue.ts | New: three-tier priority queue (high/normal/low) with O(1) enqueue, maxSize/onPressure overflow hooks, and drain filter. Logic is correct. |
| packages/typescript/src/utils/batch-queue/semaphore.ts | Canonical Semaphore extracted from runtime; logic is correct and re-exported consistently across all entry points. |
| packages/typescript/src/services/embedding.ts | Refactored to use BatchQueue; onExhausted makes async runtime.log/emitEvent calls that can throw — which would propagate through drain() due to the P1 issue in batch-processor. |
| packages/typescript/src/features/knowledge/llm.ts | generateTextEmbeddingsBatch now uses BatchProcessor for concurrency limiting but swallows errors inside process(), bypassing retry/onExhausted (P2). generateBatchEmbeddingsViaRuntime fallback adds retries — correct. |
| packages/typescript/src/features/knowledge/document-processor.ts | generateBatchEmbeddingsViaRuntime fallback migrated to BatchProcessor with retries; sparse-array pattern leaves undefined holes when text is undefined (P2), but caller handles gracefully. |
| packages/typescript/src/services/action-filter.ts | buildIndex now uses BatchProcessor for action embeddings; onExhausted is synchronous (no async calls), so no propagation risk. Logic is clean. |
| packages/typescript/src/utils/prompt-batcher/batcher.ts | affinityTaskIds replaced with TaskDrain instances; skipRegisterWorker pattern for BATCHER_DRAIN confirmed correct (worker registered in task.ts:74). Dispose path properly awaits drain.dispose() per-affinity. |
| packages/typescript/src/utils/prompt-batcher/shared.ts | Re-exports canonical Semaphore from batch-queue/semaphore so existing dispatcher imports continue to work without code changes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TW as TaskWorker (repeat task)
    participant BQ as BatchQueue
    participant PQ as PriorityQueue
    participant BP as BatchProcessor
    participant S as Semaphore
    participant P as process(item)
    participant OE as onExhausted(item,err)

    TW->>BQ: drain()
    BQ->>BQ: isDraining = true
    BQ->>PQ: dequeueBatch(batchSize)
    PQ-->>BQ: items[]
    BQ->>BP: processBatch(items[])
    BP->>BP: Promise.all(items.map(processOne))
    loop per item
        BP->>S: acquire()
        BP->>P: await process(item)
        alt success
            P-->>BP: returns
            BP->>S: release()
            BP-->>BP: outcome success:true
        else all retries exhausted
            P-->>BP: throws
            BP->>OE: await onExhausted(item, err)
            Note over BP,OE: If OE throws, Promise.all rejects
            OE-->>BP: returns or throws
            BP->>S: release() via finally
            BP-->>BP: outcome success:false
        end
    end
    BP-->>BQ: BatchItemOutcome[]
    BQ->>BQ: onDrainBatchOutcomes(outcomes)
    BQ->>BQ: isDraining = false
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/typescript/src/features/knowledge/document-processor.ts`, line 549-580 ([link](https://github.com/elizaos/eliza/blob/a5f6ac9d40ca8cb8c68b0a9dcd40320591228cd0/packages/typescript/src/features/knowledge/document-processor.ts#L549-L580)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Sparse array leaves `undefined` holes when `text` is `undefined`**

   `new Array(texts.length)` creates a sparse array. The `if (text === undefined) { return; }` guard makes `process` return successfully without writing `slots[idx]`, and `onExhausted` is never triggered (since no error was thrown). The slot stays `undefined`, which differs from the `onExhausted` path that writes `[]`. The caller in `generateEmbeddingsBatch` handles `undefined` correctly (`embedding && embedding.length > 0`), so this is not a runtime crash, but the inconsistency between the two failure paths could confuse future changes.

   Consider replacing the early-return guard with an explicit `throw` so `onExhausted` consistently handles all failure cases:
   ```ts
   process: async (idx) => {
     const text = texts[idx];
     if (text === undefined) {
       throw new Error(`No text for index ${idx}`);
     }
     // ...
   },
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(core): shared batch-queue drains an..."](https://github.com/elizaos/eliza/commit/a5f6ac9d40ca8cb8c68b0a9dcd40320591228cd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28155519)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->