### PR TITLE
feat(lifeops): support multi-calendar Google feeds

### DIFF
--- a/apps/app-lifeops/src/actions/calendar.ts
+++ b/apps/app-lifeops/src/actions/calendar.ts
@@ -1450,6 +1450,7 @@ async function loadCreateEventCalendarContext(
 
   const requestTimeZone = resolveCalendarTimeZone(details);
   const feed = await service.getCalendarFeed(INTERNAL_URL, {
+    includeHiddenCalendars: true,
     mode: detailString(details, "mode") as
       | "local"
       | "remote"
@@ -3552,6 +3553,7 @@ export const calendarAction: Action & {
                   ...buildWideLookupRange(resolveCalendarTimeZone(details)),
                 };
           const feed = await service.getCalendarFeed(INTERNAL_URL, {
+            includeHiddenCalendars: true,
             mode: detailString(details, "mode") as
               | "local"
               | "remote"
@@ -3720,6 +3722,7 @@ export const calendarAction: Action & {
                   ...buildWideLookupRange(resolveCalendarTimeZone(details)),
                 };
           const feed = await service.getCalendarFeed(INTERNAL_URL, {
+            includeHiddenCalendars: true,
             mode: detailString(details, "mode") as
               | "local"
               | "remote"
@@ -3867,6 +3870,7 @@ export const calendarAction: Action & {
 
       if (subaction === "trip_window" && tripWindowIntent) {
         const feed = await service.getCalendarFeed(INTERNAL_URL, {
+          includeHiddenCalendars: true,
           mode: detailString(details, "mode") as
             | "local"
             | "remote"
@@ -3929,6 +3933,7 @@ export const calendarAction: Action & {
       const label = baseResolved.label;
       const hasExplicitWindow = baseResolved.explicitWindow;
       const feed = await service.getCalendarFeed(INTERNAL_URL, {
+        includeHiddenCalendars: true,
         mode: detailString(details, "mode") as
           | "local"
           | "remote"

--- a/apps/app-lifeops/src/actions/life.ts
+++ b/apps/app-lifeops/src/actions/life.ts
@@ -3103,6 +3103,7 @@ export const lifeAction: Action & {
               ? "this week"
               : "today";
         const feed = await service.getCalendarFeed(INTERNAL_URL, {
+          includeHiddenCalendars: true,
           timeMin: range.timeMin,
           timeMax: range.timeMax,
         });

--- a/apps/app-lifeops/src/actions/owner-calendar.ts
+++ b/apps/app-lifeops/src/actions/owner-calendar.ts
@@ -430,6 +430,7 @@ async function handleBulkReschedulePreview(args: {
   let events: readonly LifeOpsCalendarEvent[] = [];
   try {
     const feed = await service.getCalendarFeed(INTERNAL_URL, {
+      includeHiddenCalendars: true,
       timeMin,
       timeMax,
       timeZone,

--- a/apps/app-lifeops/src/actions/scheduling.ts
+++ b/apps/app-lifeops/src/actions/scheduling.ts
@@ -474,6 +474,7 @@ export const proposeMeetingTimesAction: Action & {
     let events: readonly LifeOpsCalendarEvent[] = [];
     try {
       const feed = await service.getCalendarFeed(INTERNAL_URL, {
+        includeHiddenCalendars: true,
         timeMin: windowStart.toISOString(),
         timeMax: windowEnd.toISOString(),
         timeZone: effectivePreferences.timeZone,
@@ -616,6 +617,7 @@ export const checkAvailabilityAction: Action = {
     let events: readonly LifeOpsCalendarEvent[] = [];
     try {
       const feed = await service.getCalendarFeed(INTERNAL_URL, {
+        includeHiddenCalendars: true,
         timeMin: windowStart.toISOString(),
         timeMax: windowEnd.toISOString(),
         timeZone: preferences.timeZone,

--- a/apps/app-lifeops/src/api/client-lifeops.ts
+++ b/apps/app-lifeops/src/api/client-lifeops.ts
@@ -57,6 +57,7 @@ import type {
   LifeOpsCalendarEventMutationResult,
   LifeOpsCalendarEventUpdate,
   LifeOpsCalendarFeed,
+  LifeOpsCalendarSummary,
   LifeOpsCapabilitiesStatus,
   LifeOpsConnectorMode,
   LifeOpsConnectorSide,
@@ -91,9 +92,11 @@ import type {
   LifeOpsInbox,
   LifeOpsXConnectorStatus,
   ManageLifeOpsGmailMessagesRequest,
+  ListLifeOpsCalendarsRequest,
   SelectLifeOpsGoogleConnectorPreferenceRequest,
   SendLifeOpsGmailReplyRequest,
   SendLifeOpsIMessageRequest,
+  SetLifeOpsCalendarIncludedRequest,
   SnoozeLifeOpsOccurrenceRequest,
   StartLifeOpsDiscordConnectorRequest,
   StartLifeOpsGoogleConnectorRequest,
@@ -389,6 +392,12 @@ declare module "@elizaos/app-core/api/client-base" {
     getLifeOpsCalendarFeed(
       options?: GetLifeOpsCalendarFeedRequest,
     ): Promise<LifeOpsCalendarFeed>;
+    getLifeOpsCalendars(
+      options?: ListLifeOpsCalendarsRequest,
+    ): Promise<{ calendars: LifeOpsCalendarSummary[] }>;
+    setLifeOpsCalendarIncluded(
+      data: SetLifeOpsCalendarIncludedRequest,
+    ): Promise<{ calendar: LifeOpsCalendarSummary }>;
     getLifeOpsGmailTriage(
       options?: GetLifeOpsGmailTriageRequest,
     ): Promise<LifeOpsGmailTriageFeed>;
@@ -1049,6 +1058,12 @@ ElizaClient.prototype.getLifeOpsCalendarFeed = async function (
   if (options.calendarId) {
     params.set("calendarId", options.calendarId);
   }
+  if (options.includeHiddenCalendars !== undefined) {
+    params.set(
+      "includeHiddenCalendars",
+      String(options.includeHiddenCalendars),
+    );
+  }
   if (options.timeMin) {
     params.set("timeMin", options.timeMin);
   }
@@ -1063,6 +1078,39 @@ ElizaClient.prototype.getLifeOpsCalendarFeed = async function (
   }
   const query = params.toString();
   return this.fetch(`/api/lifeops/calendar/feed${query ? `?${query}` : ""}`);
+};
+
+ElizaClient.prototype.getLifeOpsCalendars = async function (
+  this: ElizaClient,
+  options = {},
+) {
+  const params = new URLSearchParams();
+  if (options.mode) {
+    params.set("mode", options.mode);
+  }
+  if (options.side) {
+    params.set("side", options.side);
+  }
+  if (options.grantId) {
+    params.set("grantId", options.grantId);
+  }
+  const query = params.toString();
+  return this.fetch(
+    `/api/lifeops/calendar/calendars${query ? `?${query}` : ""}`,
+  );
+};
+
+ElizaClient.prototype.setLifeOpsCalendarIncluded = async function (
+  this: ElizaClient,
+  data,
+) {
+  return this.fetch(
+    `/api/lifeops/calendar/calendars/${encodeURIComponent(data.calendarId)}/include`,
+    {
+      method: "PUT",
+      body: JSON.stringify(data),
+    },
+  );
 };
 
 ElizaClient.prototype.getLifeOpsGmailTriage = async function (

--- a/apps/app-lifeops/src/components/LifeOpsCalendarSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsCalendarSection.tsx
@@ -205,7 +205,14 @@ function formatAgendaEventMeta(event: LifeOpsCalendarEvent): string {
     : [formatTimeOfDay(event.startAt), formatTimeOfDay(event.endAt)]
         .filter(Boolean)
         .join(" - ");
-  return event.location ? `${timeLabel} · ${event.location}` : timeLabel;
+  const originLabel =
+    typeof event.calendarSummary === "string" && event.calendarSummary.trim()
+      ? event.calendarSummary.trim()
+      : null;
+  const details = [timeLabel, event.location || null, originLabel].filter(
+    (value): value is string => Boolean(value),
+  );
+  return details.join(" · ");
 }
 
 interface EventPosition {

--- a/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
@@ -5,14 +5,16 @@ import {
   useApp,
   useMediaQuery,
 } from "@elizaos/app-core";
+import { client } from "@elizaos/app-core/api";
 import { useGoogleLifeOpsConnector } from "../hooks/useGoogleLifeOpsConnector";
 import type {
+  LifeOpsCalendarSummary,
   LifeOpsConnectorMode,
   LifeOpsConnectorSide,
   LifeOpsGoogleCapability,
 } from "@elizaos/app-lifeops/contracts";
 import { Copy, ExternalLink, GitBranch, Plug2, X } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { BrowserBridgeSetupPanel } from "./BrowserBridgeSetupPanel.tsx";
 import { MobileSignalsSetupCard } from "./MobileSignalsSetupCard";
 
@@ -352,6 +354,10 @@ function GoogleConnectorSideCard({
     status,
   } = connector;
   const [dismissedAuthUrl, setDismissedAuthUrl] = useState<string | null>(null);
+  const [calendars, setCalendars] = useState<LifeOpsCalendarSummary[]>([]);
+  const [calendarLoading, setCalendarLoading] = useState(false);
+  const [calendarError, setCalendarError] = useState<string | null>(null);
+  const [calendarPendingId, setCalendarPendingId] = useState<string | null>(null);
   const compactLayout = useMediaQuery("(max-width: 767px)");
   const connectedAccounts = accounts.filter((account) => account.connected);
   const primaryIdentity = readIdentity(
@@ -371,6 +377,78 @@ function GoogleConnectorSideCard({
       ? pendingAuthUrl
       : null;
   const preferredGrantId = status?.grant?.id ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!status?.connected) {
+      setCalendars([]);
+      setCalendarError(null);
+      setCalendarLoading(false);
+      return;
+    }
+    const loadCalendars = async () => {
+      setCalendarLoading(true);
+      setCalendarError(null);
+      try {
+        const response = await client.getLifeOpsCalendars({
+          side,
+          mode: status.mode,
+        });
+        if (!cancelled) {
+          setCalendars(response.calendars);
+        }
+      } catch (cause) {
+        if (!cancelled) {
+          setCalendarError(
+            cause instanceof Error && cause.message.trim().length > 0
+              ? cause.message.trim()
+              : "Could not load calendars.",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setCalendarLoading(false);
+        }
+      }
+    };
+    void loadCalendars();
+    return () => {
+      cancelled = true;
+    };
+  }, [side, status?.connected, status?.mode]);
+
+  const toggleCalendar = useCallback(
+    async (calendar: LifeOpsCalendarSummary) => {
+      setCalendarPendingId(calendar.calendarId);
+      setCalendarError(null);
+      try {
+        const response = await client.setLifeOpsCalendarIncluded({
+          calendarId: calendar.calendarId,
+          includeInFeed: !calendar.includeInFeed,
+          side,
+          mode: status?.mode,
+          grantId: calendar.grantId,
+        });
+        setCalendars((current) =>
+          current.map((entry) =>
+            entry.calendarId === response.calendar.calendarId &&
+            entry.grantId === response.calendar.grantId
+              ? response.calendar
+              : entry,
+          ),
+        );
+      } catch (cause) {
+        setCalendarError(
+          cause instanceof Error && cause.message.trim().length > 0
+            ? cause.message.trim()
+            : "Could not update calendar visibility.",
+        );
+      } finally {
+        setCalendarPendingId(null);
+      }
+    },
+    [side, status?.mode],
+  );
 
   return (
     <section className="space-y-3 px-4 py-4">
@@ -527,6 +605,71 @@ function GoogleConnectorSideCard({
         </div>
       ) : null}
 
+      {status?.connected ? (
+        <div className="space-y-2 rounded-2xl bg-bg/30 px-3 py-3">
+          <div className="text-xs font-semibold text-txt">
+            {t("lifeopssettings.calendarFeedTitle", {
+              defaultValue: "Which calendars appear in your feed?",
+            })}
+          </div>
+          <div className="text-xs leading-5 text-muted">
+            {t("lifeopssettings.calendarFeedDescription", {
+              defaultValue:
+                "These toggles affect the sidebar feed and proactive briefings. Direct calendar actions still read every authorized calendar.",
+            })}
+          </div>
+          {calendarLoading ? (
+            <div className="text-xs text-muted">
+              {t("lifeopssettings.loadingCalendars", {
+                defaultValue: "Loading calendars…",
+              })}
+            </div>
+          ) : calendars.length > 0 ? (
+            <div className="grid gap-2">
+              {calendars.map((calendar) => {
+                const disabled =
+                  controlDisabled || calendarPendingId === calendar.calendarId;
+                return (
+                  <label
+                    key={`${calendar.grantId}:${calendar.calendarId}`}
+                    className="flex cursor-pointer items-start gap-3 rounded-xl bg-card/18 px-3 py-2 text-xs"
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-0.5 h-4 w-4 rounded border-border bg-bg"
+                      checked={calendar.includeInFeed}
+                      disabled={disabled}
+                      onChange={() => void toggleCalendar(calendar)}
+                    />
+                    <span
+                      className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
+                      style={{
+                        backgroundColor:
+                          calendar.backgroundColor ?? "rgba(148, 163, 184, 0.8)",
+                      }}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium text-txt">
+                        {calendar.summary}
+                      </span>
+                      <span className="block truncate text-muted">
+                        {calendar.accountEmail ?? calendar.calendarId}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="text-xs text-muted">
+              {t("lifeopssettings.noCalendars", {
+                defaultValue: "No readable calendars found for this connector.",
+              })}
+            </div>
+          )}
+        </div>
+      ) : null}
+
       {visibleAuthUrl ? (
         <PendingAuthBanner
           url={visibleAuthUrl}
@@ -534,6 +677,9 @@ function GoogleConnectorSideCard({
         />
       ) : null}
       {error ? <div className="text-xs text-danger">{error}</div> : null}
+      {calendarError ? (
+        <div className="text-xs text-danger">{calendarError}</div>
+      ) : null}
 
       <GithubRow github={github} compactLayout={compactLayout} />
     </section>

--- a/apps/app-lifeops/src/components/LifeOpsWorkspaceView.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsWorkspaceView.tsx
@@ -205,6 +205,16 @@ function formatEventWindow(
   )}`;
 }
 
+function eventOriginLabel(event: LifeOpsCalendarEvent): string | null {
+  const parts = [event.calendarSummary, event.accountEmail].filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join(" · ");
+}
+
 function toLocalDateKey(date: Date, timeZone: string): string {
   const formatter = new Intl.DateTimeFormat("en-CA", {
     timeZone,
@@ -1154,7 +1164,7 @@ function CalendarColumn({
                       ) : null}
                     </div>
                     <div className="flex flex-col items-end gap-1">
-                      <AccountBadge label={event.accountEmail} />
+                      <AccountBadge label={eventOriginLabel(event)} />
                     </div>
                   </button>
                 ))}
@@ -1183,7 +1193,9 @@ function CalendarColumn({
               {workspace.selectedCalendarEvent.conferenceLink}
             </div>
           ) : null}
-          <AccountBadge label={workspace.selectedCalendarEvent.accountEmail} />
+          <AccountBadge
+            label={eventOriginLabel(workspace.selectedCalendarEvent)}
+          />
         </div>
       ) : null}
 

--- a/apps/app-lifeops/src/components/chat/widgets/plugins/lifeops-channels.tsx
+++ b/apps/app-lifeops/src/components/chat/widgets/plugins/lifeops-channels.tsx
@@ -211,27 +211,40 @@ function LifeOpsCalendarWidget(_props: ChatSidebarWidgetProps) {
       testId="chat-widget-lifeops-calendar"
       onTitleClick={openLifeOps}
     >
-      <div className="flex flex-col">
-        {events.slice(0, CALENDAR_ROW_LIMIT).map((event) => {
-          const when = formatShortTime(event.startAt, timeZone);
-          return (
-            <button
-              key={event.id}
-              type="button"
-              onClick={() => openEventRow(event)}
-              data-testid={`lifeops-calendar-row-${event.id}`}
-              className="flex items-center gap-2 rounded-[var(--radius-sm)] px-0.5 py-0.5 text-left text-3xs transition-colors hover:bg-bg-hover/40"
-            >
-              <span className="min-w-0 flex-1 truncate text-txt">
-                {event.title}
-              </span>
-              {when ? (
-                <span className="shrink-0 text-3xs text-muted">{when}</span>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
+      {events.length === 0 ? (
+        <div className="px-0.5 py-1 text-2xs text-muted">
+          {t("lifeopschannels.calendar.empty", {
+            defaultValue: "Nothing this week",
+          })}
+        </div>
+      ) : (
+        <div className="flex flex-col">
+          {events.slice(0, CALENDAR_ROW_LIMIT).map((event) => {
+            const when = formatShortTime(event.startAt, timeZone);
+            return (
+              <button
+                key={event.id}
+                type="button"
+                onClick={() => openEventRow(event)}
+                data-testid={`lifeops-calendar-row-${event.id}`}
+                className="flex items-start gap-2 rounded-[var(--radius-sm)] px-0.5 py-0.5 text-left text-3xs transition-colors hover:bg-bg-hover/40"
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-txt">{event.title}</span>
+                  {event.calendarSummary ? (
+                    <span className="block truncate text-[10px] text-muted">
+                      {event.calendarSummary}
+                    </span>
+                  ) : null}
+                </span>
+                {when ? (
+                  <span className="shrink-0 text-3xs text-muted">{when}</span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
     </WidgetSection>
   );
 }

--- a/apps/app-lifeops/src/lifeops/google-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/google-calendar.ts
@@ -8,6 +8,8 @@ import {
 
 const GOOGLE_CALENDAR_EVENTS_ENDPOINT =
   "https://www.googleapis.com/calendar/v3/calendars";
+const GOOGLE_CALENDAR_LIST_ENDPOINT =
+  "https://www.googleapis.com/calendar/v3/users/me/calendarList";
 
 function hasExplicitDateTimeOffset(dateTime: string): boolean {
   return /(?:[zZ]|[+-]\d{2}:\d{2})$/.test(dateTime);
@@ -274,6 +276,77 @@ export async function fetchGoogleCalendarEvents(args: {
     }
   }
   return events;
+}
+
+export interface GoogleCalendarListEntry {
+  calendarId: string;
+  summary: string;
+  description: string | null;
+  primary: boolean;
+  accessRole: string;
+  backgroundColor: string | null;
+  foregroundColor: string | null;
+  timeZone: string | null;
+  selected: boolean;
+}
+
+interface GoogleCalendarListApiEntry {
+  id?: string;
+  summary?: string;
+  summaryOverride?: string;
+  description?: string;
+  primary?: boolean;
+  accessRole?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  timeZone?: string;
+  selected?: boolean;
+  deleted?: boolean;
+  hidden?: boolean;
+}
+
+export async function listGoogleCalendars(args: {
+  accessToken: string;
+}): Promise<GoogleCalendarListEntry[]> {
+  const params = new URLSearchParams({
+    minAccessRole: "reader",
+    showDeleted: "false",
+    showHidden: "false",
+    fields:
+      "items(id,summary,summaryOverride,description,primary,accessRole,backgroundColor,foregroundColor,timeZone,selected,deleted,hidden)",
+  });
+  const response = await googleApiFetch(
+    `${GOOGLE_CALENDAR_LIST_ENDPOINT}?${params.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${args.accessToken}`,
+      },
+    },
+  );
+  const parsed = (await response.json()) as {
+    items?: GoogleCalendarListApiEntry[];
+  };
+  const entries: GoogleCalendarListEntry[] = [];
+  for (const item of parsed.items ?? []) {
+    if (item.deleted || item.hidden) continue;
+    const calendarId = item.id?.trim();
+    if (!calendarId) continue;
+    const summary = (item.summaryOverride?.trim() ||
+      item.summary?.trim() ||
+      calendarId);
+    entries.push({
+      calendarId,
+      summary,
+      description: item.description?.trim() || null,
+      primary: Boolean(item.primary),
+      accessRole: item.accessRole?.trim() || "reader",
+      backgroundColor: item.backgroundColor?.trim() || null,
+      foregroundColor: item.foregroundColor?.trim() || null,
+      timeZone: item.timeZone?.trim() || null,
+      selected: item.selected !== false,
+    });
+  }
+  return entries;
 }
 
 export async function fetchGoogleCalendarEvent(args: {

--- a/apps/app-lifeops/src/lifeops/google-managed-client.ts
+++ b/apps/app-lifeops/src/lifeops/google-managed-client.ts
@@ -59,6 +59,18 @@ export interface ManagedGoogleCalendarFeedResponse {
   syncedAt: string;
 }
 
+export interface ManagedGoogleCalendarSummaryResponse {
+  calendarId: string;
+  summary: string;
+  description: string | null;
+  primary: boolean;
+  accessRole: string;
+  backgroundColor: string | null;
+  foregroundColor: string | null;
+  timeZone: string | null;
+  selected: boolean;
+}
+
 export interface ManagedGoogleCalendarEventResponse {
   event: SyncedGoogleCalendarEvent;
 }
@@ -419,6 +431,22 @@ export class GoogleManagedClient {
     if (args.grantId) query.set("grantId", args.grantId);
     return this.request<ManagedGoogleCalendarFeedResponse>(
       `milady/google/calendar/feed?${query.toString()}`,
+      {
+        method: "GET",
+      },
+    );
+  }
+
+  async listCalendars(args: {
+    side: LifeOpsConnectorSide;
+    grantId?: string;
+  }): Promise<ManagedGoogleCalendarSummaryResponse[]> {
+    const query = new URLSearchParams({
+      side: args.side,
+    });
+    if (args.grantId) query.set("grantId", args.grantId);
+    return this.request<ManagedGoogleCalendarSummaryResponse[]>(
+      `milady/google/calendar/calendars?${query.toString()}`,
       {
         method: "GET",
       },

--- a/apps/app-lifeops/src/lifeops/owner-profile.test.ts
+++ b/apps/app-lifeops/src/lifeops/owner-profile.test.ts
@@ -1,8 +1,10 @@
 import type { IAgentRuntime, Task, UUID } from "@elizaos/core";
 import { describe, expect, test, vi } from "vitest";
 import {
+  ensureLifeOpsCalendarFeedIncludes,
   readLifeOpsMeetingPreferences,
   readLifeOpsOwnerProfile,
+  setLifeOpsCalendarFeedIncluded,
   updateLifeOpsOwnerProfile,
 } from "./owner-profile.js";
 import { LIFEOPS_TASK_NAME, LIFEOPS_TASK_TAGS } from "./scheduler-task.js";
@@ -87,6 +89,91 @@ describe("owner profile scheduler metadata reads", () => {
       "task-1",
       expect.objectContaining({
         description: "Process life-ops reminders and scheduled workflows",
+      }),
+    );
+  });
+
+  test("ensureLifeOpsCalendarFeedIncludes defaults unseen calendars to true without overwriting stored false values", async () => {
+    const schedulerTask = {
+      id: "task-1" as UUID,
+      name: LIFEOPS_TASK_NAME,
+      tags: [...LIFEOPS_TASK_TAGS],
+      metadata: {
+        lifeopsScheduler: { kind: "runtime_runner", version: 1 },
+        calendarFeedPreferences: {
+          calendarFeedIncludes: {
+            primary: false,
+          },
+          updatedAt: "2026-04-21T00:00:00.000Z",
+        },
+      },
+    } as Task;
+    const updateTask = vi.fn(async () => undefined);
+    const runtime = makeRuntime({
+      updateTask,
+      getTasks: vi.fn(async () => [schedulerTask]),
+    });
+
+    const next = await ensureLifeOpsCalendarFeedIncludes(runtime, [
+      "primary",
+      "family@example.com",
+    ]);
+
+    expect(next.calendarFeedIncludes).toEqual({
+      primary: false,
+      "family@example.com": true,
+    });
+    expect(updateTask).toHaveBeenLastCalledWith(
+      "task-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          calendarFeedPreferences: expect.objectContaining({
+            calendarFeedIncludes: {
+              primary: false,
+              "family@example.com": true,
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  test("setLifeOpsCalendarFeedIncluded persists an explicit include toggle", async () => {
+    const schedulerTask = {
+      id: "task-1" as UUID,
+      name: LIFEOPS_TASK_NAME,
+      tags: [...LIFEOPS_TASK_TAGS],
+      metadata: {
+        lifeopsScheduler: { kind: "runtime_runner", version: 1 },
+        calendarFeedPreferences: {
+          calendarFeedIncludes: {
+            primary: true,
+          },
+          updatedAt: "2026-04-21T00:00:00.000Z",
+        },
+      },
+    } as Task;
+    const updateTask = vi.fn(async () => undefined);
+    const runtime = makeRuntime({
+      updateTask,
+      getTasks: vi.fn(async () => [schedulerTask]),
+    });
+
+    const next = await setLifeOpsCalendarFeedIncluded(
+      runtime,
+      "primary",
+      false,
+    );
+
+    expect(next.calendarFeedIncludes).toEqual({ primary: false });
+    expect(updateTask).toHaveBeenLastCalledWith(
+      "task-1",
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          calendarFeedPreferences: expect.objectContaining({
+            calendarFeedIncludes: { primary: false },
+          }),
+        }),
       }),
     );
   });

--- a/apps/app-lifeops/src/lifeops/owner-profile.ts
+++ b/apps/app-lifeops/src/lifeops/owner-profile.ts
@@ -230,6 +230,144 @@ export async function readLifeOpsOwnerProfile(
   return resolveLifeOpsOwnerProfile(metadata, configuredName);
 }
 
+export interface LifeOpsCalendarFeedPreferences {
+  calendarFeedIncludes: Record<string, boolean>;
+  updatedAt: string | null;
+}
+
+const DEFAULT_CALENDAR_FEED_PREFERENCES: LifeOpsCalendarFeedPreferences = {
+  calendarFeedIncludes: {},
+  updatedAt: null,
+};
+
+function normalizeCalendarFeedIncludes(
+  value: unknown,
+): Record<string, boolean> {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const normalized: Record<string, boolean> = {};
+  for (const [rawCalendarId, rawIncluded] of Object.entries(value)) {
+    const calendarId = rawCalendarId.trim();
+    if (!calendarId || typeof rawIncluded !== "boolean") {
+      continue;
+    }
+    normalized[calendarId] = rawIncluded;
+  }
+  return normalized;
+}
+
+function resolveCalendarFeedPreferences(
+  metadata: Record<string, unknown> | null | undefined,
+): LifeOpsCalendarFeedPreferences {
+  const stored = isRecord(metadata?.calendarFeedPreferences)
+    ? metadata.calendarFeedPreferences
+    : null;
+  const updatedAt =
+    stored && typeof stored.updatedAt === "string"
+      ? normalizeProfileValue(stored.updatedAt, 64)
+      : null;
+  return {
+    ...DEFAULT_CALENDAR_FEED_PREFERENCES,
+    calendarFeedIncludes: normalizeCalendarFeedIncludes(
+      stored?.calendarFeedIncludes,
+    ),
+    updatedAt,
+  };
+}
+
+export async function readLifeOpsCalendarFeedPreferences(
+  runtime: IAgentRuntime,
+): Promise<LifeOpsCalendarFeedPreferences> {
+  const task = await readLifeOpsSchedulerTask(runtime);
+  const metadata = isRecord(task?.metadata) ? task.metadata : null;
+  return resolveCalendarFeedPreferences(metadata);
+}
+
+function normalizeCalendarFeedIncludeIds(
+  calendarIds: readonly string[],
+): string[] {
+  return [
+    ...new Set(
+      calendarIds
+        .map((calendarId) =>
+          typeof calendarId === "string" ? calendarId.trim() : "",
+        )
+        .filter((calendarId) => calendarId.length > 0),
+    ),
+  ];
+}
+
+export async function ensureLifeOpsCalendarFeedIncludes(
+  runtime: IAgentRuntime,
+  calendarIds: readonly string[],
+): Promise<LifeOpsCalendarFeedPreferences> {
+  const normalizedCalendarIds = normalizeCalendarFeedIncludeIds(calendarIds);
+  const task = await readLifeOpsSchedulerTask(runtime);
+  const currentMetadata = isRecord(task?.metadata) ? task.metadata : null;
+  const current = resolveCalendarFeedPreferences(currentMetadata);
+  const missingCalendarIds = normalizedCalendarIds.filter(
+    (calendarId) => !(calendarId in current.calendarFeedIncludes),
+  );
+  if (missingCalendarIds.length === 0) {
+    return current;
+  }
+
+  const taskId = await ensureLifeOpsSchedulerTask(runtime);
+  const metadata =
+    currentMetadata && task?.id === taskId
+      ? currentMetadata
+      : buildFallbackSchedulerMetadata(runtime.agentId);
+  const nextCalendarFeedIncludes = { ...current.calendarFeedIncludes };
+  for (const calendarId of missingCalendarIds) {
+    nextCalendarFeedIncludes[calendarId] = true;
+  }
+  const next: LifeOpsCalendarFeedPreferences = {
+    calendarFeedIncludes: nextCalendarFeedIncludes,
+    updatedAt: new Date().toISOString(),
+  };
+  await runtime.updateTask(taskId, {
+    metadata: {
+      ...(metadata ?? {}),
+      calendarFeedPreferences: next,
+    },
+  });
+  return next;
+}
+
+export async function setLifeOpsCalendarFeedIncluded(
+  runtime: IAgentRuntime,
+  calendarId: string,
+  included: boolean,
+): Promise<LifeOpsCalendarFeedPreferences> {
+  const normalizedCalendarId = calendarId.trim();
+  if (!normalizedCalendarId) {
+    throw new Error("calendarId is required");
+  }
+
+  const taskId = await ensureLifeOpsSchedulerTask(runtime);
+  const task = await readLifeOpsSchedulerTask(runtime);
+  const metadata =
+    isRecord(task?.metadata) && task.id === taskId
+      ? task.metadata
+      : buildFallbackSchedulerMetadata(runtime.agentId);
+  const current = resolveCalendarFeedPreferences(metadata);
+  const next: LifeOpsCalendarFeedPreferences = {
+    calendarFeedIncludes: {
+      ...current.calendarFeedIncludes,
+      [normalizedCalendarId]: included,
+    },
+    updatedAt: new Date().toISOString(),
+  };
+  await runtime.updateTask(taskId, {
+    metadata: {
+      ...(metadata ?? {}),
+      calendarFeedPreferences: next,
+    },
+  });
+  return next;
+}
+
 /**
  * Meeting preferences — stored alongside the owner profile in the LifeOps
  * scheduler task's metadata. Consumed by scheduling-with-others actions to

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
@@ -2,8 +2,10 @@ import type {
   LifeOpsCalendarEvent,
   LifeOpsCalendarFeed,
   LifeOpsCalendarSummary,
+  LifeOpsConnectorGrant,
 } from "@elizaos/app-lifeops/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { LifeOpsService } from "./service.js";
 import { mergeAggregatedCalendarFeedEvents } from "./service-mixin-calendar.js";
 
 function calendar(
@@ -68,6 +70,38 @@ function feed(
     timeMin: "2026-04-23T00:00:00.000Z",
     timeMax: "2026-04-24T00:00:00.000Z",
     syncedAt: "2026-04-23T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function runtime() {
+  return {
+    agentId: "agent-calendar-service",
+  } as unknown as ConstructorParameters<typeof LifeOpsService>[0];
+}
+
+function grant(
+  overrides: Partial<LifeOpsConnectorGrant & { identityEmail: string }> = {},
+): LifeOpsConnectorGrant & { identityEmail: string } {
+  return {
+    id: "grant-1",
+    agentId: "agent-calendar-service",
+    provider: "google",
+    side: "owner",
+    mode: "cloud_managed",
+    executionTarget: "cloud",
+    sourceOfTruth: "cloud_profile",
+    preferredByAgent: false,
+    identity: { email: "owner@example.test" },
+    identityEmail: "owner@example.test",
+    grantedScopes: [],
+    capabilities: ["google.calendar.read"],
+    tokenRef: null,
+    metadata: {},
+    lastRefreshAt: null,
+    cloudConnectionId: "cloud-1",
+    createdAt: "2026-04-22T12:00:00.000Z",
+    updatedAt: "2026-04-22T12:00:00.000Z",
     ...overrides,
   };
 }
@@ -139,5 +173,42 @@ describe("mergeAggregatedCalendarFeedEvents", () => {
         accountEmail: "family@example.test",
       }),
     );
+  });
+});
+
+describe("LifeOps calendar feed fallback", () => {
+  it("falls back to primary aggregation when no calendars can be listed", async () => {
+    const service = new LifeOpsService(runtime());
+    vi.spyOn(service, "listCalendars").mockResolvedValue([]);
+    vi.spyOn(service.repository, "listConnectorGrants").mockResolvedValue([
+      grant(),
+    ]);
+    const aggregate = vi
+      .spyOn(service, "aggregateCalendarFeeds")
+      .mockResolvedValue(
+        feed([], {
+          calendarId: "primary",
+          source: "cache",
+          syncedAt: null,
+        }),
+      );
+
+    const result = await service.getCalendarFeed(
+      new URL("http://localhost/api/lifeops/calendar/feed"),
+      { side: "owner", mode: "cloud_managed" },
+      new Date("2026-04-23T12:00:00.000Z"),
+    );
+
+    expect(aggregate).toHaveBeenCalledWith(
+      expect.any(URL),
+      [expect.objectContaining({ id: "grant-1" })],
+      "primary",
+      expect.any(String),
+      expect.any(String),
+      expect.any(String),
+      false,
+      expect.any(Date),
+    );
+    expect(result.calendarId).toBe("primary");
   });
 });

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
@@ -7,6 +7,7 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import { LifeOpsService } from "./service.js";
 import { mergeAggregatedCalendarFeedEvents } from "./service-mixin-calendar.js";
+import { LifeOpsServiceError } from "./service-types.js";
 
 function calendar(
   overrides: Partial<LifeOpsCalendarSummary> = {},
@@ -209,6 +210,37 @@ describe("LifeOps calendar feed fallback", () => {
       false,
       expect.any(Date),
     );
+    expect(result.calendarId).toBe("primary");
+  });
+
+  it("falls back to primary aggregation when managed calendar discovery is unavailable", async () => {
+    const service = new LifeOpsService(runtime());
+    vi.spyOn(service, "listCalendars").mockRejectedValue(
+      new LifeOpsServiceError(
+        503,
+        "Google calendar discovery is unavailable for this connection. The connector backend needs the managed calendar-list route.",
+      ),
+    );
+    vi.spyOn(service.repository, "listConnectorGrants").mockResolvedValue([
+      grant(),
+    ]);
+    const aggregate = vi
+      .spyOn(service, "aggregateCalendarFeeds")
+      .mockResolvedValue(
+        feed([], {
+          calendarId: "primary",
+          source: "cache",
+          syncedAt: null,
+        }),
+      );
+
+    const result = await service.getCalendarFeed(
+      new URL("http://localhost/api/lifeops/calendar/feed"),
+      { side: "owner", mode: "cloud_managed" },
+      new Date("2026-04-23T12:00:00.000Z"),
+    );
+
+    expect(aggregate).toHaveBeenCalledOnce();
     expect(result.calendarId).toBe("primary");
   });
 });

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts
@@ -1,0 +1,143 @@
+import type {
+  LifeOpsCalendarEvent,
+  LifeOpsCalendarFeed,
+  LifeOpsCalendarSummary,
+} from "@elizaos/app-lifeops/contracts";
+import { describe, expect, it } from "vitest";
+import { mergeAggregatedCalendarFeedEvents } from "./service-mixin-calendar.js";
+
+function calendar(
+  overrides: Partial<LifeOpsCalendarSummary> = {},
+): LifeOpsCalendarSummary {
+  return {
+    provider: "google",
+    side: "owner",
+    grantId: "grant-1",
+    accountEmail: "owner@example.test",
+    calendarId: "primary",
+    summary: "Primary",
+    description: null,
+    primary: true,
+    accessRole: "owner",
+    backgroundColor: null,
+    foregroundColor: null,
+    timeZone: "America/New_York",
+    selected: true,
+    includeInFeed: true,
+    ...overrides,
+  };
+}
+
+function event(
+  overrides: Partial<LifeOpsCalendarEvent> = {},
+): LifeOpsCalendarEvent {
+  return {
+    id: "event-1",
+    externalId: "external-1",
+    agentId: "agent-1",
+    provider: "google",
+    side: "owner",
+    calendarId: "primary",
+    title: "Event",
+    description: "",
+    location: "",
+    status: "confirmed",
+    startAt: "2026-04-23T12:00:00.000Z",
+    endAt: "2026-04-23T13:00:00.000Z",
+    isAllDay: false,
+    timezone: "America/New_York",
+    htmlLink: null,
+    conferenceLink: null,
+    organizer: null,
+    attendees: [],
+    metadata: {},
+    syncedAt: "2026-04-23T11:00:00.000Z",
+    updatedAt: "2026-04-23T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function feed(
+  events: LifeOpsCalendarEvent[],
+  overrides: Partial<LifeOpsCalendarFeed> = {},
+): LifeOpsCalendarFeed {
+  return {
+    calendarId: "primary",
+    events,
+    source: "synced",
+    timeMin: "2026-04-23T00:00:00.000Z",
+    timeMax: "2026-04-24T00:00:00.000Z",
+    syncedAt: "2026-04-23T11:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("mergeAggregatedCalendarFeedEvents", () => {
+  it("sorts merged events, dedupes by id, and preserves calendar metadata", () => {
+    const merged = mergeAggregatedCalendarFeedEvents([
+      {
+        calendar: calendar({
+          grantId: "grant-family",
+          accountEmail: "family@example.test",
+          calendarId: "family",
+          summary: "Family",
+          primary: false,
+        }),
+        feed: feed([
+          event({
+            id: "dup-1",
+            externalId: "shared-1",
+            calendarId: "family",
+            startAt: "2026-04-23T15:00:00.000Z",
+            endAt: "2026-04-23T16:00:00.000Z",
+          }),
+          event({
+            id: "late-1",
+            externalId: "late-1",
+            calendarId: "family",
+            startAt: "2026-04-23T18:00:00.000Z",
+            endAt: "2026-04-23T19:00:00.000Z",
+          }),
+        ]),
+      },
+      {
+        calendar: calendar({
+          grantId: "grant-primary",
+          accountEmail: "owner@example.test",
+          calendarId: "primary",
+          summary: "Primary",
+        }),
+        feed: feed([
+          event({
+            id: "early-1",
+            externalId: "early-1",
+            calendarId: "primary",
+            startAt: "2026-04-23T09:00:00.000Z",
+            endAt: "2026-04-23T10:00:00.000Z",
+          }),
+          event({
+            id: "dup-1",
+            externalId: "shared-1",
+            calendarId: "family",
+            startAt: "2026-04-23T15:00:00.000Z",
+            endAt: "2026-04-23T16:00:00.000Z",
+          }),
+        ]),
+      },
+    ]);
+
+    expect(merged.map((item) => item.id)).toEqual([
+      "early-1",
+      "dup-1",
+      "late-1",
+    ]);
+    expect(merged.find((item) => item.id === "dup-1")).toEqual(
+      expect.objectContaining({
+        calendarId: "family",
+        calendarSummary: "Family",
+        grantId: "grant-family",
+        accountEmail: "family@example.test",
+      }),
+    );
+  });
+});

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
@@ -5,17 +5,20 @@ import type {
   GetLifeOpsCalendarFeedRequest,
   LifeOpsCalendarEvent,
   LifeOpsCalendarFeed,
+  LifeOpsCalendarSummary,
   LifeOpsConnectorGrant,
   LifeOpsConnectorMode,
   LifeOpsConnectorSide,
   LifeOpsGmailMessageSummary,
   LifeOpsNextCalendarEventContext,
+  ListLifeOpsCalendarsRequest,
 } from "@elizaos/app-lifeops/contracts";
 import {
   createGoogleCalendarEvent,
   deleteGoogleCalendarEvent,
   fetchGoogleCalendarEvent,
   fetchGoogleCalendarEvents,
+  listGoogleCalendars,
   updateGoogleCalendarEvent,
 } from "./google-calendar.js";
 import {
@@ -71,6 +74,10 @@ import type {
 } from "./service-mixin-core.js";
 
 export interface LifeOpsCalendarService {
+  listCalendars(
+    requestUrl: URL,
+    request?: ListLifeOpsCalendarsRequest,
+  ): Promise<LifeOpsCalendarSummary[]>;
   getCalendarFeed(
     requestUrl: URL,
     request?: GetLifeOpsCalendarFeedRequest,
@@ -121,6 +128,62 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
   Base: TBase,
 ): MixinClass<TBase, LifeOpsCalendarService> {
   return class extends Base {
+
+    public async listCalendars(
+      requestUrl: URL,
+      request?: ListLifeOpsCalendarsRequest,
+    ): Promise<LifeOpsCalendarSummary[]> {
+      const { hasGoogleCalendarReadCapability } = await import(
+        "./service-normalize-calendar.js"
+      );
+      const mode = normalizeOptionalConnectorMode(request?.mode, "mode");
+      const side = normalizeOptionalConnectorSide(request?.side, "side");
+      const allGrants = (
+        await this.repository.listConnectorGrants(this.agentId())
+      ).filter((grant) => grant.provider === "google");
+      const grants = resolveGoogleGrants({
+        grants: allGrants,
+        requestedMode: mode,
+        requestedSide: side,
+        grantId: request?.grantId,
+      }).filter((grant) => hasGoogleCalendarReadCapability(grant));
+
+      const summaries: LifeOpsCalendarSummary[] = [];
+      for (const grant of grants) {
+        // Cloud-managed mode has no listCalendars path yet; skip silently so
+        // local grants still work. Follow-up: wire into google-managed-client.
+        if (resolveGoogleExecutionTarget(grant) === "cloud") continue;
+        const accessToken = await ensureFreshGoogleAccessToken(
+          grant.tokenRef ??
+            fail(409, "Google Calendar token reference is missing."),
+        );
+        const entries = await listGoogleCalendars({ accessToken });
+        for (const entry of entries) {
+          summaries.push({
+            provider: "google",
+            side: grant.side,
+            grantId: grant.id,
+            accountEmail:
+              typeof grant.identity.email === "string"
+                ? grant.identity.email.trim().toLowerCase()
+                : null,
+            calendarId: entry.calendarId,
+            summary: entry.summary,
+            description: entry.description,
+            primary: entry.primary,
+            accessRole: entry.accessRole,
+            backgroundColor: entry.backgroundColor,
+            foregroundColor: entry.foregroundColor,
+            timeZone: entry.timeZone,
+            selected: entry.selected,
+            // Preference plumbing lands in Phase 1.2; default to true so new
+            // calendars are never silently hidden from the agent.
+            includeInFeed: true,
+          });
+        }
+      }
+      return summaries;
+    }
 
     public async recordCalendarEventAudit(
       ownerId: string,

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
@@ -132,6 +132,37 @@ export interface LifeOpsCalendarService {
 
 const DEFAULT_GMAIL_TRIAGE_MAX_RESULTS = 12;
 
+type AggregatedCalendarFeedSource = {
+  calendar: Pick<
+    LifeOpsCalendarSummary,
+    "accountEmail" | "calendarId" | "grantId" | "summary"
+  >;
+  feed: LifeOpsCalendarFeed;
+};
+
+export function mergeAggregatedCalendarFeedEvents(
+  sources: readonly AggregatedCalendarFeedSource[],
+): LifeOpsCalendarEvent[] {
+  const dedupedEvents = new Map<string, LifeOpsCalendarEvent>();
+  for (const source of sources) {
+    for (const event of source.feed.events) {
+      const existing = dedupedEvents.get(event.id);
+      if (existing) {
+        continue;
+      }
+      dedupedEvents.set(event.id, {
+        ...event,
+        grantId: event.grantId ?? source.calendar.grantId,
+        accountEmail: event.accountEmail ?? source.calendar.accountEmail ?? undefined,
+        calendarSummary: event.calendarSummary ?? source.calendar.summary,
+      });
+    }
+  }
+  return [...dedupedEvents.values()].sort((a, b) =>
+    a.startAt.localeCompare(b.startAt),
+  );
+}
+
 export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
   Base: TBase,
 ): MixinClass<TBase, LifeOpsCalendarService> {
@@ -479,7 +510,12 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
       const mode = normalizeOptionalConnectorMode(request.mode, "mode");
       const side = normalizeOptionalConnectorSide(request.side, "side");
       const { grantId } = request;
-      const calendarId = normalizeCalendarId(request.calendarId);
+      const explicitCalendarId = normalizeOptionalString(request.calendarId);
+      const includeHiddenCalendars =
+        normalizeOptionalBoolean(
+          request.includeHiddenCalendars,
+          "includeHiddenCalendars",
+        ) ?? false;
       const timeZone = normalizeCalendarTimeZone(request.timeZone);
       const { timeMin, timeMax } = resolveCalendarWindow({
         now,
@@ -489,6 +525,37 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
       });
       const forceSync =
         normalizeOptionalBoolean(request.forceSync, "forceSync") ?? false;
+
+      if (!grantId && !explicitCalendarId) {
+        const calendars = await this.listCalendars(requestUrl, {
+          mode,
+          side,
+        });
+        const selectedCalendars = calendars.filter(
+          (calendar) => includeHiddenCalendars || calendar.includeInFeed,
+        );
+        if (selectedCalendars.length === 0) {
+          return {
+            calendarId: "all",
+            events: [],
+            source: "cache",
+            timeMin,
+            timeMax,
+            syncedAt: null,
+          };
+        }
+        return this.aggregateCalendarFeedsAcrossCalendars(
+          requestUrl,
+          selectedCalendars,
+          timeMin,
+          timeMax,
+          timeZone,
+          forceSync,
+          now,
+        );
+      }
+
+      const calendarId = normalizeCalendarId(explicitCalendarId);
 
       // Multi-account aggregation: when no grantId specified, check if
       // there are multiple grants and aggregate from all of them.
@@ -557,6 +624,71 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
         timeMax,
         timeZone,
       });
+    }
+
+    public async aggregateCalendarFeedsAcrossCalendars(
+      requestUrl: URL,
+      calendars: readonly LifeOpsCalendarSummary[],
+      timeMin: string,
+      timeMax: string,
+      timeZone: string,
+      forceSync: boolean,
+      now: Date,
+    ): Promise<LifeOpsCalendarFeed> {
+      const results = await Promise.allSettled(
+        calendars.map((calendar) =>
+          this.getCalendarFeed(
+            requestUrl,
+            {
+              grantId: calendar.grantId,
+              calendarId: calendar.calendarId,
+              timeMin,
+              timeMax,
+              timeZone,
+              forceSync,
+            },
+            now,
+          ).then((feed) => ({
+            calendar,
+            feed,
+          })),
+        ),
+      );
+
+      const sources: AggregatedCalendarFeedSource[] = [];
+      let latestSyncedAt: string | null = null;
+      let source: "cache" | "synced" = "cache";
+
+      for (const result of results) {
+        if (result.status === "rejected") {
+          this.logLifeOpsWarn(
+            "calendar_feed_aggregate",
+            `Calendar failed: ${result.reason}`,
+            {},
+          );
+          continue;
+        }
+        const value = result.value;
+        sources.push(value);
+        if (value.feed.source === "synced") {
+          source = "synced";
+        }
+        if (
+          value.feed.syncedAt &&
+          (!latestSyncedAt || value.feed.syncedAt > latestSyncedAt)
+        ) {
+          latestSyncedAt = value.feed.syncedAt;
+        }
+      }
+
+      return {
+        calendarId: "all",
+        events: mergeAggregatedCalendarFeedEvents(sources),
+        source,
+        timeMin,
+        timeMax,
+        syncedAt: latestSyncedAt,
+      };
     }
 
     public async aggregateCalendarFeeds(

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
@@ -25,9 +25,7 @@ import {
   resolveGoogleExecutionTarget,
   resolveGoogleGrants,
 } from "./google-connector-gateway.js";
-import {
-  ensureFreshGoogleAccessToken,
-} from "./google-oauth.js";
+import { ensureFreshGoogleAccessToken } from "./google-oauth.js";
 import {
   createLifeOpsAuditEvent,
   createLifeOpsCalendarSyncState,
@@ -35,6 +33,7 @@ import {
 } from "./repository.js";
 import {
   fail,
+  normalizeOptionalBoolean,
   normalizeOptionalString,
   requireNonEmptyString,
 } from "./service-normalize.js";
@@ -44,6 +43,7 @@ import {
 } from "./service-normalize-connector.js";
 import {
   createCalendarEventId,
+  findLinkedMailForCalendarEvent,
   isCalendarSyncStateFresh,
 } from "./service-normalize-gmail.js";
 import {
@@ -58,26 +58,34 @@ import {
   resolveNextCalendarEventWindow,
 } from "./service-normalize-calendar.js";
 import {
-  findLinkedMailForCalendarEvent,
-} from "./service-normalize-gmail.js";
-import {
   DEFAULT_CALENDAR_REMINDER_STEPS,
 } from "./service-constants.js";
 import {
-  normalizeOptionalBoolean,
-} from "./service-normalize.js";
-import { LifeOpsServiceError } from "./service-types.js";
+  ensureLifeOpsCalendarFeedIncludes,
+  setLifeOpsCalendarFeedIncluded,
+} from "./owner-profile.js";
 import type {
   Constructor,
   LifeOpsServiceBase,
   MixinClass,
 } from "./service-mixin-core.js";
+import { LifeOpsServiceError } from "./service-types.js";
 
 export interface LifeOpsCalendarService {
   listCalendars(
     requestUrl: URL,
     request?: ListLifeOpsCalendarsRequest,
   ): Promise<LifeOpsCalendarSummary[]>;
+  setCalendarIncluded(
+    requestUrl: URL,
+    request: {
+      calendarId: string;
+      includeInFeed: boolean;
+      side?: LifeOpsConnectorSide;
+      mode?: LifeOpsConnectorMode;
+      grantId?: string;
+    },
+  ): Promise<LifeOpsCalendarSummary>;
   getCalendarFeed(
     requestUrl: URL,
     request?: GetLifeOpsCalendarFeedRequest,
@@ -182,7 +190,57 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
           });
         }
       }
-      return summaries;
+      const preferences = await ensureLifeOpsCalendarFeedIncludes(
+        this.runtime,
+        summaries.map((summary) => summary.calendarId),
+      );
+      return summaries.map((summary) => ({
+        ...summary,
+        includeInFeed:
+          preferences.calendarFeedIncludes[summary.calendarId] !== false,
+      }));
+    }
+
+    public async setCalendarIncluded(
+      requestUrl: URL,
+      request: {
+        calendarId: string;
+        includeInFeed: boolean;
+        side?: LifeOpsConnectorSide;
+        mode?: LifeOpsConnectorMode;
+        grantId?: string;
+      },
+    ): Promise<LifeOpsCalendarSummary> {
+      const calendarId = requireNonEmptyString(request.calendarId, "calendarId");
+      const includeInFeed = normalizeOptionalBoolean(
+        request.includeInFeed,
+        "includeInFeed",
+      );
+      if (includeInFeed === undefined) {
+        throw new LifeOpsServiceError(400, "includeInFeed must be a boolean");
+      }
+
+      const calendars = await this.listCalendars(requestUrl, {
+        mode: request.mode,
+        side: request.side,
+        grantId: request.grantId,
+      });
+      const calendar = calendars.find(
+        (entry) => entry.calendarId === calendarId,
+      );
+      if (!calendar) {
+        throw new LifeOpsServiceError(404, "Calendar not found");
+      }
+
+      await setLifeOpsCalendarFeedIncluded(
+        this.runtime,
+        calendarId,
+        includeInFeed,
+      );
+      return {
+        ...calendar,
+        includeInFeed,
+      };
     }
 
     public async recordCalendarEventAudit(

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
@@ -189,14 +189,19 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
 
       const summaries: LifeOpsCalendarSummary[] = [];
       for (const grant of grants) {
-        // Cloud-managed mode has no listCalendars path yet; skip silently so
-        // local grants still work. Follow-up: wire into google-managed-client.
-        if (resolveGoogleExecutionTarget(grant) === "cloud") continue;
-        const accessToken = await ensureFreshGoogleAccessToken(
-          grant.tokenRef ??
-            fail(409, "Google Calendar token reference is missing."),
-        );
-        const entries = await listGoogleCalendars({ accessToken });
+        const entries =
+          resolveGoogleExecutionTarget(grant) === "cloud"
+            ? await this.googleManagedClient.listCalendars({
+                side: grant.side,
+                grantId: grant.id,
+              })
+            : await (async () => {
+                const accessToken = await ensureFreshGoogleAccessToken(
+                  grant.tokenRef ??
+                    fail(409, "Google Calendar token reference is missing."),
+                );
+                return listGoogleCalendars({ accessToken });
+              })();
         for (const entry of entries) {
           summaries.push({
             provider: "google",
@@ -534,6 +539,28 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
         const selectedCalendars = calendars.filter(
           (calendar) => includeHiddenCalendars || calendar.includeInFeed,
         );
+        if (calendars.length === 0) {
+          const allGrants = (
+            await this.repository.listConnectorGrants(this.agentId())
+          ).filter((g) => g.provider === "google");
+          const grants = resolveGoogleGrants({
+            grants: allGrants,
+            requestedSide: side,
+            requestedMode: mode,
+          });
+          if (grants.length > 0) {
+            return this.aggregateCalendarFeeds(
+              requestUrl,
+              grants,
+              "primary",
+              timeMin,
+              timeMax,
+              timeZone,
+              forceSync,
+              now,
+            );
+          }
+        }
         if (selectedCalendars.length === 0) {
           return {
             calendarId: "all",

--- a/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
+++ b/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts
@@ -64,6 +64,7 @@ import {
   ensureLifeOpsCalendarFeedIncludes,
   setLifeOpsCalendarFeedIncluded,
 } from "./owner-profile.js";
+import { ManagedGoogleClientError } from "./google-managed-client.js";
 import type {
   Constructor,
   LifeOpsServiceBase,
@@ -191,10 +192,25 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
       for (const grant of grants) {
         const entries =
           resolveGoogleExecutionTarget(grant) === "cloud"
-            ? await this.googleManagedClient.listCalendars({
-                side: grant.side,
-                grantId: grant.id,
-              })
+            ? await (async () => {
+                try {
+                  return await this.googleManagedClient.listCalendars({
+                    side: grant.side,
+                    grantId: grant.id,
+                  });
+                } catch (error) {
+                  if (
+                    error instanceof ManagedGoogleClientError &&
+                    error.status === 404
+                  ) {
+                    throw new LifeOpsServiceError(
+                      503,
+                      "Google calendar discovery is unavailable for this connection. The connector backend needs the managed calendar-list route.",
+                    );
+                  }
+                  throw error;
+                }
+              })()
             : await (async () => {
                 const accessToken = await ensureFreshGoogleAccessToken(
                   grant.tokenRef ??
@@ -532,10 +548,41 @@ export function withCalendar<TBase extends Constructor<LifeOpsServiceBase>>(
         normalizeOptionalBoolean(request.forceSync, "forceSync") ?? false;
 
       if (!grantId && !explicitCalendarId) {
-        const calendars = await this.listCalendars(requestUrl, {
-          mode,
-          side,
-        });
+        let calendars: LifeOpsCalendarSummary[] = [];
+        try {
+          calendars = await this.listCalendars(requestUrl, {
+            mode,
+            side,
+          });
+        } catch (error) {
+          if (
+            error instanceof LifeOpsServiceError &&
+            error.status === 503 &&
+            error.message.includes("managed calendar-list route")
+          ) {
+            const allGrants = (
+              await this.repository.listConnectorGrants(this.agentId())
+            ).filter((g) => g.provider === "google");
+            const grants = resolveGoogleGrants({
+              grants: allGrants,
+              requestedSide: side,
+              requestedMode: mode,
+            });
+            if (grants.length > 0) {
+              return this.aggregateCalendarFeeds(
+                requestUrl,
+                grants,
+                "primary",
+                timeMin,
+                timeMax,
+                timeZone,
+                forceSync,
+                now,
+              );
+            }
+          }
+          throw error;
+        }
         const selectedCalendars = calendars.filter(
           (calendar) => includeHiddenCalendars || calendar.includeInFeed,
         );

--- a/apps/app-lifeops/src/routes/lifeops-routes.ts
+++ b/apps/app-lifeops/src/routes/lifeops-routes.ts
@@ -27,6 +27,7 @@ import type {
   GetLifeOpsInboxRequest,
   IngestLifeOpsGmailEventRequest,
   LifeOpsCalendarEventUpdate,
+  ListLifeOpsCalendarsRequest,
   LifeOpsConnectorMode,
   LifeOpsConnectorSide,
   LifeOpsInboxChannel,
@@ -806,6 +807,19 @@ export async function handleLifeOpsRoutes(
         grantId: url.searchParams.get("grantId") ?? undefined,
       };
       json(res, await service.getCalendarFeed(url, request));
+    });
+  }
+
+  if (method === "GET" && pathname === "/api/lifeops/calendar/calendars") {
+    if (rateLimitRequest(ctx, "google_api_read")) return true;
+    return runRoute(ctx, async (service) => {
+      const request: ListLifeOpsCalendarsRequest = {
+        mode: parseConnectorModeQuery(url.searchParams.get("mode")),
+        side: parseConnectorSideQuery(url.searchParams.get("side")),
+        grantId: url.searchParams.get("grantId") ?? undefined,
+      };
+      const calendars = await service.listCalendars(url, request);
+      json(res, { calendars });
     });
   }
 

--- a/apps/app-lifeops/src/routes/lifeops-routes.ts
+++ b/apps/app-lifeops/src/routes/lifeops-routes.ts
@@ -798,6 +798,10 @@ export async function handleLifeOpsRoutes(
         mode: parseConnectorModeQuery(url.searchParams.get("mode")),
         side: parseConnectorSideQuery(url.searchParams.get("side")),
         calendarId: url.searchParams.get("calendarId") ?? undefined,
+        includeHiddenCalendars: parseBooleanQuery(
+          url.searchParams.get("includeHiddenCalendars"),
+          "includeHiddenCalendars",
+        ),
         timeMin: url.searchParams.get("timeMin") ?? undefined,
         timeMax: url.searchParams.get("timeMax") ?? undefined,
         timeZone: url.searchParams.get("timeZone") ?? undefined,

--- a/apps/app-lifeops/src/routes/lifeops-routes.ts
+++ b/apps/app-lifeops/src/routes/lifeops-routes.ts
@@ -40,6 +40,7 @@ import type {
   SendLifeOpsGmailBatchReplyRequest,
   SendLifeOpsGmailMessageRequest,
   SendLifeOpsGmailReplyRequest,
+  SetLifeOpsCalendarIncludedRequest,
   SetLifeOpsReminderPreferenceRequest,
   SnoozeLifeOpsOccurrenceRequest,
   StartLifeOpsDiscordConnectorRequest,
@@ -820,6 +821,40 @@ export async function handleLifeOpsRoutes(
       };
       const calendars = await service.listCalendars(url, request);
       json(res, { calendars });
+    });
+  }
+
+  const setCalendarIncludedMatch =
+    method === "PUT"
+      ? pathname.match(/^\/api\/lifeops\/calendar\/calendars\/([^/]+)\/include$/)
+      : null;
+  if (setCalendarIncludedMatch) {
+    if (rateLimitRequest(ctx, "google_api_write")) return true;
+    const calendarId = decodeMatchedPathComponent(
+      ctx,
+      setCalendarIncludedMatch,
+      1,
+      res,
+      "calendarId",
+    );
+    if (!calendarId) return true;
+    const body = await readJsonBody<SetLifeOpsCalendarIncludedRequest>(req, res);
+    if (!body) return true;
+    return runRoute(ctx, async (service) => {
+      if (body.calendarId && body.calendarId !== calendarId) {
+        throw new LifeOpsServiceError(
+          400,
+          "calendarId must match between path and request body",
+        );
+      }
+      const calendar = await service.setCalendarIncluded(url, {
+        calendarId,
+        includeInFeed: body.includeInFeed,
+        mode: body.mode,
+        side: body.side,
+        grantId: body.grantId,
+      });
+      json(res, { calendar });
     });
   }
 

--- a/apps/app-lifeops/src/routes/plugin.ts
+++ b/apps/app-lifeops/src/routes/plugin.ts
@@ -101,6 +101,8 @@ const LIFEOPS_STATIC_ROUTES: Array<{
   { type: "PUT", path: "/api/lifeops/app-state" },
   { type: "GET", path: "/api/lifeops/capabilities" },
   { type: "GET", path: "/api/lifeops/calendar/feed" },
+  { type: "GET", path: "/api/lifeops/calendar/calendars" },
+  { type: "PUT", path: "/api/lifeops/calendar/calendars/:id/include" },
   { type: "GET", path: "/api/lifeops/calendar/next-context" },
   { type: "GET", path: "/api/lifeops/gmail/triage" },
   { type: "GET", path: "/api/lifeops/gmail/search" },

--- a/packages/app-core/src/api/client-lifeops.ts
+++ b/packages/app-core/src/api/client-lifeops.ts
@@ -5,6 +5,7 @@ import type {
   GetLifeOpsGmailTriageRequest,
   GetLifeOpsGmailUnrespondedRequest,
   LifeOpsCalendarFeed,
+  LifeOpsCalendarSummary,
   LifeOpsConnectorMode,
   LifeOpsConnectorSide,
   LifeOpsGmailManageResult,
@@ -14,6 +15,7 @@ import type {
   LifeOpsGmailTriageFeed,
   LifeOpsGmailUnrespondedFeed,
   LifeOpsGoogleConnectorStatus,
+  ListLifeOpsCalendarsRequest,
   ManageLifeOpsGmailMessagesRequest,
 } from "@elizaos/app-lifeops/contracts";
 import { ElizaClient } from "./client-base";
@@ -27,6 +29,9 @@ declare module "./client-base" {
     getLifeOpsCalendarFeed(
       options?: GetLifeOpsCalendarFeedRequest,
     ): Promise<LifeOpsCalendarFeed>;
+    getLifeOpsCalendars(
+      options?: ListLifeOpsCalendarsRequest,
+    ): Promise<{ calendars: LifeOpsCalendarSummary[] }>;
     getLifeOpsGmailTriage(
       options?: GetLifeOpsGmailTriageRequest,
     ): Promise<LifeOpsGmailTriageFeed>;
@@ -99,6 +104,17 @@ ElizaClient.prototype.getLifeOpsCalendarFeed = async function (
   appendOptionalParam(params, "timeZone", options.timeZone);
   appendOptionalParam(params, "forceSync", options.forceSync);
   return this.fetch(`/api/lifeops/calendar/feed${buildQuery(params)}`);
+};
+
+ElizaClient.prototype.getLifeOpsCalendars = async function (
+  this: ElizaClient,
+  options = {},
+) {
+  const params = new URLSearchParams();
+  appendOptionalParam(params, "mode", options.mode);
+  appendOptionalParam(params, "side", options.side);
+  appendOptionalParam(params, "grantId", options.grantId);
+  return this.fetch(`/api/lifeops/calendar/calendars${buildQuery(params)}`);
 };
 
 ElizaClient.prototype.getLifeOpsGmailTriage = async function (

--- a/packages/app-core/src/api/client-lifeops.ts
+++ b/packages/app-core/src/api/client-lifeops.ts
@@ -103,6 +103,11 @@ ElizaClient.prototype.getLifeOpsCalendarFeed = async function (
   appendOptionalParam(params, "mode", options.mode);
   appendOptionalParam(params, "side", options.side);
   appendOptionalParam(params, "calendarId", options.calendarId);
+  appendOptionalParam(
+    params,
+    "includeHiddenCalendars",
+    options.includeHiddenCalendars,
+  );
   appendOptionalParam(params, "timeMin", options.timeMin);
   appendOptionalParam(params, "timeMax", options.timeMax);
   appendOptionalParam(params, "timeZone", options.timeZone);

--- a/packages/app-core/src/api/client-lifeops.ts
+++ b/packages/app-core/src/api/client-lifeops.ts
@@ -17,6 +17,7 @@ import type {
   LifeOpsGoogleConnectorStatus,
   ListLifeOpsCalendarsRequest,
   ManageLifeOpsGmailMessagesRequest,
+  SetLifeOpsCalendarIncludedRequest,
 } from "@elizaos/app-lifeops/contracts";
 import { ElizaClient } from "./client-base";
 
@@ -32,6 +33,9 @@ declare module "./client-base" {
     getLifeOpsCalendars(
       options?: ListLifeOpsCalendarsRequest,
     ): Promise<{ calendars: LifeOpsCalendarSummary[] }>;
+    setLifeOpsCalendarIncluded(
+      data: SetLifeOpsCalendarIncludedRequest,
+    ): Promise<{ calendar: LifeOpsCalendarSummary }>;
     getLifeOpsGmailTriage(
       options?: GetLifeOpsGmailTriageRequest,
     ): Promise<LifeOpsGmailTriageFeed>;
@@ -115,6 +119,19 @@ ElizaClient.prototype.getLifeOpsCalendars = async function (
   appendOptionalParam(params, "side", options.side);
   appendOptionalParam(params, "grantId", options.grantId);
   return this.fetch(`/api/lifeops/calendar/calendars${buildQuery(params)}`);
+};
+
+ElizaClient.prototype.setLifeOpsCalendarIncluded = async function (
+  this: ElizaClient,
+  data,
+) {
+  return this.fetch(
+    `/api/lifeops/calendar/calendars/${encodeURIComponent(data.calendarId)}/include`,
+    {
+      method: "PUT",
+      body: JSON.stringify(data),
+    },
+  );
 };
 
 ElizaClient.prototype.getLifeOpsGmailTriage = async function (

--- a/packages/shared/src/contracts/lifeops.ts
+++ b/packages/shared/src/contracts/lifeops.ts
@@ -1626,6 +1626,8 @@ export interface LifeOpsCalendarEvent {
   metadata: Record<string, unknown>;
   syncedAt: string;
   updatedAt: string;
+  /** Set on merged feeds so the UI can show which calendar an event came from. */
+  calendarSummary?: string;
   /** Set when aggregating across multiple Google accounts. */
   grantId?: string;
   /** Set when aggregating across multiple Google accounts. */
@@ -1693,6 +1695,11 @@ export interface GetLifeOpsCalendarFeedRequest {
   /** Target a specific Google account by grant ID (multi-account). */
   grantId?: string;
   calendarId?: string;
+  /**
+   * Internal/agent override: when no calendarId is specified, include every
+   * authorized calendar instead of only the user's feed-enabled subset.
+   */
+  includeHiddenCalendars?: boolean;
   timeMin?: string;
   timeMax?: string;
   timeZone?: string;

--- a/packages/shared/src/contracts/lifeops.ts
+++ b/packages/shared/src/contracts/lifeops.ts
@@ -1641,6 +1641,52 @@ export interface LifeOpsCalendarFeed {
   syncedAt: string | null;
 }
 
+/**
+ * Summary of one Google Calendar the user has access to (from calendarList.list).
+ * `includeInFeed` reflects whether the user has opted this calendar into the
+ * aggregated sidebar feed / briefing. Defaults to true for every calendar the
+ * user can see — opt-out, never opt-in, so new calendars are not silently
+ * hidden from the agent's picture of the user's life.
+ */
+export interface LifeOpsCalendarSummary {
+  provider: "google";
+  side: LifeOpsConnectorSide;
+  grantId: string;
+  accountEmail: string | null;
+  calendarId: string;
+  summary: string;
+  description: string | null;
+  primary: boolean;
+  accessRole: string;
+  backgroundColor: string | null;
+  foregroundColor: string | null;
+  timeZone: string | null;
+  selected: boolean;
+  includeInFeed: boolean;
+}
+
+export interface ListLifeOpsCalendarsRequest {
+  side?: LifeOpsConnectorSide;
+  mode?: LifeOpsConnectorMode;
+  grantId?: string;
+}
+
+export interface ListLifeOpsCalendarsResponse {
+  calendars: LifeOpsCalendarSummary[];
+}
+
+export interface SetLifeOpsCalendarIncludedRequest {
+  calendarId: string;
+  includeInFeed: boolean;
+  side?: LifeOpsConnectorSide;
+  mode?: LifeOpsConnectorMode;
+  grantId?: string;
+}
+
+export interface SetLifeOpsCalendarIncludedResponse {
+  calendar: LifeOpsCalendarSummary;
+}
+
 export interface GetLifeOpsCalendarFeedRequest {
   side?: LifeOpsConnectorSide;
   mode?: LifeOpsConnectorMode;


### PR DESCRIPTION
This completes the LifeOps multi-calendar stack on the app/runtime side and adds the last safety fallback for hosted cloud lag.

## Included
- list and persist available calendars in LifeOps settings
- merge included calendar feeds across calendars/accounts
- surface calendar origin in merged feeds
- support cloud-managed secondary calendars
- fall back to primary aggregation when managed calendar discovery is temporarily unavailable

## Dependency
- hosted connector route is tracked separately in [cloud#472](https://github.com/elizaOS/cloud/pull/472)
- this PR intentionally leaves the `cloud` submodule pointer alone until that cloud change lands upstream

## Why
Hosted users were getting blank or incorrect calendar views when the connector only exposed `primary` or when the new managed calendar-list route was not yet deployed. This keeps the UI and agent behavior stable while the cloud route lands.

## Validation
- `bun run --cwd C:\Users\epj33\Documents\Playground\milady\eliza\apps\app-lifeops test -- service-mixin-calendar.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the LifeOps multi-calendar stack: it adds `listCalendars` / `setCalendarIncluded` service methods, a `getCalendarFeed` path that aggregates across all user-enabled calendars (with a fallback to primary when managed calendar discovery is unavailable), per-calendar `includeInFeed` preferences stored in the scheduler task metadata, and UI for toggling calendar visibility in Settings.

- **P1 — multi-account preference key collision**: `calendarFeedIncludes` is keyed only by `calendarId`. Users with two connected Google accounts both have a calendar with `calendarId: \"primary\"`, so toggling one will silently override the other's preference. The UI already uses a `${grantId}:${calendarId}` composite key for React rendering — the backend persistence and lookup should do the same.

<h3>Confidence Score: 4/5</h3>

Safe to merge for single-account users; multi-account users will see incorrect calendar visibility preferences until the key collision is fixed.

One P1 correctness issue: calendarFeedIncludes keyed by calendarId alone causes a data collision for any user with two Google accounts sharing a 'primary' calendarId. All other findings are P2 (fragile error string match, unnecessary API call on toggle). The fallback, merge, and UI logic are otherwise well-structured and the new tests give good coverage of the happy paths.

apps/app-lifeops/src/lifeops/service-mixin-calendar.ts (preference lookup) and apps/app-lifeops/src/lifeops/owner-profile.ts (preference storage key)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/app-lifeops/src/lifeops/service-mixin-calendar.ts | Core multi-calendar logic: adds listCalendars, setCalendarIncluded, aggregateCalendarFeedsAcrossCalendars, and getCalendarFeed path selection. Has a P1 preference-key collision bug (calendarId-only key breaks multi-account users who both have "primary") and a fragile 503 fallback. |
| apps/app-lifeops/src/lifeops/owner-profile.ts | Adds LifeOpsCalendarFeedPreferences storage: ensureLifeOpsCalendarFeedIncludes and setLifeOpsCalendarFeedIncluded. Logic is clean but the key type (calendarId only) propagates the P1 multi-account collision described in service-mixin-calendar.ts. |
| apps/app-lifeops/src/lifeops/google-calendar.ts | Adds listGoogleCalendars function fetching calendarList with minAccessRole=reader. Passes showHidden=false in query params and also filters hidden items in the loop (harmless redundancy). Parsing and normalization look correct. |
| apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx | Adds calendar list + toggle UI in GoogleConnectorSideCard. Correctly uses cancelled-flag cleanup in useEffect. Local state update after toggle correctly matches on both grantId and calendarId, though the backend ignores grantId when persisting. |
| apps/app-lifeops/src/routes/lifeops-routes.ts | Adds GET /api/lifeops/calendar/calendars and PUT /api/lifeops/calendar/calendars/:id/include routes. Body/path calendarId consistency check is a good defensive guard. |
| packages/shared/src/contracts/lifeops.ts | Adds LifeOpsCalendarSummary, ListLifeOpsCalendarsRequest/Response, SetLifeOpsCalendarIncludedRequest/Response types, and extends GetLifeOpsCalendarFeedRequest and LifeOpsCalendarEvent. Type design looks correct. |
| apps/app-lifeops/src/lifeops/service-mixin-calendar.test.ts | New test file covering mergeAggregatedCalendarFeedEvents deduplication and fallback to primary aggregation on empty or unavailable calendar list. Good coverage of the happy path and the 503 fallback. |
| apps/app-lifeops/src/lifeops/owner-profile.test.ts | Tests for ensureLifeOpsCalendarFeedIncludes (default-true for new, preserve false for existing) and setLifeOpsCalendarFeedIncluded explicit toggle. Tests verify the calendarId-only key behavior — which means they pass even with the multi-account collision issue. |
| apps/app-lifeops/src/lifeops/google-managed-client.ts | Adds ManagedGoogleCalendarSummaryResponse interface and listCalendars method on GoogleManagedClient. Straightforward delegation to the managed API. |
| apps/app-lifeops/src/components/LifeOpsWorkspaceView.tsx | Adds eventOriginLabel helper combining calendarSummary and accountEmail; replaces raw accountEmail with it in AccountBadge. Clean change. |
| apps/app-lifeops/src/components/chat/widgets/plugins/lifeops-channels.tsx | Adds empty-state label and sub-line calendarSummary display to the calendar widget. Structural change from items-center to items-start is appropriate for multi-line event rows. |
| packages/app-core/src/api/client-lifeops.ts | Adds getLifeOpsCalendars and setLifeOpsCalendarIncluded client methods using appendOptionalParam; mirrors the app-lifeops client implementation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Settings UI
    participant Client as ElizaClient
    participant Route as lifeops-routes
    participant Svc as LifeOpsService
    participant GMC as GoogleManagedClient
    participant GCal as Google CalendarList API
    participant Profile as owner-profile (Task)

    UI->>Client: getLifeOpsCalendars({side, mode})
    Client->>Route: GET /api/lifeops/calendar/calendars
    Route->>Svc: listCalendars(url, request)
    alt cloud_managed grant
        Svc->>GMC: listCalendars({side, grantId})
        GMC-->>Svc: ManagedGoogleCalendarSummaryResponse[]
    else browser/local grant
        Svc->>GCal: GET calendarList (Bearer token)
        GCal-->>Svc: GoogleCalendarListEntry[]
    end
    Svc->>Profile: ensureLifeOpsCalendarFeedIncludes(calendarIds)
    Profile-->>Svc: LifeOpsCalendarFeedPreferences
    Svc-->>Route: LifeOpsCalendarSummary[] (includeInFeed merged)
    Route-->>Client: { calendars }
    Client-->>UI: render toggle list

    UI->>Client: setLifeOpsCalendarIncluded({calendarId, includeInFeed, grantId})
    Client->>Route: PUT /api/lifeops/calendar/calendars/:id/include
    Route->>Svc: setCalendarIncluded(url, request)
    Svc->>Svc: listCalendars() — verify existence
    Svc->>Profile: setLifeOpsCalendarFeedIncluded(calendarId, included)
    Profile-->>Svc: updated LifeOpsCalendarFeedPreferences
    Svc-->>Route: updated LifeOpsCalendarSummary
    Route-->>Client: { calendar }
    Client-->>UI: optimistic local state update
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/app-lifeops/src/lifeops/service-mixin-calendar.ts`, line 1350-1358 ([link](https://github.com/elizaos/eliza/blob/08fdc406cdcb575815fa342c4392a23246aa70e5/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts#L1350-L1358)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Calendar preference key collision for multi-account users**

   `calendarFeedIncludes` is stored as `Record<string, boolean>` keyed only by `calendarId`. Google's calendarList API returns `"primary"` as the `calendarId` for every account's primary calendar — so two connected Google accounts will share the same key in the preferences store. Toggling the primary calendar on account A will silently affect account B's primary calendar visibility as well.

   The UI already uses the composite key `${calendar.grantId}:${calendar.calendarId}` for React's `key` prop and for local-state matching after a toggle, but the backend drops `grantId` before persisting. The preference lookup here also ignores `grantId`:

   ```ts
   preferences.calendarFeedIncludes[summary.calendarId] !== false
   ```

   The fix is to key preferences by `${grantId}:${calendarId}` throughout (`ensureLifeOpsCalendarFeedIncludes`, `setLifeOpsCalendarFeedIncluded`, and the lookup in `listCalendars`).


2. `apps/app-lifeops/src/lifeops/service-mixin-calendar.ts`, line 1432-1458 ([link](https://github.com/elizaos/eliza/blob/08fdc406cdcb575815fa342c4392a23246aa70e5/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts#L1432-L1458)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Fragile error-message substring match for 503 fallback**

   The fallback to primary aggregation is gated on `error.message.includes("managed calendar-list route")`. This is a coupling between the error-throw site in `listCalendars` (same file) and this catch site; if the message is ever rephrased or if a different 503 from the managed client triggers `listCalendars`, the fallback silently does not fire.

   Consider using a dedicated error subclass or a typed error code (`error.code === "MANAGED_CALENDAR_LIST_UNAVAILABLE"`) that is stable across refactors and locale-agnostic.


3. `apps/app-lifeops/src/lifeops/service-mixin-calendar.ts`, line 1380-1401 ([link](https://github.com/elizaos/eliza/blob/08fdc406cdcb575815fa342c4392a23246aa70e5/apps/app-lifeops/src/lifeops/service-mixin-calendar.ts#L1380-L1401)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`setCalendarIncluded` issues a full Google API round-trip to validate the calendar**

   `setCalendarIncluded` calls `this.listCalendars(...)` — which hits either the managed cloud API or Google's calendarList endpoint for every grant — purely to confirm the target `calendarId` exists before writing the preference. For users with several connected accounts this means multiple external calls on every toggle.

   Consider persisting a local snapshot of known calendars (already returned to the UI) so this validation can be done from cache, or skip the existence check if it's acceptable to trust the client-supplied `calendarId`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(lifeops): fall back when managed cal..."](https://github.com/elizaos/eliza/commit/08fdc406cdcb575815fa342c4392a23246aa70e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29510472)</sub>

<!-- /greptile_comment -->