### PR TITLE
fix: handle roomId changes in InMemoryDatabaseAdapter.updateMemories

### DIFF
--- a/packages/typescript/src/database/inMemoryAdapter.ts
+++ b/packages/typescript/src/database/inMemoryAdapter.ts
@@ -852,10 +852,21 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const merged: Memory = { ...existing, ...memory };
 			this.memoriesById.set(String(memory.id), merged);
 			// Update reference in memoriesByRoom to keep consistency
-			for (const [, list] of this.memoriesByRoom) {
+			const oldRoomId = existing.roomId ?? DEFAULT_UUID;
+			const newRoomId = merged.roomId ?? DEFAULT_UUID;
+			for (const [key, list] of this.memoriesByRoom) {
 				const idx = list.findIndex((m) => String(m.id) === String(memory.id));
 				if (idx !== -1) {
-					list[idx] = merged;
+					if (String(oldRoomId) !== String(newRoomId)) {
+						const tableName = key.split(":")[0];
+						list.splice(idx, 1);
+						const newKey = roomTableKey(tableName, newRoomId);
+						const newList = this.memoriesByRoom.get(newKey) ?? [];
+						newList.push(merged);
+						this.memoriesByRoom.set(newKey, newList);
+					} else {
+						list[idx] = merged;
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
## Summary
Fix `updateMemories` to properly move memories between room lists when `roomId` changes.

## Problem
When a memory is updated with a new `roomId`, `updateMemories` updates the in-place reference in the old room's list but does not move the memory to the new room's list. This causes:
- Stale entries in the old room's memory list (with updated `roomId` pointing elsewhere)
- Missing entries in the new room's memory list

## Change
Detect when `roomId` changes and splice the memory out of the old room list into the new room list, preserving the `tableName` from the existing key.

No behavior change when `roomId` is unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `updateMemories` in `InMemoryDatabaseAdapter` to correctly move a memory to a new room's list when its `roomId` changes during an update, rather than leaving a stale reference in the old room's list. The logic — splice from old list, push to new list using the tableName recovered from the map key — is correct and has no effect when `roomId` is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style suggestions that do not affect correctness under normal usage.

The fix is logically correct: it properly splices the memory from the old room list and appends it to the new room list, the break prevents any double-processing, and the no-op path when roomId is unchanged is preserved. The two P2 notes (fragile split and missing test) are quality improvements, not blockers.

No files require special attention beyond the two P2 suggestions on inMemoryAdapter.ts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/database/inMemoryAdapter.ts | Adds roomId-change detection in updateMemories to correctly move memories between room lists; logic is sound but tableName extraction via split(":")[0] is fragile for table names containing colons, and no tests cover the new code path. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[updateMemories called] --> B{memory in memoriesById?}
    B -- No --> C[skip, continue]
    B -- Yes --> D[merge existing plus incoming]
    D --> E[update memoriesById]
    E --> F{roomId unchanged?}
    F -- Yes --> G[find memory in memoriesByRoom, update in-place, break]
    F -- No --> H[find memory in old room list]
    H --> I[splice memory from old room list]
    I --> J[extract tableName from map key]
    J --> K[compute new room map key]
    K --> L[get or create new room list]
    L --> M[push merged memory to new list]
    M --> N[set new room list in map, break]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/typescript/src/database/inMemoryAdapter.ts`, line 841-874 ([link](https://github.com/elizaos/eliza/blob/2fc93865a981464e641750b797a95bc13b64a2a9/packages/typescript/src/database/inMemoryAdapter.ts#L841-L874)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No test coverage for the new roomId-change path**

   The PR adds logic to move a memory between room lists when `roomId` changes, but the change is not accompanied by any test. A simple unit test calling `createMemories` → `updateMemories` (with a different `roomId`) → `getMemories` for both old and new rooms would lock in the expected behavior and guard against regressions. `packages/typescript/src/__tests__/database.test.ts` exists but currently has no `updateMemories` coverage at all.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: handle roomId changes in updateMemo..."](https://github.com/elizaos/eliza/commit/2fc93865a981464e641750b797a95bc13b64a2a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28893246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->