### PR TITLE
fix(tasks): silence periodic thread polling UI flicker

### DIFF
--- a/apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -508,8 +508,10 @@ export function CodingAgentTasksPanel({
   useEffect(() => {
     let cancelled = false;
 
-    const refreshThreads = async () => {
-      setLoading(true);
+    const refreshThreads = async (silent = false) => {
+      if (!silent) {
+        setLoading(true);
+      }
       try {
         const nextThreads = await client.listCodingAgentTaskThreads({
           includeArchived: showArchived,
@@ -532,19 +534,22 @@ export function CodingAgentTasksPanel({
         setLoadError(
           getClientErrorMessage(error, "Failed to load task threads."),
         );
-        setThreads([]);
-        setSelectedThreadId(null);
-        setSelectedThread(null);
+        if (!silent) {
+          setThreads([]);
+          setSelectedThreadId(null);
+          setSelectedThread(null);
+        }
       } finally {
-        if (!cancelled) {
+        if (!cancelled && !silent) {
           setLoading(false);
         }
       }
     };
 
-    void refreshThreads();
+    void refreshThreads(false);
     const timer = setInterval(() => {
-      void refreshThreads();
+      // Poll in the background without toggling loading UI to avoid flicker.
+      void refreshThreads(true);
     }, 5_000);
 
     return () => {

--- a/apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx
+++ b/apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx
@@ -531,9 +531,11 @@ export function CodingAgentTasksPanel({
         });
       } catch (error) {
         if (cancelled) return;
-        setLoadError(
-          getClientErrorMessage(error, "Failed to load task threads."),
-        );
+        if (!silent) {
+          setLoadError(
+            getClientErrorMessage(error, "Failed to load task threads."),
+          );
+        }
         if (!silent) {
           setThreads([]);
           setSelectedThreadId(null);


### PR DESCRIPTION
## Summary
- avoid flipping loading state during periodic thread polling in CodingAgentTasksPanel
- keep polling silent unless a user-visible load transition is actually needed

## Why
Removes recurring panel flicker during background refresh.

## Validation
- manual UI verification path for task panel polling refresh
- no API contract changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `silent` boolean parameter to the `refreshThreads` function in `CodingAgentTasksPanel`, preventing the periodic 5-second polling interval from toggling the loading spinner or resetting thread/selection state on each background refresh. The initial load on effect mount remains fully visible (`silent = false`), while the `setInterval` callback passes `silent = true` to suppress all UI transitions.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is narrowly scoped and correctly preserves initial-load behaviour while suppressing flicker during background polling.

Only a P2 style finding remains: `setLoadError` is still called in silent mode, which can cause a brief error-banner flash on transient poll failures — a minor UX inconsistency rather than a correctness bug. All state management and cancellation logic is correct.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx | Adds a `silent` flag to `refreshThreads` to skip loading-state toggles and state resets during periodic polling; initial load behaviour is unchanged. One minor inconsistency: `setLoadError` is still called in silent mode on error, so background poll failures can still flash the error banner. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useEffect fires] --> B["refreshThreads(false)\ninitial load"]
    A --> C["setInterval 5s"]
    B --> D{silent?}
    C --> E["refreshThreads(true)\nsilent poll"]
    E --> D
    D -- "false (initial)" --> F[setLoading true]
    D -- "true (poll)" --> G[skip setLoading]
    F --> H[await listCodingAgentTaskThreads]
    G --> H
    H -- success --> I[setThreads / clear errors]
    H -- error --> J{silent?}
    J -- false --> K[setLoadError\nsetThreads empty\nsetSelectedThread null]
    J -- true --> L[setLoadError only\nthreads preserved]
    K --> M["finally: setLoading false\n(if !cancelled)"]
    G --> N["finally: skip setLoading false\n(silent)"]
    L --> N
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx`, line 532-541 ([link](https://github.com/elizaos/eliza/blob/43d94a59548da5fe0a7e25a60989437c6fd63c51/apps/app-task-coordinator/src/CodingAgentTasksPanel.tsx#L532-L541)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Silent polls still surface `loadError` to users**

   `setLoadError` is called unconditionally in the catch block, so a transient background-poll failure will still flash the red "Failed to load task threads" banner even though the stated goal is to make periodic refresh invisible to users. The threads themselves are correctly preserved, but the error banner appears and then disappears on the next successful poll — which is the same kind of flicker this PR is trying to eliminate.

   Consider guarding `setLoadError` with `!silent` as well (or using a separate `pollError` state for background errors, surfacing them only after N consecutive failures):

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): silence periodic thread poll..."](https://github.com/elizaos/eliza/commit/43d94a59548da5fe0a7e25a60989437c6fd63c51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28436789)</sub>

<!-- /greptile_comment -->