### PR TITLE
fix: wire task synthesis end-to-end + harden runtime plugin load under bun

### DIFF
--- a/packages/agent/src/api/character-routes.ts
+++ b/packages/agent/src/api/character-routes.ts
@@ -45,7 +45,7 @@ export interface CharacterAutonomousConfigLike extends AutonomousConfigLike {
 }
 
 interface CharacterParseIssueLike {
-  path: Array<string | number>;
+  path: PropertyKey[];
   message: string;
 }
 
@@ -54,7 +54,7 @@ interface CharacterParseErrorLike {
 }
 
 type CharacterValidationResult =
-  | { success: true }
+  | { success: true; data?: unknown }
   | { success: false; error: CharacterParseErrorLike };
 
 export interface CharacterRouteState {

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1551,79 +1551,41 @@ export async function handleSwarmSynthesis(
  * For port-bound tasks, verifies the server is actually listening.
  * No LLM call required — task data already has what we need.
  */
+type SynthesisTask = {
+  sessionId: string;
+  originalTask: string;
+  completionSummary: string;
+  status: string;
+  workdir?: string;
+};
+
 async function buildSynthesisResultText(
-  payload: {
-    tasks: Array<{
-      sessionId: string;
-      originalTask: string;
-      completionSummary: string;
-      status: string;
-      workdir?: string;
-    }>;
-    total: number;
-  },
+  payload: { tasks: SynthesisTask[]; total: number },
   runtime: AgentRuntime,
 ): Promise<string> {
-  const rawParts = await Promise.all(
-    payload.tasks.map((task) => buildTaskResultLine(task, runtime)),
+  const parts = await Promise.all(
+    payload.tasks.map((task) => buildTaskLine(task, runtime)),
   );
-  const parts = dedupeAndDenoise(rawParts);
   if (parts.length === 1) return parts[0];
-  return `done — ${parts.length} task${parts.length === 1 ? "" : "s"}:\n${parts.map((p) => `• ${p}`).join("\n")}`;
+  return `done — ${parts.length} tasks:\n${parts.map((p) => `• ${p}`).join("\n")}`;
 }
 
 /**
- * Strip task outputs that are pure deferral commentary ("DECISION: I deferred
- * to the sibling agent ..."), and collapse duplicates where multiple tasks
- * reported the same public URL. A swarm that splits a prompt across siblings
- * produces one authoritative output and N near-duplicates — synthesis should
- * show the authoritative one, not a bulleted list of echoes.
+ * Deliver the subagent's actual final answer — the last end_turn assistant
+ * text from its session jsonl. Trust the agent to already have produced
+ * a coherent response; synthesis does not rewrite or trim it. Falls back
+ * to completionSummary, then a port-status check, then the original
+ * prompt text when no jsonl is available.
  */
-function dedupeAndDenoise(rawParts: string[]): string[] {
-  const isDeferral = (text: string): boolean =>
-    /\b(DECISION:\s*I deferred|deferred the build to the sibling|clobbering would have been)/i.test(
-      text,
-    );
-  const deferralFree = rawParts.filter((p) => !isDeferral(p));
-  const parts = deferralFree.length > 0 ? deferralFree : rawParts;
-  const byUrl = new Map<string, string>();
-  const out: string[] = [];
-  for (const part of parts) {
-    const url = part.match(/https?:\/\/\S+/)?.[0] ?? null;
-    if (url) {
-      if (byUrl.has(url)) continue;
-      byUrl.set(url, part);
-    }
-    out.push(part);
-  }
-  return out;
-}
-
-async function buildTaskResultLine(
-  task: {
-    sessionId: string;
-    originalTask: string;
-    completionSummary: string;
-    workdir?: string;
-  },
+async function buildTaskLine(
+  task: SynthesisTask,
   runtime: AgentRuntime,
 ): Promise<string> {
-  // Prefer the subagent's actual final answer (the last end_turn assistant
-  // message from its session jsonl) over the short completionSummary. This
-  // is what the user actually asked for — the price, the code, the answer.
-  // Workdir comes in the payload (captured at spawn time) because the PTY
-  // session is usually destroyed before synthesis runs.
-  const workdir = task.workdir ?? resolveSessionWorkdir(runtime, task.sessionId);
+  const workdir =
+    task.workdir ?? resolveSessionWorkdir(runtime, task.sessionId);
   if (workdir) {
     const assistantText = await readLastAssistantTextFromJsonl(workdir);
-    if (assistantText) {
-      // Agent-home pattern: if the subagent reported a deployed URL, collapse
-      // the whole response to "done — URL: ..." as the final chat message.
-      const urlLine = assistantText
-        .split("\n")
-        .find((line) => /^\s*URL:\s*https?:\/\//i.test(line));
-      return urlLine ? `done — ${urlLine.trim()}` : assistantText;
-    }
+    if (assistantText) return assistantText;
   }
   if (task.completionSummary) return task.completionSummary;
   const portMatch = task.originalTask.match(/port\s+(\d+)/i);

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -343,9 +343,12 @@ import {
 } from "./plugin-discovery-helpers.js";
 
 const nodeRequire = createRequire(import.meta.url);
+// Dynamic import (not require) because the plugin is ESM-only and bun's
+// createRequire cannot load ESM packages. Top-level await is settled before
+// any consumer reads the binding.
 let agentOrchestratorCompat: unknown = null;
 try {
-  agentOrchestratorCompat = nodeRequire("@elizaos/plugin-agent-orchestrator");
+  agentOrchestratorCompat = await import("@elizaos/plugin-agent-orchestrator");
 } catch {
   agentOrchestratorCompat = null;
 }
@@ -1378,7 +1381,6 @@ function getCoordinatorFromRuntime(runtime: AgentRuntime): {
   getTaskThread?: (
     threadId: string,
   ) => Promise<{ roomId?: string | null } | null>;
-  sourceRoomId?: string | null;
 } | null {
   const coordinator = runtime.getService("SWARM_COORDINATOR");
   if (coordinator) {
@@ -1465,16 +1467,16 @@ function wireCodingAgentWsBridge(st: ServerState): boolean {
  * persisted message in the conversation.
  */
 function wireCodingAgentSwarmSynthesis(st: ServerState): boolean {
-  // Same rationale as wireCodingAgentChatBridge: synthesis is generated
-  // from task metadata (originalTask = user's text), not from the
-  // subagent's actual output. The task-progress-streamer + jsonl watcher
-  // deliver the real answer. Install a no-op callback so the upstream
-  // wiring check considers this bridge wired.
+  // The task-progress-streamer was removed from this tree but the callback
+  // was left as a no-op, so subagent completions never reached the user.
+  // Invoke handleSwarmSynthesis directly so the synthesis LLM routes the
+  // final answer back to the conversation. The task jsonl is already the
+  // source of truth for per-task completionSummary.
   if (!st.runtime) return false;
   const coordinator = getCoordinatorFromRuntime(st.runtime);
   if (!coordinator?.setSwarmCompleteCallback) return false;
-  coordinator.setSwarmCompleteCallback(async () => {
-    // Deliberately no-op — synthesis happens via the streamer instead.
+  coordinator.setSwarmCompleteCallback(async (payload) => {
+    await handleSwarmSynthesis(st, payload);
   });
   return true;
 }
@@ -1497,6 +1499,8 @@ export async function handleSwarmSynthesis(
       originalTask: string;
       status: string;
       completionSummary: string;
+      workdir?: string;
+      roomId?: string;
     }>;
     total: number;
     completed: number;
@@ -1518,10 +1522,19 @@ export async function handleSwarmSynthesis(
     `[swarm-synthesis] Generating synthesis for ${payload.total} tasks (${payload.completed} completed, ${payload.stopped} stopped, ${payload.errored} errored)`,
   );
 
-  const resultText = await buildSynthesisResultText(payload);
-  logger.info("[swarm-synthesis] Synthesis generated, routing to user");
-  await routeMessage(resultText, "swarm_synthesis");
-  await routeSynthesisToConnector(runtime, resultText);
+  const resultText = await buildSynthesisResultText(payload, runtime);
+  logger.info(
+    `[swarm-synthesis] Synthesis generated (${resultText.length} chars), routing to user — preview: ${resultText.slice(0, 200).replace(/\n/g, " | ")}`,
+  );
+  // Route back to the originating chat channel via the roomId captured on
+  // the incoming user message (propagated through the task payload).
+  const roomId = payload.tasks.find((t) => t.roomId)?.roomId ?? null;
+  // Discord's per-message limit is 2000 chars. Deliver long answers as
+  // sequential chunks so the subagent's full output reaches the user.
+  for (const chunk of chunkForDiscord(resultText, 1900)) {
+    await routeMessage(chunk, "swarm_synthesis");
+    await routeSynthesisToConnector(runtime, chunk, roomId);
+  }
 }
 
 /**
@@ -1529,24 +1542,53 @@ export async function handleSwarmSynthesis(
  * For port-bound tasks, verifies the server is actually listening.
  * No LLM call required — task data already has what we need.
  */
-async function buildSynthesisResultText(payload: {
-  tasks: Array<{
-    originalTask: string;
-    completionSummary: string;
-    status: string;
-  }>;
-  total: number;
-}): Promise<string> {
-  const parts = await Promise.all(payload.tasks.map(buildTaskResultLine));
+async function buildSynthesisResultText(
+  payload: {
+    tasks: Array<{
+      sessionId: string;
+      originalTask: string;
+      completionSummary: string;
+      status: string;
+      workdir?: string;
+    }>;
+    total: number;
+  },
+  runtime: AgentRuntime,
+): Promise<string> {
+  const parts = await Promise.all(
+    payload.tasks.map((task) => buildTaskResultLine(task, runtime)),
+  );
   return parts.length === 1
-    ? `done — ${parts[0]}`
+    ? parts[0]
     : `done — ${payload.total} tasks:\n${parts.map((p) => `• ${p}`).join("\n")}`;
 }
 
-async function buildTaskResultLine(task: {
-  originalTask: string;
-  completionSummary: string;
-}): Promise<string> {
+async function buildTaskResultLine(
+  task: {
+    sessionId: string;
+    originalTask: string;
+    completionSummary: string;
+    workdir?: string;
+  },
+  runtime: AgentRuntime,
+): Promise<string> {
+  // Prefer the subagent's actual final answer (the last end_turn assistant
+  // message from its session jsonl) over the short completionSummary. This
+  // is what the user actually asked for — the price, the code, the answer.
+  // Workdir comes in the payload (captured at spawn time) because the PTY
+  // session is usually destroyed before synthesis runs.
+  const workdir = task.workdir ?? resolveSessionWorkdir(runtime, task.sessionId);
+  if (workdir) {
+    const assistantText = await readLastAssistantTextFromJsonl(workdir);
+    if (assistantText) {
+      // Agent-home pattern: if the subagent reported a deployed URL, collapse
+      // the whole response to "done — URL: ..." as the final chat message.
+      const urlLine = assistantText
+        .split("\n")
+        .find((line) => /^\s*URL:\s*https?:\/\//i.test(line));
+      return urlLine ? `done — ${urlLine.trim()}` : assistantText;
+    }
+  }
   if (task.completionSummary) return task.completionSummary;
   const portMatch = task.originalTask.match(/port\s+(\d+)/i);
   const port = portMatch?.[1];
@@ -1556,6 +1598,16 @@ async function buildTaskResultLine(task: {
     return `built and serving at http://${host}:${port}`;
   }
   return `built the files but server isn't running on port ${port} yet`;
+}
+
+function resolveSessionWorkdir(
+  runtime: AgentRuntime,
+  sessionId: string,
+): string | null {
+  const ptyService = runtime.getService("PTY_SERVICE") as
+    | { getSession?: (id: string) => { workdir?: string } | undefined }
+    | null;
+  return ptyService?.getSession?.(sessionId)?.workdir ?? null;
 }
 
 async function isPortServing(port: string): Promise<boolean> {
@@ -1577,13 +1629,22 @@ async function isPortServing(port: string): Promise<boolean> {
 async function routeSynthesisToConnector(
   runtime: AgentRuntime,
   resultText: string,
+  roomId: string | null,
 ): Promise<void> {
-  const coordinator = getCoordinatorFromRuntime(runtime);
-  const sourceRoomId = coordinator?.sourceRoomId;
-  if (!sourceRoomId) return;
+  if (!roomId) {
+    logger.debug(
+      "[swarm-synthesis] No roomId available — cannot route to connector",
+    );
+    return;
+  }
   try {
-    const room = await runtime.getRoom(sourceRoomId as UUID);
-    if (!room?.source) return;
+    const room = await runtime.getRoom(roomId as UUID);
+    if (!room?.source) {
+      logger.debug(
+        `[swarm-synthesis] Room ${roomId} has no source connector — cannot route`,
+      );
+      return;
+    }
     await runtime.sendMessageToTarget(
       {
         source: room.source,
@@ -1597,7 +1658,7 @@ async function routeSynthesisToConnector(
       `[swarm-synthesis] Routed result to ${room.source} room ${room.id}`,
     );
   } catch (err) {
-    logger.debug(`[swarm-synthesis] Connector routing failed: ${err}`);
+    logger.warn(`[swarm-synthesis] Connector routing failed: ${err}`);
   }
 }
 
@@ -1606,6 +1667,10 @@ import {
   parseActionBlock,
   stripActionBlockFromDisplay,
 } from "./parse-action-block.js";
+import {
+  chunkForDiscord,
+  readLastAssistantTextFromJsonl,
+} from "../runtime/subagent-output.js";
 
 // ── Coordinator Event Routing ───────────────────────────────────────────
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1478,6 +1478,15 @@ function wireCodingAgentSwarmSynthesis(st: ServerState): boolean {
   coordinator.setSwarmCompleteCallback(async (payload) => {
     await handleSwarmSynthesis(st, payload);
   });
+  // Same wiring path — install the task heartbeat so sessions running past
+  // 45s emit periodic "still working" pings that report the subagent's
+  // current tool activity. Synthesis delivers the final answer; heartbeat
+  // just tells the user the task is alive and moving.
+  const ptyService = st.runtime.getService("PTY_SERVICE");
+  if (ptyService) {
+    installTaskHeartbeat(st.runtime, ptyService);
+    logger.info("[task-heartbeat] installed");
+  }
   return true;
 }
 
@@ -1555,12 +1564,39 @@ async function buildSynthesisResultText(
   },
   runtime: AgentRuntime,
 ): Promise<string> {
-  const parts = await Promise.all(
+  const rawParts = await Promise.all(
     payload.tasks.map((task) => buildTaskResultLine(task, runtime)),
   );
-  return parts.length === 1
-    ? parts[0]
-    : `done — ${payload.total} tasks:\n${parts.map((p) => `• ${p}`).join("\n")}`;
+  const parts = dedupeAndDenoise(rawParts);
+  if (parts.length === 1) return parts[0];
+  return `done — ${parts.length} task${parts.length === 1 ? "" : "s"}:\n${parts.map((p) => `• ${p}`).join("\n")}`;
+}
+
+/**
+ * Strip task outputs that are pure deferral commentary ("DECISION: I deferred
+ * to the sibling agent ..."), and collapse duplicates where multiple tasks
+ * reported the same public URL. A swarm that splits a prompt across siblings
+ * produces one authoritative output and N near-duplicates — synthesis should
+ * show the authoritative one, not a bulleted list of echoes.
+ */
+function dedupeAndDenoise(rawParts: string[]): string[] {
+  const isDeferral = (text: string): boolean =>
+    /\b(DECISION:\s*I deferred|deferred the build to the sibling|clobbering would have been)/i.test(
+      text,
+    );
+  const deferralFree = rawParts.filter((p) => !isDeferral(p));
+  const parts = deferralFree.length > 0 ? deferralFree : rawParts;
+  const byUrl = new Map<string, string>();
+  const out: string[] = [];
+  for (const part of parts) {
+    const url = part.match(/https?:\/\/\S+/)?.[0] ?? null;
+    if (url) {
+      if (byUrl.has(url)) continue;
+      byUrl.set(url, part);
+    }
+    out.push(part);
+  }
+  return out;
 }
 
 async function buildTaskResultLine(
@@ -1671,6 +1707,7 @@ import {
   chunkForDiscord,
   readLastAssistantTextFromJsonl,
 } from "../runtime/subagent-output.js";
+import { installTaskHeartbeat } from "../runtime/task-heartbeat.js";
 
 // ── Coordinator Event Routing ───────────────────────────────────────────
 

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -151,9 +151,11 @@ import { shouldEnableTrajectoryLoggingByDefault } from "./trajectory-persistence
 
 const require = createRequire(import.meta.url);
 // Agent orchestrator ships as the standalone @elizaos/plugin-agent-orchestrator package.
+// Use top-level dynamic import because the package is ESM-only and fails under
+// createRequire() in bun runtime; the await is resolved before module consumers read the binding.
 let pluginAgentOrchestrator: unknown = null;
 try {
-  pluginAgentOrchestrator = require("@elizaos/plugin-agent-orchestrator");
+  pluginAgentOrchestrator = await import("@elizaos/plugin-agent-orchestrator");
 } catch {
   pluginAgentOrchestrator = null;
 }

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -909,13 +909,12 @@ export async function resolvePlugins(
         // under eliza-dist/plugins/* or from packaged node_modules.
         mod = await importOfficialPluginFromNodeModules();
       } else {
-        // Built-in/npm plugin — try bundled static import first, then
-        // fall back to bare node_modules resolution.
-        const staticMod = isOfficialElizaPlugin
-          ? await resolveStaticElizaPlugin(pluginName)
-          : null;
-        mod = staticMod
-          ? (staticMod as PluginModuleShape)
+        // Built-in/npm plugin — prefer a bundled static import regardless of
+        // naming convention (short-name plugins like "agent-orchestrator" are
+        // registered in STATIC_ELIZA_PLUGINS and would otherwise fail a bare
+        // node_modules resolution).
+        mod = staticElizaPlugin
+          ? (staticElizaPlugin as PluginModuleShape)
           : ((await import(pluginName)) as PluginModuleShape);
       }
 

--- a/packages/agent/src/runtime/subagent-output.ts
+++ b/packages/agent/src/runtime/subagent-output.ts
@@ -1,0 +1,115 @@
+/**
+ * Subagent output helpers for delivering final task output to the originating
+ * chat channel.
+ *
+ * The swarm synthesis path uses `completionSummary` (a short LLM-generated
+ * description of what the agent did). For user-facing replies we want the
+ * subagent's actual answer — the last `stop_reason: end_turn` assistant
+ * message from the Claude Code session jsonl. This module reads that and
+ * provides Discord-safe chunking.
+ *
+ * Path encoding mirrors Claude Code: `/home/milady/.milady/workspaces/abc`
+ * becomes `-home-milady--milady-workspaces-abc` (every `/` and `.` maps to
+ * `-`; the sequence `/.` produces `--`).
+ *
+ * @module runtime/subagent-output
+ */
+
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Read the latest `stop_reason: end_turn` assistant text from the Claude Code
+ * session jsonl under a subagent's workdir. Returns null when no such line
+ * exists yet (still running, crashed before responding, or wrong workdir).
+ */
+export async function readLastAssistantTextFromJsonl(
+	workdir: string,
+): Promise<string | null> {
+	const jsonlPath = await findLatestJsonl(workdir);
+	if (!jsonlPath) return null;
+	let content: string;
+	try {
+		content = await fs.readFile(jsonlPath, "utf-8");
+	} catch {
+		return null;
+	}
+	return findLatestEndTurnText(content);
+}
+
+/**
+ * Locate the newest `.jsonl` file under Claude Code's project directory for
+ * the given workdir.
+ */
+export async function findLatestJsonl(workdir: string): Promise<string | null> {
+	const projectKey = workdir.replace(/[/.]/g, "-");
+	const projectDir = join(homedir(), ".claude", "projects", projectKey);
+	let entries: string[];
+	try {
+		entries = await fs.readdir(projectDir);
+	} catch {
+		return null;
+	}
+	const jsonls = entries.filter((f) => f.endsWith(".jsonl")).sort();
+	if (jsonls.length === 0) return null;
+	return join(projectDir, jsonls[jsonls.length - 1]);
+}
+
+/**
+ * Scan jsonl text tail-first for the latest assistant message with
+ * `stop_reason: end_turn` and return its text. Returns null if the latest
+ * assistant line is still in a tool_use turn or no assistant line exists.
+ */
+export function findLatestEndTurnText(content: string): string | null {
+	const lines = content.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (!line) continue;
+		let parsed: {
+			message?: {
+				role?: string;
+				stop_reason?: string;
+				content?: Array<{ type?: string; text?: string }>;
+			};
+		};
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const msg = parsed.message;
+		if (!msg || msg.role !== "assistant") continue;
+		if (msg.stop_reason !== "end_turn") return null;
+		let text = "";
+		for (const c of msg.content ?? []) {
+			if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
+				text = c.text.trim();
+			}
+		}
+		return text || null;
+	}
+	return null;
+}
+
+/**
+ * Split text into Discord-safe chunks (≤ max chars each), preferring
+ * paragraph → line → word boundaries past the halfway mark. Callers should
+ * pass 1900 to leave headroom under Discord's 2000-char per-message limit.
+ */
+export function chunkForDiscord(text: string, max: number): string[] {
+	if (text.length <= max) return [text];
+	const out: string[] = [];
+	let remaining = text;
+	while (remaining.length > max) {
+		const half = Math.floor(max / 2);
+		let cut = remaining.lastIndexOf("\n\n", max);
+		if (cut < half) cut = remaining.lastIndexOf("\n", max);
+		if (cut < half) cut = remaining.lastIndexOf(" ", max);
+		if (cut < half) cut = max;
+		out.push(remaining.slice(0, cut).trimEnd());
+		remaining = remaining.slice(cut).trimStart();
+	}
+	if (remaining) out.push(remaining);
+	return out;
+}

--- a/packages/agent/src/runtime/subagent-output.ts
+++ b/packages/agent/src/runtime/subagent-output.ts
@@ -93,6 +93,59 @@ export function findLatestEndTurnText(content: string): string | null {
 }
 
 /**
+ * Scan jsonl tail-first for the most recent subagent activity worth showing
+ * the user in a heartbeat — the name of the most recent `tool_use` call,
+ * falling back to the leading text of the latest assistant block. Returns
+ * null if the jsonl has no assistant/tool activity yet.
+ */
+export async function readCurrentActivityFromJsonl(
+	workdir: string,
+): Promise<string | null> {
+	const jsonlPath = await findLatestJsonl(workdir);
+	if (!jsonlPath) return null;
+	let content: string;
+	try {
+		content = await fs.readFile(jsonlPath, "utf-8");
+	} catch {
+		return null;
+	}
+	const lines = content.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i].trim();
+		if (!line) continue;
+		let parsed: {
+			message?: {
+				role?: string;
+				content?: Array<{
+					type?: string;
+					text?: string;
+					name?: string;
+				}>;
+			};
+		};
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			continue;
+		}
+		const msg = parsed.message;
+		if (!msg || msg.role !== "assistant") continue;
+		for (const c of msg.content ?? []) {
+			if (c.type === "tool_use" && typeof c.name === "string") {
+				return c.name;
+			}
+		}
+		for (const c of msg.content ?? []) {
+			if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
+				const first = c.text.trim().split("\n")[0] ?? "";
+				return first.length > 80 ? `${first.slice(0, 77)}…` : first;
+			}
+		}
+	}
+	return null;
+}
+
+/**
  * Split text into Discord-safe chunks (≤ max chars each), preferring
  * paragraph → line → word boundaries past the halfway mark. Callers should
  * pass 1900 to leave headroom under Discord's 2000-char per-message limit.

--- a/packages/agent/src/runtime/subagent-output.ts
+++ b/packages/agent/src/runtime/subagent-output.ts
@@ -63,9 +63,16 @@ export async function findLatestJsonl(workdir: string): Promise<string | null> {
 	} catch {
 		return null;
 	}
-	const jsonls = entries.filter((f) => f.endsWith(".jsonl")).sort();
+	const jsonls = entries.filter((f) => f.endsWith(".jsonl"));
 	if (jsonls.length === 0) return null;
-	return join(projectDir, jsonls[jsonls.length - 1]);
+	const withMtime = await Promise.all(
+		jsonls.map(async (f) => {
+			const s = await fs.stat(join(projectDir, f));
+			return { f, mtime: s.mtimeMs };
+		}),
+	);
+	withMtime.sort((a, b) => b.mtime - a.mtime);
+	return join(projectDir, withMtime[0].f);
 }
 
 async function readJsonl(workdir: string): Promise<string | null> {
@@ -93,13 +100,13 @@ export function findLatestEndTurnText(content: string): string | null {
 		const msg = parsed.message;
 		if (!msg || msg.role !== "assistant") continue;
 		if (msg.stop_reason !== "end_turn") return null;
-		let text = "";
+		const textParts: string[] = [];
 		for (const c of msg.content ?? []) {
 			if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {
-				text = c.text.trim();
+				textParts.push(c.text.trim());
 			}
 		}
-		return text || null;
+		return textParts.length > 0 ? textParts.join("\n\n") : null;
 	}
 	return null;
 }

--- a/packages/agent/src/runtime/subagent-output.ts
+++ b/packages/agent/src/runtime/subagent-output.ts
@@ -19,6 +19,25 @@ import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+/** Subset of the Claude Code jsonl line shape we care about. Shared by the
+ *  end-turn reader and the activity scanner so both agree on what a parsed
+ *  assistant line looks like. */
+interface JsonlAssistantLine {
+	message?: {
+		role?: string;
+		stop_reason?: string;
+		content?: Array<{ type?: string; text?: string; name?: string }>;
+	};
+}
+
+function parseJsonlLine(line: string): JsonlAssistantLine | null {
+	try {
+		return JSON.parse(line) as JsonlAssistantLine;
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Read the latest `stop_reason: end_turn` assistant text from the Claude Code
  * session jsonl under a subagent's workdir. Returns null when no such line
@@ -27,15 +46,8 @@ import { join } from "node:path";
 export async function readLastAssistantTextFromJsonl(
 	workdir: string,
 ): Promise<string | null> {
-	const jsonlPath = await findLatestJsonl(workdir);
-	if (!jsonlPath) return null;
-	let content: string;
-	try {
-		content = await fs.readFile(jsonlPath, "utf-8");
-	} catch {
-		return null;
-	}
-	return findLatestEndTurnText(content);
+	const content = await readJsonl(workdir);
+	return content === null ? null : findLatestEndTurnText(content);
 }
 
 /**
@@ -56,6 +68,16 @@ export async function findLatestJsonl(workdir: string): Promise<string | null> {
 	return join(projectDir, jsonls[jsonls.length - 1]);
 }
 
+async function readJsonl(workdir: string): Promise<string | null> {
+	const jsonlPath = await findLatestJsonl(workdir);
+	if (!jsonlPath) return null;
+	try {
+		return await fs.readFile(jsonlPath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Scan jsonl text tail-first for the latest assistant message with
  * `stop_reason: end_turn` and return its text. Returns null if the latest
@@ -66,18 +88,8 @@ export function findLatestEndTurnText(content: string): string | null {
 	for (let i = lines.length - 1; i >= 0; i--) {
 		const line = lines[i].trim();
 		if (!line) continue;
-		let parsed: {
-			message?: {
-				role?: string;
-				stop_reason?: string;
-				content?: Array<{ type?: string; text?: string }>;
-			};
-		};
-		try {
-			parsed = JSON.parse(line);
-		} catch {
-			continue;
-		}
+		const parsed = parseJsonlLine(line);
+		if (!parsed) continue;
 		const msg = parsed.message;
 		if (!msg || msg.role !== "assistant") continue;
 		if (msg.stop_reason !== "end_turn") return null;
@@ -101,39 +113,18 @@ export function findLatestEndTurnText(content: string): string | null {
 export async function readCurrentActivityFromJsonl(
 	workdir: string,
 ): Promise<string | null> {
-	const jsonlPath = await findLatestJsonl(workdir);
-	if (!jsonlPath) return null;
-	let content: string;
-	try {
-		content = await fs.readFile(jsonlPath, "utf-8");
-	} catch {
-		return null;
-	}
+	const content = await readJsonl(workdir);
+	if (content === null) return null;
 	const lines = content.split("\n");
 	for (let i = lines.length - 1; i >= 0; i--) {
 		const line = lines[i].trim();
 		if (!line) continue;
-		let parsed: {
-			message?: {
-				role?: string;
-				content?: Array<{
-					type?: string;
-					text?: string;
-					name?: string;
-				}>;
-			};
-		};
-		try {
-			parsed = JSON.parse(line);
-		} catch {
-			continue;
-		}
+		const parsed = parseJsonlLine(line);
+		if (!parsed) continue;
 		const msg = parsed.message;
 		if (!msg || msg.role !== "assistant") continue;
 		for (const c of msg.content ?? []) {
-			if (c.type === "tool_use" && typeof c.name === "string") {
-				return c.name;
-			}
+			if (c.type === "tool_use" && typeof c.name === "string") return c.name;
 		}
 		for (const c of msg.content ?? []) {
 			if (c.type === "text" && typeof c.text === "string" && c.text.trim()) {

--- a/packages/agent/src/runtime/task-heartbeat.ts
+++ b/packages/agent/src/runtime/task-heartbeat.ts
@@ -40,11 +40,6 @@ interface RuntimeWithMessageTarget extends IAgentRuntime {
 	) => Promise<{ channelId?: string; source?: string } | null>;
 }
 
-interface SessionState {
-	startedAt: number;
-	timer: ReturnType<typeof setTimeout>;
-}
-
 /**
  * Install the heartbeat on a PTY service. Returns a disposer that
  * unsubscribes the listener. No-op when the service does not expose the
@@ -59,7 +54,10 @@ export function installTaskHeartbeat(
 		return () => {};
 	}
 
-	const sessions = new Map<string, SessionState>();
+	const sessions = new Map<
+		string,
+		{ startedAt: number; timer: ReturnType<typeof setTimeout> }
+	>();
 	// Global rate limit: one heartbeat per room per HEARTBEAT_MIN_INTERVAL_MS.
 	// A single user prompt can spawn multiple sessions; treating each as its
 	// own heartbeat target reads as spam.
@@ -107,7 +105,7 @@ export function installTaskHeartbeat(
 			return;
 		}
 		if (sessions.has(sessionId)) return;
-		const state: SessionState = {
+		sessions.set(sessionId, {
 			startedAt: Date.now(),
 			timer: setTimeout(() => {
 				void fire(sessionId).catch((err) => {
@@ -116,7 +114,6 @@ export function installTaskHeartbeat(
 					);
 				});
 			}, HEARTBEAT_AFTER_MS),
-		};
-		sessions.set(sessionId, state);
+		});
 	});
 }

--- a/packages/agent/src/runtime/task-heartbeat.ts
+++ b/packages/agent/src/runtime/task-heartbeat.ts
@@ -1,0 +1,122 @@
+/**
+ * Task heartbeat — one "still working" chat ping per originating room per
+ * {@link HEARTBEAT_MIN_INTERVAL_MS}, for any PTY session that's been
+ * running past {@link HEARTBEAT_AFTER_MS}.
+ *
+ * Rate-limited by roomId (not by sessionId) because a swarm can spawn
+ * multiple sessions for a single user prompt and the user sees that as
+ * one task; firing one heartbeat per session would read as spam.
+ *
+ * Silent for autonomous sessions (no originating roomId) so background
+ * coordinator work doesn't spam chat.
+ *
+ * @module runtime/task-heartbeat
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { readCurrentActivityFromJsonl } from "./subagent-output.js";
+
+/** Time before the first heartbeat fires for a freshly-spawned session. */
+const HEARTBEAT_AFTER_MS = 45_000;
+/** Minimum gap between heartbeat messages posted to the same room. */
+const HEARTBEAT_MIN_INTERVAL_MS = 120_000;
+
+interface PTYServiceWithEvents {
+	onSessionEvent: (
+		cb: (sessionId: string, event: string, data: unknown) => void,
+	) => () => void;
+	sessionMetadata?: Map<string, Record<string, unknown>>;
+	getSession?: (sessionId: string) => { workdir?: string } | undefined;
+}
+
+interface RuntimeWithMessageTarget extends IAgentRuntime {
+	sendMessageToTarget: (
+		target: { source?: string; roomId?: UUID; channelId?: string },
+		message: { text: string; source?: string },
+	) => Promise<unknown>;
+	getRoom: (
+		roomId: UUID,
+	) => Promise<{ channelId?: string; source?: string } | null>;
+}
+
+interface SessionState {
+	startedAt: number;
+	timer: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Install the heartbeat on a PTY service. Returns a disposer that
+ * unsubscribes the listener. No-op when the service does not expose the
+ * event API (tests, mocks).
+ */
+export function installTaskHeartbeat(
+	runtime: IAgentRuntime,
+	ptyService: unknown,
+): () => void {
+	const svc = ptyService as PTYServiceWithEvents | undefined;
+	if (!svc || typeof svc.onSessionEvent !== "function") {
+		return () => {};
+	}
+
+	const sessions = new Map<string, SessionState>();
+	// Global rate limit: one heartbeat per room per HEARTBEAT_MIN_INTERVAL_MS.
+	// A single user prompt can spawn multiple sessions; treating each as its
+	// own heartbeat target reads as spam.
+	const lastPostedAtByRoom = new Map<string, number>();
+
+	const fire = async (sessionId: string): Promise<void> => {
+		const state = sessions.get(sessionId);
+		if (!state) return;
+		sessions.delete(sessionId);
+
+		const meta = svc.sessionMetadata?.get(sessionId);
+		const roomId =
+			typeof meta?.roomId === "string" ? (meta.roomId as UUID) : null;
+		if (!roomId) return;
+
+		const now = Date.now();
+		const lastPosted = lastPostedAtByRoom.get(roomId) ?? 0;
+		if (now - lastPosted < HEARTBEAT_MIN_INTERVAL_MS) return;
+		lastPostedAtByRoom.set(roomId, now);
+
+		const room = await (runtime as RuntimeWithMessageTarget)
+			.getRoom(roomId)
+			.catch(() => null);
+		if (!room?.channelId || !room.source) return;
+
+		const workdir = svc.getSession?.(sessionId)?.workdir;
+		const activity = workdir
+			? await readCurrentActivityFromJsonl(workdir).catch(() => null)
+			: null;
+		const seconds = Math.round((now - state.startedAt) / 1000);
+		const text = activity
+			? `still working — ${seconds}s in (${activity})`
+			: `still working — ${seconds}s in`;
+		await (runtime as RuntimeWithMessageTarget).sendMessageToTarget(
+			{ source: room.source, roomId, channelId: room.channelId },
+			{ text, source: "task-heartbeat" },
+		);
+	};
+
+	return svc.onSessionEvent((sessionId, event) => {
+		if (event === "stopped" || event === "task_complete" || event === "error") {
+			const state = sessions.get(sessionId);
+			if (state) clearTimeout(state.timer);
+			sessions.delete(sessionId);
+			return;
+		}
+		if (sessions.has(sessionId)) return;
+		const state: SessionState = {
+			startedAt: Date.now(),
+			timer: setTimeout(() => {
+				void fire(sessionId).catch((err) => {
+					logger.debug(
+						`[task-heartbeat] fire failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+					);
+				});
+			}, HEARTBEAT_AFTER_MS),
+		};
+		sessions.set(sessionId, state);
+	});
+}

--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -14,6 +14,10 @@ export {
 } from "@elizaos/shared/restart";
 
 export * from "./api/index.ts";
+export * from "./api/auth.ts";
+export * from "./api/response.ts";
+export * from "./api/compat-route-shared.ts";
+export * from "./api/server-cloud-tts.ts";
 
 export * from "./bridge/index.ts";
 export * from "./config/index.ts";
@@ -49,6 +53,8 @@ export * from "./utils/index.ts";
 
 export * from "./character-catalog.ts";
 export * from "./security/platform-secure-store.ts";
+export * from "./security/agent-vault-id.ts";
+export * from "./security/platform-secure-store-node.ts";
 
 export * from "./onboarding/flow.ts";
 export * from "./onboarding/types.ts";

--- a/packages/elizaos/templates-manifest.json
+++ b/packages/elizaos/templates-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-04-16T01:44:51.978Z",
+  "generatedAt": "2026-04-16T04:11:21.654Z",
   "repoUrl": "https://github.com/elizaos/eliza",
   "templates": [
     {

--- a/packages/typescript/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/typescript/src/features/advanced-memory/services/memory-service.ts
@@ -206,7 +206,7 @@ export class MemoryService extends Service {
 
 	// ── Helpers ──────────────────────────────────────────────────────────
 
-	private async getStorage(): Promise<MemoryStorageProvider> {
+	private async getStorage(): Promise<MemoryStorageProvider | null> {
 		if (!this.storage && this.runtime.hasService("memoryStorage")) {
 			try {
 				this.storage = (await this.runtime.getServiceLoadPromise(
@@ -220,10 +220,17 @@ export class MemoryService extends Service {
 				);
 			}
 		}
-		if (!this.storage) {
-			return null as unknown as MemoryStorageProvider;
-		}
 		return this.storage;
+	}
+
+	private async requireStorage(op: string): Promise<MemoryStorageProvider> {
+		const storage = await this.getStorage();
+		if (!storage) {
+			throw new Error(
+				`MemoryStorageProvider is not registered — cannot ${op} (register a storage service or disable advancedMemory).`,
+			);
+		}
+		return storage;
 	}
 
 	private async countRoomMemories(roomId: UUID): Promise<number> {
@@ -375,7 +382,9 @@ export class MemoryService extends Service {
 			"id" | "createdAt" | "updatedAt" | "accessCount"
 		>,
 	): Promise<LongTermMemory> {
-		const stored = await (await this.getStorage()).storeLongTermMemory(memory);
+		const stored = await (
+			await this.requireStorage("store long-term memory")
+		).storeLongTermMemory(memory);
 		logger.info(
 			{ src: "service:memory" },
 			`Stored long-term memory: ${stored.category} for entity ${stored.entityId}`,
@@ -389,11 +398,12 @@ export class MemoryService extends Service {
 		limit = 10,
 	): Promise<LongTermMemory[]> {
 		if (limit <= 0) return [];
-		return (await this.getStorage()).getLongTermMemories(
-			this.runtime.agentId,
-			entityId,
-			{ category, limit },
-		);
+		const storage = await this.getStorage();
+		if (!storage) return [];
+		return storage.getLongTermMemories(this.runtime.agentId, entityId, {
+			category,
+			limit,
+		});
 	}
 
 	async updateLongTermMemory(
@@ -403,7 +413,8 @@ export class MemoryService extends Service {
 			Omit<LongTermMemory, "id" | "agentId" | "entityId" | "createdAt">
 		>,
 	): Promise<void> {
-		await (await this.getStorage()).updateLongTermMemory(
+		const storage = await this.requireStorage("update long-term memory");
+		await storage.updateLongTermMemory(
 			id,
 			this.runtime.agentId,
 			entityId,
@@ -416,11 +427,8 @@ export class MemoryService extends Service {
 	}
 
 	async deleteLongTermMemory(id: UUID, entityId: UUID): Promise<void> {
-		await (await this.getStorage()).deleteLongTermMemory(
-			id,
-			this.runtime.agentId,
-			entityId,
-		);
+		const storage = await this.requireStorage("delete long-term memory");
+		await storage.deleteLongTermMemory(id, this.runtime.agentId, entityId);
 		logger.info(
 			{ src: "service:memory" },
 			`Deleted long-term memory: ${id} for entity ${entityId}`,
@@ -428,16 +436,16 @@ export class MemoryService extends Service {
 	}
 
 	async getCurrentSessionSummary(roomId: UUID): Promise<SessionSummary | null> {
-		return (await this.getStorage()).getCurrentSessionSummary(
-			this.runtime.agentId,
-			roomId,
-		);
+		const storage = await this.getStorage();
+		if (!storage) return null;
+		return storage.getCurrentSessionSummary(this.runtime.agentId, roomId);
 	}
 
 	async storeSessionSummary(
 		summary: Omit<SessionSummary, "id" | "createdAt" | "updatedAt">,
 	): Promise<SessionSummary> {
-		const stored = await (await this.getStorage()).storeSessionSummary(summary);
+		const storage = await this.requireStorage("store session summary");
+		const stored = await storage.storeSessionSummary(summary);
 		logger.info(
 			{ src: "service:memory" },
 			`Stored session summary for room ${stored.roomId}`,
@@ -455,7 +463,8 @@ export class MemoryService extends Service {
 			>
 		>,
 	): Promise<void> {
-		await (await this.getStorage()).updateSessionSummary(
+		const storage = await this.requireStorage("update session summary");
+		await storage.updateSessionSummary(
 			id,
 			this.runtime.agentId,
 			roomId,
@@ -471,11 +480,9 @@ export class MemoryService extends Service {
 		roomId: UUID,
 		limit = 5,
 	): Promise<SessionSummary[]> {
-		return (await this.getStorage()).getSessionSummaries(
-			this.runtime.agentId,
-			roomId,
-			limit,
-		);
+		const storage = await this.getStorage();
+		if (!storage) return [];
+		return storage.getSessionSummaries(this.runtime.agentId, roomId, limit);
 	}
 
 	// ── Vector search (JS fallback; provider can override with native) ──

--- a/plugins/plugin-computeruse/package.json
+++ b/plugins/plugin-computeruse/package.json
@@ -70,6 +70,13 @@
         "default": "full_control",
         "enum": ["full_control", "smart_approve", "approve_all", "off"],
         "sensitive": false
+      },
+      "COMPUTER_USE_BROWSER_HEADLESS": {
+        "type": "boolean",
+        "description": "Launch browser automation in headless mode when the environment does not allow visible windows",
+        "required": false,
+        "default": false,
+        "sensitive": false
       }
     }
   }

--- a/plugins/plugin-computeruse/src/__tests__/helpers.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/helpers.test.ts
@@ -3,9 +3,13 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  canonicalKeyName,
   currentPlatform,
   escapeAppleScript,
   safeXdotoolKey,
+  toCliclickKeyName,
+  toWindowsSendKey,
+  toXdotoolKeyName,
   validateCoordinate,
   validateInt,
   validateKeypress,
@@ -31,9 +35,9 @@ describe("validateInt", () => {
     expect(() => validateInt("hello")).toThrow("Invalid numeric value");
   });
 
-  // null → Number(null) = 0, which is a valid coercion
-  it("coerces null to 0", () => {
-    expect(validateInt(null)).toBe(0);
+  it("rejects null and blank input", () => {
+    expect(() => validateInt(null)).toThrow("Invalid numeric value");
+    expect(() => validateInt("")).toThrow("Invalid numeric value");
   });
 });
 
@@ -108,6 +112,22 @@ describe("safeXdotoolKey", () => {
 
   it("rejects unknown multi-char keys", () => {
     expect(() => safeXdotoolKey("BADKEY")).toThrow("Invalid key for xdotool");
+  });
+});
+
+describe("key alias normalization", () => {
+  it("normalizes common special-key aliases", () => {
+    expect(canonicalKeyName("ESCAPE")).toBe("escape");
+    expect(canonicalKeyName("Return")).toBe("enter");
+    expect(canonicalKeyName("ArrowUp")).toBe("up");
+    expect(canonicalKeyName("Page_Down")).toBe("pagedown");
+  });
+
+  it("maps keys to platform-specific formats", () => {
+    expect(toCliclickKeyName("ESCAPE")).toBe("esc");
+    expect(toXdotoolKeyName("ESCAPE")).toBe("Escape");
+    expect(toWindowsSendKey("ESCAPE")).toBe("{ESC}");
+    expect(toWindowsSendKey("F5")).toBe("{F5}");
   });
 });
 

--- a/plugins/plugin-computeruse/src/platform/windows-list.ts
+++ b/plugins/plugin-computeruse/src/platform/windows-list.ts
@@ -8,7 +8,12 @@
 
 import { execSync } from "node:child_process";
 import type { ScreenSize, WindowInfo } from "../types.js";
-import { commandExists, currentPlatform, runCommand } from "./helpers.js";
+import {
+  commandExists,
+  currentPlatform,
+  escapeAppleScript,
+  runCommand,
+} from "./helpers.js";
 
 // ── List Windows ────────────────────────────────────────────────────────────
 
@@ -152,6 +157,72 @@ export function focusWindow(windowId: string): void {
   }
 }
 
+function isWindowId(target: string): boolean {
+  return /^[0-9]+$/.test(target) || /^0x[0-9a-f]+$/i.test(target);
+}
+
+function escapePowerShellSingleQuoted(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export function switchWindow(target: string): void {
+  const os = currentPlatform();
+  const trimmed = target.trim();
+  const byId = isWindowId(trimmed);
+
+  if (os === "darwin") {
+    const script = byId
+      ? [
+          'tell application "System Events"',
+          `set frontmost of (first process whose unix id is ${trimmed}) to true`,
+          "end tell",
+        ].join("\n")
+      : [
+          `set targetName to ${escapeAppleScript(trimmed)}`,
+          'tell application "System Events"',
+          "set targetProcess to first process whose visible is true and (name contains targetName or exists (first window whose name contains targetName))",
+          "set frontmost of targetProcess to true",
+          "end tell",
+        ].join("\n");
+    runCommand("osascript", ["-e", script], 5000);
+    return;
+  }
+
+  if (os === "linux") {
+    if (commandExists("wmctrl")) {
+      const args = byId ? ["-i", "-a", trimmed] : ["-a", trimmed];
+      runCommand("wmctrl", args, 5000);
+      return;
+    }
+    if (commandExists("xdotool")) {
+      const args = byId
+        ? ["windowactivate", trimmed]
+        : ["search", "--name", trimmed, "windowactivate"];
+      runCommand("xdotool", args, 5000);
+      return;
+    }
+    throw new Error("No supported window activation tool available");
+  }
+
+  if (os === "win32") {
+    const ps = byId
+      ? [
+          "Add-Type -MemberDefinition '[DllImport(\"user32.dll\")] public static extern bool SetForegroundWindow(IntPtr hWnd);' -Name Win32 -Namespace Win32",
+          `$proc = Get-Process -Id ${trimmed} -ErrorAction SilentlyContinue`,
+          "if (-not $proc) { throw 'Window not found' }",
+          "[Win32.Win32]::SetForegroundWindow($proc.MainWindowHandle) | Out-Null",
+        ].join("; ")
+      : [
+          "Add-Type -AssemblyName Microsoft.VisualBasic",
+          `$target = '${escapePowerShellSingleQuoted(trimmed)}'`,
+          '$proc = Get-Process | Where-Object { $_.MainWindowTitle -like ("*" + $target + "*") } | Select-Object -First 1',
+          "if (-not $proc) { throw 'Window not found' }",
+          "[Microsoft.VisualBasic.Interaction]::AppActivate($proc.Id) | Out-Null",
+        ].join("; ");
+    runCommand("powershell", ["-Command", ps], 5000);
+  }
+}
+
 // ── Minimize Window ─────────────────────────────────────────────────────────
 
 export function minimizeWindow(windowId: string): void {
@@ -201,6 +272,75 @@ export function maximizeWindow(windowId: string): void {
       $proc = Get-Process -Id ${windowId} -ErrorAction SilentlyContinue
       if ($proc) { [Win32.Win32]::ShowWindow($proc.MainWindowHandle, 3) }
     `;
+    runCommand("powershell", ["-Command", ps], 5000);
+  }
+}
+
+export function restoreWindow(target: string): void {
+  const os = currentPlatform();
+  const trimmed = target.trim();
+  const byId = isWindowId(trimmed);
+
+  if (os === "darwin") {
+    const script = byId
+      ? [
+          'tell application "System Events"',
+          `tell (first process whose unix id is ${trimmed})`,
+          "set miniaturized of window 1 to false",
+          "set frontmost to true",
+          "end tell",
+          "end tell",
+        ].join("\n")
+      : [
+          `set targetName to ${escapeAppleScript(trimmed)}`,
+          'tell application "System Events"',
+          "tell (first process whose visible is true and (name contains targetName or exists (first window whose name contains targetName)))",
+          "set miniaturized of window 1 to false",
+          "set frontmost to true",
+          "end tell",
+          "end tell",
+        ].join("\n");
+    runCommand("osascript", ["-e", script], 5000);
+    return;
+  }
+
+  if (os === "linux") {
+    if (commandExists("wmctrl")) {
+      if (byId) {
+        runCommand("wmctrl", ["-i", "-r", trimmed, "-b", "remove,hidden"], 5000);
+        runCommand("wmctrl", ["-i", "-a", trimmed], 5000);
+      } else {
+        runCommand("wmctrl", ["-r", trimmed, "-b", "remove,hidden"], 5000);
+        runCommand("wmctrl", ["-a", trimmed], 5000);
+      }
+      return;
+    }
+    if (commandExists("xdotool")) {
+      const args = byId
+        ? ["windowmap", trimmed, "windowactivate", trimmed]
+        : ["search", "--name", trimmed, "windowmap", "%@", "windowactivate", "%@"];
+      runCommand("xdotool", args, 5000);
+      return;
+    }
+    throw new Error("No supported window restore tool available");
+  }
+
+  if (os === "win32") {
+    const ps = byId
+      ? [
+          "Add-Type -MemberDefinition '[DllImport(\"user32.dll\")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow); [DllImport(\"user32.dll\")] public static extern bool SetForegroundWindow(IntPtr hWnd);' -Name Win32 -Namespace Win32",
+          `$proc = Get-Process -Id ${trimmed} -ErrorAction SilentlyContinue`,
+          "if (-not $proc) { throw 'Window not found' }",
+          "[Win32.Win32]::ShowWindow($proc.MainWindowHandle, 9) | Out-Null",
+          "[Win32.Win32]::SetForegroundWindow($proc.MainWindowHandle) | Out-Null",
+        ].join("; ")
+      : [
+          "Add-Type -AssemblyName Microsoft.VisualBasic",
+          `$target = '${escapePowerShellSingleQuoted(trimmed)}'`,
+          '$proc = Get-Process | Where-Object { $_.MainWindowTitle -like ("*" + $target + "*") } | Select-Object -First 1',
+          "if (-not $proc) { throw 'Window not found' }",
+          "[Microsoft.VisualBasic.Interaction]::AppActivate($proc.Id) | Out-Null",
+        ].join("; ");
     runCommand("powershell", ["-Command", ps], 5000);
   }
 }

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -65,6 +65,8 @@ import {
   listWindows,
   maximizeWindow,
   minimizeWindow,
+  restoreWindow,
+  switchWindow,
 } from "../platform/windows-list.js";
 import {
   clickBrowser,
@@ -627,12 +629,16 @@ export class ComputerUseService extends Service {
           });
         }
         case "focus":
-        case "switch":
           focusWindow(this.requireWindowTarget(params));
           return this.succeedEntry(entry, {
             success: true,
-            message:
-              params.action === "switch" ? "Switched window." : "Focused window.",
+            message: "Focused window.",
+          });
+        case "switch":
+          switchWindow(this.requireWindowTarget(params));
+          return this.succeedEntry(entry, {
+            success: true,
+            message: "Switched window.",
           });
         case "arrange":
           return this.succeedEntry(entry, {
@@ -659,7 +665,7 @@ export class ComputerUseService extends Service {
             message: "Window maximized.",
           });
         case "restore":
-          focusWindow(this.requireWindowTarget(params));
+          restoreWindow(this.requireWindowTarget(params));
           return this.succeedEntry(entry, {
             success: true,
             message: "Window restored.",


### PR DESCRIPTION
## Summary
Rebased and fixed version of #6761 by @NubsCarson. Fixes three end-to-end breakages:

1. **ESM import for orchestrator**: switches `@elizaos/plugin-agent-orchestrator` from `createRequire()` to `await import()` — the package is ESM-only and silently failed under bun
2. **No-op swarm callback**: wires `setSwarmCompleteCallback` to `handleSwarmSynthesis` (was `async () => {}`)  
3. **Null cast in memory service**: removes `null as unknown as MemoryStorageProvider` cast that crashed every message when no storage provider was registered

## Fixes applied on top of original PR
- **P1**: `findLatestJsonl` now sorts by mtime instead of alphabetically (UUID filenames have no chronological order)
- **P2**: `findLatestEndTurnText` now concatenates all text blocks instead of keeping only the last one

Original PR: #6761
Original author: @NubsCarson

Co-Authored-By: nubs <nubs@iqlabs.dev>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires three previously broken end-to-end paths: it switches `@elizaos/plugin-agent-orchestrator` from `createRequire()` to `await import()` (fixing a silent ESM failure under bun), connects `setSwarmCompleteCallback` to `handleSwarmSynthesis` (was a no-op), removes a `null as unknown as MemoryStorageProvider` cast that crashed message handling, and adds `mtime`-based jsonl sorting and full text-block concatenation to `subagent-output.ts`.

Two issues in the new `task-heartbeat` code are worth addressing before relying on it in production:
- The `fire()` function deletes the session from the tracking map, so any re-arm from a subsequent session event resets `startedAt` to the current time — subsequent heartbeats show `~45 s in` regardless of the actual session age.
- `installTaskHeartbeat` has no idempotency guard; it can be installed twice if both the boot-time `wireCoordinatorBridgesWhenReady` and the lazy-start path in the coding-agent route handler both succeed, resulting in duplicate heartbeat pings per room.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the three core fixes; heartbeat issues degrade gracefully (wrong time display / extra pings) rather than causing data loss.

The three primary fixes (ESM import, swarm callback wiring, null-cast removal) are correct and well-targeted. The task-heartbeat additions have two P2 bugs: incorrect elapsed-time reporting after re-arm and unguarded duplicate installation. These don't block the primary fixes but should be addressed before the heartbeat feature is considered reliable.

packages/agent/src/runtime/task-heartbeat.ts (startedAt reset bug + duplicate installation risk), packages/agent/src/api/server.ts (heartbeat installation guard)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/task-heartbeat.ts | New heartbeat module. Correct overall design but has two bugs: startedAt is reset on re-arm so subsequent heartbeats show wrong elapsed time, and no guard prevents multiple installations from the boot vs. lazy-start paths. |
| packages/agent/src/runtime/eliza.ts | Switches plugin-agent-orchestrator from createRequire() to await import() fixing the ESM-only silent failure under bun; createRequire is still correctly used for CJS-compatible plugins. |
| packages/agent/src/runtime/subagent-output.ts | Two correct fixes: findLatestJsonl now sorts by mtime instead of alphabetically (UUID filenames are not chronologically ordered), and findLatestEndTurnText now concatenates all text blocks instead of keeping only the last one. |
| packages/agent/src/api/server.ts | Wires setSwarmCompleteCallback to handleSwarmSynthesis (was previously a no-op) and installs task heartbeat; potential duplicate heartbeat installation from the boot + lazy-start paths. |
| packages/typescript/src/features/advanced-memory/services/memory-service.ts | Removes null as unknown as MemoryStorageProvider cast that crashed every message when no storage provider was registered; storage is now properly typed as MemoryStorageProvider | null = null. |
| plugins/plugin-computeruse/src/__tests__/helpers.test.ts | New unit tests for input validation helpers; comprehensive coverage for security-sensitive helpers like validateKeypress, escapeAppleScript, and safeXdotoolKey. |
| plugins/plugin-computeruse/src/platform/windows-list.ts | Cross-platform window management additions; PowerShell single-quoted strings safely escaped, window IDs validated as numeric before AppleScript/PS interpolation. |
| packages/agent/src/runtime/plugin-resolver.ts | No functional changes; part of the bun plugin-load hardening infrastructure. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sends task] --> B[wireCodingAgentSwarmSynthesis]
    B --> C[setSwarmCompleteCallback to handleSwarmSynthesis]
    B --> D[installTaskHeartbeat]
    D --> E[onSessionEvent listener registered]
    E --> F{event type}
    F -->|start or progress| G[sessions.set with startedAt=now plus timer 45s]
    F -->|stopped or complete or error| H[sessions.delete and clearTimeout]
    G --> I[45s elapsed, fire called]
    I --> J[post still-working message to room]
    I --> K[sessions.delete, startedAt lost]
    K --> L{next session event?}
    L -->|yes| M[re-add with startedAt=now WRONG elapsed time]
    M --> N[2nd heartbeat shows wrong time]
    C --> O[SwarmCoordinator: all sessions done]
    O --> P[handleSwarmSynthesis]
    P --> Q[findLatestJsonl sorted by mtime]
    Q --> R[findLatestEndTurnText concatenate all text blocks]
    R --> S[chunkForDiscord 1900 chars each]
    S --> T[routeAutonomyTextToUser to web UI]
    S --> U[routeSynthesisToConnector to Discord etc]
```

<sub>Reviews (1): Last reviewed commit: ["fix: use mtime sort for jsonl files + co..."](https://github.com/elizaos/eliza/commit/35044b9021bbe87357004c6e02d86a3183ba4850) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28585554)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->