### PR TITLE
settings UI polish: dropdown sizing, model picker, layout pairing, header drag-strip fix, hot-reload shutdown timeout

### DIFF
--- a/packages/agent/src/contracts/config.ts
+++ b/packages/agent/src/contracts/config.ts
@@ -8,6 +8,15 @@ export type MediaMode = "cloud" | "own-key";
 
 export type ImageProvider = "cloud" | "fal" | "openai" | "google" | "xai";
 
+/**
+ * Shared sub-config for cloud-hosted media routes. Lets the user pin a
+ * specific model for image/video/audio/vision generation while still using
+ * the managed cloud credentials and billing.
+ */
+export type CloudMediaConfig = {
+  model?: string;
+};
+
 export type ImageFalConfig = {
   apiKey?: string;
   model?: string;
@@ -37,6 +46,7 @@ export type ImageConfig = {
   mode?: MediaMode;
   provider?: ImageProvider;
   defaultSize?: string;
+  cloud?: CloudMediaConfig;
   fal?: ImageFalConfig;
   openai?: ImageOpenaiConfig;
   google?: ImageGoogleConfig;
@@ -66,6 +76,7 @@ export type VideoConfig = {
   mode?: MediaMode;
   provider?: VideoProvider;
   defaultDuration?: number;
+  cloud?: CloudMediaConfig;
   fal?: VideoFalConfig;
   openai?: VideoOpenaiConfig;
   google?: VideoGoogleConfig;
@@ -88,6 +99,7 @@ export type AudioGenConfig = {
   enabled?: boolean;
   mode?: MediaMode;
   provider?: AudioGenProvider;
+  cloud?: CloudMediaConfig;
   suno?: AudioSunoConfig;
   elevenlabs?: AudioElevenlabsSfxConfig;
 };
@@ -132,6 +144,7 @@ export type VisionConfig = {
   enabled?: boolean;
   mode?: MediaMode;
   provider?: VisionProvider;
+  cloud?: CloudMediaConfig;
   openai?: VisionOpenaiConfig;
   google?: VisionGoogleConfig;
   anthropic?: VisionAnthropicConfig;

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3877,9 +3877,38 @@ export async function startEliza(
         logger.info("[eliza] Hot-reload: Restarting runtime...");
         try {
           // Stop the old runtime to release resources (DB connections, timers, etc.)
-
+          //
+          // WHY the 2s timeout: some services — notably PTYService —
+          // shut down gracefully by awaiting each active session with a
+          // per-session timeout (up to ~5s). runtime.stop() awaits every
+          // service.stop() sequentially, so a single idle PTY session
+          // turns a provider switch into a multi-second block. During
+          // that window server.ts's providerSwitchInProgress flag +
+          // agentState === "restarting" guard reject further clicks,
+          // which is why flipping through providers rapidly feels stuck.
+          //
+          // Cap the shutdown window at 2s; if it doesn't finish, log and
+          // bring the new runtime up anyway. Services that miss the
+          // window get GC'd when the process unwinds. This is fine for a
+          // user-initiated restart — the user asked for a new runtime;
+          // in-flight work on the old one is already obsolete.
           try {
-            await shutdownRuntime(runtime, "hot-reload cleanup");
+            const SHUTDOWN_TIMEOUT_MS = 2000;
+            let shutdownTimedOut = false;
+            await Promise.race([
+              shutdownRuntime(runtime, "hot-reload cleanup"),
+              new Promise<void>((resolve) =>
+                setTimeout(() => {
+                  shutdownTimedOut = true;
+                  resolve();
+                }, SHUTDOWN_TIMEOUT_MS),
+              ),
+            ]);
+            if (shutdownTimedOut) {
+              logger.warn(
+                `[eliza] Hot-reload: old runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; proceeding with new runtime`,
+              );
+            }
           } catch (stopErr) {
             logger.warn(
               `[eliza] Hot-reload: old runtime stop failed: ${formatError(stopErr)}`,

--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -42,7 +42,6 @@ import {
   buildAutoTopUpFormState,
   consumeManagedDiscordCallbackUrl,
   consumeManagedGithubCallbackUrl,
-  ELIZA_CLOUD_INSTANCES_URL,
   ELIZA_CLOUD_WEB_URL,
   getBillingAutoTopUp,
   getBillingLimits,
@@ -529,28 +528,26 @@ export function CloudDashboard() {
 
   /* ── Overview (default view): account + balance + actions ────────────── */
   const overviewContent = (
-    <div className="px-5 py-6 sm:px-6">
-      <div className="mb-6 flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-muted">
+    <div className="px-4 py-3 sm:px-5 sm:py-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-xs font-medium uppercase tracking-wider text-muted">
             {t("elizaclouddashboard.Balance", { defaultValue: "Balance" })}
-          </div>
-          <div className="flex items-baseline gap-2">
-            <span
-              className={`text-3xl font-bold tracking-tight tabular-nums ${creditStatusColor}`}
-            >
-              {currencyPrefix}
-              {formattedBalance ?? (
-                <span className="text-muted">{billingLoading ? "…" : "—"}</span>
-              )}
-            </span>
-            {billingLoading && (
-              <Loader2 className="h-4 w-4 animate-spin text-muted" />
+          </span>
+          <span
+            className={`text-lg font-semibold tracking-tight tabular-nums ${creditStatusColor}`}
+          >
+            {currencyPrefix}
+            {formattedBalance ?? (
+              <span className="text-muted">{billingLoading ? "…" : "—"}</span>
             )}
-          </div>
+          </span>
+          {billingLoading && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted" />
+          )}
         </div>
         <span
-          className={`shrink-0 rounded-full border px-2.5 py-0.5 text-2xs font-semibold uppercase tracking-wider ${statusChipClass}`}
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-2xs font-semibold uppercase tracking-wider ${statusChipClass}`}
         >
           {creditStatusTone}
         </span>
@@ -574,7 +571,7 @@ export function CloudDashboard() {
         </div>
       )}
 
-      <dl className="mb-6 space-y-2 text-xs">
+      <dl className="mb-3 space-y-1 text-xs">
         <div className="flex items-center justify-between gap-3">
           <dt className="text-muted">
             {t("elizaclouddashboard.Account", { defaultValue: "Account" })}
@@ -643,17 +640,6 @@ export function CloudDashboard() {
             ? t("providerswitcher.disconnecting")
             : t("providerswitcher.disconnect")}
         </Button>
-        <div className="ml-auto">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto p-0 text-xs text-muted hover:text-txt"
-            onClick={() => void openExternalUrl(ELIZA_CLOUD_INSTANCES_URL)}
-          >
-            {t("elizaclouddashboard.AdvancedDashboard")}
-            <ExternalLink className="ml-1 h-3 w-3" />
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/packages/app-core/src/components/pages/SettingsView.tsx
+++ b/packages/app-core/src/components/pages/SettingsView.tsx
@@ -1137,57 +1137,67 @@ export function SettingsView({
         </div>
       )}
 
-      {visibleSectionIds.has("local-models") && (
-        <SettingsSection
-          id="local-models"
-          title={t("settings.sections.localModels.label", {
-            defaultValue: "Local models",
-          })}
-          description={t("settings.sections.localModels.desc", {
-            defaultValue:
-              "Run llama.cpp models on this machine. Browse the curated catalog, download, and switch between local models.",
-          })}
-          ref={registerContentItem("local-models")}
-        >
-          <LocalInferencePanel />
-        </SettingsSection>
+      {(visibleSectionIds.has("local-models") ||
+        visibleSectionIds.has("coding-agents")) && (
+        <div className="grid gap-5 xl:grid-cols-2 items-start">
+          {visibleSectionIds.has("local-models") && (
+            <SettingsSection
+              id="local-models"
+              title={t("settings.sections.localModels.label", {
+                defaultValue: "Local models",
+              })}
+              description={t("settings.sections.localModels.desc", {
+                defaultValue:
+                  "Run llama.cpp models on this machine. Browse the curated catalog, download, and switch between local models.",
+              })}
+              ref={registerContentItem("local-models")}
+            >
+              <LocalInferencePanel />
+            </SettingsSection>
+          )}
+
+          {visibleSectionIds.has("coding-agents") && (
+            <SettingsSection
+              id="coding-agents"
+              title={t("settings.sections.codingagents.label")}
+              description={t("settings.codingAgentsDescription")}
+              ref={registerContentItem("coding-agents")}
+            >
+              <CodingAgentSettingsSection />
+            </SettingsSection>
+          )}
+        </div>
       )}
 
-      {visibleSectionIds.has("coding-agents") && (
-        <SettingsSection
-          id="coding-agents"
-          title={t("settings.sections.codingagents.label")}
-          description={t("settings.codingAgentsDescription")}
-          ref={registerContentItem("coding-agents")}
-        >
-          <CodingAgentSettingsSection />
-        </SettingsSection>
-      )}
+      {(visibleSectionIds.has("capabilities") ||
+        visibleSectionIds.has("permissions")) && (
+        <div className="grid gap-5 xl:grid-cols-2 items-start">
+          {visibleSectionIds.has("capabilities") && (
+            <SettingsSection
+              id="capabilities"
+              title={t("settings.sections.capabilities.label", {
+                defaultValue: "Capabilities",
+              })}
+              description={t("settings.sections.capabilities.desc", {
+                defaultValue: "Enable or disable agent capabilities",
+              })}
+              ref={registerContentItem("capabilities")}
+            >
+              <CapabilitiesSection />
+            </SettingsSection>
+          )}
 
-      {visibleSectionIds.has("capabilities") && (
-        <SettingsSection
-          id="capabilities"
-          title={t("settings.sections.capabilities.label", {
-            defaultValue: "Capabilities",
-          })}
-          description={t("settings.sections.capabilities.desc", {
-            defaultValue: "Enable or disable agent capabilities",
-          })}
-          ref={registerContentItem("capabilities")}
-        >
-          <CapabilitiesSection />
-        </SettingsSection>
-      )}
-
-      {visibleSectionIds.has("permissions") && (
-        <SettingsSection
-          id="permissions"
-          title={t("settings.sections.permissions.label")}
-          description={t("settings.sections.permissions.desc")}
-          ref={registerContentItem("permissions")}
-        >
-          <PermissionsSection />
-        </SettingsSection>
+          {visibleSectionIds.has("permissions") && (
+            <SettingsSection
+              id="permissions"
+              title={t("settings.sections.permissions.label")}
+              description={t("settings.sections.permissions.desc")}
+              ref={registerContentItem("permissions")}
+            >
+              <PermissionsSection />
+            </SettingsSection>
+          )}
+        </div>
       )}
 
       {visibleSectionIds.has("updates") && (

--- a/packages/app-core/src/components/pages/SettingsView.tsx
+++ b/packages/app-core/src/components/pages/SettingsView.tsx
@@ -46,18 +46,47 @@ import { ProviderSwitcher } from "../settings/ProviderSwitcher";
 import { CloudDashboard } from "./ElizaCloudDashboard";
 import { ReleaseCenterView } from "./ReleaseCenterView";
 
+type SettingsComplexity = "simple" | "advanced";
+
 interface SettingsSectionDef {
   id: string;
   label: string;
   description?: string;
   keywords?: string[];
   keywordKeys?: string[];
+  /**
+   * Visibility level. "simple" sections show in both Simple and Advanced
+   * modes. "advanced" sections only show when the user toggles Advanced.
+   * Sections default to "simple" if omitted.
+   */
+  level?: SettingsComplexity;
+}
+
+const SETTINGS_COMPLEXITY_STORAGE_KEY = "milady.settings.complexity";
+
+function readStoredComplexity(): SettingsComplexity {
+  if (typeof window === "undefined") return "simple";
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_COMPLEXITY_STORAGE_KEY);
+    return raw === "advanced" ? "advanced" : "simple";
+  } catch {
+    return "simple";
+  }
+}
+
+function writeStoredComplexity(value: SettingsComplexity): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SETTINGS_COMPLEXITY_STORAGE_KEY, value);
+  } catch {
+    /* ignore quota / privacy-mode failures */
+  }
 }
 
 const SETTINGS_CONTENT_CLASS =
-  "[scroll-padding-top:7rem] [scrollbar-gutter:stable] scroll-smooth bg-bg/10 pb-6 pt-4 sm:pb-8 sm:pt-5 lg:pb-10 lg:pt-6";
+  "[scroll-padding-top:7rem] [scrollbar-gutter:stable] scroll-smooth bg-bg/10 pb-4 pt-2 sm:pb-6 sm:pt-3";
 const SETTINGS_CONTENT_WIDTH_CLASS = "w-full min-h-0";
-const SETTINGS_SECTION_STACK_CLASS = "space-y-6 pb-14 sm:space-y-8 sm:pb-16";
+const SETTINGS_SECTION_STACK_CLASS = "space-y-3 pb-10 sm:space-y-4";
 
 const SETTINGS_SECTIONS: SettingsSectionDef[] = [
   {
@@ -66,6 +95,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     description: "settings.sections.cloud.desc",
     keywords: ["cloud", "billing", "credits", "auth", "subscription"],
     keywordKeys: ["settings.keyword.cloud", "settings.keyword.billing"],
+    level: "simple",
   },
   {
     id: "ai-model",
@@ -88,6 +118,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "settings.keyword.apiKey",
       "settings.keyword.inference",
     ],
+    level: "simple",
   },
   {
     id: "local-models",
@@ -105,6 +136,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "gpu",
       "vram",
     ],
+    level: "advanced",
   },
   {
     id: "coding-agents",
@@ -121,6 +153,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "task coordinator",
       "task agents",
     ],
+    level: "advanced",
   },
   {
     id: "media",
@@ -142,6 +175,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "settings.keyword.camera",
       "settings.keyword.microphone",
     ],
+    level: "simple",
   },
   {
     id: "appearance",
@@ -163,6 +197,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "settings.keyword.avatar",
       "settings.keyword.appearance",
     ],
+    level: "simple",
   },
   {
     id: "capabilities",
@@ -183,6 +218,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "feature",
     ],
     keywordKeys: ["settings.keyword.wallet", "settings.keyword.browser"],
+    level: "advanced",
   },
   {
     id: "permissions",
@@ -198,6 +234,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "file access",
     ],
     keywordKeys: ["settings.keyword.permissions", "settings.keyword.security"],
+    level: "simple",
   },
   {
     id: "updates",
@@ -205,6 +242,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     description: "settings.sections.updates.desc",
     keywords: ["updates", "release", "version", "download"],
     keywordKeys: ["settings.keyword.updates"],
+    level: "advanced",
   },
   {
     id: "advanced",
@@ -226,6 +264,7 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
       "settings.keyword.import",
       "settings.keyword.reset",
     ],
+    level: "advanced",
   },
 ];
 
@@ -269,9 +308,11 @@ const SettingsSection = forwardRef<HTMLElement, SettingsSectionProps>(
           expanded
           variant="section"
           heading={title ?? ""}
+          headingClassName="text-base sm:text-lg font-semibold tracking-tight text-txt-strong"
           description={description}
-          bodyClassName={bodyClassName}
-          className={className}
+          descriptionClassName="mt-0.5 text-xs leading-snug text-muted"
+          bodyClassName={cn("px-4 pb-3 pt-0 sm:px-5 sm:pb-4", bodyClassName)}
+          className={cn("rounded-2xl", className)}
           {...props}
         >
           {children}
@@ -833,15 +874,27 @@ export function SettingsView({
   const { t, loadPlugins } = useApp();
   const [activeSection, setActiveSection] = useState(initialSection ?? "cloud");
   const [searchQuery, setSearchQuery] = useState("");
+  const [complexity, setComplexity] = useState<SettingsComplexity>(() =>
+    readStoredComplexity(),
+  );
   const shellRef = useRef<HTMLDivElement>(null);
 
-  const visibleSections = useMemo(
-    () =>
-      SETTINGS_SECTIONS.filter((section) =>
-        matchesSettingsSection(section, searchQuery, t),
-      ),
-    [searchQuery, t],
-  );
+  useEffect(() => {
+    writeStoredComplexity(complexity);
+  }, [complexity]);
+
+  // Advanced-only sections remain reachable via search even in Simple mode —
+  // if the user typed a keyword that matches an advanced section, show it.
+  // Otherwise Simple mode only shows sections tagged level !== "advanced".
+  const visibleSections = useMemo(() => {
+    const searchActive = searchQuery.trim().length > 0;
+    return SETTINGS_SECTIONS.filter((section) => {
+      if (!matchesSettingsSection(section, searchQuery, t)) return false;
+      if (complexity === "advanced") return true;
+      if (searchActive) return true;
+      return section.level !== "advanced";
+    });
+  }, [complexity, searchQuery, t]);
   const visibleSectionIds = useMemo(
     () => new Set(visibleSections.map((section) => section.id)),
     [visibleSections],
@@ -950,17 +1003,39 @@ export function SettingsView({
       mobileTitle={t("nav.settings")}
       mobileMeta={activeSectionDef ? t(activeSectionDef.label) : undefined}
       header={
-        <SidebarHeader
-          search={{
-            value: searchQuery,
-            onChange: (event) => setSearchQuery(event.target.value),
-            onClear: () => setSearchQuery(""),
-            placeholder: searchLabel,
-            "aria-label": searchLabel,
-            autoComplete: "off",
-            spellCheck: false,
-          }}
-        />
+        <div className="space-y-2">
+          <SidebarHeader
+            search={{
+              value: searchQuery,
+              onChange: (event) => setSearchQuery(event.target.value),
+              onClear: () => setSearchQuery(""),
+              placeholder: searchLabel,
+              "aria-label": searchLabel,
+              autoComplete: "off",
+              spellCheck: false,
+            }}
+          />
+          <div className="flex items-center justify-between gap-3 px-4 pb-1">
+            <Label
+              htmlFor="settings-advanced-toggle"
+              className="text-xs font-medium text-muted cursor-pointer select-none"
+            >
+              {t("settings.showAdvanced", {
+                defaultValue: "Show advanced",
+              })}
+            </Label>
+            <Switch
+              id="settings-advanced-toggle"
+              checked={complexity === "advanced"}
+              onCheckedChange={(checked) =>
+                setComplexity(checked ? "advanced" : "simple")
+              }
+              aria-label={t("settings.showAdvanced", {
+                defaultValue: "Show advanced",
+              })}
+            />
+          </div>
+        </div>
       }
     >
       <SidebarScrollRegion>
@@ -991,11 +1066,6 @@ export function SettingsView({
                         >
                           {t(section.label)}
                         </SidebarContent.ItemTitle>
-                        {section.description ? (
-                          <SidebarContent.ItemDescription>
-                            {t(section.description)}
-                          </SidebarContent.ItemDescription>
-                        ) : null}
                       </SidebarContent.ItemBody>
                     </SidebarContent.ItemButton>
                   </SidebarContent.Item>
@@ -1021,15 +1091,50 @@ export function SettingsView({
         </SettingsSection>
       )}
 
-      {visibleSectionIds.has("ai-model") && (
-        <SettingsSection
-          id="ai-model"
-          title={t("settings.sections.aimodel.label")}
-          description={t("settings.sections.aimodel.desc")}
-          ref={registerContentItem("ai-model")}
-        >
-          <ProviderSwitcher />
-        </SettingsSection>
+      {(visibleSectionIds.has("ai-model") ||
+        visibleSectionIds.has("media") ||
+        visibleSectionIds.has("appearance")) && (
+        <div className="grid gap-5 xl:grid-cols-2 items-start">
+          <div className="flex flex-col gap-5 min-w-0">
+            {visibleSectionIds.has("ai-model") && (
+              <SettingsSection
+                id="ai-model"
+                title={t("settings.sections.aimodel.label")}
+                description={t("settings.sections.aimodel.desc")}
+                ref={registerContentItem("ai-model")}
+              >
+                <ProviderSwitcher showAdvanced={complexity === "advanced"} />
+              </SettingsSection>
+            )}
+
+            {visibleSectionIds.has("appearance") && (
+              <SettingsSection
+                id="appearance"
+                title={t("settings.sections.appearance.label", {
+                  defaultValue: "Appearance",
+                })}
+                description={t("settings.sections.appearance.desc", {
+                  defaultValue:
+                    "Content packs, VRM avatars, backgrounds, and themes",
+                })}
+                ref={registerContentItem("appearance")}
+              >
+                <AppearanceSettingsSection />
+              </SettingsSection>
+            )}
+          </div>
+
+          {visibleSectionIds.has("media") && (
+            <SettingsSection
+              id="media"
+              title={t("settings.sections.media.label")}
+              description={t("settings.sections.media.desc")}
+              ref={registerContentItem("media")}
+            >
+              <MediaSettingsSection showAdvanced={complexity === "advanced"} />
+            </SettingsSection>
+          )}
+        </div>
       )}
 
       {visibleSectionIds.has("local-models") && (
@@ -1056,32 +1161,6 @@ export function SettingsView({
           ref={registerContentItem("coding-agents")}
         >
           <CodingAgentSettingsSection />
-        </SettingsSection>
-      )}
-
-      {visibleSectionIds.has("media") && (
-        <SettingsSection
-          id="media"
-          title={t("settings.sections.media.label")}
-          description={t("settings.sections.media.desc")}
-          ref={registerContentItem("media")}
-        >
-          <MediaSettingsSection />
-        </SettingsSection>
-      )}
-
-      {visibleSectionIds.has("appearance") && (
-        <SettingsSection
-          id="appearance"
-          title={t("settings.sections.appearance.label", {
-            defaultValue: "Appearance",
-          })}
-          description={t("settings.sections.appearance.desc", {
-            defaultValue: "Content packs, VRM avatars, backgrounds, and themes",
-          })}
-          ref={registerContentItem("appearance")}
-        >
-          <AppearanceSettingsSection />
         </SettingsSection>
       )}
 

--- a/packages/app-core/src/components/settings/MediaSettingsSection.tsx
+++ b/packages/app-core/src/components/settings/MediaSettingsSection.tsx
@@ -1,10 +1,15 @@
 import {
   Button,
   SaveFooter,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectValue,
   SettingsControls,
   Switch,
   useTimeout,
 } from "@elizaos/ui";
+import { Eye, Image, Mic, Music, Video } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
   type AudioGenProvider,
@@ -56,7 +61,65 @@ function segmentedButtonClass(active: boolean): string {
 
 // ── Main component ───────────────────────────────────────────────────
 
-export function MediaSettingsSection() {
+const CATEGORY_ICONS: Record<MediaCategory, typeof Image> = {
+  image: Image,
+  video: Video,
+  audio: Music,
+  vision: Eye,
+  voice: Mic,
+};
+
+/**
+ * Curated per-category cloud model options exposed in simple mode. Writes to
+ * `<category>.cloud.model` — unknown to the agent contract but tolerated by
+ * the config endpoint; the cloud plugin reads the corresponding
+ * `ELIZAOS_CLOUD_<CATEGORY>_MODEL` setting at runtime.
+ */
+const CLOUD_MODEL_OPTIONS: Record<
+  "image" | "video" | "audio" | "vision",
+  Array<{ id: string; label: string }>
+> = {
+  image: [
+    { id: "", label: "Default (Auto)" },
+    { id: "gpt-image-1", label: "GPT-Image 1 (OpenAI)" },
+    { id: "dall-e-3", label: "DALL-E 3 (OpenAI)" },
+    { id: "fal-ai/flux-pro", label: "Flux Pro" },
+    { id: "fal-ai/flux/schnell", label: "Flux Schnell" },
+    { id: "fal-ai/nano-banana-pro", label: "Nano Banana Pro" },
+  ],
+  video: [
+    { id: "", label: "Default (Auto)" },
+    { id: "fal-ai/veo3.1", label: "Veo 3.1 (Google)" },
+    { id: "fal-ai/veo3.1/fast", label: "Veo 3.1 Fast" },
+    { id: "fal-ai/sora-2/text-to-video/pro", label: "Sora 2 Pro" },
+    { id: "fal-ai/kling-video/v3/pro/text-to-video", label: "Kling 3 Pro" },
+  ],
+  audio: [
+    { id: "", label: "Default (Auto)" },
+    { id: "suno-v4", label: "Suno v4" },
+    { id: "eleven-music", label: "ElevenLabs Music" },
+    { id: "eleven-sfx", label: "ElevenLabs SFX" },
+  ],
+  vision: [
+    { id: "", label: "Default (Auto)" },
+    { id: "gpt-4o", label: "GPT-4o (OpenAI)" },
+    { id: "claude-3-5-sonnet-latest", label: "Claude 3.5 Sonnet" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "grok-2-vision", label: "Grok 2 Vision" },
+  ],
+};
+
+interface MediaSettingsSectionProps {
+  /**
+   * When true, render the 3D companion performance controls (GPU power mode,
+   * half frame-rate toggle, animate-in-background). Hidden by default.
+   */
+  showAdvanced?: boolean;
+}
+
+export function MediaSettingsSection({
+  showAdvanced = false,
+}: MediaSettingsSectionProps = {}) {
   const { setTimeout } = useTimeout();
 
   const {
@@ -205,7 +268,7 @@ export function MediaSettingsSection() {
     <div className="flex flex-col gap-4">
       <MusicPlayerSettingsPanel />
 
-      {COMPANION_ENABLED && (
+      {COMPANION_ENABLED && showAdvanced && (
         <div
           className="rounded-xl border border-border bg-card/60 px-3 py-3 flex flex-col gap-3"
           data-testid="settings-companion-vrm-power"
@@ -306,26 +369,36 @@ export function MediaSettingsSection() {
           })}
         </p>
 
-        {/* Category tabs — status dots removed in favour of the single
-            "Configured / Needs setup" pill shown below the tabs. */}
-        <SettingsControls.SegmentedGroup>
+        {/* Category tabs — icon + underline style. Status dots removed in
+            favour of the single "Configured / Needs setup" pill shown below. */}
+        <div
+          role="tablist"
+          className="flex flex-wrap items-stretch gap-x-1 border-b border-border/40"
+        >
           {(
             ["image", "video", "audio", "vision", "voice"] as MediaCategory[]
           ).map((cat) => {
             const active = activeTab === cat;
+            const Icon = CATEGORY_ICONS[cat];
             return (
-              <Button
+              <button
                 key={cat}
-                variant={active ? "default" : "ghost"}
-                size="sm"
-                className={segmentedButtonClass(active)}
+                type="button"
+                role="tab"
+                aria-selected={active}
                 onClick={() => setActiveTab(cat)}
+                className={`group flex flex-1 min-w-[8rem] items-center justify-center gap-2 px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
+                  active
+                    ? "border-accent text-accent"
+                    : "border-transparent text-muted hover:text-txt hover:border-border"
+                }`}
               >
-                {t(CATEGORY_LABELS[cat])}
-              </Button>
+                <Icon className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{t(CATEGORY_LABELS[cat])}</span>
+              </button>
             );
           })}
-        </SettingsControls.SegmentedGroup>
+        </div>
 
         {/* Voice tab — render VoiceConfigView instead of media config */}
         {activeTab === "voice" ? (
@@ -376,12 +449,59 @@ export function MediaSettingsSection() {
 
             {/* Cloud mode status */}
             {currentMode === "cloud" && (
-              <CloudConnectionStatus
-                connected={elizaCloudConnected}
-                disconnectedText={t(
-                  "elizaclouddashboard.ElizaCloudNotConnectedSettings",
-                )}
-              />
+              <>
+                <CloudConnectionStatus
+                  connected={elizaCloudConnected}
+                  disconnectedText={t(
+                    "elizaclouddashboard.ElizaCloudNotConnectedSettings",
+                  )}
+                />
+                {activeTab !== "voice" &&
+                  CLOUD_MODEL_OPTIONS[
+                    activeTab as keyof typeof CLOUD_MODEL_OPTIONS
+                  ] && (
+                    <div className="flex flex-col gap-1.5">
+                      <span className="text-xs font-semibold text-muted">
+                        {t("mediasettingssection.Model", {
+                          defaultValue: "Model",
+                        })}
+                      </span>
+                      <Select
+                        value={
+                          ((getNestedValue(
+                            mediaConfig as Record<string, unknown>,
+                            `${activeTab}.cloud.model`,
+                          ) as string) ?? "") || "__default__"
+                        }
+                        onValueChange={(value: string) =>
+                          updateNestedValue(
+                            `${activeTab}.cloud.model`,
+                            value === "__default__" ? undefined : value,
+                          )
+                        }
+                      >
+                        <SettingsControls.SelectTrigger
+                          variant="compact"
+                          className="max-w-sm"
+                        >
+                          <SelectValue />
+                        </SettingsControls.SelectTrigger>
+                        <SelectContent className="max-h-64">
+                          {CLOUD_MODEL_OPTIONS[
+                            activeTab as keyof typeof CLOUD_MODEL_OPTIONS
+                          ].map((m) => (
+                            <SelectItem
+                              key={m.id || "__default__"}
+                              value={m.id || "__default__"}
+                            >
+                              {m.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+              </>
             )}
 
             {/* Own-key mode: provider selection */}

--- a/packages/app-core/src/components/settings/PermissionsSection.tsx
+++ b/packages/app-core/src/components/settings/PermissionsSection.tsx
@@ -137,7 +137,7 @@ function MobilePermissionsView() {
   const { websiteBlockerSettingsCard: WebsiteBlockerSettingsCard } =
     useBootConfig();
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       <StreamingPermissionsSettingsView
         mode="mobile"
         testId="mobile-permissions"
@@ -161,7 +161,7 @@ function WebPermissionsView() {
   const { websiteBlockerSettingsCard: WebsiteBlockerSettingsCard } =
     useBootConfig();
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       <StreamingPermissionsSettingsView
         mode="web"
         testId="web-permissions-info"
@@ -244,7 +244,7 @@ function DesktopPermissionsView() {
   const copy = platformCopy(platform);
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       {/* System Permissions */}
       <section className="space-y-2">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">

--- a/packages/app-core/src/components/settings/PermissionsSection.tsx
+++ b/packages/app-core/src/components/settings/PermissionsSection.tsx
@@ -137,7 +137,7 @@ function MobilePermissionsView() {
   const { websiteBlockerSettingsCard: WebsiteBlockerSettingsCard } =
     useBootConfig();
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-3xl">
       <StreamingPermissionsSettingsView
         mode="mobile"
         testId="mobile-permissions"
@@ -161,7 +161,7 @@ function WebPermissionsView() {
   const { websiteBlockerSettingsCard: WebsiteBlockerSettingsCard } =
     useBootConfig();
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-3xl">
       <StreamingPermissionsSettingsView
         mode="web"
         testId="web-permissions-info"
@@ -244,7 +244,7 @@ function DesktopPermissionsView() {
   const copy = platformCopy(platform);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-3xl">
       {/* System Permissions */}
       <section className="space-y-2">
         <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">

--- a/packages/app-core/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.tsx
@@ -317,12 +317,14 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
   const availableProviderIds = useMemo(
     () =>
       new Set(
-        allAiProviders.map(
-          (provider) =>
-            getOnboardingProviderOption(
-              normalizeAiProviderPluginId(provider.id),
-            )?.id ?? normalizeAiProviderPluginId(provider.id),
-        ),
+        allAiProviders
+          .map(
+            (provider) =>
+              getOnboardingProviderOption(
+                normalizeAiProviderPluginId(provider.id),
+              )?.id,
+          )
+          .filter((id): id is NonNullable<typeof id> => id != null),
       ),
     [allAiProviders],
   );
@@ -459,15 +461,25 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
       label: getSubscriptionProviderLabel(provider, t),
       disabled: false,
     })),
-    ...allAiProviders.map((provider) => ({
-      id:
-        getOnboardingProviderOption(normalizeAiProviderPluginId(provider.id))
-          ?.id ?? normalizeAiProviderPluginId(provider.id),
-      label:
-        getOnboardingProviderOption(normalizeAiProviderPluginId(provider.id))
-          ?.name ?? provider.name,
-      disabled: false,
-    })),
+    // Only surface providers the backend's /api/provider/switch endpoint
+    // actually accepts (i.e. entries in ONBOARDING_PROVIDER_CATALOG). Plugins
+    // without a catalog entry — e.g. `local-ai`, which is configured via the
+    // dedicated "Local Models" settings section, not this dropdown — are
+    // filtered out, otherwise selecting them returns "Invalid provider".
+    ...allAiProviders
+      .map((provider) => {
+        const option = getOnboardingProviderOption(
+          normalizeAiProviderPluginId(provider.id),
+        );
+        return option
+          ? {
+              id: option.id,
+              label: option.name,
+              disabled: false,
+            }
+          : null;
+      })
+      .filter((choice): choice is NonNullable<typeof choice> => choice !== null),
   ];
 
   /* ── Cloud-model schema ───────────────────────────────────────── */

--- a/packages/app-core/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.tsx
@@ -77,6 +77,11 @@ interface ProviderSwitcherProps {
     values: Record<string, unknown>,
   ) => void | Promise<void>;
   handleCloudLogin?: () => Promise<void>;
+  /**
+   * When true, render the full 7-dropdown model-tier override grid. In simple
+   * mode only the provider picker + API key / login action are shown.
+   */
+  showAdvanced?: boolean;
 }
 
 function getSubscriptionProviderLabel(
@@ -623,11 +628,11 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
         >
           <SelectTrigger
             id="provider-switcher-select"
-            className="h-9 w-full rounded-lg border border-border bg-card text-sm"
+            className="h-9 w-full max-w-sm rounded-lg border border-border bg-card text-sm"
           >
             <SelectValue />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent className="max-h-64">
             {providerChoices.map((choice) => (
               <SelectItem
                 key={choice.id}
@@ -639,9 +644,6 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
             ))}
           </SelectContent>
         </Select>
-        <p className="mt-1.5 text-xs-tight text-muted">
-          {t("providerswitcher.chooseYourPreferredProvider")}
-        </p>
       </div>
 
       {/* Cloud model tiers (when Cloud is selected) */}
@@ -687,7 +689,7 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
                 </>
               )}
             </div>
-          ) : cloudModelSchema ? (
+          ) : cloudModelSchema && props.showAdvanced ? (
             <div className="border-t border-border/40 pt-4">
               <ConfigRenderer
                 schema={cloudModelSchema.schema}
@@ -698,6 +700,54 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
                 onChange={handleModelFieldChange}
               />
               <div className="mt-3 flex items-center justify-between gap-2">
+                <p className="text-xs-tight text-muted">
+                  {t("providerswitcher.restartRequiredHint")}
+                </p>
+                <div className="flex items-center gap-2">
+                  {modelSaving && (
+                    <span className="text-xs-tight text-muted">
+                      {t("providerswitcher.savingRestarting")}
+                    </span>
+                  )}
+                  {modelSaveSuccess && (
+                    <span className="text-xs-tight text-ok">
+                      {t("providerswitcher.savedRestartingAgent")}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : modelOptions && modelOptions.large.length > 0 ? (
+            <div className="border-t border-border/40 pt-4">
+              <label
+                htmlFor="provider-switcher-primary-model"
+                className="mb-1.5 block text-xs font-medium uppercase tracking-wider text-muted"
+              >
+                {t("providerswitcher.model", { defaultValue: "Model" })}
+              </label>
+              <Select
+                value={currentLargeModel || ""}
+                onValueChange={(v) => handleModelFieldChange("large", v)}
+              >
+                <SelectTrigger
+                  id="provider-switcher-primary-model"
+                  className="h-9 w-full max-w-sm rounded-lg border border-border bg-card text-sm"
+                >
+                  <SelectValue
+                    placeholder={t("providerswitcher.chooseModel", {
+                      defaultValue: "Choose a model",
+                    })}
+                  />
+                </SelectTrigger>
+                <SelectContent className="max-h-64">
+                  {modelOptions.large.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="mt-2 flex items-center justify-between gap-2">
                 <p className="text-xs-tight text-muted">
                   {t("providerswitcher.restartRequiredHint")}
                 </p>

--- a/packages/app-core/src/config/zod-schema.core.ts
+++ b/packages/app-core/src/config/zod-schema.core.ts
@@ -573,6 +573,15 @@ export const ImageProviderSchema = z.enum([
   "xai",
 ]);
 
+// Shared cloud sub-config: pin a specific cloud-hosted model per category
+// (image/video/audio/vision). Applied when `mode === "cloud"`.
+export const CloudMediaConfigSchema = z
+  .object({
+    model: z.string().optional(),
+  })
+  .strict()
+  .optional();
+
 export const ImageFalConfigSchema = z
   .object({
     apiKey: z.string().optional(),
@@ -615,6 +624,7 @@ export const ImageConfigSchema = z
     mode: MediaModeSchema.optional(),
     provider: ImageProviderSchema.optional(),
     defaultSize: z.string().optional(),
+    cloud: CloudMediaConfigSchema,
     fal: ImageFalConfigSchema,
     openai: ImageOpenaiConfigSchema,
     google: ImageGoogleConfigSchema,
@@ -658,6 +668,7 @@ export const VideoConfigSchema = z
     mode: MediaModeSchema.optional(),
     provider: VideoProviderSchema.optional(),
     defaultDuration: z.number().int().positive().optional(),
+    cloud: CloudMediaConfigSchema,
     fal: VideoFalConfigSchema,
     openai: VideoOpenaiConfigSchema,
     google: VideoGoogleConfigSchema,
@@ -691,6 +702,7 @@ export const AudioGenConfigSchema = z
     enabled: z.boolean().optional(),
     mode: MediaModeSchema.optional(),
     provider: AudioGenProviderSchema.optional(),
+    cloud: CloudMediaConfigSchema,
     suno: AudioSunoConfigSchema,
     elevenlabs: AudioElevenlabsSfxConfigSchema,
   })
@@ -756,6 +768,7 @@ export const VisionConfigSchema = z
     enabled: z.boolean().optional(),
     mode: MediaModeSchema.optional(),
     provider: VisionProviderSchema.optional(),
+    cloud: CloudMediaConfigSchema,
     openai: VisionOpenaiConfigSchema,
     google: VisionGoogleConfigSchema,
     anthropic: VisionAnthropicConfigSchema,

--- a/packages/ui/src/components/shell/Header.tsx
+++ b/packages/ui/src/components/shell/Header.tsx
@@ -218,7 +218,20 @@ export function Header({
         style={{ WebkitUserSelect: "none", userSelect: "none" }}
         data-no-camera-drag="true"
       >
-        <div className="py-1 ps-2 pe-2" data-header-toolbar-padding>
+        {/*
+         * Push the interactive toolbar row below the macOS native drag strip
+         * (see electrobun-mac-window-drag.css and window-effects.mm). Without
+         * this, the top ~22pt of the nav buttons sits under the transparent
+         * NSView that handles window-move, so half the button only responds
+         * on its bottom half. `--eliza-macos-frame-top-inset` is only set
+         * when html.eliza-electrobun-frameless is active, so other shells
+         * (web, detached overlays) are unaffected.
+         */}
+        <div
+          className="py-1 ps-2 pe-2"
+          style={{ paddingTop: "var(--eliza-macos-frame-top-inset, 0.25rem)" }}
+          data-header-toolbar-padding
+        >
           <div
             className={`pointer-events-auto relative mx-auto w-full rounded-[20px] border bg-clip-padding transition-all sm:rounded-[22px] ${headerFrameClassName} ${headerShellClassName}`}
             data-testid="header-glass-shell"


### PR DESCRIPTION
## Summary

A batch of focused fixes to the elizaOS app shell + settings UI, all six commits stacked cleanly on top of \`develop\`:

- **a3f9fdddc3** \`feat(settings): constrain provider dropdown, drop Advanced Dashboard button, add simple Model picker\`
  - Cap \`SelectTrigger\` at \`max-w-sm\` (was stretching to full panel width) and \`SelectContent\` at \`max-h-64\`.
  - Add a single Model dropdown in the AI Model card so users can pick the primary tier without clicking "Show advanced".
  - Remove the \`elizaclouddashboard.AdvancedDashboard\` external-link button from the Cloud overview row (and the now-unused \`ELIZA_CLOUD_INSTANCES_URL\` import).

- **f4fe726f6a** \`feat(settings): add cloud media model picker, advanced-gate companion perf, side-by-side AI/Media layout\`
  - In MediaSettingsSection, surface a per-category Model select for cloud mode (image/video/audio/vision) writing to \`<category>.cloud.model\` (new \`CloudMediaConfig\` type + zod schema entry, additive).
  - Hide the 3D companion performance controls behind \`Show advanced\`.
  - Pair AI Model + Media in a 2-col grid on \`xl\`; Appearance flows into the left column.

- **aeca256d36** \`fix(settings,shell): hide local-ai from provider dropdown; push header below native mac drag strip\`
  - Filter the AI provider dropdown to only catalog-recognised entries — \`local-ai\` was offered but the backend's \`/api/provider/switch\` rejected it (it's configured via the dedicated Local Models section).
  - Apply the previously-declared-but-unconsumed \`--eliza-macos-frame-top-inset\` as \`padding-top\` on the header toolbar wrapper. Without it, the top ~22pt of every nav button sits under the native \`ElectrobunNativeDragView\` (window-effects.mm), so only the bottom half of each tab is click-through. Falls back to \`0.25rem\` when the frameless class isn't present (web / detached shells).

- **f9420a3b4e** \`fix(settings): cap Permissions section width (max-w-3xl)\` _(superseded — see below)_

- **f08629c09f** \`refactor(settings): pair remaining sections into 2-col grids; drop Permissions width cap\`
  - Group Local Models + Coding Agents into one \`xl:grid-cols-2\` row.
  - Group Capabilities + Permissions into another.
  - Drop the max-w-3xl cap inside PermissionsSection so it fills its grid column naturally.

- **e35a10d706** \`fix(runtime): cap hot-reload shutdown at 2s so provider switches don't block on PTY teardown\`
  - \`runtime.stop()\` awaits every service.stop() sequentially. PTYService.stop drains active sessions with a per-session timeout (~5s), so any one idle PTY session turns a provider-dropdown click into a multi-second block, during which the server's \`providerSwitchInProgress\` flag rejects further clicks with 409 — the "switch feels stuck / dropdown reverts" UX.
  - Wrap \`shutdownRuntime()\` in the hot-reload \`onRestart\` path with a 2 s \`Promise.race\`. If the old runtime stops in time, great; otherwise log and bring up the new runtime anyway. Services that miss the window are GC'd as the reference drops.

## Test plan

- [ ] Settings → AI Model: provider dropdown caps at 384 px wide; popover scrolls within ~256 px instead of \~384 px.
- [ ] Settings → AI Model: Model picker visible without "Show advanced"; selecting a model persists and triggers a restart.
- [ ] Settings → AI Model: provider dropdown no longer lists "Local AI"; switching to any catalog provider succeeds.
- [ ] Settings → Cloud Dashboard: "Advanced External Dashboard" link is gone from the overview row.
- [ ] Settings → Media: cloud mode shows a per-category Model select for image/video/audio/vision; companion 3D controls only visible with "Show advanced" on.
- [ ] Settings layout: at \`xl\` (≥1280px), AI Model + Appearance share a column with Media on the right; Local Models + Coding Agents pair below; Capabilities + Permissions pair below that.
- [ ] macOS Electrobun shell: top of every header nav tab is now click-through (no longer hits the native drag NSView).
- [ ] Rapidly click through 3+ providers in the dropdown — no "stuck" 5+ second block; restart completes inside ~3 s even with active PTY sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a batch of UI polish across the settings shell: dropdown width capping, a simple-mode primary model picker, per-category cloud media model selectors, 2-col xl grid layouts, local-ai filtered out of the provider dropdown, the macOS drag-strip header fix, and a 2 s `Promise.race` timeout on hot-reload shutdown to eliminate PTY-induced provider-switch stalls.

- **P1 (`eliza.ts`)**: `Promise.race` resolves via the 2 s timer but leaves `shutdownRuntime` still running with no `.catch`. If it subsequently rejects, Node.js surfaces an unhandled rejection (process-crashing in Node ≥ v15 default mode). The fix is to attach `.catch` to the shutdown promise before passing it to the race.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the unhandled-rejection bug in the hot-reload shutdown race.

All seven UI/type changes are low-risk and well-structured; the one P1 is in the runtime hot-reload path where a late-throwing shutdownRuntime could produce an unhandled rejection that crashes the process.

packages/agent/src/runtime/eliza.ts — the Promise.race pattern around shutdownRuntime needs a .catch on the shutdown promise to prevent unhandled rejections.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/eliza.ts | Adds a 2 s Promise.race timeout around shutdownRuntime in the hot-reload path — solves the PTY-stall UX — but the dangling shutdownRuntime promise can produce an unhandled rejection if it throws after the timer fires (P1). |
| packages/app-core/src/components/pages/SettingsView.tsx | Adds simple/advanced complexity toggle with localStorage persistence, 2-col xl grid layouts for paired sections, and section-level visibility gating. activeSection is correctly reset via useEffect when a section becomes invisible. |
| packages/app-core/src/components/settings/ProviderSwitcher.tsx | Filters out providers with no ONBOARDING_PROVIDER_CATALOG entry (fixing local-ai), constrains dropdown width, adds a simple-mode primary model picker, and hides the 7-dropdown cloud model grid behind showAdvanced. |
| packages/app-core/src/components/settings/MediaSettingsSection.tsx | Adds per-category cloud model dropdowns (writing to category.cloud.model), replaces SegmentedGroup tabs with icon+underline tab bar, and gates 3D companion controls behind showAdvanced. Contains a redundant activeTab !== "voice" guard (P2). |
| packages/app-core/src/config/zod-schema.core.ts | Additive: introduces CloudMediaConfigSchema (strict, optional object with optional model string) and wires it into ImageConfigSchema, VideoConfigSchema, AudioGenConfigSchema, and VisionConfigSchema. |
| packages/agent/src/contracts/config.ts | Additive type changes: introduces CloudMediaConfig and adds optional cloud field to all four media config types. Mirrors the zod-schema changes correctly. |
| packages/app-core/src/components/pages/ElizaCloudDashboard.tsx | Removes the AdvancedDashboard external-link button and unused ELIZA_CLOUD_INSTANCES_URL import; shrinks the balance display to a more compact inline layout. |
| packages/ui/src/components/shell/Header.tsx | Applies --eliza-macos-frame-top-inset as inline paddingTop on the toolbar wrapper so nav buttons clear the native macOS drag strip; falls back to 0.25rem on other shells. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as ProviderSwitcher (UI)
    participant API as /api/provider/switch
    participant Eliza as startEliza onRestart
    participant RT as shutdownRuntime
    participant Timer as 2s Timer

    UI->>API: POST /provider/switch
    API->>Eliza: onRestart()
    Eliza->>RT: shutdownRuntime() [async]
    Eliza->>Timer: setTimeout(2000ms)
    alt shutdown completes < 2s
        RT-->>Eliza: resolved
        Note over Timer: timer still fires later (handle not cleared)
    else shutdown exceeds 2s
        Timer-->>Eliza: resolved (shutdownTimedOut=true)
        Note over RT: still running — if it rejects, UNHANDLED REJECTION
    end
    Eliza->>Eliza: loadElizaConfig() + start new runtime
    Eliza-->>API: new runtime ready
    API-->>UI: 200 OK
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/agent/src/runtime/eliza.ts`, line 3895-3916 ([link](https://github.com/elizaos/eliza/blob/e35a10d706b6b033fe3d490cb08ee5eba429d4ae/packages/agent/src/runtime/eliza.ts#L3895-L3916)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Unhandled rejection when `shutdownRuntime` throws after the 2 s timeout**

   `Promise.race` resolves via the timer if shutdown takes longer than 2 s, but the `shutdownRuntime` promise is still running in the background. If it subsequently rejects, that rejection has no `.catch` handler — the outer `try/catch` only guards `Promise.race` itself, not the dangling promise. In Node.js ≥ v15 (with `--unhandled-rejections=throw`) this crashes the process.

   Fix: attach a `.catch` to the shutdown promise before passing it to the race so any late rejection is absorbed:

   ```
   try {
     const SHUTDOWN_TIMEOUT_MS = 2000;
     let shutdownTimedOut = false;
     const shutdownPromise = shutdownRuntime(runtime, "hot-reload cleanup").catch(
       (stopErr) => {
         logger.warn(
           `[eliza] Hot-reload: old runtime stop failed: ${formatError(stopErr)}`,
         );
       },
     );
     await Promise.race([
       shutdownPromise,
       new Promise<void>((resolve) =>
         setTimeout(() => {
           shutdownTimedOut = true;
           resolve();
         }, SHUTDOWN_TIMEOUT_MS),
       ),
     ]);
     if (shutdownTimedOut) {
       logger.warn(
         `[eliza] Hot-reload: old runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; proceeding with new runtime`,
       );
     }
   } catch (stopErr) {
     logger.warn(
       `[eliza] Hot-reload: old runtime stop failed: ${formatError(stopErr)}`,
     );
   }
   ```


2. `packages/app-core/src/components/settings/MediaSettingsSection.tsx`, line 782-784 ([link](https://github.com/elizaos/eliza/blob/e35a10d706b6b033fe3d490cb08ee5eba429d4ae/packages/app-core/src/components/settings/MediaSettingsSection.tsx#L782-L784)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `activeTab !== "voice"` guard**

   This code lives inside the `else` branch of the `activeTab === "voice" ? … : …` ternary (outer JSX), so `activeTab` is already guaranteed to be non-`"voice"` here. The extra check is a no-op but signals potential confusion about the render tree structure.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): cap hot-reload shutdown at..."](https://github.com/elizaos/eliza/commit/e35a10d706b6b033fe3d490cb08ee5eba429d4ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29373689)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->