### PR TITLE
fix(message): preserve SPAWN_AGENT against metadata action correction

### DIFF
--- a/packages/typescript/src/__tests__/owned-action-correction.test.ts
+++ b/packages/typescript/src/__tests__/owned-action-correction.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { findOwnedActionCorrectionFromMetadata } from "../services/message.ts";
+
+describe("findOwnedActionCorrectionFromMetadata", () => {
+	it("returns null when planner already included an explicit-intent action (SPAWN_AGENT)", () => {
+		// Regression: the metadata corrector scores actions by keyword overlap
+		// against the user message. SPAWN_AGENT has no keywords to match, so for
+		// any coding-delegation request the scorer would otherwise rank a cross-
+		// channel send action higher and silently override the planner's
+		// deliberate SPAWN_AGENT choice, breaking the delegation.
+		const result = findOwnedActionCorrectionFromMetadata(
+			{ actions: [] },
+			{ content: { text: "send a small pr to elizaOS/eliza" } },
+			{ actions: ["REPLY", "SPAWN_AGENT"] },
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when planner picked SPAWN_AGENT alone", () => {
+		const result = findOwnedActionCorrectionFromMetadata(
+			{ actions: [] },
+			{ content: { text: "build me an app that tracks coffee" } },
+			{ actions: ["SPAWN_AGENT"] },
+		);
+		expect(result).toBeNull();
+	});
+
+	it("returns null when response has no actions", () => {
+		const result = findOwnedActionCorrectionFromMetadata(
+			{ actions: [] },
+			{ content: { text: "anything" } },
+			{ actions: [] },
+		);
+		expect(result).toBeNull();
+	});
+});

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -1266,6 +1266,15 @@ const ACTION_REPAIR_PASSIVE_ACTIONS = new Set(
 	["REPLY", "RESPOND", "NONE", "IGNORE"].map(normalizeActionIdentifier),
 );
 
+// Actions the planner selects as explicit delegation / orchestration intent.
+// These cannot be evaluated by keyword-overlap against the user's message
+// (e.g. "build me an app" does not contain "spawn" or "agent"), so the
+// metadata-based corrector must not override them with a keyword-matched
+// alternative like a cross-channel send action.
+const EXPLICIT_INTENT_ACTIONS = new Set(
+	["SPAWN_AGENT"].map(normalizeActionIdentifier),
+);
+
 function shouldAttemptCanonicalActionRepair(
 	rawPlannerActions: string[],
 	normalizedActions: string[],
@@ -1799,11 +1808,20 @@ export function suggestOwnedActionFromMetadata(
 	};
 }
 
-function findOwnedActionCorrectionFromMetadata(
+export function findOwnedActionCorrectionFromMetadata(
 	runtime: Pick<IAgentRuntime, "actions">,
 	message: Pick<Memory, "content">,
 	responseContent: Pick<Content, "actions"> | null | undefined,
 ): ActionOwnershipSuggestion | null {
+	const hasExplicitIntent = (responseContent?.actions ?? []).some(
+		(actionName) =>
+			typeof actionName === "string" &&
+			EXPLICIT_INTENT_ACTIONS.has(normalizeActionIdentifier(actionName)),
+	);
+	if (hasExplicitIntent) {
+		return null;
+	}
+
 	const currentAction = responseContent?.actions?.find(
 		(actionName) =>
 			typeof actionName === "string" &&


### PR DESCRIPTION
## Summary

`findOwnedActionCorrectionFromMetadata` is a metadata-based safety net that keyword-scores the planner's chosen action against the user message, and upgrades it if any other registered action scores meaningfully higher. This is helpful for cases like REPLY → OWNER_SEND_MESSAGE when the user says *"text mom,"* but it silently breaks coding-delegation flows.

`SPAWN_AGENT` has no user-message keywords to match against — its name and description describe the action itself (spawn a task agent), not the work the user is requesting (*"send a small PR to elizaOS/eliza"*, *"build me an app"*, etc.). As a result, for any coding-delegation request:

- `SPAWN_AGENT` scores ~0 against the message
- `OWNER_SEND_MESSAGE` (cross-channel send) scores highly because words like *"send,"* *"discord,"* or *"workflow"* in the user message overlap with its metadata
- The corrector replaces `[REPLY, SPAWN_AGENT]` with `[OWNER_SEND_MESSAGE]`
- The corrector doesn't replan, so the downstream param-repair pass has no context and hallucinates `channel: "current"`
- Validator rejects the param, action is dropped, and the agent sits silent — no reply, no task dispatch

Live signature in `service:message` logs:
```
Corrected routed action from action metadata (originalActions=["REPLY","SPAWN_AGENT"], suggestedAction=OWNER_SEND_MESSAGE, score=37.2, reasons=["overlap:discord,send","overlap:discord,send","workflow"])
Planner response still has invalid action params after repair pass (... "channel 'current' not in allowed values" ...)
Skipping action with invalid parameters (action=OWNER_SEND_MESSAGE, ...)
```

This effectively disables `SPAWN_AGENT` for any message containing common cross-channel keywords.

## Fix

Introduce `EXPLICIT_INTENT_ACTIONS` (starts with `SPAWN_AGENT`) and bail out of correction when the planner already picked one. These actions represent explicit delegation / orchestration intent that keyword overlap cannot meaningfully evaluate, so the corrector must defer to the planner rather than second-guess it. Additive, narrow: behavior is unchanged for every response that doesn't contain an explicit-intent action.

`findOwnedActionCorrectionFromMetadata` is exported to enable a focused regression test.

## Test plan

- [x] New regression test `packages/typescript/src/__tests__/owned-action-correction.test.ts` covers:
  - `[REPLY, SPAWN_AGENT]` + keyword-rich message → returns null (the bug)
  - `[SPAWN_AGENT]` alone → returns null
  - `[]` baseline → returns null
- [x] Existing tests still pass: `message-planner-actions.test.ts` (6), `planner-preamble.test.ts` + `actions.test.ts` (38)
- [x] `tsc --noEmit` clean
- [x] Verified live on a real agent: coding-delegation request that previously silently dropped now correctly dispatches `SPAWN_AGENT` (see log line `Dropped REPLY because another selected action already owns the turn (filteredActions=["SPAWN_AGENT"])`), and the spawned task agent opens the PR as expected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the metadata-based action corrector would override the planner's deliberate `SPAWN_AGENT` selection because `SPAWN_AGENT` has no user-message keywords to match, causing keyword-rich orchestration requests (e.g. "send a PR") to silently drop the delegation entirely. The fix is narrow: a new `EXPLICIT_INTENT_ACTIONS` Set and an early-return guard in `findOwnedActionCorrectionFromMetadata` bail out before scoring when the planner already chose an explicit-delegation action.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is additive and narrowly scoped; behavior is unchanged for every response that doesn't include an explicit-intent action.

The only finding is a P2 suggestion to add a positive-path test. The fix itself is correct, well-commented, and matches the described root cause. No existing paths are altered.

No files require special attention; the test file could benefit from a positive-path case but this does not block the merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds `EXPLICIT_INTENT_ACTIONS` Set and an early-return guard in `findOwnedActionCorrectionFromMetadata` to prevent keyword-overlap scoring from overriding the planner's deliberate `SPAWN_AGENT` selection; exports the function to enable unit testing. |
| packages/typescript/src/__tests__/owned-action-correction.test.ts | New regression tests covering the explicit-intent early-return path; tests only validate the null-return guard, not the positive correction path, leaving that branch untested in isolation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["findOwnedActionCorrectionFromMetadata"] --> B{"Any action in\nEXPLICIT_INTENT_ACTIONS?"}
    B -->|"Yes - SPAWN_AGENT etc"| C["return null - planner intent preserved"]
    B -->|No| D{"currentAction found?"}
    D -->|No| E["return null"]
    D -->|Yes| F["suggestOwnedActionFromMetadata"]
    F --> G{"suggestion\nreturned?"}
    G -->|No| H["return null"]
    G -->|Yes| I{"suggestion ==\ncurrentAction?"}
    I -->|Yes| J["return null"]
    I -->|No| K{"score gap >= 4?"}
    K -->|No| L["return null"]
    K -->|Yes| M["return suggestion - correction applied"]

    style C fill:#d4edda,stroke:#28a745
    style M fill:#fff3cd,stroke:#ffc107
```

<sub>Reviews (1): Last reviewed commit: ["fix(message): preserve SPAWN\_AGENT again..."](https://github.com/elizaos/eliza/commit/3ff602257f7a0b941714193756c5da69009548ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29542784)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->