### PR TITLE
docs: fix typo in README

### DIFF
--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,6 +1,6 @@
 # elizaOS Documentation
 
-Welcome to the official documentation repository for [elizaOS](https://github.com/elizaos/elizaos) - a powerful framework for building AI agents with memory, planning, and tool use capabilities.
+Welcome to the official documentation repository for [elizaOS](https://github.com/elizaos/eliza) - a powerful framework for building AI agents with memory, planning, and tool use capabilities.
 
 ## 📚 About This Documentation
 


### PR DESCRIPTION
Fix a small typo found in documentation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a single-character typo in `packages/docs/README.md`, correcting the GitHub link from `github.com/elizaos/elizaos` to `github.com/elizaos/eliza`. The change is accurate and matches the actual repository name.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single documentation fix with no code changes.

One-line documentation typo fix correcting a broken URL; no logic, no code, no risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/docs/README.md | Corrects the GitHub repository URL from elizaos/elizaos to elizaos/eliza in the introductory line |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["packages/docs/README.md"] --> B["GitHub URL in introduction"]
    B -->|"Before"| C["github.com/elizaos/elizaos ❌"]
    B -->|"After"| D["github.com/elizaos/eliza ✅"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: fix typo in README"](https://github.com/elizaos/eliza/commit/2fc80ca1803a7a1f0710b5ef867a8e637ba52520) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29554506)</sub>

<!-- /greptile_comment -->