### PR TITLE
docs: fix typo in readme

### DIFF
--- a/packages/docs/guides/deploy-a-project.mdx
+++ b/packages/docs/guides/deploy-a-project.mdx
@@ -231,7 +231,7 @@ Render is comparable to Railway, but its Free/Hobby plan is less generous and sl
 </Step>
 
 <Step title="Add environment variables">
-  Put all your environment variables in here, even if you commited your .env
+  Put all your environment variables in here, even if you committed your .env
   file, you still need to add it on Render-side:
   <img
     src="/images/render-env.png"


### PR DESCRIPTION
fixes a small typo

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a single-character typo in `packages/docs/guides/deploy-a-project.mdx`, correcting "commited" to "committed" in the Render deployment instructions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only typo fix with no functional impact.

The change is a one-word spelling correction in a markdown documentation file. No code, logic, or configuration is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/docs/guides/deploy-a-project.mdx | Single typo fix: "commited" → "committed". No logic or functional changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deploy-a-project.mdx] --> B[Typo corrected]
    B --> C["commited → committed"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: fix typo in readme"](https://github.com/elizaos/eliza/commit/9828e846190e2a13e4367edf6fa10631f50fcf26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29551396)</sub>

<!-- /greptile_comment -->