### PR TITLE
docs: fix typo in deploy-a-project.mdx

### DIFF
--- a/packages/docs/guides/deploy-a-project.mdx
+++ b/packages/docs/guides/deploy-a-project.mdx
@@ -70,7 +70,7 @@ The easiest deployment method, best for rapid prototyping. These platforms handl
 <Note>
   **Cost Reality Check:** A simple agent might cost ~$20 dollars per month, but
   as you scale up, the costs can quickly balloon. For this reason, it's smart to
-  set spending threshholds and closely monitor resource usage.
+  set spending thresholds and closely monitor resource usage.
 </Note>
 
 ### Pros & Cons


### PR DESCRIPTION
Fix typo: threshholds -> thresholds in packages/docs/guides/deploy-a-project.mdx.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a single spelling typo in `packages/docs/guides/deploy-a-project.mdx`, correcting `threshholds` to `thresholds` in a note about monitoring spending.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single documentation typo fix with no functional impact.

The change is a one-word spelling correction in a documentation file. No logic, configuration, or code is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/docs/guides/deploy-a-project.mdx | Single typo fix: "threshholds" corrected to "thresholds" in a documentation note about cost management. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["deploy-a-project.mdx"] --> B["Typo fix: threshholds → thresholds"]
    B --> C["No functional changes"]
```

<sub>Reviews (1): Last reviewed commit: ["docs: fix typo in deploy-a-project.mdx"](https://github.com/elizaos/eliza/commit/afc85fb08cda2e6ea3b2b192b300d34d49ee8a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29559412)</sub>

<!-- /greptile_comment -->