### PR TITLE
fix(ui): make inbox reply hint platform-neutral

### DIFF
--- a/packages/app-core/src/components/pages/ChatView.tsx
+++ b/packages/app-core/src/components/pages/ChatView.tsx
@@ -927,7 +927,7 @@ function InboxChatPanel({
                   ? replyError
                   : t("inboxview.ReplyHint", {
                       defaultValue:
-                        "Sent through the connected {{source}} account on this Mac.",
+                        "Sent through the connected {{source}} account on this device.",
                       source: sourceLabel,
                     })}
               </div>

--- a/packages/app-core/src/i18n/locales/en.json
+++ b/packages/app-core/src/i18n/locales/en.json
@@ -1141,7 +1141,7 @@
   "inboxview.EmptyRoom": "No messages in this chat yet.",
   "inboxview.Loading": "Loading messages…",
   "inboxview.ReadOnlyReplyHint": "Read-only view. Reply from the {{source}} app — the connector plugin handles outbound messages.",
-  "inboxview.ReplyHint": "Sent through the connected {{source}} account on this Mac.",
+  "inboxview.ReplyHint": "Sent through the connected {{source}} account on this device.",
   "inboxview.ReplyPlaceholder": "Reply in {{source}}",
   "inboxview.Send": "Send",
   "inboxview.SendFailed": "Failed to send message.",


### PR DESCRIPTION
## Summary
- change Inbox reply footer copy from "on this Mac" to "on this device"
- update both the ChatView fallback string and the `inboxview.ReplyHint` English locale entry

## Why
On Windows, the current copy is incorrect and confusing.

## Scope
UI text-only change; no runtime behavior changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `inboxview.ReplyHint` copy from "on this Mac" to "on this device" in both `ChatView.tsx` (inline `defaultValue`) and `en.json`, making the hint platform-neutral for Windows users.

- The fix is incomplete: `es.json`, `ko.json`, `pt.json`, `tl.json`, `vi.json`, and `zh-CN.json` all still contain the old `"on this Mac"` string for `inboxview.ReplyHint` — Windows users on those locales will continue seeing the incorrect copy.

<h3>Confidence Score: 4/5</h3>

Safe to merge for English-locale users; Windows users on es/ko/pt/tl/vi/zh-CN locales will still see the incorrect "on this Mac" copy.

One P1 finding: the fix is applied to en.json but the same stale string exists verbatim in five other locale files, leaving the stated bug present for a significant portion of non-English users.

packages/app-core/src/i18n/locales/es.json, ko.json, pt.json, tl.json, vi.json, zh-CN.json — all need the same one-line update to inboxview.ReplyHint

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/ChatView.tsx | Inline `defaultValue` for `inboxview.ReplyHint` updated from "on this Mac" to "on this device" — correct and consistent with en.json change. |
| packages/app-core/src/i18n/locales/en.json | English locale `inboxview.ReplyHint` updated to "on this device" — correct, but five other locale files (es, ko, pt, tl, vi, zh-CN) still have the old "on this Mac" value. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Inbox reply panel] --> B{i18n locale?}
    B -->|en| C["inboxview.ReplyHint ✅\n'…on this device'"]
    B -->|es / ko / pt / tl / vi / zh-CN| D["inboxview.ReplyHint ⚠️\n'…on this Mac' — not updated"]
    B -->|missing key → fallback| E["defaultValue in ChatView.tsx ✅\n'…on this device'"]
    D --> F[Windows user sees incorrect copy]
    C --> G[Correct copy shown]
    E --> G
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use platform-neutral inbox repl..."](https://github.com/elizaos/eliza/commit/4ca7582172d9ded612eaad4b7241136e8f84ea17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28486855)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->