### PR TITLE
docs: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For complete guides and API references, visit our official **[documentation](htt
 - 🛠️ **Highly Extensible**: Build your own functionality with a powerful plugin system.
 - 📦 **It Just Works**: A seamless setup and development experience from day one.
 
-> **Looking for plugins?** Browse the community plugin registry at **[elizaOS-plugins/registry](https://github.com/elizaOS-plugins/registry)** for a full list of available ElizaOS plugins.
+> **Looking for plugins?** Browse the community plugin registry at **[elizaOS-plugins/registry](https://github.com/elizaOS-plugins/registry)** for a full list of available elizaOS plugins.
 
 ## 🏁 Getting Started (5-Minute Quick Start)
 


### PR DESCRIPTION
fixes a minor typo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a capitalisation inconsistency in `README.md`, changing "ElizaOS" to "elizaOS" to match the project's canonical casing. The change is purely cosmetic and has no functional impact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single cosmetic capitalisation fix in documentation.

The change is a one-word capitalisation correction with no code, logic, or functional impact whatsoever.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Single-word capitalisation fix: "ElizaOS" → "elizaOS" in the plugin registry blurb. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README.md (before)\n'ElizaOS plugins'"] -->|capitalisation fix| B["README.md (after)\n'elizaOS plugins'"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: fix typo in readme"](https://github.com/elizaos/eliza/commit/53ffc5d136d04996de75b4d37cc73b0332e02358) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29542582)</sub>

<!-- /greptile_comment -->