### PR TITLE
fix: correct malformed Anthropic Haiku model ID

### DIFF
--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -403,7 +403,7 @@ const PROVIDER_DEFAULT_MODELS: Record<
 > = {
   anthropic: {
     smallKey: "ANTHROPIC_SMALL_MODEL",
-    smallVal: "claude-haiku-4-5-20251001-5",
+    smallVal: "claude-haiku-4-5-20251001",
     largeKey: "ANTHROPIC_LARGE_MODEL",
     largeVal: "claude-sonnet-4-6",
   },


### PR DESCRIPTION
The default small model ID had typos causing 404 errors from the Anthropic API:

- plugin-anthropic config/package.json: duplicated suffix "claude-haiku-4-5-20251001-5-20251001"
- provider-switch-config: trailing "-5" "claude-haiku-4-5-20251001-5"

All corrected to "claude-haiku-4-5-20251001".

<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two malformed Anthropic Haiku model IDs that were causing 404 errors: a trailing `-5` in `provider-switch-config.ts` and a duplicated suffix in `plugin-anthropic`'s config, both corrected to the valid versioned ID `claude-haiku-4-5-20251001`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix for two malformed model IDs with no other logic changes.

Both changes are minimal, isolated string corrections. The model ID `claude-haiku-4-5-20251001` is confirmed as the correct versioned Anthropic Haiku 4.5 identifier. No new logic, no side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/api/provider-switch-config.ts | Fixes trailing `-5` typo in `smallVal` for the Anthropic provider default model mapping; corrected to the valid `claude-haiku-4-5-20251001`. |
| plugins/plugin-anthropic | Submodule bumped to fix duplicated `-5-20251001` suffix in the plugin's config/package.json default model ID. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent starts with Anthropic provider] --> B[applyDefaultModelNames called]
    B --> C{ANTHROPIC_SMALL_MODEL set?}
    C -- No --> D["Use smallVal from PROVIDER_DEFAULT_MODELS\n(was: claude-haiku-4-5-20251001-5\nnow: claude-haiku-4-5-20251001)"]
    C -- Yes --> E[Use user-configured model]
    D --> F[Anthropic API call]
    E --> F
    F -- Before fix --> G[404 Error: Model not found]
    F -- After fix --> H[200 OK: Valid response]
```

<sub>Reviews (1): Last reviewed commit: ["fix: correct malformed Anthropic Haiku m..."](https://github.com/elizaos/eliza/commit/cc17ba1e293c7fe928d37c0569ebd15c451047bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29552587)</sub>

<!-- /greptile_comment -->