### PR TITLE
fix(packaging): inject tailwindcss for snap builds

### DIFF
--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -268,6 +268,23 @@ parts:
       # trying to build the (now-removed) plugin-agent-orchestrator from source.
       bun install --ignore-scripts
 
+      # Inject tailwindcss into eliza/packages/app-core/node_modules so the
+      # Vite CSS pipeline can resolve @import "tailwindcss" from the app-core
+      # source tree during the snap production build.
+      mkdir -p eliza/packages/app-core/node_modules
+      if [ ! -d "eliza/packages/app-core/node_modules/tailwindcss" ]; then
+        TAILWIND_URL=$(npm view tailwindcss dist.tarball 2>/dev/null || true)
+        if [ -z "$TAILWIND_URL" ]; then
+          echo "Failed to resolve tailwindcss tarball URL" >&2
+          exit 1
+        fi
+        rm -rf /tmp/tw_extract
+        mkdir -p /tmp/tw_extract
+        curl -fsSL "$TAILWIND_URL" | tar xz -C /tmp/tw_extract
+        rm -rf eliza/packages/app-core/node_modules/tailwindcss
+        mv /tmp/tw_extract/package eliza/packages/app-core/node_modules/tailwindcss
+      fi
+
       # Fresh CI checkouts do not track generated protobuf JS output.
       if [ -d eliza/packages/schemas ] && [ -f eliza/packages/schemas/buf.gen.yaml ] && [ ! -f eliza/packages/typescript/src/types/generated/eliza/v1/agent_pb.js ]; then
         (


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes snap builds by injecting the `tailwindcss` package directly into `eliza/packages/app-core/node_modules` during the build phase, resolving a Vite/PostCSS CSS pipeline failure where `@import "tailwindcss"` could not be resolved in the snap sandbox.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 style suggestions that don't block the fix from working.

The change is a targeted build-time fix with no runtime or security impact. Both issues found are non-blocking style improvements: version pinning for reproducibility and a defensive tar extraction pattern. The fix itself correctly solves the tailwindcss resolution problem for snap builds.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/packaging/snap/snapcraft.yaml | Adds a tailwindcss injection step to the snap build — downloads and extracts the tailwindcss npm package into the app-core node_modules. No version is pinned, making builds non-deterministic. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[snap build starts] --> B[bun install --ignore-scripts]
    B --> C{tailwindcss already in eliza/packages/app-core/node_modules?}
    C -- yes --> E[skip injection]
    C -- no --> D1[npm view tailwindcss dist.tarball]
    D1 --> D2{URL resolved?}
    D2 -- no --> FAIL[exit 1]
    D2 -- yes --> D3[curl tarball URL]
    D3 --> D4[tar xz to /tmp/tw_extract]
    D4 --> D5[mv /tmp/tw_extract/package to node_modules/tailwindcss]
    D5 --> E
    E --> F[generate protobuf + i18n]
    F --> G[bun run build]
    G --> H[copy artifacts to CRAFT_PART_INSTALL]
```

<sub>Reviews (1): Last reviewed commit: ["fix(packaging): inject tailwindcss for s..."](https://github.com/elizaos/eliza/commit/5b09f23423b65f03a0ec2eeeeb88b5105a126f99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28825171)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->