### PR TITLE
Shaw/wallet runtime fix

### DIFF
--- a/apps/app-clawville/src/routes.ts
+++ b/apps/app-clawville/src/routes.ts
@@ -178,7 +178,21 @@ function formatNearestBuildingGoal(
   perception?: Record<string, unknown> | null,
 ): string | null {
   const label = readNearestBuildingLabel(perception);
-  return label ? `Nearest: ${label}` : "Exploring the reef";
+  return label
+    ? `Near ${label}. Visit or ask the local NPC.`
+    : "Exploring the reef";
+}
+
+function formatSessionSummary(
+  connectResult: ClawvilleConnectResponse,
+  perception?: Record<string, unknown> | null,
+): string {
+  const location = readNearestBuildingLabel(perception);
+  const learned = connectResult.knowledge.length;
+  const skillLabel = learned === 1 ? "skill" : "skills";
+  return location
+    ? `Near ${location}. ${learned} ${skillLabel} learned.`
+    : `Exploring ClawVille. ${learned} ${skillLabel} learned.`;
 }
 
 function buildSessionState(
@@ -186,8 +200,6 @@ function buildSessionState(
   connectResult: ClawvilleConnectResponse | null,
   perception?: Record<string, unknown> | null,
 ): AppSessionState {
-  const agentName = config.miladyCharacterName ?? "Milady Agent";
-
   if (!connectResult) {
     return {
       sessionId: config.miladyAgentId ?? "clawville",
@@ -201,24 +213,13 @@ function buildSessionState(
       summary: "Connecting to ClawVille...",
       goalLabel: null,
       suggestedPrompts: [
-        "Move to Krusty Krab",
+        "Move to tool workshop",
         "Visit the nearest building",
         "Ask the nearest NPC what to learn next",
       ],
       telemetry: null,
     };
   }
-
-  const returningMarker = connectResult.isReturning ? "returning" : "new";
-  const walletShort = connectResult.walletAddress
-    ? `${connectResult.walletAddress.slice(0, 6)}...${connectResult.walletAddress.slice(-4)}`
-    : "no wallet";
-  const summaryParts = [
-    `${agentName} (${returningMarker})`,
-    `session #${connectResult.totalSessions}`,
-    walletShort,
-    `${connectResult.knowledge.length} skills learned`,
-  ];
 
   return {
     sessionId: connectResult.sessionId,
@@ -229,13 +230,13 @@ function buildSessionState(
     agentId: connectResult.agentId,
     canSendCommands: true,
     controls: [],
-    summary: summaryParts.join(" | "),
+    summary: formatSessionSummary(connectResult, perception),
     goalLabel: formatNearestBuildingGoal(perception),
     suggestedPrompts: [
-      "Move to Krusty Krab",
+      "Move to tool workshop",
       "Visit the nearest building",
       "Ask the nearest NPC what to learn next",
-      "Move to Chum Bucket",
+      "Move to skill forge",
     ],
     telemetry: {
       walletAddress: connectResult.walletAddress,

--- a/apps/app-clawville/src/routes.ts
+++ b/apps/app-clawville/src/routes.ts
@@ -4,6 +4,7 @@ import type {
   AppLaunchResult,
   AppLaunchSessionContext,
   AppRunSessionContext,
+  AppSessionActivityItem,
   AppSessionActionResult,
   AppSessionState,
 } from "@elizaos/shared/contracts/apps";
@@ -27,6 +28,7 @@ const APP_NAME = "@clawville/app-clawville";
 const APP_DISPLAY_NAME = "ClawVille";
 const VIEWER_ROUTE_PATH = "/api/apps/clawville/viewer";
 const VIEWER_FETCH_TIMEOUT_MS = 8_000;
+const SESSION_ACTIVITY_LIMIT = 12;
 
 /**
  * CSP frame-ancestors directive we send on the viewer HTML response so that
@@ -95,6 +97,8 @@ const BUILDINGS = [
 
 type ClawvilleSubroute = "move" | "visit-building" | "chat" | "buy";
 type ClawvilleBuildingId = (typeof BUILDINGS)[number]["id"];
+
+const sessionActivities = new Map<string, AppSessionActivityItem[]>();
 
 interface RouteContext {
   method: string;
@@ -238,6 +242,7 @@ function buildSessionState(
       "Ask the nearest NPC what to learn next",
       "Move to skill forge",
     ],
+    activity: readSessionActivity(config, connectResult.sessionId),
     telemetry: {
       walletAddress: connectResult.walletAddress,
       botUuid: connectResult.uuid,
@@ -544,6 +549,62 @@ function readStringField(
   return null;
 }
 
+function sessionActivityKey(
+  config: ClawvilleConfig,
+  sessionId: string,
+): string {
+  return `${config.miladyAgentId ?? "clawville"}:${sessionId}`;
+}
+
+function readSessionActivity(
+  config: ClawvilleConfig,
+  sessionId: string,
+): AppSessionActivityItem[] {
+  return sessionActivities.get(sessionActivityKey(config, sessionId)) ?? [];
+}
+
+function appendSessionActivity(
+  config: ClawvilleConfig,
+  sessionId: string,
+  items: AppSessionActivityItem[],
+): void {
+  sessionActivities.set(
+    sessionActivityKey(config, sessionId),
+    [...readSessionActivity(config, sessionId), ...items].slice(
+      -SESSION_ACTIVITY_LIMIT,
+    ),
+  );
+}
+
+function formatBuildingId(value: string): string {
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function describeCommand(
+  subroute: ClawvilleSubroute,
+  body: Record<string, unknown>,
+): string {
+  if (subroute === "chat") {
+    return (
+      readStringField(body, ["message", "content", "command"]) ??
+      "Ask the nearest NPC."
+    );
+  }
+
+  if (subroute === "move" || subroute === "visit-building") {
+    const buildingId = readStringField(body, ["buildingId", "building"]);
+    const target = buildingId
+      ? formatBuildingId(buildingId)
+      : "nearest building";
+    return subroute === "move" ? `Move to ${target}.` : `Visit ${target}.`;
+  }
+
+  return "Command sent.";
+}
+
 function readNumberField(
   body: Record<string, unknown>,
   keys: string[],
@@ -629,18 +690,10 @@ async function buildMessageCommand(
     };
   }
 
-  if (/\b(visit|enter|learn|skill)\b/.test(normalized)) {
-    const buildingId =
-      explicitBuildingId ?? (await resolveNearestBuildingId(config, sessionId));
-    if (!buildingId) {
-      return {
-        subroute: "chat",
-        body: { message: content },
-      };
-    }
+  if (/\b(ask|talk|chat|npc|say|message)\b/.test(normalized)) {
     return {
-      subroute: "visit-building",
-      body: { buildingId },
+      subroute: "chat",
+      body: { message: content },
     };
   }
 
@@ -655,6 +708,21 @@ async function buildMessageCommand(
     }
     return {
       subroute: "move",
+      body: { buildingId },
+    };
+  }
+
+  if (/\b(visit|enter|learn)\b/.test(normalized)) {
+    const buildingId =
+      explicitBuildingId ?? (await resolveNearestBuildingId(config, sessionId));
+    if (!buildingId) {
+      return {
+        subroute: "chat",
+        body: { message: content },
+      };
+    }
+    return {
+      subroute: "visit-building",
       body: { buildingId },
     };
   }
@@ -725,12 +793,32 @@ async function buildCommandResult(
   body: Record<string, unknown>,
 ): Promise<AppSessionActionResult> {
   const response = await proxyCommand(config, sessionId, subroute, body);
+  const message = resultMessage(subroute, response.data);
+  if (response.ok) {
+    const timestamp = Date.now();
+    appendSessionActivity(config, sessionId, [
+      {
+        id: `clawville-user-${timestamp}`,
+        type: "You",
+        message: describeCommand(subroute, body),
+        timestamp,
+        severity: "info",
+      },
+      {
+        id: `clawville-game-${timestamp}`,
+        type: subroute,
+        message,
+        timestamp: timestamp + 1,
+        severity: "info",
+      },
+    ]);
+  }
   const perception = response.ok
     ? await clawvillePerception(config, sessionId)
     : null;
   return {
     success: response.ok,
-    message: resultMessage(subroute, response.data),
+    message,
     session: response.ok
       ? buildSessionState(
           config,

--- a/apps/app-clawville/src/ui/ClawvilleOperatorSurface.tsx
+++ b/apps/app-clawville/src/ui/ClawvilleOperatorSurface.tsx
@@ -76,16 +76,36 @@ function localEventId(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
+function formatBuildingId(value: string): string {
+  return value
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function cleanClawvilleMessage(message: string): string {
+  const tooFar = message.match(/^Too far from ([a-z0-9-]+)/i);
+  if (tooFar?.[1]) {
+    return `Too far from ${formatBuildingId(tooFar[1])}. Move closer before visiting.`;
+  }
+  return message;
+}
+
 function collectRunEvents(
   run: AppRunSummary,
   localEvents: GameOperatorEvent[],
 ): GameOperatorEvent[] {
   const serverEvents = (run.recentEvents ?? [])
-    .filter((event) => event.kind !== "refresh")
+    .filter(
+      (event) =>
+        event.kind !== "refresh" &&
+        event.kind !== "attach" &&
+        event.kind !== "detach",
+    )
     .map((event) => ({
       id: event.eventId,
       label: event.kind,
-      message: event.message,
+      message: cleanClawvilleMessage(event.message),
       tone:
         event.severity === "error"
           ? "error"
@@ -99,7 +119,7 @@ function collectRunEvents(
     run.session?.activity?.map((entry) => ({
       id: entry.id,
       label: entry.type,
-      message: entry.message,
+      message: cleanClawvilleMessage(entry.message),
       tone:
         entry.severity === "error"
           ? "error"
@@ -160,11 +180,17 @@ export function ClawvilleOperatorSurface({
 
       try {
         const response = await client.sendAppRunMessage(run.runId, trimmed);
+        const persistedSession =
+          response.run?.session ?? response.session ?? null;
         if (response.run) {
           setState("appRuns", replaceRun(appRuns, response.run));
         }
         if (clearDraftOnSuccess) {
           setDraft((current) => (current.trim() === trimmed ? "" : current));
+        }
+        if (persistedSession) {
+          setLocalEvents([]);
+          return;
         }
         setLocalEvents((current) => [
           ...current,

--- a/apps/app-clawville/src/ui/ClawvilleOperatorSurface.tsx
+++ b/apps/app-clawville/src/ui/ClawvilleOperatorSurface.tsx
@@ -1,29 +1,37 @@
-import { useCallback, useMemo, useState } from "react";
-import { client } from "@elizaos/app-core/api";
+import { client, type AppRunSummary } from "@elizaos/app-core/api";
+import {
+  type GameOperatorAction,
+  type GameOperatorEvent,
+  GameOperatorShell,
+} from "@elizaos/app-core/components/apps/surfaces/GameOperatorShell";
 import type { AppOperatorSurfaceProps } from "@elizaos/app-core/components/apps/surfaces/types";
 import { useApp } from "@elizaos/app-core/state";
-import { Button, Input } from "@elizaos/ui";
+import { useCallback, useMemo, useState } from "react";
 
 const PRIMARY_COMMANDS = [
   {
-    id: "move-krusty",
-    label: "Move Krusty Krab",
-    command: "Move to Krusty Krab",
+    id: "move-tools",
+    label: "Go to Tools",
+    command: "Move to tool workshop",
+    testId: "clawville-command-move-krusty",
   },
   {
-    id: "move-chum",
-    label: "Move Chum Bucket",
-    command: "Move to Chum Bucket",
+    id: "move-code",
+    label: "Go to Code",
+    command: "Move to skill forge",
+    testId: "clawville-command-move-chum",
   },
   {
     id: "visit-nearest",
-    label: "Visit Nearest",
+    label: "Visit nearest",
     command: "Visit the nearest building",
+    testId: "clawville-command-visit-nearest",
   },
   {
     id: "ask-npc",
     label: "Ask NPC",
     command: "Ask the nearest NPC what to learn next",
+    testId: "clawville-command-ask-npc",
   },
 ] as const;
 
@@ -45,28 +53,70 @@ function readNumber(
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function shortenWallet(value: string | null): string {
-  if (!value) return "No wallet";
-  if (value.length <= 12) return value;
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+function statusLabel(status: string): string {
+  if (status === "running" || status === "ready") return "Live";
+  if (status === "degraded" || status === "failed") return "Needs attention";
+  return "Starting";
 }
 
-function statusTone(status: string): string {
-  if (status === "running" || status === "ready") {
-    return "border-ok/30 bg-ok/10 text-ok";
-  }
-  if (status === "degraded" || status === "failed") {
-    return "border-danger/30 bg-danger/10 text-danger";
-  }
-  return "border-border/45 bg-bg-hover/70 text-muted-strong";
+function statusTone(status: string): "live" | "attention" | "idle" {
+  if (status === "running" || status === "ready") return "live";
+  if (status === "degraded" || status === "failed") return "attention";
+  return "idle";
+}
+
+function replaceRun(appRuns: AppRunSummary[], nextRun: AppRunSummary) {
+  return [
+    ...appRuns.filter((candidate) => candidate.runId !== nextRun.runId),
+    nextRun,
+  ].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+function localEventId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function collectRunEvents(
+  run: AppRunSummary,
+  localEvents: GameOperatorEvent[],
+): GameOperatorEvent[] {
+  const serverEvents = (run.recentEvents ?? [])
+    .filter((event) => event.kind !== "refresh")
+    .map((event) => ({
+      id: event.eventId,
+      label: event.kind,
+      message: event.message,
+      tone:
+        event.severity === "error"
+          ? "error"
+          : event.severity === "warning"
+            ? "warning"
+            : "info",
+      timestamp: event.createdAt,
+    })) satisfies GameOperatorEvent[];
+
+  const activityEvents: GameOperatorEvent[] =
+    run.session?.activity?.map((entry) => ({
+      id: entry.id,
+      label: entry.type,
+      message: entry.message,
+      tone:
+        entry.severity === "error"
+          ? "error"
+          : entry.severity === "warning"
+            ? "warning"
+            : "info",
+      timestamp: entry.timestamp ?? null,
+    })) ?? [];
+
+  return [...serverEvents, ...activityEvents, ...localEvents];
 }
 
 export function ClawvilleOperatorSurface({
   appName,
   variant = "detail",
-  focus = "all",
 }: AppOperatorSurfaceProps) {
-  const { appRuns } = useApp();
+  const { appRuns, setState } = useApp();
   const run = useMemo(
     () =>
       [...(Array.isArray(appRuns) ? appRuns : [])]
@@ -77,7 +127,7 @@ export function ClawvilleOperatorSurface({
     [appName, appRuns],
   );
   const [draft, setDraft] = useState("");
-  const [notice, setNotice] = useState<string | null>(null);
+  const [localEvents, setLocalEvents] = useState<GameOperatorEvent[]>([]);
   const [sendingCommand, setSendingCommand] = useState<string | null>(null);
 
   const telemetry =
@@ -87,12 +137,9 @@ export function ClawvilleOperatorSurface({
   const nearestBuilding =
     readString(telemetry, "nearestBuildingLabel") ??
     readString(telemetry, "nearestBuildingId") ??
-    "reef";
-  const walletLabel = shortenWallet(readString(telemetry, "walletAddress"));
+    "the reef";
   const knowledgeCount = readNumber(telemetry, "knowledgeCount");
   const canSend = Boolean(run?.runId && run.session?.canSendCommands);
-  const showDashboard = focus !== "chat";
-  const showChat = focus !== "dashboard";
 
   const sendCommand = useCallback(
     async (content: string, clearDraftOnSuccess = false) => {
@@ -100,22 +147,59 @@ export function ClawvilleOperatorSurface({
       if (!run?.runId || !trimmed || sendingCommand) return;
 
       setSendingCommand(trimmed);
-      setNotice(null);
+      setLocalEvents((current) => [
+        ...current,
+        {
+          id: localEventId("clawville-user"),
+          label: "You",
+          message: trimmed,
+          tone: "user",
+          timestamp: Date.now(),
+        },
+      ]);
+
       try {
         const response = await client.sendAppRunMessage(run.runId, trimmed);
+        if (response.run) {
+          setState("appRuns", replaceRun(appRuns, response.run));
+        }
         if (clearDraftOnSuccess) {
           setDraft((current) => (current.trim() === trimmed ? "" : current));
         }
-        setNotice(response.message ?? "Command sent.");
+        setLocalEvents((current) => [
+          ...current,
+          {
+            id: localEventId("clawville-game"),
+            label: response.disposition === "queued" ? "Queued" : "ClawVille",
+            message: response.message ?? "Command accepted.",
+            tone:
+              response.disposition === "accepted"
+                ? "success"
+                : response.disposition === "queued"
+                  ? "info"
+                  : "error",
+            timestamp: Date.now(),
+          },
+        ]);
       } catch (error) {
-        setNotice(
-          error instanceof Error ? error.message : "ClawVille command failed.",
-        );
+        setLocalEvents((current) => [
+          ...current,
+          {
+            id: localEventId("clawville-error"),
+            label: "Error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "ClawVille command failed.",
+            tone: "error",
+            timestamp: Date.now(),
+          },
+        ]);
       } finally {
         setSendingCommand(null);
       }
     },
-    [run?.runId, sendingCommand],
+    [appRuns, run?.runId, sendingCommand, setState],
   );
 
   if (!run) {
@@ -125,117 +209,61 @@ export function ClawvilleOperatorSurface({
         data-testid="clawville-operator-empty"
       >
         <div className="rounded-2xl border border-border/35 bg-card/74 p-4 text-xs text-muted-strong">
-          Launch ClawVille to open live controls.
+          Launch ClawVille to open game chat.
         </div>
       </section>
     );
   }
 
+  const primaryActions: GameOperatorAction[] = PRIMARY_COMMANDS.map((item) => ({
+    ...item,
+  }));
+  const suggestedActions = (run.session?.suggestedPrompts ?? []).map(
+    (prompt) => ({
+      id: prompt,
+      label: prompt,
+      command: prompt,
+      testId: "clawville-suggested-command",
+    }),
+  );
+  const events = collectRunEvents(run, localEvents);
+
   return (
-    <section
-      className={`space-y-3 ${variant === "live" ? "p-3" : ""}`}
-      data-testid={
+    <GameOperatorShell
+      surfaceTestId={
         variant === "live"
           ? "clawville-live-operator-surface"
           : "clawville-detail-operator-surface"
       }
-    >
-      {showDashboard ? (
-        <div className="rounded-2xl border border-border/35 bg-card/74 p-3 shadow-sm">
-          <div className="flex flex-wrap items-center gap-2">
-            <span
-              className={`inline-flex min-h-6 items-center rounded-full border px-2.5 py-1 text-2xs font-medium uppercase tracking-[0.14em] ${statusTone(run.status)}`}
-            >
-              {run.status}
-            </span>
-            <span className="text-xs font-semibold text-txt">
-              Near {nearestBuilding}
-            </span>
-          </div>
-          <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-strong">
-            <span>{walletLabel}</span>
-            {knowledgeCount !== null ? (
-              <span>{knowledgeCount} skills learned</span>
-            ) : null}
-          </div>
-        </div>
-      ) : null}
-
-      {showDashboard ? (
-        <div className="grid grid-cols-2 gap-2" data-testid="clawville-actions">
-          {PRIMARY_COMMANDS.map((item) => (
-            <Button
-              key={item.id}
-              type="button"
-              variant="outline"
-              size="sm"
-              className="min-h-9 rounded-xl shadow-sm"
-              data-testid={`clawville-command-${item.id}`}
-              disabled={!canSend || Boolean(sendingCommand)}
-              onClick={() => void sendCommand(item.command)}
-            >
-              {item.label}
-            </Button>
-          ))}
-        </div>
-      ) : null}
-
-      {showChat ? (
-        <div className="rounded-2xl border border-border/35 bg-card/74 p-3 shadow-sm">
-          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-            <Input
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              placeholder="Tell ClawVille what to do..."
-              className="min-h-10 rounded-xl"
-              data-testid="clawville-chat-input"
-              disabled={!canSend}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  void sendCommand(draft, true);
-                }
-              }}
-            />
-            <Button
-              type="button"
-              className="min-h-10 rounded-xl px-4 shadow-sm"
-              data-testid="clawville-chat-send"
-              disabled={!canSend || Boolean(sendingCommand) || !draft.trim()}
-              onClick={() => void sendCommand(draft, true)}
-            >
-              {sendingCommand === draft.trim() ? "Sending" : "Send"}
-            </Button>
-          </div>
-          {run.session?.suggestedPrompts?.length ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {run.session.suggestedPrompts.map((prompt) => (
-                <Button
-                  key={prompt}
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="min-h-8 rounded-xl px-3 shadow-sm"
-                  data-testid="clawville-suggested-command"
-                  disabled={!canSend || Boolean(sendingCommand)}
-                  onClick={() => void sendCommand(prompt)}
-                >
-                  {prompt}
-                </Button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {notice ? (
-        <div
-          className="rounded-2xl border border-border/35 bg-card/70 px-4 py-3 text-xs leading-5 text-muted-strong"
-          data-testid="clawville-command-notice"
-        >
-          {notice}
-        </div>
-      ) : null}
-    </section>
+      title="ClawVille chat"
+      statusLabel={statusLabel(run.status)}
+      statusTone={statusTone(run.status)}
+      objective={run.session?.goalLabel ?? `Near ${nearestBuilding}`}
+      detailItems={[
+        { label: "Location", value: nearestBuilding },
+        {
+          label: "Skills",
+          value:
+            knowledgeCount === null
+              ? "Not loaded"
+              : `${knowledgeCount} learned`,
+        },
+      ]}
+      primaryActions={primaryActions}
+      suggestedActions={suggestedActions}
+      events={events}
+      emptyEventsLabel="Movement, NPC chat, and visit results will appear here. Start by visiting the nearest building or asking an NPC what to learn."
+      draft={draft}
+      inputPlaceholder="Tell ClawVille what to do..."
+      canSend={canSend}
+      sending={Boolean(sendingCommand)}
+      chatInputTestId="clawville-chat-input"
+      chatSendTestId="clawville-chat-send"
+      noticeTestId="clawville-command-notice"
+      variant={variant}
+      onDraftChange={setDraft}
+      onSendDraft={() => void sendCommand(draft, true)}
+      onCommand={(command) => void sendCommand(command)}
+    />
   );
 }

--- a/apps/app-clawville/test/routes.test.ts
+++ b/apps/app-clawville/test/routes.test.ts
@@ -144,6 +144,59 @@ describe("ClawVille app routes", () => {
     expect(moveRequest?.body).toEqual({ buildingId: "tool-workshop" });
   });
 
+  it("keeps explicit movement ahead of skill-building visit commands", async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        if (url.endsWith("/move")) {
+          return jsonResponse({ message: "moving to code" });
+        }
+        return jsonResponse({});
+      }),
+    );
+    const { ctx, captured } = makeCtx({
+      method: "POST",
+      pathname: "/api/apps/clawville/session/session-1/message",
+      body: { content: "Go to skill forge" },
+    });
+
+    await handleAppRoutes(ctx);
+
+    const moveRequest = requests.find((request) =>
+      request.url.endsWith("/move"),
+    );
+    const visitRequest = requests.find((request) =>
+      request.url.endsWith("/visit-building"),
+    );
+    expect(captured.status).toBe(200);
+    expect(captured.body).toMatchObject({
+      success: true,
+      message: "moving to code",
+    });
+    expect(captured.body).toMatchObject({
+      session: {
+        activity: expect.arrayContaining([
+          expect.objectContaining({
+            type: "You",
+            message: "Move to Skill Forge.",
+          }),
+          expect.objectContaining({
+            type: "move",
+            message: "moving to code",
+          }),
+        ]),
+      },
+    });
+    expect(moveRequest?.body).toEqual({ buildingId: "skill-forge" });
+    expect(visitRequest).toBeUndefined();
+  });
+
   it("uses perception for nearest-building visit commands", async () => {
     const requests: Array<{ url: string; body: unknown }> = [];
     vi.stubGlobal(
@@ -216,5 +269,52 @@ describe("ClawVille app routes", () => {
     expect(chatRequest?.body).toEqual({
       message: "Ask the nearest NPC what to learn next",
     });
+  });
+
+  it("keeps NPC chat ahead of learn-or-visit phrasing", async () => {
+    const requests: Array<{ url: string; body: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        requests.push({
+          url,
+          body: init?.body ? JSON.parse(String(init.body)) : null,
+        });
+        if (url.endsWith("/chat")) {
+          return jsonResponse({ message: "npc replied" });
+        }
+        return jsonResponse({});
+      }),
+    );
+    const { ctx, captured } = makeCtx({
+      method: "POST",
+      pathname: "/api/apps/clawville/session/session-1/message",
+      body: { content: "Talk to the nearby NPC about what to learn next" },
+    });
+
+    await handleAppRoutes(ctx);
+
+    const chatRequest = requests.find((request) =>
+      request.url.endsWith("/chat"),
+    );
+    const visitRequest = requests.find((request) =>
+      request.url.endsWith("/visit-building"),
+    );
+    expect(captured.status).toBe(200);
+    expect(chatRequest?.body).toEqual({
+      message: "Talk to the nearby NPC about what to learn next",
+    });
+    expect(captured.body).toMatchObject({
+      session: {
+        activity: expect.arrayContaining([
+          expect.objectContaining({
+            type: "chat",
+            message: "npc replied",
+          }),
+        ]),
+      },
+    });
+    expect(visitRequest).toBeUndefined();
   });
 });

--- a/apps/app-defense-of-the-agents/src/routes.ts
+++ b/apps/app-defense-of-the-agents/src/routes.ts
@@ -1679,6 +1679,46 @@ function buildUnavailableSession(
   };
 }
 
+function readCachedSessionState(ctx: SessionContext): AppSessionState | null {
+  return sessionStateCache.get(sessionCacheKey(ctx))?.session ?? null;
+}
+
+function clearCachedSessionState(ctx: SessionContext): void {
+  sessionStateCache.delete(sessionCacheKey(ctx));
+}
+
+function buildCommandOnlySessionState(ctx: SessionContext): AppSessionState {
+  const agentId = asRuntimeLike(ctx.runtime)?.agentId;
+  return {
+    sessionId: ctx.agentName,
+    appName: APP_NAME,
+    mode: "spectate-and-steer",
+    status: "ready",
+    displayName: APP_DISPLAY_NAME,
+    agentId,
+    canSendCommands: Boolean(
+      ctx.apiKey ?? process.env.DEFENSE_OF_THE_AGENTS_API_KEY,
+    ),
+    controls: [],
+    summary:
+      "Strategy note recorded. Open the live viewer for current battlefield state.",
+    goalLabel:
+      "Use autoplay, lane, recall, or ability commands for direct play.",
+    suggestedPrompts: ["Autoplay on", "Recall", "Go mid", "Use Fireball"],
+    telemetry: {
+      apiBaseUrl: ctx.apiBaseUrl,
+      viewerUrl: resolveViewerUrl(ctx.runtime),
+      preferredGameId: ctx.preferredGameId ?? null,
+      autoPlay: isAutoPlayActive(ctx.runtime),
+      recentActivity: getRecentActivity(agentId).map((entry) => ({
+        ts: entry.ts,
+        action: entry.action,
+        detail: entry.detail,
+      })),
+    },
+  };
+}
+
 function normalizeText(value: string): string {
   return value.trim().toLowerCase().replace(/[_-]+/g, " ");
 }
@@ -1748,6 +1788,26 @@ function parseStructuredDeployment(
   } catch {
     return null;
   }
+}
+
+function isDeploymentControlCommand(
+  content: string,
+  hero: DefenseHero | null,
+): boolean {
+  const trimmed = content.trim();
+  if (parseStructuredDeployment(trimmed)) return true;
+  if (parseExplicitMessage(trimmed)) return true;
+
+  const normalized = normalizeText(trimmed);
+  if (
+    /\b(melee|ranged|mage|top|mid|middle|bot|bottom|recall|heal|base|retreat)\b/.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
+
+  return Boolean(parseAbilityChoice(trimmed, hero));
 }
 
 function parseDeploymentCommand(
@@ -2088,6 +2148,7 @@ export async function handleAppRoutes(ctx: {
       if (normalizedCmd === "autoplay on" || normalizedCmd === "auto play on") {
         const sessionCtx = resolveSessionContext(runtime, sessionId);
         startGameLoop(runtime, sessionCtx);
+        clearCachedSessionState(sessionCtx);
         if (cmdAgentId)
           pushActivity(cmdAgentId, "auto-play-on", "Auto-play enabled");
         const refreshed = await readSessionState(runtime, sessionId);
@@ -2105,7 +2166,9 @@ export async function handleAppRoutes(ctx: {
         normalizedCmd === "autoplay off" ||
         normalizedCmd === "auto play off"
       ) {
+        const sessionCtx = resolveSessionContext(runtime, sessionId);
         stopGameLoop(runtime);
+        clearCachedSessionState(sessionCtx);
         if (cmdAgentId)
           pushActivity(cmdAgentId, "auto-play-off", "Auto-play disabled");
         const refreshed = await readSessionState(runtime, sessionId);
@@ -2166,6 +2229,28 @@ export async function handleAppRoutes(ctx: {
       }
 
       const sessionCtx = resolveSessionContext(runtime, sessionId);
+
+      if (!isDeploymentControlCommand(content, null)) {
+        if (cmdAgentId) {
+          pushActivity(
+            cmdAgentId,
+            "strategy-note",
+            `Strategy note: ${content.slice(0, 120)}`,
+          );
+        }
+        const refreshed =
+          readCachedSessionState(sessionCtx) ??
+          buildCommandOnlySessionState(sessionCtx);
+        ctx.json(
+          ctx.res,
+          okResponse(
+            true,
+            "Strategy note recorded. Use lane, recall, ability, or autoplay commands for direct control.",
+            refreshed,
+          ),
+        );
+        return true;
+      }
 
       // If we have a preferred game, do a single fast fetch to get hero state.
       // If not (first deploy), skip the scan to avoid rate limits — deploy

--- a/apps/app-defense-of-the-agents/src/ui/DefenseAgentsOperatorSurface.tsx
+++ b/apps/app-defense-of-the-agents/src/ui/DefenseAgentsOperatorSurface.tsx
@@ -87,6 +87,9 @@ function cleanDefenseMessage(message: string): string {
   if (message.includes("Too many requests") || message.includes("(429)")) {
     return "Defense controls are rate-limited right now. Try again shortly.";
   }
+  if (message.includes("Failed to fetch game state")) {
+    return "Defense state is temporarily unavailable. Retrying automatically.";
+  }
   if (message.startsWith("Defense control API unavailable")) {
     return "Defense controls are temporarily unavailable.";
   }
@@ -99,7 +102,12 @@ function collectRunEvents(
   localEvents: GameOperatorEvent[],
 ): GameOperatorEvent[] {
   const serverEvents = (run.recentEvents ?? [])
-    .filter((event) => event.kind !== "refresh")
+    .filter(
+      (event) =>
+        event.kind !== "refresh" &&
+        event.kind !== "attach" &&
+        event.kind !== "detach",
+    )
     .map((event) => ({
       id: event.eventId,
       label: event.kind,
@@ -207,11 +215,17 @@ export function DefenseAgentsOperatorSurface({
 
       try {
         const response = await client.sendAppRunMessage(run.runId, trimmed);
+        const persistedSession =
+          response.run?.session ?? response.session ?? null;
         if (response.run) {
           setState("appRuns", replaceRun(appRuns, response.run));
         }
         if (clearDraftOnSuccess) {
           setDraft((current) => (current.trim() === trimmed ? "" : current));
+        }
+        if (persistedSession) {
+          setLocalEvents([]);
+          return;
         }
         setLocalEvents((current) => [
           ...current,

--- a/apps/app-defense-of-the-agents/src/ui/DefenseAgentsOperatorSurface.tsx
+++ b/apps/app-defense-of-the-agents/src/ui/DefenseAgentsOperatorSurface.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useMemo, useState } from "react";
-import { client } from "@elizaos/app-core/api";
+import { client, type AppRunSummary } from "@elizaos/app-core/api";
+import {
+  type GameOperatorAction,
+  type GameOperatorEvent,
+  GameOperatorShell,
+} from "@elizaos/app-core/components/apps/surfaces/GameOperatorShell";
 import type { AppOperatorSurfaceProps } from "@elizaos/app-core/components/apps/surfaces/types";
 import { useApp } from "@elizaos/app-core/state";
-import { Button, Input } from "@elizaos/ui";
+import { useCallback, useMemo, useState } from "react";
 
 const LANES = ["top", "mid", "bot"] as const;
 
@@ -55,22 +59,110 @@ function isRelevantPrompt(prompt: string): boolean {
   );
 }
 
-function statusTone(status: string): string {
-  if (status === "running" || status === "ready") {
-    return "border-ok/30 bg-ok/10 text-ok";
+function statusLabel(status: string): string {
+  if (status === "running" || status === "ready") return "Live";
+  if (status === "degraded" || status === "failed") return "Needs attention";
+  if (status === "respawning") return "Respawning";
+  return "Starting";
+}
+
+function statusTone(status: string): "live" | "attention" | "idle" {
+  if (status === "running" || status === "ready") return "live";
+  if (status === "degraded" || status === "failed") return "attention";
+  return "idle";
+}
+
+function replaceRun(appRuns: AppRunSummary[], nextRun: AppRunSummary) {
+  return [
+    ...appRuns.filter((candidate) => candidate.runId !== nextRun.runId),
+    nextRun,
+  ].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+function localEventId(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function cleanDefenseMessage(message: string): string {
+  if (message.includes("Too many requests") || message.includes("(429)")) {
+    return "Defense controls are rate-limited right now. Try again shortly.";
   }
-  if (status === "degraded" || status === "failed") {
-    return "border-danger/30 bg-danger/10 text-danger";
+  if (message.startsWith("Defense control API unavailable")) {
+    return "Defense controls are temporarily unavailable.";
   }
-  return "border-border/45 bg-bg-hover/70 text-muted-strong";
+  return message;
+}
+
+function collectRunEvents(
+  run: AppRunSummary,
+  telemetry: Record<string, unknown> | null,
+  localEvents: GameOperatorEvent[],
+): GameOperatorEvent[] {
+  const serverEvents = (run.recentEvents ?? [])
+    .filter((event) => event.kind !== "refresh")
+    .map((event) => ({
+      id: event.eventId,
+      label: event.kind,
+      message: cleanDefenseMessage(event.message),
+      tone:
+        event.severity === "error"
+          ? "error"
+          : event.severity === "warning"
+            ? "warning"
+            : "info",
+      timestamp: event.createdAt,
+    })) satisfies GameOperatorEvent[];
+
+  const activityEvents: GameOperatorEvent[] =
+    run.session?.activity?.map((entry) => ({
+      id: entry.id,
+      label: entry.type,
+      message: cleanDefenseMessage(entry.message),
+      tone:
+        entry.severity === "error"
+          ? "error"
+          : entry.severity === "warning"
+            ? "warning"
+            : "info",
+      timestamp: entry.timestamp ?? null,
+    })) ?? [];
+
+  const recentActivity: GameOperatorEvent[] = Array.isArray(
+    telemetry?.recentActivity,
+  )
+    ? (
+        telemetry.recentActivity as Array<{
+          ts?: number;
+          action?: string;
+          detail?: string;
+        }>
+      )
+        .filter(
+          (entry) =>
+            typeof entry.detail === "string" && entry.detail.trim().length > 0,
+        )
+        .map((entry, index) => ({
+          id: `defense-telemetry-${entry.ts ?? index}-${index}`,
+          label: entry.action ?? "game",
+          message: cleanDefenseMessage(entry.detail ?? ""),
+          tone: entry.action === "error" ? "error" : "info",
+          timestamp: entry.ts ?? null,
+        }))
+    : [];
+
+  return [
+    ...serverEvents,
+    ...activityEvents,
+    ...recentActivity,
+    ...localEvents,
+  ];
 }
 
 export function DefenseAgentsOperatorSurface({
   appName,
   variant = "detail",
-  focus = "all",
 }: AppOperatorSurfaceProps) {
-  const { appRuns } = useApp();
+  const { appRuns, setState } = useApp();
   const run = useMemo(
     () =>
       [...(Array.isArray(appRuns) ? appRuns : [])]
@@ -81,7 +173,7 @@ export function DefenseAgentsOperatorSurface({
     [appName, appRuns],
   );
   const [draft, setDraft] = useState("");
-  const [notice, setNotice] = useState<string | null>(null);
+  const [localEvents, setLocalEvents] = useState<GameOperatorEvent[]>([]);
   const [sendingCommand, setSendingCommand] = useState<string | null>(null);
 
   const telemetry =
@@ -92,14 +184,9 @@ export function DefenseAgentsOperatorSurface({
   const heroClass = readString(telemetry, "heroClass") ?? "mage";
   const autoPlay = telemetry?.autoPlay === true;
   const canSend = Boolean(run?.runId && run.session?.canSendCommands);
-  const suggestedPrompts = (run?.session?.suggestedPrompts ?? []).filter(
-    isRelevantPrompt,
-  );
-  const tacticalPrompts = suggestedPrompts.filter(
-    (prompt) => !/^auto[- ]?play/i.test(prompt),
-  );
-  const showDashboard = focus !== "chat";
-  const showChat = focus !== "dashboard";
+  const tacticalPrompts = (run?.session?.suggestedPrompts ?? [])
+    .filter(isRelevantPrompt)
+    .filter((prompt) => !/^auto[- ]?play/i.test(prompt));
 
   const sendCommand = useCallback(
     async (content: string, clearDraftOnSuccess = false) => {
@@ -107,22 +194,59 @@ export function DefenseAgentsOperatorSurface({
       if (!run?.runId || !trimmed || sendingCommand) return;
 
       setSendingCommand(trimmed);
-      setNotice(null);
+      setLocalEvents((current) => [
+        ...current,
+        {
+          id: localEventId("defense-user"),
+          label: "You",
+          message: trimmed,
+          tone: "user",
+          timestamp: Date.now(),
+        },
+      ]);
+
       try {
         const response = await client.sendAppRunMessage(run.runId, trimmed);
+        if (response.run) {
+          setState("appRuns", replaceRun(appRuns, response.run));
+        }
         if (clearDraftOnSuccess) {
           setDraft((current) => (current.trim() === trimmed ? "" : current));
         }
-        setNotice(response.message ?? "Command sent.");
+        setLocalEvents((current) => [
+          ...current,
+          {
+            id: localEventId("defense-game"),
+            label: response.disposition === "queued" ? "Queued" : "Defense",
+            message: response.message ?? "Command accepted.",
+            tone:
+              response.disposition === "accepted"
+                ? "success"
+                : response.disposition === "queued"
+                  ? "info"
+                  : "error",
+            timestamp: Date.now(),
+          },
+        ]);
       } catch (error) {
-        setNotice(
-          error instanceof Error ? error.message : "Defense command failed.",
-        );
+        setLocalEvents((current) => [
+          ...current,
+          {
+            id: localEventId("defense-error"),
+            label: "Error",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Defense command failed.",
+            tone: "error",
+            timestamp: Date.now(),
+          },
+        ]);
       } finally {
         setSendingCommand(null);
       }
     },
-    [run?.runId, sendingCommand],
+    [appRuns, run?.runId, sendingCommand, setState],
   );
 
   if (!run) {
@@ -132,146 +256,76 @@ export function DefenseAgentsOperatorSurface({
         data-testid="defense-operator-empty"
       >
         <div className="rounded-2xl border border-border/35 bg-card/74 p-4 text-xs text-muted-strong">
-          Launch Defense of the Agents to open live controls.
+          Launch Defense of the Agents to open game chat.
         </div>
       </section>
     );
   }
 
+  const primaryActions: GameOperatorAction[] = [
+    {
+      id: "autoplay",
+      label: autoPlay ? "Autoplay on" : "Autoplay off",
+      command: autoPlay ? "Auto-play OFF" : "Auto-play ON",
+      active: autoPlay,
+      testId: "defense-command-autoplay",
+    },
+    {
+      id: "recall",
+      label: "Recall",
+      command: "Recall to base",
+      testId: "defense-command-recall",
+    },
+    ...LANES.map((lane) => ({
+      id: `lane-${lane}`,
+      label: heroLane ? `Move ${lane}` : `Deploy ${lane}`,
+      command: heroLane
+        ? `Move to ${lane} lane`
+        : `Deploy as ${heroClass} in ${lane} lane`,
+      active: heroLane === lane,
+      testId: `defense-command-lane-${lane}`,
+    })),
+  ];
+
+  const suggestedActions = tacticalPrompts.map((prompt) => ({
+    id: prompt,
+    label: prompt,
+    command: prompt,
+    testId: "defense-suggested-command",
+  }));
+
+  const events = collectRunEvents(run, telemetry, localEvents);
+
   return (
-    <section
-      className={`space-y-3 ${variant === "live" ? "p-3" : ""}`}
-      data-testid={
+    <GameOperatorShell
+      surfaceTestId={
         variant === "live"
           ? "defense-live-operator-surface"
           : "defense-detail-operator-surface"
       }
-    >
-      {showDashboard ? (
-        <div className="rounded-2xl border border-border/35 bg-card/74 p-3 shadow-sm">
-          <div className="flex flex-wrap items-center gap-2">
-            <span
-              className={`inline-flex min-h-6 items-center rounded-full border px-2.5 py-1 text-2xs font-medium uppercase tracking-[0.14em] ${statusTone(run.status)}`}
-            >
-              {run.status}
-            </span>
-            <span className="text-xs font-semibold text-txt">
-              {formatHeroLine(telemetry)}
-            </span>
-          </div>
-          {run.session?.summary ? (
-            <div className="mt-2 text-xs leading-5 text-muted-strong">
-              {run.session.summary}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {showDashboard ? (
-        <div className="grid grid-cols-2 gap-2" data-testid="defense-actions">
-          <Button
-            type="button"
-            variant={autoPlay ? "default" : "outline"}
-            size="sm"
-            className="min-h-9 rounded-xl shadow-sm"
-            data-testid="defense-command-autoplay"
-            disabled={!canSend || Boolean(sendingCommand)}
-            onClick={() =>
-              void sendCommand(autoPlay ? "Auto-play OFF" : "Auto-play ON")
-            }
-          >
-            {autoPlay ? "Autoplay On" : "Autoplay Off"}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="min-h-9 rounded-xl shadow-sm"
-            data-testid="defense-command-recall"
-            disabled={!canSend || Boolean(sendingCommand)}
-            onClick={() => void sendCommand("Recall to base")}
-          >
-            Recall
-          </Button>
-          {LANES.map((lane) => {
-            const label = heroLane ? `Move ${lane}` : `Deploy ${lane}`;
-            const command = heroLane
-              ? `Move to ${lane} lane`
-              : `Deploy as ${heroClass} in ${lane} lane`;
-            return (
-              <Button
-                key={lane}
-                type="button"
-                variant={heroLane === lane ? "default" : "outline"}
-                size="sm"
-                className="min-h-9 rounded-xl shadow-sm"
-                data-testid={`defense-command-lane-${lane}`}
-                disabled={!canSend || Boolean(sendingCommand)}
-                onClick={() => void sendCommand(command)}
-              >
-                {label}
-              </Button>
-            );
-          })}
-        </div>
-      ) : null}
-
-      {showChat ? (
-        <div className="rounded-2xl border border-border/35 bg-card/74 p-3 shadow-sm">
-          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
-            <Input
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              placeholder="Command the hero..."
-              className="min-h-10 rounded-xl"
-              data-testid="defense-chat-input"
-              disabled={!canSend}
-              onKeyDown={(event) => {
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  void sendCommand(draft, true);
-                }
-              }}
-            />
-            <Button
-              type="button"
-              className="min-h-10 rounded-xl px-4 shadow-sm"
-              data-testid="defense-chat-send"
-              disabled={!canSend || Boolean(sendingCommand) || !draft.trim()}
-              onClick={() => void sendCommand(draft, true)}
-            >
-              {sendingCommand === draft.trim() ? "Sending" : "Send"}
-            </Button>
-          </div>
-          {tacticalPrompts.length > 0 ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {tacticalPrompts.map((prompt) => (
-                <Button
-                  key={prompt}
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="min-h-8 rounded-xl px-3 shadow-sm"
-                  data-testid="defense-suggested-command"
-                  disabled={!canSend || Boolean(sendingCommand)}
-                  onClick={() => void sendCommand(prompt)}
-                >
-                  {prompt}
-                </Button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {notice ? (
-        <div
-          className="rounded-2xl border border-border/35 bg-card/70 px-4 py-3 text-xs leading-5 text-muted-strong"
-          data-testid="defense-command-notice"
-        >
-          {notice}
-        </div>
-      ) : null}
-    </section>
+      title="Defense command"
+      statusLabel={statusLabel(run.status)}
+      statusTone={statusTone(run.status)}
+      objective={run.session?.goalLabel ?? run.session?.summary ?? run.summary}
+      detailItems={[
+        { label: "Hero", value: formatHeroLine(telemetry) },
+        { label: "Mode", value: autoPlay ? "Autoplay" : "Manual" },
+      ]}
+      primaryActions={primaryActions}
+      suggestedActions={suggestedActions}
+      events={events}
+      emptyEventsLabel="Commands and match events will appear here. Start with a lane move, recall, or a strategy note."
+      draft={draft}
+      inputPlaceholder="Command the hero..."
+      canSend={canSend}
+      sending={Boolean(sendingCommand)}
+      chatInputTestId="defense-chat-input"
+      chatSendTestId="defense-chat-send"
+      noticeTestId="defense-command-notice"
+      variant={variant}
+      onDraftChange={setDraft}
+      onSendDraft={() => void sendCommand(draft, true)}
+      onCommand={(command) => void sendCommand(command)}
+    />
   );
 }

--- a/apps/app-defense-of-the-agents/test/lifecycle.test.ts
+++ b/apps/app-defense-of-the-agents/test/lifecycle.test.ts
@@ -7,10 +7,11 @@
  * runtimes sharing a character name do not cross-pollute their cache slots.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   activeLoops,
   clearAgentRunState,
+  handleAppRoutes,
   recentActivity,
   resetInMemoryStateForTests,
   resolveSessionContext,
@@ -46,6 +47,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   resetInMemoryStateForTests();
 });
 
@@ -153,5 +155,43 @@ describe("clearAgentRunState", () => {
     expect(recentActivity.has(ctxB.agentId ?? "")).toBe(true);
     expect(sessionStateCache.has(sessionCacheKey(ctxA))).toBe(false);
     expect(sessionStateCache.has(sessionCacheKey(ctxB))).toBe(true);
+  });
+});
+
+describe("message commands", () => {
+  it("records strategy notes without deploying a default hero", async () => {
+    const runtime = makeRuntime("agent-strategy", "ElizaStrategy");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const captured: { status: number; body: unknown } = {
+      status: 0,
+      body: null,
+    };
+
+    await handleAppRoutes({
+      method: "POST",
+      pathname: "/api/apps/defense-of-the-agents/session/session-1/message",
+      runtime,
+      res: {},
+      readJsonBody: async () => ({
+        content: "Play defensively and rotate to the weakest lane.",
+      }),
+      json: (_response: unknown, data: unknown, status = 200) => {
+        captured.status = status;
+        captured.body = data;
+      },
+      error: (_response: unknown, message: string, status = 500) => {
+        captured.status = status;
+        captured.body = { error: message };
+      },
+    });
+
+    expect(captured.status).toBe(200);
+    expect(captured.body).toMatchObject({
+      success: true,
+      message:
+        "Strategy note recorded. Use lane, recall, ability, or autoplay commands for direct control.",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/app-lifeops/docs/settings-access-ux.md
+++ b/apps/app-lifeops/docs/settings-access-ux.md
@@ -1,0 +1,510 @@
+# LifeOps Access UX Review
+
+## Scope
+
+This writeup covers the LifeOps setup/access surface after the earlier cleanup requests:
+
+- Remove the macOS permission checklist from Settings.
+- Remove the X post-writing UI and keep only connection state plus actions.
+- Remove stretch reminder setup from Settings.
+- Keep all visible information real, live, and sourced from the existing hooks or API responses.
+- Reduce headers, explanatory copy, repeated labels, and diagnostic panels that make setup feel like an internal console.
+
+The captured setup screenshot showed a single Access page containing account setup, device data, browser companion setup, messaging connectors, sleep and schedule diagnostics, capability diagnostics, and X connection state. The biggest issue is not that any one block is impossible to understand. The issue is that the page mixes user-facing sources with implementation details, which makes the user scan too much text before learning what is connected.
+
+## Target Model
+
+The Access page should behave like a source-health console:
+
+- Each row is a real data source or external account.
+- Each row answers "connected, blocked, loading, or unavailable."
+- Each row exposes the next action only when an action is useful.
+- Details are hidden behind disclosure controls when they are real but secondary.
+- Debugging and derived LifeOps state stay on their domain pages.
+
+This follows a common pattern in Apple Settings, Google Account connected-apps/security pages, Slack and Notion integration settings, Linear's integrations pages, and GitHub account settings: the primary page is a status list with compact actions; implementation details, permissions, scopes, and diagnostics live one click deeper.
+
+## Screenshot Description: Current Setup Page
+
+The current setup screenshot begins with an `Access` heading and two full-width actions: `Run setup again` and `Disable LifeOps`. The page then shows `Accounts`, a large `Device Data` card, two Google account sections for User and Agent, a `Your Browser` panel, a `Messaging` heading with five connector rows, then Sleep and schedule, Capabilities, and X panels.
+
+What is really there:
+
+- `Access`: page-level controls for the LifeOps app.
+- `Run setup again`: reopens the onboarding/setup gate.
+- `Disable LifeOps`: turns off the LifeOps app integration.
+- `Device Data`: platform-level mobile or desktop device-signal availability.
+- `User Google`: owner-side Google OAuth connection, calendar feed selection, and GitHub owner connection.
+- `Agent Google`: agent-side Google OAuth connection, calendar feed selection, and GitHub agent connection.
+- `Your Browser`: browser companion install, pairing, settings, and profile status.
+- `Messaging`: Signal, Discord, WhatsApp, Telegram, and iMessage connector status.
+- `Sleep and schedule`: derived sleep model state and manual sleep overrides.
+- `Capabilities`: internal capability health.
+- `X`: owner and agent X OAuth status.
+
+What is weak:
+
+- The page asks the user to understand internal categories: capabilities, sleep model, browser companion packages, manual pairing, scopes, and calendar-feed side effects.
+- It repeats labels. For example, Google appears under User/Agent, then GitHub appears inside each side, then there is a separate Messaging heading.
+- It exposes empty setup controls. Telegram displayed a phone input even when the user had not chosen to connect it.
+- It makes Settings look like a debug tool. Sleep, schedule, and capability health are useful, but they are not setup primitives.
+- It uses too much explanatory copy on the primary path. Text should appear when the state is degraded, blocked, or expanded.
+
+## Element Review
+
+### Access Header
+
+What it does:
+
+- Names the page and hosts page-level actions.
+- `Run setup again` is a recovery path for users who skipped onboarding or need to reconnect multiple sources.
+- `Disable LifeOps` is the irreversible app-level off switch.
+
+Why it should be there:
+
+- The user needs a stable page-level control for setup recovery and disabling.
+- It is the only place where `Disable LifeOps` belongs because it affects the whole app, not one source.
+
+Does it need to be there:
+
+- Yes, but it should stay compact. It should not explain LifeOps again because the user already chose the LifeOps app.
+
+Alternative approaches:
+
+- A kebab menu could hide `Run setup again` and `Disable LifeOps`, but this makes destructive controls less discoverable.
+- A bottom sticky action area would waste space and compete with mobile navigation.
+
+External patterns:
+
+- Apple Settings keeps destructive app toggles close to the app settings page.
+- Google Account pages keep security/recovery actions visible but visually separated from connected app rows.
+
+Responsive constraints:
+
+- On narrow screens, the two buttons stack full width so text never truncates inside fixed-width controls.
+- On wider screens, they can sit to the right of the page title.
+
+### Device Data
+
+What it does:
+
+- Shows whether device signals are available in the current runtime.
+- On native mobile it can request or refresh permissions.
+- On desktop or web it shows the runtime class, such as Web or Desktop.
+
+Why it should be there:
+
+- Device signals feed sleep, screen time, presence, and context.
+- The status is real and comes from native permission APIs when available.
+
+Does it need to be there:
+
+- Yes, as a source row. It should not show the old macOS permission checklist because that checklist was generic and redundant.
+
+Alternative approaches:
+
+- Move device permissions into global Milady Settings. This is clean for platform permissions, but LifeOps still needs a source health row so users know whether device data is available to LifeOps.
+
+External patterns:
+
+- Apple Privacy settings show permission classes as rows with status, not explanatory setup cards.
+- Android Digital Wellbeing and Screen Time surface device access as an app-level dependency, then put the permission-specific details deeper.
+
+Responsive constraints:
+
+- The row must tolerate no action buttons, one action, or multiple native actions.
+- It should not leave a large empty content area when the platform has nothing to request.
+
+### User Google
+
+What it does:
+
+- Shows the owner-side Google account identity.
+- Lets the user connect, reconnect, add, or disconnect Google.
+- Lets the user choose cloud-managed or local mode.
+- Shows connected account grants and calendar feed inclusion when expanded.
+
+Why it should be there:
+
+- Google is the main source for calendar and Gmail.
+- Owner-side Google is distinct from agent-side Google because the account permissions and automation identity differ.
+
+Does it need to be there:
+
+- Yes. It is one of the core LifeOps sources.
+
+Alternative approaches:
+
+- Combine User and Agent into one `Google` block with tabs. That is cleaner on desktop but worse on mobile because the user would need to switch context to compare owner and agent.
+- Show only one Google row and infer agent access from the owner account. That hides an important authority boundary.
+
+External patterns:
+
+- Google Account's third-party access view separates account identity, app authorization, and permission scope.
+- Slack integration settings show connected identity and workspace-specific action buttons in the same row.
+
+Responsive constraints:
+
+- The mode segmented control must wrap below the identity on mobile.
+- The identity must truncate safely because Google names and emails can be long.
+- Calendar feed selection should be behind a disclosure because it is useful but secondary.
+
+### Agent Google
+
+What it does:
+
+- Shows the agent-side Google account or cloud-agent availability.
+- Uses the same connect/add/disconnect pattern as User Google.
+- Keeps agent authority visually separate from owner authority.
+
+Why it should be there:
+
+- Agent actions may need a separate identity from the user's own Google account.
+- Users need to understand whether LifeOps will act as them or through an agent-owned account.
+
+Does it need to be there:
+
+- Yes, if agent automation can use a distinct Google account.
+
+Alternative approaches:
+
+- Hide Agent Google until the user enables agent-side automation. This reduces first-run complexity but risks confusing users when an automation later fails due to missing agent permissions.
+
+External patterns:
+
+- GitHub and Slack distinguish user tokens from app/bot tokens because they act with different authority.
+- Notion integrations separate personal account identity from workspace integration access.
+
+Responsive constraints:
+
+- It should use the same row grammar as User Google so users compare status quickly.
+- It should not duplicate explanatory text already implied by the row title and status badge.
+
+### GitHub Rows
+
+What they do:
+
+- Show owner and agent GitHub connection identity.
+- Provide connect, reconnect, or disconnect actions.
+
+Why they should be there:
+
+- GitHub is an account source used by LifeOps for developer workflows.
+- It belongs close to User/Agent account identity because it follows the same authority split.
+
+Does it need to be there:
+
+- Yes, while LifeOps exposes GitHub-based workflows.
+
+Alternative approaches:
+
+- Make GitHub a separate top-level row. This is clearer if GitHub becomes a major data source. For now, it is lighter as a sub-row under User/Agent authority.
+
+External patterns:
+
+- GitHub's own OAuth app settings list app identity, scope, and revoke action, with details secondary.
+- Linear and Slack show integration connection state with one primary action.
+
+Responsive constraints:
+
+- The identity must truncate.
+- Action buttons wrap so long labels never collide with the identity.
+
+### Browser Profiles
+
+What it does:
+
+- Shows browser companion status.
+- Lets users refresh status.
+- Lets users expand into connected profiles, install actions, manual pairing, and advanced rules.
+
+Why it should be there:
+
+- Browser context is essential for Discord DMs, screen context, and owner-side web activity.
+- Browser setup is complicated enough to require details, but those details should not be primary page content.
+
+Does it need to be there:
+
+- Yes, but only the status row needs to be visible by default. Install/build/manual pairing details are secondary.
+
+Alternative approaches:
+
+- Move browser companion setup into global Settings and show only a read-only status in LifeOps. That is clean long-term, but LifeOps still needs an immediate repair path when Discord or browser-derived context is blocked.
+- Use a modal wizard for install and pairing. This would be more polished but adds modal complexity and requires state persistence for partially complete installs.
+
+External patterns:
+
+- Chrome Extension settings hide site access and incognito details behind extension-specific pages.
+- Slack and Notion keep integration install details behind a `Manage` or expanded details page.
+
+Responsive constraints:
+
+- The visible row should not include install instructions.
+- Expanded browser profile details should remain one column on mobile.
+- Long local paths must truncate and never stretch the page.
+
+### Signal
+
+What it does:
+
+- Shows Signal linked, pairing, or disconnected state.
+- Starts QR pairing when not connected.
+- Shows the linked phone number only after connection.
+
+Why it should be there:
+
+- Signal is a direct messaging source.
+- QR pairing is the real connection flow, so the QR surface is justified only during pairing.
+
+Does it need to be there:
+
+- Yes, if Signal is supported.
+
+Alternative approaches:
+
+- Hide Signal until its service is available. That reduces noise but makes users wonder why a supported source is absent.
+
+External patterns:
+
+- WhatsApp Web, Signal Desktop, and Telegram Desktop all use a compact status row that expands into QR/code state only during pairing.
+
+Responsive constraints:
+
+- QR images need fixed dimensions so they do not resize the page unpredictably.
+- Buttons should remain reachable below the QR on narrow screens.
+
+### Discord
+
+What it does:
+
+- Shows whether LifeOps can see Discord DMs.
+- Uses browser access state to guide the next action: connect browser, open Discord, open DMs, or log in.
+- Shows visible DM labels only when the DM inbox is visible.
+
+Why it should be there:
+
+- Discord is not just an OAuth connector. It depends on real browser or desktop browser state.
+- The most useful status is whether the DM inbox is visible, not whether a backend connector flag exists.
+
+Does it need to be there:
+
+- Yes, because the social page depends on Discord browser capture.
+
+Alternative approaches:
+
+- Put Discord entirely under the Social page. This is semantically clean, but setup failures would be harder to repair from Access.
+- Use a browser-only `Social capture` row instead of a Discord row. This is scalable if multiple websites share the same capture system, but the user expects Discord-specific status.
+
+External patterns:
+
+- Slack and Discord app settings emphasize workspace/account connection state first, then channel or DM access second.
+- Chrome permission UIs separate extension pairing from site access, which maps well to the current `Your Browser` plus `Discord` split.
+
+Responsive constraints:
+
+- The status label may be long when it includes a next action. It must truncate in the row and keep the action button on the next line if needed.
+- Browser access diagnostics should only appear when DMs are not visible.
+
+### WhatsApp
+
+What it does:
+
+- Shows WhatsApp Business Cloud API configuration state.
+- Opens setup guidance or refreshes status.
+- Shows phone number ID when configured.
+
+Why it should be there:
+
+- WhatsApp is a messaging source, but its setup is API/config driven rather than user OAuth.
+
+Does it need to be there:
+
+- Yes, if WhatsApp is a supported connector. It should not show long inbound/outbound webhook explanations on the primary page.
+
+Alternative approaches:
+
+- Move WhatsApp to a developer/admin settings section. That may be better if the target user is not expected to configure Business Cloud API credentials.
+
+External patterns:
+
+- Meta Business settings expose phone number ID, webhook health, and action buttons but keep setup docs linked out.
+
+Responsive constraints:
+
+- Phone number ID is long and must wrap or truncate.
+- The setup guide button should be the only primary call to action when disconnected.
+
+### Telegram
+
+What it does:
+
+- Shows Telegram connection/auth state.
+- Starts login only after the user clicks Connect.
+- Shows phone/code/password fields only during the active login flow.
+
+Why it should be there:
+
+- Telegram is a messaging source, but the phone number field is sensitive and visually heavy.
+- A blank phone input should not be visible until the user intentionally starts the flow.
+
+Does it need to be there:
+
+- Yes, but the field-level flow should be progressive.
+
+Alternative approaches:
+
+- Use a modal login wizard. This would be cleaner if Telegram auth grows more steps.
+- Put Telegram login in a separate detail page. That is more scalable but adds navigation overhead for a short flow.
+
+External patterns:
+
+- Telegram Desktop and WhatsApp Web start with one connect action, then reveal QR/code entry only while pairing.
+- Google and Slack OAuth flows do not show credential-like inputs until the user begins authentication.
+
+Responsive constraints:
+
+- Phone/code/password fields and action buttons must wrap vertically on mobile.
+- The status row should remain compact before Connect is clicked.
+
+### iMessage
+
+What it does:
+
+- Shows iMessage bridge availability.
+- Offers local Mac setup actions when possible.
+- Shows degraded send path and full disk access controls only when relevant.
+
+Why it should be there:
+
+- iMessage is a high-value local-first source, but its backend availability is platform-dependent.
+
+Does it need to be there:
+
+- Yes, because users need to know whether the local bridge is available.
+
+Alternative approaches:
+
+- Move detailed BlueBubbles/imsg setup to a platform-specific settings page and leave only a status row in Access.
+- Use a wizard for Mac setup. That is better long-term but unnecessary for the current cleanup.
+
+External patterns:
+
+- Apple Continuity, Messages forwarding, and device handoff settings show device availability as concise rows, with error details only when blocked.
+
+Responsive constraints:
+
+- Setup buttons must wrap.
+- Diagnostics should be shown only when they are actionable.
+- Local file paths and implementation labels should not appear unless expanded or needed for troubleshooting.
+
+### X
+
+What it does:
+
+- Shows owner and agent X connection state.
+- Provides connect/reconnect actions.
+- Shows pending auth link and errors when present.
+
+Why it should be there:
+
+- X is an account source. The user asked to remove post writing and keep only connection/status.
+
+Does it need to be there:
+
+- Yes, while X is a supported account connector. The composer does not belong in Settings.
+
+Alternative approaches:
+
+- Move X into Social setup. That is reasonable if X is only used by the Social page.
+- Keep it in Access as an account source. This is better while setup is centralized.
+
+External patterns:
+
+- Twitter/X developer and OAuth app settings show connected identity and revoke/reconnect actions, not posting UI.
+- Slack and Notion integration pages keep content creation out of integration settings.
+
+Responsive constraints:
+
+- Owner and Agent boxes should stack on mobile and sit side-by-side on wider screens.
+- Scope/provider badges are not needed on the primary surface.
+
+### Removed Sleep And Capability Panels
+
+What they did:
+
+- Sleep and schedule showed derived sleep state, awake probability, baselines, manual overrides, rule firings, and observations.
+- Capabilities showed internal capability health.
+
+Why they were removed from Access:
+
+- They are not connection sources.
+- They are dense derived data, better suited to the Sleep page or developer diagnostics.
+- Showing them in setup made Access feel unreliable because loading diagnostics appeared before the user had any connected sources.
+
+Where they should live:
+
+- Sleep history, cycles, baselines, sources, rule firings, and manual overrides belong on the Sleep page.
+- Capability health should either become an internal diagnostics detail or a compact source health summary only when it blocks user-facing features.
+
+Alternative approaches:
+
+- Keep one `Diagnostics` disclosure on Access. This is defensible for debug builds but should not be default production UX.
+
+External patterns:
+
+- Apple Health and Screen Time put models, history, and charts on their domain pages, not in account setup.
+- Linear and GitHub status pages expose service health separately from integration setup.
+
+Responsive constraints:
+
+- Removing these panels reduces vertical scroll and keeps Access usable in the current split workspace with bottom navigation and optional chat pane.
+
+## Dashboard And Other Section Guidance
+
+The same source-health principle should extend beyond setup:
+
+- Dashboard should start with live outcomes: today, next event, unread urgent threads, sleep state, screen time anomaly, reminders due. It should not explain LifeOps.
+- Sleep should show history first: timeline, episodes, cycles, wake/bed trends, contributing evidence, and all observations. Raw rules should be expandable.
+- Social should present browser/app/screen-time capture as a pipeline: source availability, last capture, account/session, and visible conversations. It should not rely on placeholder social data.
+- Messages and email should be threaded. The primary object should be a conversation or email chain, not individual messages.
+- Calendar should support direct manipulation: click to inspect, right-click/context menu to edit, duplicate, delete, convert to reminder, or open source calendar. The editor modal must close reliably.
+- Reminders can be integrated into Calendar if they are time-bound. Use a distinct color/key and a filter. Untimed reminders need a lightweight list or agenda lane.
+
+## Responsive System
+
+Breakpoints:
+
+- Mobile: one column. Source rows stack; controls wrap below identities; no fixed two-column subpanels.
+- Tablet: account rows can become two columns if both columns have stable minimum widths.
+- Desktop: the page can use two columns for comparable sources, but details should remain collapsed by default.
+- Split workspace/chat: the page must still fit when the chat pane is open and the content width is closer to tablet than desktop.
+
+Rules:
+
+- No primary surface should depend on a long paragraph.
+- Status labels must truncate, not resize buttons.
+- Long account identities, handles, local paths, phone IDs, calendar IDs, and browser profile labels must truncate or wrap inside the row.
+- Empty states should be compact and action-oriented.
+- Error text should appear only where it affects the source.
+
+## Implementation Decisions
+
+Implemented high-confidence changes:
+
+- Access no longer renders Sleep and schedule or Capabilities panels.
+- Browser companion setup is collapsed behind `Browser profiles`; the visible row shows real status and refresh.
+- Google User and Agent were restyled as compact account rows with status badges, identity, mode, actions, and collapsed calendar feed controls.
+- The redundant `Accounts` and `Messaging` headings were removed.
+- Messaging connectors now render as compact source rows.
+- Telegram no longer shows a phone input until the user clicks Connect.
+- Telegram test-send verification UI was removed from the primary setup surface.
+- WhatsApp and iMessage primary copy was reduced to real status and actions.
+- X was reduced to connection/status and actions, with scope/provider badges removed from the primary surface.
+
+Remaining recommended work:
+
+- Add a first-screen dashboard redesign around live outcome cards and source health.
+- Move sleep diagnostics into a richer Sleep history page.
+- Convert messages and mail into thread-first views.
+- Add calendar event context menus and repair the event editor close path.
+- Decide whether Reminders belongs as a Calendar lane, a separate section, or both.

--- a/apps/app-lifeops/src/components/BrowserBridgeSetupPanel.tsx
+++ b/apps/app-lifeops/src/components/BrowserBridgeSetupPanel.tsx
@@ -462,14 +462,10 @@ function BrowserCompanionRow({
     localWorkspaceAvailable,
   );
   const hasLocalArtifact = Boolean(buildPath || packagePath || appPath);
-  const installLabel = installButtonLabel(
-    browser,
-    releaseManifest,
-    {
-      hasLocalArtifact,
-      localWorkspaceAvailable,
-    },
-  );
+  const installLabel = installButtonLabel(browser, releaseManifest, {
+    hasLocalArtifact,
+    localWorkspaceAvailable,
+  });
   const buildBadgeLabel = buildStateBadgeLabel(
     hasLocalArtifact,
     localWorkspaceAvailable,
@@ -1127,7 +1123,9 @@ export function BrowserBridgeSetupPanel() {
       ) {
         navigatePreOpenedWindow(preOpenWindow(), CHROME_EXTENSIONS_URL);
         if (!options?.silent) {
-          setStatusMessage("Opened chrome://extensions/ in this browser profile.");
+          setStatusMessage(
+            "Opened chrome://extensions/ in this browser profile.",
+          );
         }
         setError(null);
         return true;
@@ -1195,15 +1193,18 @@ export function BrowserBridgeSetupPanel() {
           const folderResult = await openPackageTarget("chrome_build", true, {
             silent: true,
           });
-          const managerOpened = preOpenedChromeManager
-            ? (navigatePreOpenedWindow(
-                preOpenedChromeManager,
-                CHROME_EXTENSIONS_URL,
-              ),
-              true)
-            : await openBrowserManager("chrome", {
-                silent: true,
-              });
+          let managerOpened: boolean;
+          if (preOpenedChromeManager) {
+            navigatePreOpenedWindow(
+              preOpenedChromeManager,
+              CHROME_EXTENSIONS_URL,
+            );
+            managerOpened = true;
+          } else {
+            managerOpened = await openBrowserManager("chrome", {
+              silent: true,
+            });
+          }
           setStatusMessage(
             managerOpened
               ? folderResult.opened
@@ -1288,16 +1289,21 @@ export function BrowserBridgeSetupPanel() {
             </div>
           </div>
         </div>
-        <Button
-          size="sm"
-          variant="outline"
-          className="h-8 rounded-xl px-3 text-xs font-semibold"
-          disabled={loading}
-          onClick={() => void refresh({ preserveDraft: true })}
-        >
-          <RefreshCw className="mr-1.5 h-3 w-3" />
-          Refresh
-        </Button>
+        <div className="flex items-center gap-2">
+          <Badge variant={connectionSummary.badgeVariant}>
+            {connectionSummary.badge}
+          </Badge>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            disabled={loading}
+            onClick={() => void refresh({ preserveDraft: true })}
+          >
+            <RefreshCw className="mr-1.5 h-3 w-3" />
+            Refresh
+          </Button>
+        </div>
       </div>
       {statusMessage ? (
         <div className="rounded-2xl bg-card/22 px-3 py-2 text-xs text-txt">
@@ -1310,185 +1316,197 @@ export function BrowserBridgeSetupPanel() {
         </div>
       ) : null}
 
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-        <div className="space-y-4">
-          <div className="rounded-3xl border border-border/18 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_94%,transparent),color-mix(in_srgb,var(--bg)_98%,transparent))] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="space-y-1">
-                <div className="text-sm font-semibold text-txt">
-                  {connectionSummary.title}
-                </div>
-                <div className="max-w-xl text-xs leading-relaxed text-muted">
-                  {connectionSummary.detail}
-                </div>
-              </div>
-              <Badge variant={connectionSummary.badgeVariant}>
-                {connectionSummary.badge}
-              </Badge>
-            </div>
+      <details className="rounded-2xl border border-border/18 bg-card/12 px-4 py-3">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-txt">
+          <span>Browser profiles</span>
+          <span className="text-xs font-medium text-muted">
+            {connectedCompanions.length}/{companions.length}
+          </span>
+        </summary>
 
-            {connectionSummary.steps.length > 0 ? (
-              <div className="mt-4 grid gap-2">
-                {connectionSummary.steps.map((step) => (
-                  <div
-                    key={step}
-                    className="rounded-2xl bg-card/20 px-3 py-2 text-xs text-muted"
-                  >
-                    {step}
+        <div className="mt-4 grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="space-y-4">
+            <div className="rounded-3xl border border-border/18 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_94%,transparent),color-mix(in_srgb,var(--bg)_98%,transparent))] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <div className="text-sm font-semibold text-txt">
+                    {connectionSummary.title}
                   </div>
-                ))}
-              </div>
-            ) : null}
-
-            {primaryCompanion ? (
-              <div className="mt-4 rounded-2xl bg-card/20 px-3 py-2 text-xs text-muted">
-                Primary browser:{" "}
-                <span className="font-semibold text-txt">
-                  {primaryCompanion.browser === "safari" ? "Safari" : "Chrome"}{" "}
-                  / {primaryCompanion.profileLabel}
-                </span>
-                {" • "}
-                {permissionSummary(primaryCompanion.permissions)}
-              </div>
-            ) : null}
-
-            {isElectrobunRuntime() ? (
-              <div className="mt-4">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl px-3 text-xs font-semibold"
-                  onClick={() => void openDesktopBrowser()}
-                >
-                  <Monitor className="mr-1.5 h-3 w-3" />
-                  Open Milady Desktop Browser
-                </Button>
-              </div>
-            ) : null}
-          </div>
-
-          <div className="space-y-2">
-            <div className="text-sm font-semibold text-txt">
-              Connected Browsers
-            </div>
-            {companions.length > 0 ? (
-              <div className="grid gap-2">
-                {companions.map((companion) => (
-                  <div
-                    key={companion.id}
-                    className="rounded-2xl bg-card/16 px-3 py-3 text-xs"
-                  >
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant="outline" className="text-2xs">
-                        {companion.browser}/{companion.profileLabel}
-                      </Badge>
-                      <Badge variant="secondary" className="text-2xs">
-                        {companion.connectionState}
-                      </Badge>
-                      <span className="text-muted">
-                        {formatTimestamp(companion.lastSeenAt) ?? "Never seen"}
-                      </span>
-                    </div>
-                    <div className="mt-1 text-muted">
-                      {permissionSummary(companion.permissions)}
-                    </div>
+                  <div className="max-w-xl text-xs leading-relaxed text-muted">
+                    {connectionSummary.detail}
                   </div>
-                ))}
+                </div>
+                <Badge variant={connectionSummary.badgeVariant}>
+                  {connectionSummary.badge}
+                </Badge>
               </div>
-            ) : (
-              <div className="rounded-2xl bg-card/14 px-3 py-3 text-xs text-muted">
-                No browser profiles have connected yet. After installing the
-                extension, open its popup once in the browser profile you want
-                LifeOps to use.
-              </div>
-            )}
-          </div>
-        </div>
 
-        <div className="space-y-3">
-          <div className="text-sm font-semibold text-txt">
-            Connect a Browser
-          </div>
-          <BrowserCompanionRow
-            currentBrowser={currentBrowser}
-            browser="chrome"
-            buildPath={packageStatus?.chromeBuildPath}
-            packagePath={packageStatus?.chromePackagePath}
-            localWorkspaceAvailable={Boolean(packageStatus?.extensionPath)}
-            releaseManifest={packageStatus?.releaseManifest ?? null}
-            busy={
-              buildingBrowser === "chrome" ||
-              pairingBrowser === "chrome" ||
-              installingBrowser === "chrome"
-            }
-            pairing={pairings.chrome ?? null}
-            onInstall={installCompanion}
-            onBuild={buildPackage}
-            onCreatePairing={createPairing}
-            onCopyPairing={copyPairing}
-            onDownload={downloadPackage}
-            onOpenTarget={openPackageTarget}
-            onOpenManager={openBrowserManager}
-          />
-          <BrowserCompanionRow
-            currentBrowser={currentBrowser}
-            browser="safari"
-            buildPath={packageStatus?.safariWebExtensionPath}
-            packagePath={packageStatus?.safariPackagePath}
-            appPath={packageStatus?.safariAppPath}
-            localWorkspaceAvailable={Boolean(packageStatus?.extensionPath)}
-            releaseManifest={packageStatus?.releaseManifest ?? null}
-            busy={
-              buildingBrowser === "safari" ||
-              pairingBrowser === "safari" ||
-              installingBrowser === "safari"
-            }
-            pairing={pairings.safari ?? null}
-            onInstall={installCompanion}
-            onBuild={buildPackage}
-            onCreatePairing={createPairing}
-            onCopyPairing={copyPairing}
-            onDownload={downloadPackage}
-            onOpenTarget={openPackageTarget}
-            onOpenManager={openBrowserManager}
-          />
+              {connectionSummary.steps.length > 0 ? (
+                <div className="mt-4 grid gap-2">
+                  {connectionSummary.steps.map((step) => (
+                    <div
+                      key={step}
+                      className="rounded-2xl bg-card/20 px-3 py-2 text-xs text-muted"
+                    >
+                      {step}
+                    </div>
+                  ))}
+                </div>
+              ) : null}
 
-          {(["chrome", "safari"] as const).map((browser) => {
-            const payload = pairingPayloads[browser];
-            if (!payload) {
-              return null;
-            }
-            return (
-              <div key={browser} className="space-y-1">
-                <div className="flex items-center justify-between gap-2">
-                  <span className="text-xs font-semibold text-txt">
-                    {browser === "chrome" ? "Chrome" : "Safari"} pairing
+              {primaryCompanion ? (
+                <div className="mt-4 rounded-2xl bg-card/20 px-3 py-2 text-xs text-muted">
+                  Primary browser:{" "}
+                  <span className="font-semibold text-txt">
+                    {primaryCompanion.browser === "safari"
+                      ? "Safari"
+                      : "Chrome"}{" "}
+                    / {primaryCompanion.profileLabel}
                   </span>
+                  {" • "}
+                  {permissionSummary(primaryCompanion.permissions)}
+                </div>
+              ) : null}
+
+              {isElectrobunRuntime() ? (
+                <div className="mt-4">
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => void copyPairing(browser)}
+                    className="h-8 rounded-xl px-3 text-xs font-semibold"
+                    onClick={() => void openDesktopBrowser()}
                   >
-                    <Copy className="mr-1.5 h-3 w-3" />
-                    Copy
+                    <Monitor className="mr-1.5 h-3 w-3" />
+                    Open Milady Desktop Browser
                   </Button>
                 </div>
-                <Textarea
-                  readOnly
-                  rows={5}
-                  value={payload}
-                  className="font-mono text-xs"
-                />
-                <div className="text-[11px] text-muted">
-                  Manual fallback only. Automatic pairing should work as soon as
-                  the extension popup can see this app in the same browser
-                  profile.
-                </div>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <div className="text-sm font-semibold text-txt">
+                Connected Browsers
               </div>
-            );
-          })}
+              {companions.length > 0 ? (
+                <div className="grid gap-2">
+                  {companions.map((companion) => (
+                    <div
+                      key={companion.id}
+                      className="rounded-2xl bg-card/16 px-3 py-3 text-xs"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant="outline" className="text-2xs">
+                          {companion.browser}/{companion.profileLabel}
+                        </Badge>
+                        <Badge variant="secondary" className="text-2xs">
+                          {companion.connectionState}
+                        </Badge>
+                        <span className="text-muted">
+                          {formatTimestamp(companion.lastSeenAt) ??
+                            "Never seen"}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-muted">
+                        {permissionSummary(companion.permissions)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-2xl bg-card/14 px-3 py-3 text-xs text-muted">
+                  No browser profiles have connected yet. After installing the
+                  extension, open its popup once in the browser profile you want
+                  LifeOps to use.
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <div className="text-sm font-semibold text-txt">
+              Connect a Browser
+            </div>
+            <BrowserCompanionRow
+              currentBrowser={currentBrowser}
+              browser="chrome"
+              buildPath={packageStatus?.chromeBuildPath}
+              packagePath={packageStatus?.chromePackagePath}
+              localWorkspaceAvailable={Boolean(packageStatus?.extensionPath)}
+              releaseManifest={packageStatus?.releaseManifest ?? null}
+              busy={
+                buildingBrowser === "chrome" ||
+                pairingBrowser === "chrome" ||
+                installingBrowser === "chrome"
+              }
+              pairing={pairings.chrome ?? null}
+              onInstall={installCompanion}
+              onBuild={buildPackage}
+              onCreatePairing={createPairing}
+              onCopyPairing={copyPairing}
+              onDownload={downloadPackage}
+              onOpenTarget={openPackageTarget}
+              onOpenManager={openBrowserManager}
+            />
+            <BrowserCompanionRow
+              currentBrowser={currentBrowser}
+              browser="safari"
+              buildPath={packageStatus?.safariWebExtensionPath}
+              packagePath={packageStatus?.safariPackagePath}
+              appPath={packageStatus?.safariAppPath}
+              localWorkspaceAvailable={Boolean(packageStatus?.extensionPath)}
+              releaseManifest={packageStatus?.releaseManifest ?? null}
+              busy={
+                buildingBrowser === "safari" ||
+                pairingBrowser === "safari" ||
+                installingBrowser === "safari"
+              }
+              pairing={pairings.safari ?? null}
+              onInstall={installCompanion}
+              onBuild={buildPackage}
+              onCreatePairing={createPairing}
+              onCopyPairing={copyPairing}
+              onDownload={downloadPackage}
+              onOpenTarget={openPackageTarget}
+              onOpenManager={openBrowserManager}
+            />
+
+            {(["chrome", "safari"] as const).map((browser) => {
+              const payload = pairingPayloads[browser];
+              if (!payload) {
+                return null;
+              }
+              return (
+                <div key={browser} className="space-y-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold text-txt">
+                      {browser === "chrome" ? "Chrome" : "Safari"} pairing
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void copyPairing(browser)}
+                    >
+                      <Copy className="mr-1.5 h-3 w-3" />
+                      Copy
+                    </Button>
+                  </div>
+                  <Textarea
+                    readOnly
+                    rows={5}
+                    value={payload}
+                    className="font-mono text-xs"
+                  />
+                  <div className="text-[11px] text-muted">
+                    Manual fallback only. Automatic pairing should work as soon
+                    as the extension popup can see this app in the same browser
+                    profile.
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      </details>
 
       <details className="rounded-3xl border border-border/18 bg-card/12 px-5 py-4">
         <summary className="cursor-pointer list-none text-sm font-semibold text-txt">

--- a/apps/app-lifeops/src/components/BrowserBridgeSetupPanel.tsx
+++ b/apps/app-lifeops/src/components/BrowserBridgeSetupPanel.tsx
@@ -388,6 +388,53 @@ function buildStateBadgeLabel(
   return "Download";
 }
 
+function BridgeDot({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: "ok" | "warning" | "muted";
+}) {
+  const className =
+    tone === "ok"
+      ? "bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]"
+      : tone === "warning"
+        ? "bg-amber-500 shadow-[0_0_0_3px_rgba(245,158,11,0.14)]"
+        : "bg-muted/45";
+  return (
+    <span
+      aria-label={label}
+      className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${className}`}
+      role="img"
+      title={label}
+    />
+  );
+}
+
+function BridgeMeter({
+  connected,
+  total,
+}: {
+  connected: number;
+  total: number;
+}) {
+  const safeTotal = Math.max(total, 0);
+  const width =
+    safeTotal > 0
+      ? `${(Math.min(Math.max(connected, 0), safeTotal) / safeTotal) * 100}%`
+      : "0%";
+  return (
+    <span
+      aria-label={`${connected}/${total} browser profiles connected`}
+      className="inline-flex h-1.5 w-16 overflow-hidden rounded-full bg-bg/70"
+      role="img"
+      title={`${connected}/${total} browser profiles connected`}
+    >
+      <span className="h-full rounded-full bg-emerald-500" style={{ width }} />
+    </span>
+  );
+}
+
 function installHint(
   browser: BrowserBridgeKind,
   currentBrowser: BrowserBridgeKind | null,
@@ -887,6 +934,12 @@ export function BrowserBridgeSetupPanel() {
       ],
     };
   }, [companions.length, connectedCompanions.length, draft]);
+  const connectionTone =
+    connectionSummary.badgeVariant === "default"
+      ? "ok"
+      : connectionSummary.badgeVariant === "secondary"
+        ? "warning"
+        : "muted";
 
   const updateDraft = <K extends keyof SettingsDraft>(
     key: K,
@@ -1279,29 +1332,22 @@ export function BrowserBridgeSetupPanel() {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-start gap-2 text-muted">
-          <ShieldCheck className="mt-0.5 h-4 w-4" />
-          <div>
-            <div className="text-sm font-semibold text-txt">Your Browser</div>
-            <div className="text-xs text-muted">
-              Connect a real Chrome or Safari profile, or use Milady Desktop
-              Browser when you want built-in browser access.
-            </div>
-          </div>
+        <div className="flex items-center gap-2 text-muted">
+          <ShieldCheck className="h-4 w-4" aria-hidden />
+          <div className="text-sm font-semibold text-txt">Your Browser</div>
+          <BridgeDot label={connectionSummary.badge} tone={connectionTone} />
         </div>
         <div className="flex items-center gap-2">
-          <Badge variant={connectionSummary.badgeVariant}>
-            {connectionSummary.badge}
-          </Badge>
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={loading}
             onClick={() => void refresh({ preserveDraft: true })}
+            title="Refresh"
+            aria-label="Refresh"
           >
-            <RefreshCw className="mr-1.5 h-3 w-3" />
-            Refresh
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       </div>
@@ -1310,22 +1356,23 @@ export function BrowserBridgeSetupPanel() {
           {statusMessage}
         </div>
       ) : null}
-      {error ? (
-        <div className="rounded-2xl bg-danger/10 px-3 py-1.5 text-xs text-danger">
-          {error}
-        </div>
-      ) : null}
 
       <details className="rounded-2xl border border-border/18 bg-card/12 px-4 py-3">
         <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold text-txt">
           <span>Browser profiles</span>
-          <span className="text-xs font-medium text-muted">
-            {connectedCompanions.length}/{companions.length}
-          </span>
+          <BridgeMeter
+            connected={connectedCompanions.length}
+            total={companions.length}
+          />
         </summary>
 
         <div className="mt-4 grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
           <div className="space-y-4">
+            {error ? (
+              <div className="rounded-2xl bg-danger/10 px-3 py-1.5 text-xs text-danger">
+                {error}
+              </div>
+            ) : null}
             <div className="rounded-3xl border border-border/18 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_94%,transparent),color-mix(in_srgb,var(--bg)_98%,transparent))] px-5 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="space-y-1">
@@ -1506,238 +1553,244 @@ export function BrowserBridgeSetupPanel() {
             })}
           </div>
         </div>
-      </details>
 
-      <details className="rounded-3xl border border-border/18 bg-card/12 px-5 py-4">
-        <summary className="cursor-pointer list-none text-sm font-semibold text-txt">
-          Advanced Browser Rules
-        </summary>
-        <div className="mt-4 space-y-4">
-          {draft ? (
-            <>
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-xs text-muted">
-                  These settings control what LifeOps is allowed to see or
-                  automate in Your Browser.
-                </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-8 rounded-xl px-3 text-xs font-semibold"
-                  disabled={savingSettings || loading}
-                  onClick={() => void saveSettings()}
-                >
-                  {savingSettings ? "Saving..." : "Save"}
-                </Button>
-              </div>
-
-              <div className="divide-y divide-border/18">
-                <BrowserSettingRow
-                  checked={draft.enabled}
-                  hint="Master switch for owner-side browser visibility."
-                  label="Enabled"
-                  onCheckedChange={(checked) => updateDraft("enabled", checked)}
-                />
-                <BrowserSettingRow
-                  checked={draft.allowBrowserControl}
-                  hint="Required if LifeOps should open Discord, switch tabs, or navigate for you."
-                  label="Browser control"
-                  onCheckedChange={(checked) =>
-                    updateDraft("allowBrowserControl", checked)
-                  }
-                />
-                <BrowserSettingRow
-                  checked={draft.requireConfirmationForAccountAffecting}
-                  hint="Ask before actions that could change accounts or submit data."
-                  label="Require confirmation"
-                  onCheckedChange={(checked) =>
-                    updateDraft(
-                      "requireConfirmationForAccountAffecting",
-                      checked,
-                    )
-                  }
-                />
-                <BrowserSettingRow
-                  checked={draft.incognitoEnabled}
-                  hint="Include incognito windows when the browser has granted that permission."
-                  label="Incognito"
-                  onCheckedChange={(checked) =>
-                    updateDraft("incognitoEnabled", checked)
-                  }
-                />
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted">Tracking</Label>
-                  <div className="text-[11px] text-muted">
-                    Choose whether LifeOps sees only the current tab or multiple
-                    active tabs.
+        <details className="mt-4 rounded-2xl border border-border/18 bg-card/12 px-4 py-3">
+          <summary className="cursor-pointer list-none text-sm font-semibold text-txt">
+            Advanced Browser Rules
+          </summary>
+          <div className="mt-4 space-y-4">
+            {draft ? (
+              <>
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-xs text-muted">
+                    These settings control what LifeOps is allowed to see or
+                    automate in Your Browser.
                   </div>
-                  <SegmentedControl<BrowserBridgeTrackingMode>
-                    value={draft.trackingMode}
-                    onValueChange={(mode) => updateDraft("trackingMode", mode)}
-                    items={(["off", "current_tab", "active_tabs"] as const).map(
-                      (mode) => ({
-                        value: mode,
-                        label: trackingModeLabel(mode),
-                      }),
-                    )}
-                    className="w-full max-w-full border-border/28 bg-transparent p-0.5"
-                    buttonClassName="min-h-8 flex-1 justify-center px-2.5 py-1.5 text-xs"
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label className="text-xs text-muted">Site access</Label>
-                  <div className="text-[11px] text-muted">
-                    Restrict LifeOps to the current site, an allow-list, or all
-                    sites.
-                  </div>
-                  <SegmentedControl<BrowserBridgeSiteAccessMode>
-                    value={draft.siteAccessMode}
-                    onValueChange={(mode) =>
-                      updateDraft("siteAccessMode", mode)
-                    }
-                    items={BROWSER_BRIDGE_SITE_ACCESS_MODES.map((mode) => ({
-                      value: mode,
-                      label: siteAccessModeLabel(mode),
-                    }))}
-                    className="w-full max-w-full border-border/28 bg-transparent p-0.5"
-                    buttonClassName="min-h-8 flex-1 justify-center px-2.5 py-1.5 text-xs"
-                  />
-                </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1">
-                  <Label
-                    htmlFor="browser-bridge-max-tabs"
-                    className="text-xs text-muted"
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-xl px-3 text-xs font-semibold"
+                    disabled={savingSettings || loading}
+                    onClick={() => void saveSettings()}
                   >
-                    Max remembered tabs
-                  </Label>
-                  <div className="text-[11px] text-muted">
-                    Controls how much recent browser context LifeOps keeps
-                    around.
-                  </div>
-                  <Input
-                    id="browser-bridge-max-tabs"
-                    value={draft.maxRememberedTabs}
-                    onChange={(event) =>
+                    {savingSettings ? "Saving..." : "Save"}
+                  </Button>
+                </div>
+
+                <div className="divide-y divide-border/18">
+                  <BrowserSettingRow
+                    checked={draft.enabled}
+                    hint="Master switch for owner-side browser visibility."
+                    label="Enabled"
+                    onCheckedChange={(checked) =>
+                      updateDraft("enabled", checked)
+                    }
+                  />
+                  <BrowserSettingRow
+                    checked={draft.allowBrowserControl}
+                    hint="Required if LifeOps should open Discord, switch tabs, or navigate for you."
+                    label="Browser control"
+                    onCheckedChange={(checked) =>
+                      updateDraft("allowBrowserControl", checked)
+                    }
+                  />
+                  <BrowserSettingRow
+                    checked={draft.requireConfirmationForAccountAffecting}
+                    hint="Ask before actions that could change accounts or submit data."
+                    label="Require confirmation"
+                    onCheckedChange={(checked) =>
                       updateDraft(
-                        "maxRememberedTabs",
-                        event.currentTarget.value,
+                        "requireConfirmationForAccountAffecting",
+                        checked,
                       )
                     }
-                    inputMode="numeric"
+                  />
+                  <BrowserSettingRow
+                    checked={draft.incognitoEnabled}
+                    hint="Include incognito windows when the browser has granted that permission."
+                    label="Incognito"
+                    onCheckedChange={(checked) =>
+                      updateDraft("incognitoEnabled", checked)
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label
-                    htmlFor="browser-bridge-pause-until"
-                    className="text-xs text-muted"
-                  >
-                    Pause until
-                  </Label>
-                  <div className="text-[11px] text-muted">
-                    Temporarily stop browser visibility without disconnecting
-                    your paired browser.
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <Label className="text-xs text-muted">Tracking</Label>
+                    <div className="text-[11px] text-muted">
+                      Choose whether LifeOps sees only the current tab or
+                      multiple active tabs.
+                    </div>
+                    <SegmentedControl<BrowserBridgeTrackingMode>
+                      value={draft.trackingMode}
+                      onValueChange={(mode) =>
+                        updateDraft("trackingMode", mode)
+                      }
+                      items={(
+                        ["off", "current_tab", "active_tabs"] as const
+                      ).map((mode) => ({
+                        value: mode,
+                        label: trackingModeLabel(mode),
+                      }))}
+                      className="w-full max-w-full border-border/28 bg-transparent p-0.5"
+                      buttonClassName="min-h-8 flex-1 justify-center px-2.5 py-1.5 text-xs"
+                    />
                   </div>
-                  <div className="flex flex-wrap gap-1.5 sm:flex-nowrap">
+                  <div className="space-y-1">
+                    <Label className="text-xs text-muted">Site access</Label>
+                    <div className="text-[11px] text-muted">
+                      Restrict LifeOps to the current site, an allow-list, or
+                      all sites.
+                    </div>
+                    <SegmentedControl<BrowserBridgeSiteAccessMode>
+                      value={draft.siteAccessMode}
+                      onValueChange={(mode) =>
+                        updateDraft("siteAccessMode", mode)
+                      }
+                      items={BROWSER_BRIDGE_SITE_ACCESS_MODES.map((mode) => ({
+                        value: mode,
+                        label: siteAccessModeLabel(mode),
+                      }))}
+                      className="w-full max-w-full border-border/28 bg-transparent p-0.5"
+                      buttonClassName="min-h-8 flex-1 justify-center px-2.5 py-1.5 text-xs"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="browser-bridge-max-tabs"
+                      className="text-xs text-muted"
+                    >
+                      Max remembered tabs
+                    </Label>
+                    <div className="text-[11px] text-muted">
+                      Controls how much recent browser context LifeOps keeps
+                      around.
+                    </div>
                     <Input
-                      id="browser-bridge-pause-until"
-                      type="datetime-local"
-                      value={draft.pauseUntilLocal}
+                      id="browser-bridge-max-tabs"
+                      value={draft.maxRememberedTabs}
                       onChange={(event) =>
                         updateDraft(
-                          "pauseUntilLocal",
+                          "maxRememberedTabs",
                           event.currentTarget.value,
                         )
                       }
-                      className="min-w-0 flex-1"
+                      inputMode="numeric"
                     />
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-9 rounded-xl px-3 text-xs font-semibold"
-                      onClick={() =>
+                  </div>
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="browser-bridge-pause-until"
+                      className="text-xs text-muted"
+                    >
+                      Pause until
+                    </Label>
+                    <div className="text-[11px] text-muted">
+                      Temporarily stop browser visibility without disconnecting
+                      your paired browser.
+                    </div>
+                    <div className="flex flex-wrap gap-1.5 sm:flex-nowrap">
+                      <Input
+                        id="browser-bridge-pause-until"
+                        type="datetime-local"
+                        value={draft.pauseUntilLocal}
+                        onChange={(event) =>
+                          updateDraft(
+                            "pauseUntilLocal",
+                            event.currentTarget.value,
+                          )
+                        }
+                        className="min-w-0 flex-1"
+                      />
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 rounded-xl px-3 text-xs font-semibold"
+                        onClick={() =>
+                          updateDraft(
+                            "pauseUntilLocal",
+                            formatDateTimeLocalValue(
+                              new Date(
+                                Date.now() + 60 * 60 * 1000,
+                              ).toISOString(),
+                            ),
+                          )
+                        }
+                      >
+                        1h
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-9 rounded-xl px-3 text-xs font-semibold"
+                        onClick={() => updateDraft("pauseUntilLocal", "")}
+                      >
+                        Now
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="browser-bridge-granted-origins"
+                      className="text-xs text-muted"
+                    >
+                      Granted origins
+                    </Label>
+                    <div className="text-[11px] text-muted">
+                      When Site access is set to Granted sites, only these
+                      origins are readable.
+                    </div>
+                    <Textarea
+                      id="browser-bridge-granted-origins"
+                      rows={3}
+                      placeholder="https://mail.google.com"
+                      value={draft.grantedOriginsText}
+                      onChange={(event) =>
                         updateDraft(
-                          "pauseUntilLocal",
-                          formatDateTimeLocalValue(
-                            new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-                          ),
+                          "grantedOriginsText",
+                          event.currentTarget.value,
                         )
                       }
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label
+                      htmlFor="browser-bridge-blocked-origins"
+                      className="text-xs text-muted"
                     >
-                      1h
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-9 rounded-xl px-3 text-xs font-semibold"
-                      onClick={() => updateDraft("pauseUntilLocal", "")}
-                    >
-                      Now
-                    </Button>
+                      Blocked origins
+                    </Label>
+                    <div className="text-[11px] text-muted">
+                      These origins are never readable, even if broader site
+                      access is enabled.
+                    </div>
+                    <Textarea
+                      id="browser-bridge-blocked-origins"
+                      rows={3}
+                      placeholder="https://bank.example.com"
+                      value={draft.blockedOriginsText}
+                      onChange={(event) =>
+                        updateDraft(
+                          "blockedOriginsText",
+                          event.currentTarget.value,
+                        )
+                      }
+                    />
                   </div>
                 </div>
-              </div>
-
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="space-y-1">
-                  <Label
-                    htmlFor="browser-bridge-granted-origins"
-                    className="text-xs text-muted"
-                  >
-                    Granted origins
-                  </Label>
-                  <div className="text-[11px] text-muted">
-                    When Site access is set to Granted sites, only these origins
-                    are readable.
-                  </div>
-                  <Textarea
-                    id="browser-bridge-granted-origins"
-                    rows={3}
-                    placeholder="https://mail.google.com"
-                    value={draft.grantedOriginsText}
-                    onChange={(event) =>
-                      updateDraft(
-                        "grantedOriginsText",
-                        event.currentTarget.value,
-                      )
-                    }
-                  />
-                </div>
-                <div className="space-y-1">
-                  <Label
-                    htmlFor="browser-bridge-blocked-origins"
-                    className="text-xs text-muted"
-                  >
-                    Blocked origins
-                  </Label>
-                  <div className="text-[11px] text-muted">
-                    These origins are never readable, even if broader site
-                    access is enabled.
-                  </div>
-                  <Textarea
-                    id="browser-bridge-blocked-origins"
-                    rows={3}
-                    placeholder="https://bank.example.com"
-                    value={draft.blockedOriginsText}
-                    onChange={(event) =>
-                      updateDraft(
-                        "blockedOriginsText",
-                        event.currentTarget.value,
-                      )
-                    }
-                  />
-                </div>
-              </div>
-            </>
-          ) : loading ? (
-            <div className="text-xs text-muted">Loading</div>
-          ) : null}
-        </div>
+              </>
+            ) : loading ? (
+              <div className="text-xs text-muted">Loading</div>
+            ) : null}
+          </div>
+        </details>
       </details>
     </div>
   );

--- a/apps/app-lifeops/src/components/EventEditorDrawer.tsx
+++ b/apps/app-lifeops/src/components/EventEditorDrawer.tsx
@@ -201,7 +201,7 @@ export function EventEditorDrawer({
     <>
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
         <DialogContent
-          className="fixed bottom-0 right-0 top-0 m-0 h-full w-full max-w-sm translate-x-0 translate-y-0 overflow-y-auto rounded-l-2xl rounded-r-none border-l border-t-0 border-border/16 bg-bg p-0 shadow-xl duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full sm:w-96"
+          className="fixed bottom-0 right-0 top-0 !left-auto !right-0 !top-0 m-0 h-full w-[min(24rem,100vw)] max-w-[100vw] !translate-x-0 !translate-y-0 overflow-y-auto rounded-l-2xl rounded-r-none border-l border-t-0 border-border/16 bg-bg p-0 shadow-xl duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full"
           data-testid="event-editor-drawer"
         >
           <div className="flex items-center justify-between gap-3 border-b border-border/12 px-5 py-4">

--- a/apps/app-lifeops/src/components/LifeOpsCalendarSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsCalendarSection.tsx
@@ -16,11 +16,11 @@ import {
 import type { LifeOpsCalendarEvent } from "@elizaos/shared/contracts/lifeops";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { getPrimedLifeOpsEvent } from "../lifeops-route.js";
 import {
   type CalendarViewMode,
   useCalendarWeek,
 } from "../hooks/useCalendarWeek.js";
+import { getPrimedLifeOpsEvent } from "../lifeops-route.js";
 import { EventEditorDrawer } from "./EventEditorDrawer.js";
 import { useLifeOpsChatLauncher } from "./LifeOpsChatAdapter.js";
 import {
@@ -256,16 +256,16 @@ function eventWindowMs(event: LifeOpsCalendarEvent): {
  * width is then divided by the max concurrent lane count within each
  * cluster of connected events.
  */
-function layoutDayEvents(
-  events: LifeOpsCalendarEvent[],
-): PositionedEvent[] {
+function layoutDayEvents(events: LifeOpsCalendarEvent[]): PositionedEvent[] {
   const windows = events
     .map((event) => {
       const window = eventWindowMs(event);
       return window ? { event, ...window } : null;
     })
     .filter(
-      (entry): entry is { event: LifeOpsCalendarEvent; start: number; end: number } =>
+      (
+        entry,
+      ): entry is { event: LifeOpsCalendarEvent; start: number; end: number } =>
         entry !== null,
     )
     .sort((a, b) => a.start - b.start);
@@ -387,8 +387,8 @@ function AllDayBandCell({
   onSelectEvent: (event: LifeOpsCalendarEvent) => void;
 }) {
   return (
-    <div
-      className={`space-y-0.5 px-1 py-1 ${isFirst ? "" : "border-l border-border/12"}`}
+    <fieldset
+      className={`m-0 min-w-0 space-y-0.5 border-0 px-1 py-1 ${isFirst ? "" : "border-l border-border/12"}`}
       aria-label={`All-day events for ${day.toISOString()}`}
     >
       {events.map((event) => {
@@ -398,6 +398,10 @@ function AllDayBandCell({
             key={event.id}
             type="button"
             onClick={() => onSelectEvent(event)}
+            onContextMenu={(mouseEvent) => {
+              mouseEvent.preventDefault();
+              onSelectEvent(event);
+            }}
             className={`block w-full truncate rounded-md ${color.softBg} ${color.softText} px-1.5 py-0.5 text-left text-[10px] font-medium hover:${color.bg} hover:${color.text}`}
             aria-pressed={event.id === selectedEventId}
           >
@@ -405,7 +409,7 @@ function AllDayBandCell({
           </button>
         );
       })}
-    </div>
+    </fieldset>
   );
 }
 
@@ -455,13 +459,15 @@ function DayColumnGrid({
       style={{ height: `${gridHeight}px` }}
     >
       {/* hour lines */}
-      {Array.from({ length: totalHours }, (_, i) => (
-        <div
-          key={i}
-          className="pointer-events-none absolute inset-x-0 border-t border-border/6"
-          style={{ top: `${i * HOUR_HEIGHT_PX}px` }}
-        />
-      ))}
+      {Array.from({ length: totalHours }, (_, i) => DAY_START_HOUR + i).map(
+        (hour) => (
+          <div
+            key={hour}
+            className="pointer-events-none absolute inset-x-0 border-t border-border/6"
+            style={{ top: `${(hour - DAY_START_HOUR) * HOUR_HEIGHT_PX}px` }}
+          />
+        ),
+      )}
 
       {/* now indicator */}
       {nowTopPx !== null ? (
@@ -486,6 +492,10 @@ function DayColumnGrid({
             key={event.id}
             type="button"
             onClick={() => onSelectEvent(event)}
+            onContextMenu={(mouseEvent) => {
+              mouseEvent.preventDefault();
+              onSelectEvent(event);
+            }}
             aria-pressed={isSelected}
             className={`group absolute overflow-hidden rounded-md border px-1.5 py-1 text-left shadow-sm transition-transform ${color.bg} ${color.border} ${color.text} ${isSelected ? "ring-2 ring-white/50 z-10" : "hover:translate-y-[-1px]"}`}
             style={{
@@ -533,14 +543,15 @@ function TimeGrid({
     [days, eventsByDay],
   );
 
-  const hourLabels = useMemo(() => {
-    const out: string[] = [];
+  const hours = useMemo(() => {
+    const out: Array<{ hour: number; label: string }> = [];
     for (let hour = DAY_START_HOUR; hour < DAY_END_HOUR; hour++) {
-      out.push(
-        new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(
+      out.push({
+        hour,
+        label: new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(
           new Date(2024, 0, 1, hour, 0),
         ),
-      );
+      });
     }
     return out;
   }, []);
@@ -557,10 +568,7 @@ function TimeGrid({
         className="grid border-b border-border/12"
         style={{ gridTemplateColumns }}
       >
-        <div
-          aria-hidden
-          style={{ height: `${HEADER_ROW_HEIGHT_REM}rem` }}
-        />
+        <div aria-hidden style={{ height: `${HEADER_ROW_HEIGHT_REM}rem` }} />
         {days.map((day, index) => (
           <DayColumnHeader
             key={toLocalDayKey(day)}
@@ -600,12 +608,12 @@ function TimeGrid({
       {/* Hour rail + day columns — all share one row so lines align */}
       <div className="grid" style={{ gridTemplateColumns }}>
         <div className="relative" style={{ height: `${gridHeight}px` }}>
-          {hourLabels.map((label, index) => (
+          {hours.map(({ hour, label }) => (
             <div
-              key={label + index}
+              key={hour}
               className="absolute right-2 text-[10px] font-medium uppercase tracking-wide text-muted/70"
               style={{
-                top: `${index * HOUR_HEIGHT_PX - 6}px`,
+                top: `${(hour - DAY_START_HOUR) * HOUR_HEIGHT_PX - 6}px`,
               }}
             >
               {label}
@@ -677,8 +685,8 @@ function MonthGrid({
   return (
     <div className="overflow-hidden rounded-2xl border border-border/12 bg-bg/20">
       <div className="grid grid-cols-7 border-b border-border/12 bg-bg-muted/20 text-[10px] font-semibold uppercase tracking-wide text-muted">
-        {weekdayLabels.map((label, index) => (
-          <div key={label + index} className="px-2 py-1.5 text-center">
+        {weekdayLabels.map((label) => (
+          <div key={label} className="px-2 py-1.5 text-center">
             {label}
           </div>
         ))}
@@ -716,6 +724,10 @@ function MonthGrid({
                       key={event.id}
                       type="button"
                       onClick={() => onSelectEvent(event)}
+                      onContextMenu={(mouseEvent) => {
+                        mouseEvent.preventDefault();
+                        onSelectEvent(event);
+                      }}
                       className={`flex min-w-0 items-center gap-1 rounded-sm px-1.5 py-0.5 text-left text-[10px] font-medium ${
                         isSelected
                           ? `${color.bg} ${color.text}`
@@ -803,6 +815,10 @@ function AgendaView({
                   key={event.id}
                   type="button"
                   onClick={() => onSelectEvent(event)}
+                  onContextMenu={(mouseEvent) => {
+                    mouseEvent.preventDefault();
+                    onSelectEvent(event);
+                  }}
                   aria-pressed={isSelected}
                   className={`flex w-full items-start gap-3 px-4 py-3 text-left transition-colors ${
                     isSelected ? "bg-white/5" : "hover:bg-white/3"

--- a/apps/app-lifeops/src/components/LifeOpsOperationalPanels.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsOperationalPanels.tsx
@@ -112,6 +112,27 @@ function PanelShell({
   );
 }
 
+function StatusDot({
+  connected,
+  label,
+}: {
+  connected: boolean;
+  label: string;
+}) {
+  return (
+    <span
+      aria-label={label}
+      className={`inline-block h-2.5 w-2.5 rounded-full ${
+        connected
+          ? "bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]"
+          : "bg-muted/45"
+      }`}
+      role="img"
+      title={label}
+    />
+  );
+}
+
 export function LifeOpsCapabilitiesPanel() {
   const { t } = useApp();
   const capabilities = useLifeOpsCapabilitiesStatus();
@@ -541,14 +562,8 @@ export function LifeOpsXPanel() {
   const agentStatus = agentX.status;
   const connected = status?.connected === true;
   const agentConnected = agentStatus?.connected === true;
-  const ownerIdentity = readXIdentity(
-    status?.identity ?? null,
-    t("lifeopspanels.notConnected", { defaultValue: "Not connected" }),
-  );
-  const agentIdentity = readXIdentity(
-    agentStatus?.identity ?? null,
-    t("chat.agentType", { defaultValue: "Agent" }),
-  );
+  const ownerIdentity = readXIdentity(status?.identity ?? null, "");
+  const agentIdentity = readXIdentity(agentStatus?.identity ?? null, "");
   const mode = status?.mode ?? status?.defaultMode ?? "cloud_managed";
   const actionPending = ownerX.actionPending || agentX.actionPending;
 
@@ -558,25 +573,27 @@ export function LifeOpsXPanel() {
       icon={<Sparkles className="h-4 w-4 shrink-0 text-muted" />}
       status={
         <div className="flex items-center gap-2">
-          <Badge
-            variant={connected ? "secondary" : "outline"}
-            className="text-2xs"
-          >
-            {connected
-              ? t("lifeopspanels.connected", { defaultValue: "Connected" })
-              : t("lifeopspanels.disconnected", {
-                  defaultValue: "Disconnected",
-                })}
-          </Badge>
+          <StatusDot
+            connected={connected}
+            label={
+              connected
+                ? t("lifeopspanels.connected", { defaultValue: "Connected" })
+                : t("lifeopspanels.disconnected", {
+                    defaultValue: "Disconnected",
+                  })
+            }
+          />
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             onClick={() => {
               void ownerX.refresh();
               void agentX.refresh();
             }}
             disabled={ownerX.loading || agentX.loading}
+            title={t("common.refresh", { defaultValue: "Refresh" })}
+            aria-label={t("common.refresh", { defaultValue: "Refresh" })}
           >
             {ownerX.loading || agentX.loading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -592,30 +609,44 @@ export function LifeOpsXPanel() {
           <div className="text-[11px] uppercase tracking-wide text-muted">
             {t("lifeopspanels.owner", { defaultValue: "Owner" })}
           </div>
-          <div className="mt-1 text-sm font-semibold text-txt">
-            {ownerIdentity}
-          </div>
-          <div className="mt-1 text-xs text-muted">
-            {connected
-              ? t("lifeopspanels.connected", { defaultValue: "Connected" })
-              : t("lifeopspanels.disconnected", {
-                  defaultValue: "Disconnected",
-                })}
+          <div className="mt-1 flex items-center gap-2">
+            <StatusDot
+              connected={connected}
+              label={
+                connected
+                  ? t("lifeopspanels.connected", { defaultValue: "Connected" })
+                  : t("lifeopspanels.disconnected", {
+                      defaultValue: "Disconnected",
+                    })
+              }
+            />
+            {ownerIdentity ? (
+              <div className="min-w-0 truncate text-sm font-semibold text-txt">
+                {ownerIdentity}
+              </div>
+            ) : null}
           </div>
         </div>
         <div className="rounded-2xl border border-border/20 bg-bg/36 px-3 py-2">
           <div className="text-[11px] uppercase tracking-wide text-muted">
             {t("chat.agentType", { defaultValue: "Agent" })}
           </div>
-          <div className="mt-1 text-sm font-semibold text-txt">
-            {agentIdentity}
-          </div>
-          <div className="mt-1 text-xs text-muted">
-            {agentConnected
-              ? t("lifeopspanels.connected", { defaultValue: "Connected" })
-              : t("lifeopspanels.disconnected", {
-                  defaultValue: "Disconnected",
-                })}
+          <div className="mt-1 flex items-center gap-2">
+            <StatusDot
+              connected={agentConnected}
+              label={
+                agentConnected
+                  ? t("lifeopspanels.connected", { defaultValue: "Connected" })
+                  : t("lifeopspanels.disconnected", {
+                      defaultValue: "Disconnected",
+                    })
+              }
+            />
+            {agentIdentity ? (
+              <div className="min-w-0 truncate text-sm font-semibold text-txt">
+                {agentIdentity}
+              </div>
+            ) : null}
           </div>
         </div>
       </div>
@@ -626,19 +657,22 @@ export function LifeOpsXPanel() {
           className="h-8 rounded-xl px-3 text-xs font-semibold"
           onClick={() => void ownerX.connect(mode)}
           disabled={actionPending}
+          title={
+            connected
+              ? t("lifeopspanels.reconnectOwnerX", {
+                  defaultValue: "Reconnect Owner X",
+                })
+              : t("lifeopspanels.connectOwnerX", {
+                  defaultValue: "Connect Owner X",
+                })
+          }
         >
           {actionPending ? (
             <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
           ) : (
             <Sparkles className="mr-1.5 h-3.5 w-3.5" />
           )}
-          {connected
-            ? t("lifeopspanels.reconnectOwnerX", {
-                defaultValue: "Reconnect Owner X",
-              })
-            : t("lifeopspanels.connectOwnerX", {
-                defaultValue: "Connect Owner X",
-              })}
+          {t("lifeopspanels.owner", { defaultValue: "Owner" })}
         </Button>
         <Button
           size="sm"
@@ -646,15 +680,18 @@ export function LifeOpsXPanel() {
           className="h-8 rounded-xl px-3 text-xs font-semibold"
           onClick={() => void agentX.connect("cloud_managed")}
           disabled={actionPending}
+          title={
+            agentConnected
+              ? t("lifeopspanels.reconnectAgentX", {
+                  defaultValue: "Reconnect Agent X",
+                })
+              : t("lifeopspanels.connectAgentX", {
+                  defaultValue: "Connect Agent X",
+                })
+          }
         >
           <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-          {agentConnected
-            ? t("lifeopspanels.reconnectAgentX", {
-                defaultValue: "Reconnect Agent X",
-              })
-            : t("lifeopspanels.connectAgentX", {
-                defaultValue: "Connect Agent X",
-              })}
+          {t("chat.agentType", { defaultValue: "Agent" })}
         </Button>
         {connected ? (
           <Button

--- a/apps/app-lifeops/src/components/LifeOpsOperationalPanels.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsOperationalPanels.tsx
@@ -554,7 +554,7 @@ export function LifeOpsXPanel() {
 
   return (
     <PanelShell
-      title={t("lifeopspanels.xAccount", { defaultValue: "X account" })}
+      title={t("lifeopspanels.xAccount", { defaultValue: "X" })}
       icon={<Sparkles className="h-4 w-4 shrink-0 text-muted" />}
       status={
         <div className="flex items-center gap-2">
@@ -671,20 +671,6 @@ export function LifeOpsXPanel() {
           </Button>
         ) : null}
       </div>
-
-      {status?.grant ? (
-        <div className="flex flex-wrap gap-2">
-          <Badge variant="outline" className="text-2xs">
-            {status.grant.provider}
-          </Badge>
-          <Badge variant="outline" className="text-2xs">
-            {status.grant.mode}
-          </Badge>
-          <Badge variant="outline" className="text-2xs">
-            {status.grantedScopes.length} scopes
-          </Badge>
-        </div>
-      ) : null}
 
       {ownerX.pendingAuthUrl || agentX.pendingAuthUrl ? (
         <a

--- a/apps/app-lifeops/src/components/LifeOpsPageView.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsPageView.tsx
@@ -28,11 +28,7 @@ import {
   LIFEOPS_MESSAGE_CHANNELS,
   LifeOpsInboxSection,
 } from "./LifeOpsInboxSection.js";
-import {
-  LifeOpsCapabilitiesPanel,
-  LifeOpsSchedulePanel,
-  LifeOpsXPanel,
-} from "./LifeOpsOperationalPanels";
+import { LifeOpsXPanel } from "./LifeOpsOperationalPanels";
 import { LifeOpsOverviewSection } from "./LifeOpsOverviewSection.js";
 import type { ManagedAgentGithubEntry } from "./LifeOpsPageSections";
 import { LifeOpsPaymentsSection } from "./LifeOpsPaymentsSection.js";
@@ -403,11 +399,7 @@ function LifeOpsSettingsSectionView({
       />
       <MessagingConnectorGrid />
 
-      <div className="grid gap-4 xl:grid-cols-2">
-        <LifeOpsSchedulePanel />
-        <LifeOpsCapabilitiesPanel />
-        <LifeOpsXPanel />
-      </div>
+      <LifeOpsXPanel />
     </div>
   );
 }

--- a/apps/app-lifeops/src/components/LifeOpsPageView.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsPageView.tsx
@@ -10,6 +10,7 @@ import {
 } from "@elizaos/app-core";
 import { PageScopedChatPane } from "@elizaos/app-core/components/pages/PageScopedChatPane";
 import { AppWorkspaceChrome } from "@elizaos/app-core/components/workspace/AppWorkspaceChrome";
+import { Power, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   LIFEOPS_GITHUB_CALLBACK_EVENT,
@@ -365,29 +366,39 @@ function LifeOpsSettingsSectionView({
 }: LifeOpsSettingsSectionViewProps) {
   return (
     <div className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h2 className="text-base font-semibold tracking-tight text-txt">
           {t("lifeopspage.accessTitle", { defaultValue: "Access" })}
         </h2>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="flex items-center gap-2">
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold sm:w-auto"
+            className="h-8 w-8 rounded-xl p-0"
             onClick={onRunSetupAgain}
-          >
-            {t("lifeopspage.runSetupAgain", {
+            title={t("lifeopspage.runSetupAgain", {
               defaultValue: "Run setup again",
             })}
+            aria-label={t("lifeopspage.runSetupAgain", {
+              defaultValue: "Run setup again",
+            })}
+          >
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden />
           </Button>
           <Button
             variant="surfaceDestructive"
             size="sm"
-            className="h-8 rounded-xl px-3 text-xs font-semibold sm:w-auto"
+            className="h-8 w-8 rounded-xl p-0"
             onClick={onDisableLifeOps}
             disabled={disableLifeOpsDisabled}
+            title={t("lifeopspage.disable", {
+              defaultValue: "Disable LifeOps",
+            })}
+            aria-label={t("lifeopspage.disable", {
+              defaultValue: "Disable LifeOps",
+            })}
           >
-            {t("lifeopspage.disable", { defaultValue: "Disable LifeOps" })}
+            <Power className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       </div>

--- a/apps/app-lifeops/src/components/LifeOpsPaymentsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsPaymentsSection.tsx
@@ -53,7 +53,7 @@ function cadenceLabel(cadence: LifeOpsRecurringCharge["cadence"]): string {
   }
 }
 
-export function LifeOpsPaymentsSection(): JSX.Element {
+export function LifeOpsPaymentsSection(): JSX.Element | null {
   const [dashboard, setDashboard] = useState<LifeOpsPaymentsDashboard | null>(
     null,
   );

--- a/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
@@ -12,7 +12,7 @@ import type {
   LifeOpsConnectorSide,
   LifeOpsGoogleCapability,
 } from "@elizaos/app-lifeops/contracts";
-import { Copy, ExternalLink, GitBranch, Plug2, X } from "lucide-react";
+import { Copy, ExternalLink, GitBranch, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useGoogleLifeOpsConnector } from "../hooks/useGoogleLifeOpsConnector";
 import { BrowserBridgeSetupPanel } from "./BrowserBridgeSetupPanel.tsx";
@@ -345,7 +345,10 @@ function GoogleConnectorSideCard({
   const [calendars, setCalendars] = useState<LifeOpsCalendarSummary[]>([]);
   const [calendarLoading, setCalendarLoading] = useState(false);
   const [calendarError, setCalendarError] = useState<string | null>(null);
-  const [calendarPendingId, setCalendarPendingId] = useState<string | null>(null);
+  const [calendarPendingId, setCalendarPendingId] = useState<string | null>(
+    null,
+  );
+  const [calendarFeedOpen, setCalendarFeedOpen] = useState(false);
   const compactLayout = useMediaQuery("(max-width: 767px)");
   const connectedAccounts = accounts.filter((account) => account.connected);
   const primaryIdentity = readIdentity(
@@ -439,30 +442,36 @@ function GoogleConnectorSideCard({
   );
 
   return (
-    <section className="space-y-3 px-4 py-4">
-      <div className="flex items-center gap-3">
-        <div className="text-sm font-semibold text-txt">
-          {sideTitle(side, t)}
-        </div>
-      </div>
-
-      <div className="min-w-0">
-        <div className="truncate text-sm font-semibold text-txt">
-          {primaryIdentity.primary}
-        </div>
-        {primaryIdentity.secondary ? (
-          <div className="mt-1 truncate text-xs text-muted">
-            {primaryIdentity.secondary}
+    <section className="space-y-3 rounded-2xl border border-border/20 bg-card/14 px-4 py-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-border/30 bg-bg/38">
+            <GoogleIcon className="h-5 w-5" />
           </div>
-        ) : null}
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted">
-          <GoogleIcon className="h-4 w-4 shrink-0" />
-          <span>Google</span>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="text-sm font-semibold text-txt">
+                {sideTitle(side, t)}
+              </div>
+              <Badge
+                variant={status?.connected ? "secondary" : "outline"}
+                className="text-2xs"
+              >
+                {currentStatusLabel}
+              </Badge>
+            </div>
+            <div className="mt-1 truncate text-sm font-semibold text-txt">
+              {primaryIdentity.primary}
+            </div>
+            {primaryIdentity.secondary ? (
+              <div className="mt-0.5 truncate text-xs text-muted">
+                {primaryIdentity.secondary}
+              </div>
+            ) : null}
+          </div>
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+
+        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
           <SegmentedControl<VisibleConnectorMode>
             aria-label={t("lifeopssettings.googleModeAria", {
               defaultValue: "{{side}} Google mode",
@@ -475,7 +484,7 @@ function GoogleConnectorSideCard({
               label: modeLabel(mode, t),
               disabled: controlDisabled,
             }))}
-            className="w-full bg-bg/40 p-0.5 sm:w-auto"
+            className="min-w-40 flex-1 bg-bg/40 p-0.5 sm:w-auto sm:flex-none"
             buttonClassName="min-h-8 flex-1 px-3 py-1.5 text-xs"
           />
           {!status?.connected ? (
@@ -522,12 +531,6 @@ function GoogleConnectorSideCard({
             </Button>
           ) : null}
         </div>
-      </div>
-
-      <div
-        className={status?.connected ? "text-xs text-ok" : "text-xs text-muted"}
-      >
-        {currentStatusLabel}
       </div>
 
       {connectedAccounts.length > 0 ? (
@@ -590,68 +593,81 @@ function GoogleConnectorSideCard({
       ) : null}
 
       {status?.connected ? (
-        <div className="space-y-2 rounded-2xl bg-bg/30 px-3 py-3">
-          <div className="text-xs font-semibold text-txt">
-            {t("lifeopssettings.calendarFeedTitle", {
-              defaultValue: "Which calendars appear in your feed?",
-            })}
-          </div>
-          <div className="text-xs leading-5 text-muted">
-            {t("lifeopssettings.calendarFeedDescription", {
-              defaultValue:
-                "These toggles affect the sidebar feed and proactive briefings. Direct calendar actions still read every authorized calendar.",
-            })}
-          </div>
-          {calendarLoading ? (
-            <div className="text-xs text-muted">
-              {t("lifeopssettings.loadingCalendars", {
-                defaultValue: "Loading calendars…",
+        <details
+          className="rounded-2xl bg-bg/30 px-3 py-3"
+          open={calendarFeedOpen}
+          onToggle={(event) =>
+            setCalendarFeedOpen(event.currentTarget.open)
+          }
+        >
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-semibold text-txt">
+            <span>
+              {t("lifeopssettings.calendarFeedTitle", {
+                defaultValue: "Calendar feed",
               })}
-            </div>
-          ) : calendars.length > 0 ? (
-            <div className="grid gap-2">
-              {calendars.map((calendar) => {
-                const disabled =
-                  controlDisabled || calendarPendingId === calendar.calendarId;
-                return (
-                  <label
-                    key={`${calendar.grantId}:${calendar.calendarId}`}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl bg-card/18 px-3 py-2 text-xs"
-                  >
-                    <input
-                      type="checkbox"
-                      className="mt-0.5 h-4 w-4 rounded border-border bg-bg"
-                      checked={calendar.includeInFeed}
-                      disabled={disabled}
-                      onChange={() => void toggleCalendar(calendar)}
-                    />
-                    <span
-                      className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
-                      style={{
-                        backgroundColor:
-                          calendar.backgroundColor ?? "rgba(148, 163, 184, 0.8)",
-                      }}
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-medium text-txt">
-                        {calendar.summary}
+            </span>
+            {calendars.length > 0 ? (
+              <span className="text-muted">
+                {calendars.filter((calendar) => calendar.includeInFeed).length}/
+                {calendars.length}
+              </span>
+            ) : null}
+          </summary>
+          <div className="mt-3 space-y-2">
+            {calendarLoading ? (
+              <div className="text-xs text-muted">
+                {t("lifeopssettings.loadingCalendars", {
+                  defaultValue: "Loading calendars…",
+                })}
+              </div>
+            ) : calendars.length > 0 ? (
+              <div className="grid gap-2">
+                {calendars.map((calendar) => {
+                  const disabled =
+                    controlDisabled ||
+                    calendarPendingId === calendar.calendarId;
+                  return (
+                    <label
+                      key={`${calendar.grantId}:${calendar.calendarId}`}
+                      className="flex cursor-pointer items-start gap-3 rounded-xl bg-card/18 px-3 py-2 text-xs"
+                    >
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 h-4 w-4 rounded border-border bg-bg"
+                        checked={calendar.includeInFeed}
+                        disabled={disabled}
+                        onChange={() => void toggleCalendar(calendar)}
+                      />
+                      <span
+                        className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full"
+                        style={{
+                          backgroundColor:
+                            calendar.backgroundColor ??
+                            "rgba(148, 163, 184, 0.8)",
+                        }}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate font-medium text-txt">
+                          {calendar.summary}
+                        </span>
+                        <span className="block truncate text-muted">
+                          {calendar.accountEmail ?? calendar.calendarId}
+                        </span>
                       </span>
-                      <span className="block truncate text-muted">
-                        {calendar.accountEmail ?? calendar.calendarId}
-                      </span>
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="text-xs text-muted">
-              {t("lifeopssettings.noCalendars", {
-                defaultValue: "No readable calendars found for this connector.",
-              })}
-            </div>
-          )}
-        </div>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="text-xs text-muted">
+                {t("lifeopssettings.noCalendars", {
+                  defaultValue:
+                    "No readable calendars found for this connector.",
+                })}
+              </div>
+            )}
+          </div>
+        </details>
       ) : null}
 
       {visibleAuthUrl ? (
@@ -712,13 +728,8 @@ export function LifeOpsSettingsSection({
 
   return (
     <section className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="text-sm font-semibold text-txt">
-          {t("lifeopssettings.accounts", {
-            defaultValue: "Accounts",
-          })}
-        </div>
-        {cloudAction ? (
+      {cloudAction ? (
+        <div className="flex justify-end">
           <Button
             size="sm"
             variant="outline"
@@ -727,8 +738,8 @@ export function LifeOpsSettingsSection({
           >
             {cloudAction.label}
           </Button>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       {githubError ? (
         <div className="py-1 text-xs text-muted">{githubError}</div>

--- a/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
@@ -604,7 +604,13 @@ function GoogleConnectorSideCard({
                 defaultValue: "Calendar feed",
               })}
             </span>
-            {calendars.length > 0 ? (
+            {calendarError ? (
+              <span className="text-danger">
+                {t("lifeopssettings.calendarFeedIssue", {
+                  defaultValue: "Issue",
+                })}
+              </span>
+            ) : calendars.length > 0 ? (
               <span className="text-muted">
                 {calendars.filter((calendar) => calendar.includeInFeed).length}/
                 {calendars.length}
@@ -664,6 +670,9 @@ function GoogleConnectorSideCard({
                 })}
               </div>
             )}
+            {calendarError ? (
+              <div className="text-xs text-danger">{calendarError}</div>
+            ) : null}
           </div>
         </details>
       ) : null}
@@ -675,10 +684,6 @@ function GoogleConnectorSideCard({
         />
       ) : null}
       {error ? <div className="text-xs text-danger">{error}</div> : null}
-      {calendarError ? (
-        <div className="text-xs text-danger">{calendarError}</div>
-      ) : null}
-
       <GithubRow github={github} compactLayout={compactLayout} />
     </section>
   );

--- a/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
@@ -596,9 +596,7 @@ function GoogleConnectorSideCard({
         <details
           className="rounded-2xl bg-bg/30 px-3 py-3"
           open={calendarFeedOpen}
-          onToggle={(event) =>
-            setCalendarFeedOpen(event.currentTarget.open)
-          }
+          onToggle={(event) => setCalendarFeedOpen(event.currentTarget.open)}
         >
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-semibold text-txt">
             <span>

--- a/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
+++ b/apps/app-lifeops/src/components/LifeOpsSettingsSection.tsx
@@ -1,10 +1,4 @@
-import {
-  Badge,
-  Button,
-  SegmentedControl,
-  useApp,
-  useMediaQuery,
-} from "@elizaos/app-core";
+import { Button, SegmentedControl, useApp } from "@elizaos/app-core";
 import { client } from "@elizaos/app-core/api";
 import type {
   LifeOpsCalendarSummary,
@@ -12,8 +6,21 @@ import type {
   LifeOpsConnectorSide,
   LifeOpsGoogleCapability,
 } from "@elizaos/app-lifeops/contracts";
-import { Copy, ExternalLink, GitBranch, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarDays,
+  Cloud,
+  Copy,
+  ExternalLink,
+  GitBranch,
+  HardDrive,
+  Mail,
+  Plug2,
+  Plus,
+  Unplug,
+  X,
+} from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useGoogleLifeOpsConnector } from "../hooks/useGoogleLifeOpsConnector";
 import { BrowserBridgeSetupPanel } from "./BrowserBridgeSetupPanel.tsx";
 import { MobileSignalsSetupCard } from "./MobileSignalsSetupCard";
@@ -141,32 +148,34 @@ function sideTitle(side: LifeOpsConnectorSide, t: TranslateFn): string {
       });
 }
 
-function capabilityLabels(
+function capabilityItems(
   capabilities: readonly LifeOpsGoogleCapability[],
   t: TranslateFn,
-): string[] {
-  const labels: string[] = [];
+): Array<{ key: "calendar" | "mail"; label: string }> {
+  const items: Array<{ key: "calendar" | "mail"; label: string }> = [];
   if (
     capabilities.includes("google.calendar.read") ||
     capabilities.includes("google.calendar.write")
   ) {
-    labels.push(
-      t("lifeopssettings.capabilityCalendar", {
+    items.push({
+      key: "calendar",
+      label: t("lifeopssettings.capabilityCalendar", {
         defaultValue: "Cal",
       }),
-    );
+    });
   }
   if (
     capabilities.includes("google.gmail.triage") ||
     capabilities.includes("google.gmail.send")
   ) {
-    labels.push(
-      t("lifeopssettings.capabilityMail", {
+    items.push({
+      key: "mail",
+      label: t("lifeopssettings.capabilityMail", {
         defaultValue: "Mail",
       }),
-    );
+    });
   }
-  return labels;
+  return items;
 }
 
 function GoogleIcon({ className }: { className?: string }) {
@@ -194,6 +203,102 @@ function GoogleIcon({ className }: { className?: string }) {
         d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
       />
     </svg>
+  );
+}
+
+type StatusTone = "ok" | "warning" | "muted";
+
+function statusDotClassName(tone: StatusTone): string {
+  switch (tone) {
+    case "ok":
+      return "bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.14)]";
+    case "warning":
+      return "bg-amber-500 shadow-[0_0_0_3px_rgba(245,158,11,0.14)]";
+    default:
+      return "bg-muted/45";
+  }
+}
+
+function StatusDot({
+  label,
+  tone,
+  className = "",
+}: {
+  label: string;
+  tone: StatusTone;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-label={label}
+      className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${statusDotClassName(tone)} ${className}`}
+      role="img"
+      title={label}
+    />
+  );
+}
+
+function IconOnlyLabel({
+  children,
+  label,
+}: {
+  children: ReactNode;
+  label: string;
+}) {
+  return (
+    <span className="inline-flex items-center justify-center" title={label}>
+      {children}
+      <span className="sr-only">{label}</span>
+    </span>
+  );
+}
+
+function ModeLabel({
+  mode,
+  label,
+}: {
+  mode: VisibleConnectorMode;
+  label: string;
+}) {
+  const Icon = mode === "cloud_managed" ? Cloud : HardDrive;
+  return (
+    <IconOnlyLabel label={label}>
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+    </IconOnlyLabel>
+  );
+}
+
+function MiniMeter({
+  label,
+  tone,
+  total,
+  value,
+}: {
+  label: string;
+  tone: StatusTone;
+  total: number;
+  value: number;
+}) {
+  const boundedTotal = Math.max(total, 0);
+  const boundedValue =
+    boundedTotal > 0 ? Math.min(Math.max(value, 0), boundedTotal) : 0;
+  const width =
+    boundedTotal > 0 ? `${(boundedValue / boundedTotal) * 100}%` : "0%";
+  const fill =
+    tone === "ok"
+      ? "bg-emerald-500"
+      : tone === "warning"
+        ? "bg-amber-500"
+        : "bg-muted/45";
+  return (
+    <span
+      aria-label={label}
+      className="relative inline-flex h-1.5 w-16 overflow-hidden rounded-full bg-bg/70"
+      role="img"
+      title={label}
+    >
+      <span className={`h-full rounded-full ${fill}`} style={{ width }} />
+    </span>
   );
 }
 
@@ -262,57 +367,84 @@ function PendingAuthBanner({
   );
 }
 
-function GithubRow({
-  github,
-  compactLayout,
-}: {
-  github: GithubSetupState;
-  compactLayout: boolean;
-}) {
+function GithubRow({ github }: { github: GithubSetupState }) {
   const { t } = useApp();
+  const identity = github.identity.trim();
+  const identityLower = identity.toLowerCase();
+  const showIdentity =
+    identity.length > 0 &&
+    identityLower !== "not linked" &&
+    identityLower !== "no agent" &&
+    identityLower !== "cloud required";
+  const linked =
+    github.status.trim().startsWith("1 /") ||
+    (showIdentity && !identityLower.includes("not linked"));
+  const tone: StatusTone = linked
+    ? "ok"
+    : github.connectDisabled
+      ? "muted"
+      : "warning";
+  const status = linked
+    ? t("lifeopssettings.connected", { defaultValue: "Connected" })
+    : t("lifeopssettings.notConnected", { defaultValue: "Not connected" });
   return (
     <div className="space-y-2 pt-2">
       <div className="flex flex-wrap items-center gap-2">
         <div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted">
           <GitBranch className="h-4 w-4 shrink-0" />
           <span>GitHub</span>
+          <StatusDot label={status} tone={tone} />
         </div>
-        <div className="min-w-0 flex-1 truncate text-sm font-semibold text-txt">
-          {github.identity}
-        </div>
-        <div className="flex flex-wrap items-center gap-2">
+        {showIdentity ? (
+          <div className="min-w-0 flex-1 truncate text-sm font-semibold text-txt">
+            {identity}
+          </div>
+        ) : (
+          <div className="flex-1" />
+        )}
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
           {github.onConnect ? (
             <Button
               size="sm"
               variant="outline"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={github.connectDisabled}
               onClick={github.onConnect}
-            >
-              {github.connectLabel ??
+              title={
+                github.connectLabel ??
                 t("common.connect", {
                   defaultValue: "Connect",
-                })}
+                })
+              }
+              aria-label={
+                github.connectLabel ??
+                t("common.connect", {
+                  defaultValue: "Connect",
+                })
+              }
+            >
+              <Plug2 className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
           {github.onDisconnect ? (
             <Button
               size="sm"
               variant="outline"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={github.disconnectDisabled}
               onClick={github.onDisconnect}
-            >
-              {t("common.disconnect", {
+              title={t("common.disconnect", {
                 defaultValue: "Disconnect",
               })}
+              aria-label={t("common.disconnect", {
+                defaultValue: "Disconnect",
+              })}
+            >
+              <Unplug className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
         </div>
       </div>
-      {!compactLayout && github.status.trim().length > 0 ? (
-        <div className="text-xs text-muted">{github.status}</div>
-      ) : null}
     </div>
   );
 }
@@ -349,17 +481,29 @@ function GoogleConnectorSideCard({
     null,
   );
   const [calendarFeedOpen, setCalendarFeedOpen] = useState(false);
-  const compactLayout = useMediaQuery("(max-width: 767px)");
   const connectedAccounts = accounts.filter((account) => account.connected);
   const primaryIdentity = readIdentity(
     connectedAccounts[0]?.identity ?? status?.identity ?? null,
     t,
   );
+  const emptyIdentityLabel = t("lifeopssettings.googleNotConnected", {
+    defaultValue: "Google not connected",
+  });
+  const showPrimaryIdentity =
+    status?.connected === true ||
+    primaryIdentity.primary !== emptyIdentityLabel;
   const currentStatusLabel = statusLabel(
     status?.reason ?? "disconnected",
     status?.connected === true,
     t,
   );
+  const currentStatusTone: StatusTone = status?.connected
+    ? "ok"
+    : status?.reason === "needs_reauth" ||
+        status?.reason === "config_missing" ||
+        status?.reason === "token_missing"
+      ? "warning"
+      : "muted";
   const controlDisabled = loading || actionPending;
   const visibleMode: VisibleConnectorMode =
     activeMode === "local" ? "local" : "cloud_managed";
@@ -453,16 +597,13 @@ function GoogleConnectorSideCard({
               <div className="text-sm font-semibold text-txt">
                 {sideTitle(side, t)}
               </div>
-              <Badge
-                variant={status?.connected ? "secondary" : "outline"}
-                className="text-2xs"
-              >
-                {currentStatusLabel}
-              </Badge>
+              <StatusDot label={currentStatusLabel} tone={currentStatusTone} />
             </div>
-            <div className="mt-1 truncate text-sm font-semibold text-txt">
-              {primaryIdentity.primary}
-            </div>
+            {showPrimaryIdentity ? (
+              <div className="mt-1 truncate text-sm font-semibold text-txt">
+                {primaryIdentity.primary}
+              </div>
+            ) : null}
             {primaryIdentity.secondary ? (
               <div className="mt-0.5 truncate text-xs text-muted">
                 {primaryIdentity.secondary}
@@ -481,7 +622,12 @@ function GoogleConnectorSideCard({
             onValueChange={(mode) => void selectMode(mode)}
             items={VISIBLE_CONNECTOR_MODES.map((mode) => ({
               value: mode,
-              label: modeLabel(mode, t),
+              label: (
+                <ModeLabel
+                  mode={mode}
+                  label={modeLabel(mode as LifeOpsConnectorMode, t)}
+                />
+              ),
               disabled: controlDisabled,
             }))}
             className="min-w-40 flex-1 bg-bg/40 p-0.5 sm:w-auto sm:flex-none"
@@ -490,17 +636,29 @@ function GoogleConnectorSideCard({
           {!status?.connected ? (
             <Button
               size="sm"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={controlDisabled}
               onClick={() => void connect()}
+              title={
+                status?.reason === "needs_reauth"
+                  ? t("common.reconnect", {
+                      defaultValue: "Reconnect",
+                    })
+                  : t("common.connect", {
+                      defaultValue: "Connect",
+                    })
+              }
+              aria-label={
+                status?.reason === "needs_reauth"
+                  ? t("common.reconnect", {
+                      defaultValue: "Reconnect",
+                    })
+                  : t("common.connect", {
+                      defaultValue: "Connect",
+                    })
+              }
             >
-              {status?.reason === "needs_reauth"
-                ? t("common.reconnect", {
-                    defaultValue: "Reconnect",
-                  })
-                : t("common.connect", {
-                    defaultValue: "Connect",
-                  })}
+              <Plug2 className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
           {status?.connected &&
@@ -508,26 +666,34 @@ function GoogleConnectorSideCard({
             <Button
               size="sm"
               variant="outline"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={controlDisabled}
               onClick={() => void connectAdditional()}
-            >
-              {t("common.add", {
+              title={t("common.add", {
                 defaultValue: "Add",
               })}
+              aria-label={t("common.add", {
+                defaultValue: "Add",
+              })}
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
           {status?.connected && connectedAccounts.length <= 1 ? (
             <Button
               size="sm"
               variant="outline"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={controlDisabled}
               onClick={() => void disconnect()}
-            >
-              {t("common.disconnect", {
+              title={t("common.disconnect", {
                 defaultValue: "Disconnect",
               })}
+              aria-label={t("common.disconnect", {
+                defaultValue: "Disconnect",
+              })}
+            >
+              <Unplug className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
         </div>
@@ -537,7 +703,10 @@ function GoogleConnectorSideCard({
         <div className="grid gap-2">
           {connectedAccounts.map((account) => {
             const accountIdentity = readIdentity(account.identity ?? null, t);
-            const labels = capabilityLabels(account.grantedCapabilities, t);
+            const capabilities = capabilityItems(
+              account.grantedCapabilities,
+              t,
+            );
             const isPreferred =
               preferredGrantId != null &&
               account.grant?.id === preferredGrantId;
@@ -552,11 +721,12 @@ function GoogleConnectorSideCard({
                   </span>
                   <div className="flex shrink-0 items-center gap-2">
                     {isPreferred ? (
-                      <Badge variant="secondary" className="text-3xs">
-                        {t("lifeopssettings.active", {
+                      <StatusDot
+                        label={t("lifeopssettings.active", {
                           defaultValue: "Active",
                         })}
-                      </Badge>
+                        tone="ok"
+                      />
                     ) : null}
                     {account.grant?.id ? (
                       <button
@@ -577,12 +747,22 @@ function GoogleConnectorSideCard({
                     ) : null}
                   </div>
                 </div>
-                {labels.length > 0 ? (
+                {capabilities.length > 0 ? (
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {labels.map((label) => (
-                      <Badge key={label} variant="outline" className="text-3xs">
-                        {label}
-                      </Badge>
+                    {capabilities.map((capability) => (
+                      <span
+                        key={capability.key}
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border/26 bg-card/28 text-muted"
+                        title={capability.label}
+                        aria-label={capability.label}
+                        role="img"
+                      >
+                        {capability.key === "calendar" ? (
+                          <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+                        ) : (
+                          <Mail className="h-3.5 w-3.5" aria-hidden />
+                        )}
+                      </span>
                     ))}
                   </div>
                 ) : null}
@@ -599,22 +779,29 @@ function GoogleConnectorSideCard({
           onToggle={(event) => setCalendarFeedOpen(event.currentTarget.open)}
         >
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 text-xs font-semibold text-txt">
-            <span>
+            <span className="inline-flex items-center gap-2">
+              <CalendarDays className="h-3.5 w-3.5 text-muted" aria-hidden />
               {t("lifeopssettings.calendarFeedTitle", {
                 defaultValue: "Calendar feed",
               })}
             </span>
             {calendarError ? (
-              <span className="text-danger">
-                {t("lifeopssettings.calendarFeedIssue", {
+              <AlertTriangle
+                className="h-3.5 w-3.5 text-danger"
+                aria-label={t("lifeopssettings.calendarFeedIssue", {
                   defaultValue: "Issue",
                 })}
-              </span>
+                role="img"
+              />
             ) : calendars.length > 0 ? (
-              <span className="text-muted">
-                {calendars.filter((calendar) => calendar.includeInFeed).length}/
-                {calendars.length}
-              </span>
+              <MiniMeter
+                label={`${calendars.filter((calendar) => calendar.includeInFeed).length}/${calendars.length}`}
+                tone="ok"
+                total={calendars.length}
+                value={
+                  calendars.filter((calendar) => calendar.includeInFeed).length
+                }
+              />
             ) : null}
           </summary>
           <div className="mt-3 space-y-2">
@@ -684,7 +871,7 @@ function GoogleConnectorSideCard({
         />
       ) : null}
       {error ? <div className="text-xs text-danger">{error}</div> : null}
-      <GithubRow github={github} compactLayout={compactLayout} />
+      <GithubRow github={github} />
     </section>
   );
 }
@@ -692,7 +879,6 @@ function GoogleConnectorSideCard({
 export function LifeOpsSettingsSection({
   ownerGithub = DEFAULT_OWNER_GITHUB,
   agentGithub = DEFAULT_AGENT_GITHUB,
-  githubError = null,
   cloudAction = null,
 }: LifeOpsSettingsSectionProps = {}) {
   const { t } = useApp();
@@ -742,10 +928,6 @@ export function LifeOpsSettingsSection({
             {cloudAction.label}
           </Button>
         </div>
-      ) : null}
-
-      {githubError ? (
-        <div className="py-1 text-xs text-muted">{githubError}</div>
       ) : null}
 
       <MobileSignalsSetupCard />

--- a/apps/app-lifeops/src/components/MessagingConnectorCards.tsx
+++ b/apps/app-lifeops/src/components/MessagingConnectorCards.tsx
@@ -10,26 +10,22 @@ import type {
   LifeOpsOwnerBrowserAccessStatus,
   LifeOpsTelegramAuthState,
 } from "@elizaos/shared/contracts/lifeops";
-import { Loader2, MessageCircle, Phone, QrCode } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  ExternalLink,
+  Loader2,
+  MessageCircle,
+  Phone,
+  Plug2,
+  QrCode,
+  RefreshCw,
+  Unplug,
+} from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useDiscordConnector } from "../hooks/useDiscordConnector.js";
 import { useIMessageConnector } from "../hooks/useIMessageConnector.js";
 import { useSignalConnector } from "../hooks/useSignalConnector.js";
 import { useTelegramConnector } from "../hooks/useTelegramConnector.js";
 import { useWhatsAppConnector } from "../hooks/useWhatsAppConnector.js";
-
-function isIosRuntime(): boolean {
-  if (
-    typeof navigator !== "undefined" &&
-    /iPad|iPhone|iPod/.test(navigator.userAgent)
-  ) {
-    return true;
-  }
-  const capacitor = (
-    globalThis as { Capacitor?: { getPlatform?: () => string } }
-  ).Capacitor;
-  return capacitor?.getPlatform?.() === "ios";
-}
 
 const BLUEBUBBLES_INSTALL_URL = "https://bluebubbles.app/install/";
 const MACOS_FULL_DISK_ACCESS_SETTINGS_URL =
@@ -44,7 +40,7 @@ function ConnectorCardShell({
   statusVariant,
   children,
 }: {
-  icon: React.ReactNode;
+  icon: ReactNode;
   platform: string;
   status: string;
   statusVariant: "ok" | "muted" | "warning";
@@ -65,12 +61,46 @@ function ConnectorCardShell({
           <span className="text-sm font-medium text-txt">{platform}</span>
           <span
             className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`}
+            title={status}
+            aria-label={status}
+            role="img"
           />
-          <span className="min-w-0 truncate text-xs text-muted">{status}</span>
         </div>
       </div>
       {children}
     </div>
+  );
+}
+
+function AccessPips({
+  items,
+  label,
+}: {
+  items: Array<"ok" | "warning" | "muted">;
+  label: string;
+}) {
+  const dots = items.length > 0 ? items : ["muted" as const];
+  const slots = ["a", "b", "c", "d", "e", "f"] as const;
+  return (
+    <span
+      aria-label={label}
+      className="inline-flex items-center gap-1"
+      role="img"
+      title={label}
+    >
+      {slots.slice(0, dots.slice(0, 6).length).map((slot, slotIndex) => {
+        const tone = dots[slotIndex];
+        const color =
+          tone === "ok"
+            ? "bg-emerald-500"
+            : tone === "warning"
+              ? "bg-amber-500"
+              : "bg-muted/45";
+        return (
+          <span key={slot} className={`h-1.5 w-1.5 rounded-full ${color}`} />
+        );
+      })}
+    </span>
   );
 }
 
@@ -296,20 +326,16 @@ export function SignalConnectorCard() {
       {!isConnected && !isPairing ? (
         <Button
           size="sm"
-          className="h-8 rounded-xl px-3 text-xs font-semibold"
+          className="h-8 w-8 rounded-xl p-0"
           disabled={busy}
           onClick={() => void signal.startPairing()}
+          title="Link Signal"
+          aria-label="Link Signal"
         >
           {signal.actionPending ? (
-            <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              Starting...
-            </>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
           ) : (
-            <>
-              <QrCode className="mr-1.5 h-3.5 w-3.5" />
-              Link Signal
-            </>
+            <QrCode className="h-3.5 w-3.5" aria-hidden />
           )}
         </Button>
       ) : null}
@@ -333,10 +359,12 @@ export function SignalConnectorCard() {
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             onClick={() => void signal.stopPairing()}
+            title="Cancel"
+            aria-label="Cancel"
           >
-            Cancel
+            <Unplug className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       ) : null}
@@ -352,11 +380,13 @@ export function SignalConnectorCard() {
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={busy}
             onClick={() => void signal.disconnect()}
+            title="Disconnect"
+            aria-label="Disconnect"
           >
-            Disconnect
+            <Unplug className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       ) : null}
@@ -426,6 +456,13 @@ export function DiscordConnectorCard() {
     : pairing || authPending
       ? "warning"
       : "muted";
+  const browserAccessTones = browserAccess.map((access) =>
+    access.active && access.tabState === "dm_inbox_visible"
+      ? "ok"
+      : access.active || access.available
+        ? "warning"
+        : "muted",
+  );
 
   const handleOpenDesktopDiscord = useCallback(async () => {
     try {
@@ -458,18 +495,31 @@ export function DiscordConnectorCard() {
       {showConnectButton ? (
         <Button
           size="sm"
-          className="h-8 rounded-xl px-3 text-xs font-semibold"
+          className="h-8 w-8 rounded-xl p-0"
           disabled={busy || !available}
           onClick={() => void discord.connect()}
-        >
-          {browserAccessActionLabel(preferredAccess?.nextAction) ??
+          title={
+            browserAccessActionLabel(preferredAccess?.nextAction) ??
             (authPending
               ? "Open Discord Login"
               : isConnected
                 ? "Show Discord DMs"
                 : pairing
                   ? "Open Discord"
-                  : "Connect Discord")}
+                  : "Connect Discord")
+          }
+          aria-label={
+            browserAccessActionLabel(preferredAccess?.nextAction) ??
+            (authPending
+              ? "Open Discord Login"
+              : isConnected
+                ? "Show Discord DMs"
+                : pairing
+                  ? "Open Discord"
+                  : "Connect Discord")
+          }
+        >
+          <Plug2 className="h-3.5 w-3.5" aria-hidden />
         </Button>
       ) : null}
 
@@ -482,11 +532,13 @@ export function DiscordConnectorCard() {
         <Button
           size="sm"
           variant="outline"
-          className="h-8 rounded-xl px-3 text-xs font-semibold"
+          className="h-8 w-8 rounded-xl p-0"
           disabled={busy}
           onClick={() => void handleOpenDesktopDiscord()}
+          title="Open in Milady Desktop Browser"
+          aria-label="Open in Milady Desktop Browser"
         >
-          Open in Milady Desktop Browser
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
         </Button>
       ) : null}
 
@@ -508,64 +560,63 @@ export function DiscordConnectorCard() {
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={busy}
             onClick={() => void discord.disconnect()}
+            title="Disconnect"
+            aria-label="Disconnect"
           >
-            Disconnect
+            <Unplug className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       ) : null}
 
-      {!isConnected && authPending ? (
-        <div className="text-xs text-muted">
-          {preferredAccess
-            ? browserAccessMessage(preferredAccess)
-            : "LifeOps found Discord, but that browser session still needs you to log in."}
-        </div>
-      ) : null}
-
-      {!available ? (
-        <div className="text-xs text-muted">Connect browser.</div>
-      ) : null}
-
       {!dmInboxVisible && browserAccess.length > 0 ? (
-        <div className="space-y-2">
-          {browserAccess.map((access) => {
-            const badge = browserAccessBadge(access);
-            return (
-              <div
-                key={`${access.source}:${access.browser ?? "desktop"}:${access.profileId ?? "default"}`}
-                className="rounded-2xl border border-border/20 bg-card/18 px-3 py-2"
-              >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div className="text-xs font-semibold text-txt">
-                    {browserAccessTitle(access)}
+        <details className="rounded-2xl bg-bg/24 px-3 py-2">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+            <span className="text-xs font-semibold text-txt">Sources</span>
+            <AccessPips
+              items={browserAccessTones}
+              label={`${browserAccess.length} browser sources`}
+            />
+          </summary>
+          <div className="mt-2 space-y-2">
+            {browserAccess.map((access) => {
+              const badge = browserAccessBadge(access);
+              return (
+                <div
+                  key={`${access.source}:${access.browser ?? "desktop"}:${access.profileId ?? "default"}`}
+                  className="rounded-2xl border border-border/20 bg-card/18 px-3 py-2"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="text-xs font-semibold text-txt">
+                      {browserAccessTitle(access)}
+                    </div>
+                    <Badge variant={badge.variant} className="text-2xs">
+                      {badge.label}
+                    </Badge>
                   </div>
-                  <Badge variant={badge.variant} className="text-2xs">
-                    {badge.label}
-                  </Badge>
+                  <div className="mt-1 text-xs text-muted">
+                    {browserAccessMessage(access)}
+                  </div>
+                  <div className="mt-1 text-[11px] text-muted/80">
+                    {access.canControl ? "Control on" : "Control off"}
+                    {access.siteAccessOk === false
+                      ? " • Discord not granted yet"
+                      : ""}
+                    {access.tabState === "dm_inbox_visible"
+                      ? " • DM inbox visible"
+                      : access.tabState === "discord_open"
+                        ? " • Discord open"
+                        : access.tabState === "background_discord"
+                          ? " • Discord tab found"
+                          : ""}
+                  </div>
                 </div>
-                <div className="mt-1 text-xs text-muted">
-                  {browserAccessMessage(access)}
-                </div>
-                <div className="mt-1 text-[11px] text-muted/80">
-                  {access.canControl ? "Control on" : "Control off"}
-                  {access.siteAccessOk === false
-                    ? " • Discord not granted yet"
-                    : ""}
-                  {access.tabState === "dm_inbox_visible"
-                    ? " • DM inbox visible"
-                    : access.tabState === "discord_open"
-                      ? " • Discord open"
-                      : access.tabState === "background_discord"
-                        ? " • Discord tab found"
-                        : ""}
-                </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        </details>
       ) : null}
 
       {discord.error ? (
@@ -672,11 +723,13 @@ export function TelegramConnectorCard() {
       {showStartStep ? (
         <Button
           size="sm"
-          className="h-8 rounded-xl px-3 text-xs font-semibold"
+          className="h-8 w-8 rounded-xl p-0"
           disabled={busy}
           onClick={() => setLoginOpen(true)}
+          title={authState === "error" ? "Retry" : "Connect"}
+          aria-label={authState === "error" ? "Retry" : "Connect"}
         >
-          {authState === "error" ? "Retry" : "Connect"}
+          <Plug2 className="h-3.5 w-3.5" aria-hidden />
         </Button>
       ) : null}
 
@@ -786,11 +839,13 @@ export function TelegramConnectorCard() {
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={busy}
             onClick={() => void telegram.disconnect()}
+            title="Disconnect"
+            aria-label="Disconnect"
           >
-            Disconnect
+            <Unplug className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       ) : null}
@@ -851,21 +906,25 @@ export function WhatsAppConnectorCard() {
           {!isConnected ? (
             <Button
               size="sm"
-              className="h-8 rounded-xl px-3 text-xs font-semibold"
+              className="h-8 w-8 rounded-xl p-0"
               disabled={busy}
               onClick={() => void handleOpenSetupGuide()}
+              title="Open setup guide"
+              aria-label="Open setup guide"
             >
-              Open setup guide
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
             </Button>
           ) : null}
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={busy}
             onClick={() => void whatsapp.refresh()}
+            title="Refresh"
+            aria-label="Refresh"
           >
-            Refresh
+            <RefreshCw className="h-3.5 w-3.5" aria-hidden />
           </Button>
         </div>
       </div>
@@ -908,7 +967,6 @@ function formatIMessageDiagnostic(code: string): string {
 export function IMessageConnectorCard() {
   const imessage = useIMessageConnector();
   const { setActionNotice } = useApp();
-  const iosRuntime = isIosRuntime();
   const status = imessage.status;
   const installingImsg = imessage.actionPending === "install_imsg";
   const busy = imessage.loading || installingImsg;
@@ -951,6 +1009,19 @@ export function IMessageConnectorCard() {
         : busy && !status
           ? "warning"
           : "muted";
+  const bridgePips: Array<"ok" | "warning" | "muted"> = [
+    isConnected ? "ok" : "muted",
+    status?.privateApiEnabled === false || status?.helperConnected === false
+      ? "warning"
+      : isConnected
+        ? "ok"
+        : "muted",
+    status?.sendMode === "apple-script"
+      ? "warning"
+      : isConnected
+        ? "ok"
+        : "muted",
+  ];
 
   const handleInstallImsg = useCallback(async () => {
     try {
@@ -1017,17 +1088,6 @@ export function IMessageConnectorCard() {
       statusVariant={statusVariant}
     >
       <div className="space-y-2">
-        <div className="text-xs text-muted">
-          {isConnected
-            ? (bridgeLabel ?? "Connected")
-            : iosRuntime
-              ? "Requires paired Mac"
-              : canOfferLocalMacSetup
-                ? imessage.shellEnabled === false
-                  ? "Shell access off"
-                  : "Mac setup available"
-                : "No bridge detected"}
-        </div>
         {canOfferLocalMacSetup ? (
           <div className="flex flex-wrap items-center gap-2">
             <Button
@@ -1099,56 +1159,75 @@ export function IMessageConnectorCard() {
           </div>
         ) : null}
         {isConnected ? (
-          <div className="rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted">
-            <div>
-              Send path: {formatIMessageSendMode(status?.sendMode ?? "none")}
+          <details className="rounded-2xl bg-bg/24 px-3 py-2">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <span className="text-xs font-semibold text-txt">
+                {bridgeLabel ?? "Bridge"}
+              </span>
+              <AccessPips items={bridgePips} label="iMessage bridge status" />
+            </summary>
+            <div className="mt-2 rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted">
+              <div>
+                Send path: {formatIMessageSendMode(status?.sendMode ?? "none")}
+              </div>
+              {status?.privateApiEnabled !== null ? (
+                <div>
+                  Private API:{" "}
+                  {status.privateApiEnabled ? "enabled" : "disabled"}
+                </div>
+              ) : null}
+              {status?.helperConnected !== null ? (
+                <div>
+                  Helper:{" "}
+                  {status.helperConnected ? "connected" : "disconnected"}
+                </div>
+              ) : null}
             </div>
-            {status?.privateApiEnabled !== null ? (
-              <div>
-                Private API: {status.privateApiEnabled ? "enabled" : "disabled"}
-              </div>
-            ) : null}
-            {status?.helperConnected !== null ? (
-              <div>
-                Helper: {status.helperConnected ? "connected" : "disconnected"}
-              </div>
-            ) : null}
-          </div>
+          </details>
         ) : null}
         <div className="flex items-center gap-2">
           <Button
             size="sm"
             variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
+            className="h-8 w-8 rounded-xl p-0"
             disabled={busy}
             onClick={() => void imessage.refresh()}
+            title="Refresh"
+            aria-label="Refresh"
           >
             {busy ? (
-              <>
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                {installingImsg ? "Working..." : "Refreshing"}
-              </>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
             ) : (
-              "Refresh"
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden />
             )}
           </Button>
-          {status?.lastCheckedAt ? (
-            <span className="text-xs text-muted">
-              Checked {new Date(status.lastCheckedAt).toLocaleTimeString()}
-            </span>
-          ) : null}
         </div>
         {status?.error ? (
           <div className="text-xs text-danger">{status.error}</div>
         ) : null}
-        {status?.diagnostics.map((diagnostic) => (
-          <div
-            key={diagnostic}
-            className="rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted"
-          >
-            {formatIMessageDiagnostic(diagnostic)}
-          </div>
-        ))}
+        {status?.diagnostics.length ? (
+          <details className="rounded-2xl bg-bg/24 px-3 py-2">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <span className="text-xs font-semibold text-txt">
+                Diagnostics
+              </span>
+              <AccessPips
+                items={status.diagnostics.map(() => "warning")}
+                label={`${status.diagnostics.length} diagnostics`}
+              />
+            </summary>
+            <div className="mt-2 space-y-2">
+              {status.diagnostics.map((diagnostic) => (
+                <div
+                  key={diagnostic}
+                  className="rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted"
+                >
+                  {formatIMessageDiagnostic(diagnostic)}
+                </div>
+              ))}
+            </div>
+          </details>
+        ) : null}
         {imessage.error ? (
           <div className="text-xs text-danger">{imessage.error}</div>
         ) : null}

--- a/apps/app-lifeops/src/components/MessagingConnectorCards.tsx
+++ b/apps/app-lifeops/src/components/MessagingConnectorCards.tsx
@@ -58,15 +58,15 @@ function ConnectorCardShell({
         : "bg-muted/40";
 
   return (
-    <div className="space-y-2 py-3">
+    <div className="space-y-2 rounded-2xl border border-border/20 bg-card/14 px-3 py-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2.5">
+        <div className="flex min-w-0 items-center gap-2.5">
           {icon}
           <span className="text-sm font-medium text-txt">{platform}</span>
           <span
             className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`}
           />
-          <span className="text-xs text-muted">{status}</span>
+          <span className="min-w-0 truncate text-xs text-muted">{status}</span>
         </div>
       </div>
       {children}
@@ -500,17 +500,11 @@ export function DiscordConnectorCard() {
           ) : null}
           {dmInboxVisible ? (
             <div className="text-xs text-muted">
-              LifeOps can currently see your Discord DM list.
               {visibleDmLabels.length > 0
-                ? ` Visible now: ${visibleDmLabels.join(", ")}.`
-                : ""}
+                ? visibleDmLabels.join(", ")
+                : "DM inbox visible"}
             </div>
-          ) : (
-            <div className="text-xs text-muted">
-              LifeOps sees your Discord session, but not the DM inbox yet. Use{" "}
-              Show Discord DMs to focus the right tab.
-            </div>
-          )}
+          ) : null}
           <Button
             size="sm"
             variant="outline"
@@ -588,6 +582,7 @@ export function TelegramConnectorCard() {
   const [phoneInput, setPhoneInput] = useState("");
   const [codeInput, setCodeInput] = useState("");
   const [passwordInput, setPasswordInput] = useState("");
+  const [loginOpen, setLoginOpen] = useState(false);
 
   const isConnected = telegram.status?.connected === true;
   const authError = telegram.status?.authError ?? telegram.error;
@@ -603,6 +598,16 @@ export function TelegramConnectorCard() {
       setPhoneInput(telegram.status.phone);
     }
   }, [telegram.status?.phone, phoneInput]);
+
+  useEffect(() => {
+    if (isConnected) {
+      setLoginOpen(false);
+      return;
+    }
+    if (authState !== "idle" && authState !== "error") {
+      setLoginOpen(true);
+    }
+  }, [authState, isConnected]);
 
   const handleSendCode = useCallback(() => {
     if (phoneInput.trim().length > 0) {
@@ -628,8 +633,14 @@ export function TelegramConnectorCard() {
     void telegram.cancelAuth();
   }, [telegram]);
 
+  const showStartStep =
+    !isConnected &&
+    !loginOpen &&
+    (authState === "idle" || authState === "error");
   const showPhoneStep =
-    !isConnected && (authState === "idle" || authState === "error");
+    !isConnected &&
+    loginOpen &&
+    (authState === "idle" || authState === "error");
   const showCodeStep =
     authState === "waiting_for_provisioning_code" ||
     authState === "waiting_for_code";
@@ -658,6 +669,17 @@ export function TelegramConnectorCard() {
       status={statusLabel}
       statusVariant={statusVariant}
     >
+      {showStartStep ? (
+        <Button
+          size="sm"
+          className="h-8 rounded-xl px-3 text-xs font-semibold"
+          disabled={busy}
+          onClick={() => setLoginOpen(true)}
+        >
+          {authState === "error" ? "Retry" : "Connect"}
+        </Button>
+      ) : null}
+
       {showPhoneStep ? (
         <div className="flex items-center gap-2">
           <input
@@ -761,46 +783,6 @@ export function TelegramConnectorCard() {
               )}
             </div>
           ) : null}
-          <div className="rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted">
-            Reads recent chats and sends a test note to Saved Messages.
-          </div>
-          <Button
-            size="sm"
-            variant="outline"
-            className="h-8 rounded-xl px-3 text-xs font-semibold"
-            disabled={busy}
-            onClick={() => void telegram.verify()}
-          >
-            {telegram.verifyPending ? (
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : null}
-            Verify Read + Send
-          </Button>
-          {telegram.verification ? (
-            <div className="rounded-xl border border-border/40 bg-card/18 px-3 py-2 text-xs text-muted">
-              <div>
-                Read:{" "}
-                {telegram.verification.read.ok
-                  ? `${telegram.verification.read.dialogCount} recent chats`
-                  : (telegram.verification.read.error ?? "failed")}
-              </div>
-              <div>
-                Send:{" "}
-                {telegram.verification.send.ok
-                  ? `sent to ${telegram.verification.send.target}`
-                  : (telegram.verification.send.error ?? "failed")}
-              </div>
-              {telegram.verification.read.dialogs.length > 0 ? (
-                <div className="mt-1 truncate">
-                  Recent:{" "}
-                  {telegram.verification.read.dialogs
-                    .slice(0, 3)
-                    .map((dialog) => dialog.title)
-                    .join(", ")}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
           <Button
             size="sm"
             variant="outline"
@@ -859,11 +841,6 @@ export function WhatsAppConnectorCard() {
       statusVariant={statusVariant}
     >
       <div className="space-y-2">
-        <div className="text-xs text-muted">
-          {isConnected
-            ? "LifeOps can send WhatsApp messages through the configured Business Cloud API credentials. Inbound delivery still comes from your webhook setup."
-            : "Configure WhatsApp Business Cloud API access to let LifeOps send messages and receive inbound webhook events."}
-        </div>
         {whatsapp.status?.phoneNumberId ? (
           <div className="flex items-center gap-1.5 text-xs text-muted">
             <Phone className="h-3.5 w-3.5" />
@@ -1042,18 +1019,14 @@ export function IMessageConnectorCard() {
       <div className="space-y-2">
         <div className="text-xs text-muted">
           {isConnected
-            ? bridgeLabel === "BlueBubbles"
-              ? status?.sendMode === "private-api"
-                ? "LifeOps is using the Mac-side BlueBubbles bridge with Private API enabled."
-                : "LifeOps is using the Mac-side BlueBubbles bridge. Sends are currently using the AppleScript fallback."
-              : "LifeOps is using the Mac-side imsg bridge for iMessage access."
+            ? (bridgeLabel ?? "Connected")
             : iosRuntime
-              ? "iMessage access must run through a paired Mac or BlueBubbles bridge. Connect this iPhone to a remote Mac or cloud backend that has iMessage configured."
+              ? "Requires paired Mac"
               : canOfferLocalMacSetup
                 ? imessage.shellEnabled === false
-                  ? "Shell access is off. Enable it or set up BlueBubbles."
-                  : "Install imsg locally or set up BlueBubbles."
-                : "No iMessage bridge detected."}
+                  ? "Shell access off"
+                  : "Mac setup available"
+                : "No bridge detected"}
         </div>
         {canOfferLocalMacSetup ? (
           <div className="flex flex-wrap items-center gap-2">
@@ -1187,9 +1160,6 @@ export function IMessageConnectorCard() {
 export function MessagingConnectorGrid() {
   return (
     <div className="space-y-1">
-      <div className="pb-1 text-xs font-semibold uppercase tracking-wide text-muted">
-        Messaging
-      </div>
       <div className="space-y-1">
         <SignalConnectorCard />
         <DiscordConnectorCard />

--- a/apps/app-lifeops/src/components/MobileSignalsSetupCard.tsx
+++ b/apps/app-lifeops/src/components/MobileSignalsSetupCard.tsx
@@ -6,7 +6,13 @@ import {
   type MobileSignalsSetupAction,
 } from "@elizaos/app-core/bridge/native-plugins";
 import { isNative } from "@elizaos/app-core/platform";
-import { Activity, RefreshCw, Settings } from "lucide-react";
+import {
+  Activity,
+  Monitor,
+  RefreshCw,
+  Settings,
+  Smartphone,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 type TranslateOptions = { defaultValue?: string } & Record<
@@ -64,6 +70,31 @@ function nonMobileBadgeLabel(t: TranslateFn): string {
     : t("lifeopssettings.deviceSetupWeb", {
         defaultValue: "Web",
       });
+}
+
+function DeviceRuntimeGlyph({
+  label,
+  nativeMobile,
+  ready,
+}: {
+  label: string;
+  nativeMobile: boolean;
+  ready: boolean;
+}) {
+  const Icon = nativeMobile ? Smartphone : Monitor;
+  const tone = ready
+    ? "border-emerald-500/30 bg-emerald-500/12 text-emerald-500"
+    : "border-border/50 bg-bg/40 text-muted";
+  return (
+    <span
+      aria-label={label}
+      className={`inline-flex h-8 w-8 items-center justify-center rounded-full border ${tone}`}
+      role="img"
+      title={label}
+    >
+      <Icon className="h-4 w-4" aria-hidden />
+    </span>
+  );
 }
 
 export function MobileSignalsSetupCard() {
@@ -169,12 +200,18 @@ export function MobileSignalsSetupCard() {
   const needsRequest = actions.some(
     (action) => action.status !== "ready" && action.canRequest,
   );
+  const runtimeLabel = nativeMobile
+    ? (permissionStatus?.status ?? "checking")
+    : nonMobileBadgeLabel(t);
+  const runtimeReady = nativeMobile
+    ? permissionStatus?.status === "granted"
+    : true;
 
   return (
-    <div className="rounded-2xl border border-border/60 bg-card/92 shadow-sm">
-      <div className="flex flex-col gap-3 px-4 py-4 sm:flex-row sm:items-start sm:justify-between">
+    <div className="rounded-2xl border border-border/40 bg-card/62 shadow-sm">
+      <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border/50 bg-bg/40">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-border/40 bg-bg/36">
             <Activity className="h-5 w-5 text-txt" aria-hidden />
           </div>
           <div className="min-w-0 space-y-1">
@@ -184,18 +221,11 @@ export function MobileSignalsSetupCard() {
                   defaultValue: "Device Data",
                 })}
               </div>
-              <Badge
-                variant={
-                  permissionStatus?.status === "granted"
-                    ? "secondary"
-                    : "outline"
-                }
-                className="text-2xs"
-              >
-                {nativeMobile
-                  ? (permissionStatus?.status ?? "checking")
-                  : nonMobileBadgeLabel(t)}
-              </Badge>
+              <DeviceRuntimeGlyph
+                label={runtimeLabel}
+                nativeMobile={nativeMobile}
+                ready={runtimeReady}
+              />
             </div>
             {message ? <p className="text-xs text-muted">{message}</p> : null}
           </div>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "workspaces": [
     "packages/*",
     "packages/native-plugins/*",
+    "packages/app-core/deploy/cloud-agent-template",
     "apps/*",
     "plugins/*",
     "plugins/*/typescript",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -143,7 +143,7 @@
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-agent-orchestrator": "workspace:*",
     "@elizaos/plugin-browser-bridge": "workspace:*",
-    "@elizaos/plugin-local-embedding": "^2.0.0-alpha.3",
+    "@elizaos/plugin-local-embedding": "workspace:*",
     "@elizaos/plugin-ollama": "workspace:*",
     "@elizaos/plugin-pdf": "workspace:*",
     "@elizaos/plugin-solana": "workspace:*",

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -977,65 +977,71 @@ export async function handleConversationRoutes(
             return;
           }
 
-          const storedSenderProfile = await resolveStoredDiscordEntityProfile(
-            runtime,
-            message.senderEntityId,
-          );
-          if (!message.from && storedSenderProfile?.displayName) {
-            message.from = storedSenderProfile.displayName;
-          }
-          if (!message.fromUserName && storedSenderProfile?.username) {
-            message.fromUserName = storedSenderProfile.username;
-          }
-          if (!message.avatarUrl && storedSenderProfile?.avatarUrl) {
-            message.avatarUrl = storedSenderProfile.avatarUrl;
-          }
-
-          const messageAuthorProfile =
-            message.rawDiscordChannelId && message.rawDiscordMessageId
-              ? await resolveDiscordMessageAuthorProfile(
-                  runtime,
-                  message.rawDiscordChannelId,
-                  message.rawDiscordMessageId,
-                )
-              : null;
-          if (!message.from && messageAuthorProfile?.displayName) {
-            message.from = messageAuthorProfile.displayName;
-          }
-          if (!message.fromUserName && messageAuthorProfile?.username) {
-            message.fromUserName = messageAuthorProfile.username;
-          }
-          if (!message.avatarUrl && messageAuthorProfile?.avatarUrl) {
-            message.avatarUrl = messageAuthorProfile.avatarUrl;
-          }
-
-          const rawSenderId =
-            message.rawSenderId ??
-            storedSenderProfile?.rawUserId ??
-            messageAuthorProfile?.rawUserId;
-          if (rawSenderId) {
-            const profile = await resolveDiscordUserProfile(
+          try {
+            const storedSenderProfile = await resolveStoredDiscordEntityProfile(
               runtime,
-              rawSenderId,
+              message.senderEntityId,
             );
-            if (profile) {
-              if (profile.displayName) {
-                message.from = profile.displayName;
-              }
-              if (profile.username) {
-                message.fromUserName = profile.username;
-              }
-              if (profile.avatarUrl) {
-                message.avatarUrl = profile.avatarUrl;
+            if (!message.from && storedSenderProfile?.displayName) {
+              message.from = storedSenderProfile.displayName;
+            }
+            if (!message.fromUserName && storedSenderProfile?.username) {
+              message.fromUserName = storedSenderProfile.username;
+            }
+            if (!message.avatarUrl && storedSenderProfile?.avatarUrl) {
+              message.avatarUrl = storedSenderProfile.avatarUrl;
+            }
+
+            const messageAuthorProfile =
+              message.rawDiscordChannelId && message.rawDiscordMessageId
+                ? await resolveDiscordMessageAuthorProfile(
+                    runtime,
+                    message.rawDiscordChannelId,
+                    message.rawDiscordMessageId,
+                  )
+                : null;
+            if (!message.from && messageAuthorProfile?.displayName) {
+              message.from = messageAuthorProfile.displayName;
+            }
+            if (!message.fromUserName && messageAuthorProfile?.username) {
+              message.fromUserName = messageAuthorProfile.username;
+            }
+            if (!message.avatarUrl && messageAuthorProfile?.avatarUrl) {
+              message.avatarUrl = messageAuthorProfile.avatarUrl;
+            }
+
+            const rawSenderId =
+              message.rawSenderId ??
+              storedSenderProfile?.rawUserId ??
+              messageAuthorProfile?.rawUserId;
+            if (rawSenderId) {
+              const profile = await resolveDiscordUserProfile(
+                runtime,
+                rawSenderId,
+              );
+              if (profile) {
+                if (profile.displayName) {
+                  message.from = profile.displayName;
+                }
+                if (profile.username) {
+                  message.fromUserName = profile.username;
+                }
+                if (profile.avatarUrl) {
+                  message.avatarUrl = profile.avatarUrl;
+                }
               }
             }
-          }
 
-          message.avatarUrl = await cacheDiscordAvatarForRuntime(
-            runtime,
-            message.avatarUrl,
-            rawSenderId,
-          );
+            message.avatarUrl = await cacheDiscordAvatarForRuntime(
+              runtime,
+              message.avatarUrl,
+              rawSenderId,
+            );
+          } catch (err) {
+            logger.debug(
+              `[conversations] Failed to enrich Discord message metadata: ${getErrorMessage(err)}`,
+            );
+          }
         }),
       );
       json(res, {

--- a/packages/agent/src/api/relationships-routes.ts
+++ b/packages/agent/src/api/relationships-routes.ts
@@ -94,6 +94,26 @@ function asEvidenceRecord(value: unknown): Record<string, unknown> {
   return {};
 }
 
+function parseActivityInteger(
+  value: string | null,
+  fallback: number,
+  options: { min: number; max?: number },
+): number | null {
+  if (value === null) {
+    return fallback;
+  }
+  if (!/^\d+$/.test(value)) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < options.min) {
+    return null;
+  }
+  return typeof options.max === "number"
+    ? Math.min(parsed, options.max)
+    : parsed;
+}
+
 export async function handleRelationshipsRoutes(
   ctx: RelationshipsRouteContext,
 ): Promise<boolean> {
@@ -335,14 +355,20 @@ export async function handleRelationshipsRoutes(
       req.url ?? "/api/relationships/activity",
       "http://localhost",
     );
-    const limitParam = activityUrl.searchParams.get("limit");
-    const limit = limitParam
-      ? Math.min(Number.parseInt(limitParam, 10), 100)
-      : 50;
-    const offsetParam = activityUrl.searchParams.get("offset");
-    const offset = offsetParam
-      ? Math.max(0, Number.parseInt(offsetParam, 10))
-      : 0;
+    const limit = parseActivityInteger(
+      activityUrl.searchParams.get("limit"),
+      50,
+      { min: 1, max: 100 },
+    );
+    const offset = parseActivityInteger(
+      activityUrl.searchParams.get("offset"),
+      0,
+      { min: 0 },
+    );
+    if (limit === null || offset === null) {
+      error(res, "Invalid relationships activity pagination.", 400);
+      return true;
+    }
 
     json(
       res,

--- a/packages/app-core/deploy/Dockerfile.cloud
+++ b/packages/app-core/deploy/Dockerfile.cloud
@@ -26,29 +26,131 @@ WORKDIR /src
 # Copy only the manifests Bun needs to resolve the production dependency graph.
 COPY package.json bun.lock ./
 COPY eliza/packages/app-core/patches ./eliza/packages/app-core/patches
+COPY eliza/packages/typescript/package.json ./eliza/packages/typescript/package.json
 COPY eliza/packages/agent/package.json ./eliza/packages/agent/package.json
 COPY eliza/packages/app-core/package.json ./eliza/packages/app-core/package.json
 COPY eliza/packages/shared/package.json ./eliza/packages/shared/package.json
 COPY eliza/packages/ui/package.json ./eliza/packages/ui/package.json
+COPY eliza/plugins/plugin-sql/typescript/package.json ./eliza/plugins/plugin-sql/typescript/package.json
+COPY eliza/plugins/plugin-elizacloud/typescript/package.json ./eliza/plugins/plugin-elizacloud/typescript/package.json
 COPY apps/app/package.json ./apps/app/package.json
 COPY eliza/packages/app-core/platforms/electrobun/package.json ./eliza/packages/app-core/platforms/electrobun/package.json
 COPY eliza/packages/app-core/deploy/cloud-agent-template/package.json ./eliza/packages/app-core/deploy/cloud-agent-template/package.json
 
 ENV NODE_LLAMA_CPP_SKIP_DOWNLOAD=true
-# Strip workspaces + workspace:* deps that reference packages absent from this
-# build context. The cloud image only ships the agent runtime — apps/app,
-# eliza/apps/*, and eliza/packages/native-plugins/* are intentionally not
-# COPY'd, so we must remove them from the workspaces array AND from any
-# COPY'd package.json's workspace:* deps before bun install runs.
-RUN node -e "const fs=require('fs');\
-const KEEP=['eliza/packages/agent','eliza/packages/app-core','eliza/packages/shared','eliza/packages/ui','eliza/packages/app-core/platforms/electrobun','eliza/packages/app-core/deploy/cloud-agent-template','apps/app'];\
-const ALLOW=new Set(['@elizaos/agent','@elizaos/app-core','@elizaos/shared','@elizaos/ui','@elizaos/core']);\
-const PRUNE_FIELDS=['dependencies','devDependencies','optionalDependencies','peerDependencies','overrides'];\
-const STRIP_NAMES=/^@elizaos\/(app-|capacitor-|plugin-agent-orchestrator|plugin-cli|plugin-imessage|plugin-local-ai|plugin-pdf|plugin-wechat|steward-)/;\
-function prune(p){if(!fs.existsSync(p))return;const j=JSON.parse(fs.readFileSync(p,'utf8'));for(const s of PRUNE_FIELDS){const d=j[s];if(!d)continue;for(const[k,v]of Object.entries(d)){const isWs=typeof v==='string'&&v.startsWith('workspace:');const isStripName=STRIP_NAMES.test(k);if((isWs&&!ALLOW.has(k))||isStripName)delete d[k];}}fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n');}\
-const r=JSON.parse(fs.readFileSync('package.json','utf8'));r.workspaces=KEEP;fs.writeFileSync('package.json',JSON.stringify(r,null,2)+'\n');\
-['package.json','apps/app/package.json','eliza/packages/agent/package.json','eliza/packages/app-core/package.json','eliza/packages/shared/package.json','eliza/packages/ui/package.json','eliza/packages/app-core/platforms/electrobun/package.json','eliza/packages/app-core/deploy/cloud-agent-template/package.json'].forEach(prune);\
-if(fs.existsSync('bun.lock'))fs.unlinkSync('bun.lock');"
+# Materialize the standalone cloud-agent template at the Docker deploy
+# boundary. Source manifests stay workspace-local; the image install uses the
+# local package versions as exact npm dependencies.
+RUN node <<'EOF'
+const fs = require("fs");
+
+const KEEP = [
+  "eliza/packages/agent",
+  "eliza/packages/app-core",
+  "eliza/packages/shared",
+  "eliza/packages/ui",
+  "eliza/packages/app-core/platforms/electrobun",
+  "eliza/packages/app-core/deploy/cloud-agent-template",
+  "apps/app",
+];
+const ALLOW = new Set([
+  "@elizaos/agent",
+  "@elizaos/app-core",
+  "@elizaos/shared",
+  "@elizaos/ui",
+]);
+const PRUNE_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+  "overrides",
+];
+const STRIP_NAMES =
+  /^@elizaos\/(app-|capacitor-|plugin-agent-orchestrator|plugin-cli|plugin-imessage|plugin-local-ai|plugin-pdf|plugin-wechat|steward-)/;
+const VERSION_MANIFESTS = [
+  "eliza/packages/typescript/package.json",
+  "eliza/plugins/plugin-sql/typescript/package.json",
+  "eliza/plugins/plugin-elizacloud/typescript/package.json",
+];
+const CLOUD_AGENT_RELEASE_DEPS = [
+  "@elizaos/core",
+  "@elizaos/plugin-sql",
+  "@elizaos/plugin-elizacloud",
+];
+
+function readJson(path) {
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function writeJson(path, data) {
+  fs.writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+}
+
+function collectVersions() {
+  const versions = new Map();
+  for (const manifest of VERSION_MANIFESTS) {
+    const pkg = readJson(manifest);
+    if (typeof pkg.name === "string" && typeof pkg.version === "string") {
+      versions.set(pkg.name, pkg.version);
+    }
+  }
+  return versions;
+}
+
+function materializeWorkspaceDeps(path, dependencyNames, versions) {
+  const pkg = readJson(path);
+  let changed = false;
+  for (const name of dependencyNames) {
+    const spec = pkg.dependencies?.[name];
+    if (typeof spec !== "string" || !spec.startsWith("workspace:")) continue;
+    const version = versions.get(name);
+    if (!version) throw new Error(`No local package version found for ${name}`);
+    pkg.dependencies[name] = version;
+    changed = true;
+  }
+  if (changed) writeJson(path, pkg);
+}
+
+function prune(path) {
+  if (!fs.existsSync(path)) return;
+  const pkg = readJson(path);
+  for (const section of PRUNE_FIELDS) {
+    const deps = pkg[section];
+    if (!deps) continue;
+    for (const [name, spec] of Object.entries(deps)) {
+      const isWorkspace =
+        typeof spec === "string" && spec.startsWith("workspace:");
+      const isStripName = STRIP_NAMES.test(name);
+      if ((isWorkspace && !ALLOW.has(name)) || isStripName) {
+        delete deps[name];
+      }
+    }
+  }
+  writeJson(path, pkg);
+}
+
+materializeWorkspaceDeps(
+  "eliza/packages/app-core/deploy/cloud-agent-template/package.json",
+  CLOUD_AGENT_RELEASE_DEPS,
+  collectVersions(),
+);
+
+const root = readJson("package.json");
+root.workspaces = KEEP;
+writeJson("package.json", root);
+[
+  "package.json",
+  "apps/app/package.json",
+  "eliza/packages/agent/package.json",
+  "eliza/packages/app-core/package.json",
+  "eliza/packages/shared/package.json",
+  "eliza/packages/ui/package.json",
+  "eliza/packages/app-core/platforms/electrobun/package.json",
+  "eliza/packages/app-core/deploy/cloud-agent-template/package.json",
+].forEach(prune);
+if (fs.existsSync("bun.lock")) fs.unlinkSync("bun.lock");
+EOF
 # Drop --frozen-lockfile: bun.lock has been removed above so bun regenerates
 # fresh against the pruned workspace set.
 RUN bun install --ignore-scripts --no-progress

--- a/packages/app-core/deploy/cloud-agent-template/package.json
+++ b/packages/app-core/deploy/cloud-agent-template/package.json
@@ -6,9 +6,9 @@
     "start": "tsx entrypoint.ts"
   },
   "dependencies": {
-    "@elizaos/core": "2.0.0-alpha.336",
-    "@elizaos/plugin-sql": "2.0.0-alpha.19",
-    "@elizaos/plugin-elizacloud": "2.0.0-alpha.8",
+    "@elizaos/core": "workspace:*",
+    "@elizaos/plugin-sql": "workspace:*",
+    "@elizaos/plugin-elizacloud": "workspace:*",
     "tsx": "4.21.0"
   }
 }

--- a/packages/app-core/docs/automations-ux-redesign.md
+++ b/packages/app-core/docs/automations-ux-redesign.md
@@ -1,0 +1,499 @@
+# Automations UX Redesign
+
+## Scope
+
+This writeup covers the Automations product surface: overview, creation, task editing, workflow editing, drafts, events, graph/data flow, sidebar navigation, nodes, and the right sidebar agent. It is intentionally a product and interaction spec, not a visual mood board. The goal is to make automations feel obvious, compact, and powerful without exposing internal implementation details.
+
+Primary references:
+
+- n8n AI Workflow Builder: natural-language creation, build feedback, review, refinement, and credential review are core to the builder model. Source: https://docs.n8n.io/advanced-ai/ai-workflow-builder/
+- Slack Workflow Builder: starts from templates or scratch, distinguishes steps, connector steps, activity, errors, and management actions. Source: https://join.slack.com/help/articles/360035692513-Guide-to-Slack-Workflow-Builder
+- Zapier drafts and versions: drafts belong in the editor/sidebar, can be deleted, and publish/version history is separate from active runtime state. Source: https://help.zapier.com/hc/en-us/articles/9693520498445-Create-Zap-drafts-and-versions
+- Apple Shortcuts: shortcuts are multi-step action sequences, actions are the atomic building blocks, and gallery/examples teach by showing useful possibilities. Source: https://support.apple.com/guide/shortcuts/welcome/ios
+
+## North Star
+
+Automations should feel like this:
+
+1. Say what should happen.
+2. Let the system choose the simplest shape.
+3. Inspect only the parts that affect trust: start condition, action path, state, and errors.
+4. Edit either by clicking a compact visual element or by telling the sidebar agent what to change.
+
+The user should not have to learn our backend vocabulary. They should not see UUIDs, room IDs, node catalog counts, coordinator language, or empty debug panels. They should see live work, drafts, problems, and the graph when the automation is actually a graph.
+
+## Current Screenshots
+
+### Screenshot A: Catalog-First Overview
+
+What is really there:
+
+- Left sidebar with Overview, Workflows, Coordinator, Scheduled, and Node Catalog.
+- Main content opens on a Heartbeat automation and immediately exposes schedule metadata, run history, and an Automation Nodes catalog.
+- Status appears as a large ACTIVE badge instead of a lightweight state signal.
+- The page spends the user's primary workspace on implementation internals.
+
+Why it is weak:
+
+- The overview should answer operational questions, not teach the node registry.
+- Node Catalog implies building from primitives, which is the opposite of the desired AI-generated workflow model.
+- Scheduled, Workflows, and Coordinator create overlapping concepts without explaining user intent.
+- Empty run history and node lists make the page feel like a debug console.
+
+What should replace it:
+
+- Overview: command input, health strip, next item, running items, drafts, failures, recent changes.
+- Nodes: a collapsed secondary section for users who need primitives.
+- Agent Owned: collapsed by default, no add button, framed as system-owned automations.
+
+### Screenshot B: Draft Workflow With Two Chats
+
+What is really there:
+
+- A workflow draft detail page with a graph canvas, a local Automations Assistant panel, and a separate right sidebar chat.
+- The draft content is mostly empty: no generated nodes, no clear primary action, and no durable editor state beyond the draft label.
+- The assistant panel asks the user to describe a workflow even though there is already a page-level chat.
+
+Why it is weak:
+
+- Two chat surfaces split responsibility. Users cannot know which one edits the workflow.
+- The draft is not useful until it becomes the actual editor object.
+- The graph is correct as the primary workflow surface, but it needs one obvious start action.
+
+What should replace it:
+
+- One right sidebar agent only.
+- A visible "Describe your workflow" command box on the workflow editor when no nodes exist.
+- Drafts remain real selectable objects with delete and continue actions.
+
+### Screenshot C: Sparse Overview With Floating Chat
+
+What is really there:
+
+- Sidebar contains Tasks, Workflows, Agent Owned, and Nodes.
+- Main overview shows top-line counts and a mostly empty content area.
+- Right chat is present, but the page itself gives little direction.
+
+Why it is weak:
+
+- Sparse is better than slop, but empty space must still guide the user's next action.
+- Counts alone do not explain what needs attention.
+- The overview should fill the page with useful operational state when data exists and useful creation affordances when it does not.
+
+What should replace it:
+
+- Empty state: one sentence explaining tasks vs workflows, one command input, a few example chips.
+- Non-empty state: compact command center with next, running, needs attention, drafts, and recent changes.
+
+## Element-by-Element Spec
+
+### 1. Left Sidebar
+
+What each element does:
+
+- Overview opens the command center.
+- Tasks lists prompt-based automations.
+- Workflows lists graph-based n8n automations.
+- Agent Owned contains system-managed automations and should start collapsed.
+- Nodes opens the node catalog only when the user explicitly needs primitives.
+- Plus buttons beside Tasks and Workflows create that shape directly.
+- Status dots show live, draft/setup, paused, or failed without full badges.
+
+Defense:
+
+- The sidebar is navigation, not analytics. Counts on the right of headers add noise and do not help users choose where to go.
+- Tasks above Workflows is correct because tasks are simpler and more common.
+- Agent Owned belongs below user-owned objects because it is not where users start.
+
+Does it need to be there:
+
+- Required: Overview, Tasks, Workflows, status dots, add buttons for user-created sections.
+- Optional: Nodes, but it should remain secondary.
+- Not needed: search in the sidebar for early scale; it takes space and does not solve the primary creation problem.
+
+Other ways to do it:
+
+- A single Automations list with filters would reduce taxonomy but hide the task/workflow difference too late.
+- A nested tree by trigger type would help admins but increase mental overhead for normal users.
+
+How other companies do it:
+
+- Zapier and Slack keep primary navigation centered on created automations/workflows and management views, not primitive catalogs.
+- Apple Shortcuts uses Gallery and Shortcuts as high-level concepts; actions are deeper inside editing.
+
+Responsive rules:
+
+- Desktop sidebar can show section labels and rows.
+- Tablet can keep labels but collapse secondary sections.
+- Mobile should become a drawer or bottom sheet; status dots remain, but section controls need larger tap targets.
+
+### 2. Overview Command Center
+
+What each element does:
+
+- Command input creates from intent: "What should happen?"
+- Status strip summarizes Live, Timed, Events, and Attention.
+- Next panel shows the next scheduled run or the next draft to continue.
+- Running panel shows enabled automations.
+- Needs attention shows failures or blocked setup.
+- Drafts shows unfinished tasks/workflows that can be resumed or deleted.
+- Recently changed provides a lightweight recency trail.
+- Task and Workflow inventory stays lower because inventory is less urgent than operational state.
+
+Defense:
+
+- The overview is the product's cockpit. It should answer: what will run, what is live, what is broken, and what should I create next?
+- It should not duplicate every detail from the editor.
+- It should not display UUIDs, room IDs, raw node counts, coordinator internals, or empty log panels.
+
+Does it need to be there:
+
+- Required: command input, Next, Needs attention.
+- Strongly useful: Running, Drafts, Recently changed.
+- Optional: detailed inventory if the lists become long enough to require a table.
+
+Other ways to do it:
+
+- Table-first dashboard. Efficient at high scale but cold and harder for new users.
+- Activity-feed-first dashboard. Good after heavy use, poor for first-run creation.
+- Card grid. Friendly but wastes space and repeats labels.
+
+How other companies do it:
+
+- Slack emphasizes workflow starts, steps, activity, and errors.
+- Zapier separates drafts/versioning from live Zap operation.
+- Apple Shortcuts starts with useful examples and created shortcuts, not raw internals.
+
+Responsive rules:
+
+- Desktop: command input and Next panel can sit in a two-column top area.
+- Tablet: top area stacks, status chips wrap.
+- Mobile: command input first, then Next, Attention, Drafts, Running, Recent. Inventory can collapse behind section headers.
+
+### 3. Single Creation Input
+
+What each element does:
+
+- Text input captures intent.
+- Create button submits intent.
+- The system infers task vs workflow using simple defaults.
+- Direct Task and Workflow buttons remain as escape hatches for users who know the shape.
+
+Defense:
+
+- Asking users to pick Task or Workflow before describing the automation makes them solve our information architecture first.
+- Most simple scheduled prompts should become tasks.
+- Conditional, event-based, multi-step, or pipeline prompts should become workflows.
+
+Does it need to be there:
+
+- Required. It is the most important simplification.
+
+Other ways to do it:
+
+- Modal wizard: clearer validation, slower creation.
+- Template gallery first: good onboarding, slower for users with intent.
+- Chat-only creation: powerful, but invisible unless the user already trusts the chat.
+
+How other companies do it:
+
+- n8n's AI builder starts from a workflow description, then refines.
+- Zapier supports AI-assisted Zap creation but still exposes the resulting editor.
+- Slack starts from templates or scratch and then manages steps.
+
+Responsive rules:
+
+- Input must remain the largest obvious target on every viewport.
+- Submit button stacks below on narrow screens.
+- Placeholder should be an example, not a paragraph.
+
+### 4. Task Editor
+
+What each element does:
+
+- Name/title identifies the task.
+- Prompt/instructions is the task body.
+- Starts when controls schedule or event trigger.
+- Status controls live, paused, or draft.
+- Runs/history shows outcomes after execution.
+- Advanced settings contain raw details only when needed.
+
+Defense:
+
+- A task is not a graph. It should be a simple text editor plus trigger configuration.
+- The task body is the primary content; surrounding settings should not dominate it.
+- Event and schedule triggers should use the same start-condition model as workflows.
+
+Does it need to be there:
+
+- Required: prompt, start condition, status, save/delete.
+- Useful: run history and failure repair.
+- Not needed by default: raw cron, UUIDs, backing room, internal wake mode.
+
+Other ways to do it:
+
+- Form-only wizard. Clear but too rigid for editing.
+- Chat-only task editor. Fast but poor for verification.
+- YAML/JSON editor. Powerful but wrong for this product surface.
+
+How other companies do it:
+
+- OpenClaw Heartbeat-like tasks are background prompts with a schedule, but user-facing editing should stay simpler than implementation.
+- Apple Shortcuts keeps action details editable but hides platform internals.
+
+Responsive rules:
+
+- Mobile task editor should put prompt first, then trigger, then actions.
+- Save/delete should be sticky or reachable without scrolling through advanced details.
+
+### 5. Workflow Editor
+
+What each element does:
+
+- Header identifies title, status, start condition, and primary actions.
+- Graph canvas displays the directed n8n workflow.
+- Node inspector edits selected node details.
+- Data-flow strip summarizes how information moves from input to output.
+- Settings panel controls trigger, credentials, enablement, and advanced execution details.
+- Sidebar agent can generate, revise, explain, or repair the workflow.
+
+Defense:
+
+- Workflows are directed graphs. The graph is not decorative; it is the user's proof of what will happen.
+- A workflow needs both a visual overview and a compact linear explanation because graphs can become hard to parse.
+- n8n compatibility matters, but Milady should wrap n8n complexity in clearer product language.
+
+Does it need to be there:
+
+- Required: graph, start condition, status, save/delete/duplicate, agent edit path.
+- Useful: node inspector, data-flow strip, undo/redo.
+- Advanced-only: raw n8n JSON, node IDs, credential IDs, execution internals.
+
+Other ways to do it:
+
+- Linear step editor. Easier for mobile and simple workflows, weaker for branching.
+- Full embedded n8n. Maximum power, less integrated and more intimidating.
+- Mermaid-like generated preview. Readable, but not sufficiently editable.
+
+How other companies do it:
+
+- n8n uses a canvas as the real workflow editor.
+- Zapier's editor is step-oriented because most Zaps are linear.
+- Slack workflows use starts and steps, emphasizing understandable sequence over raw graph internals.
+
+Responsive rules:
+
+- Desktop: graph left, inspector/settings right or drawer, agent in global sidebar.
+- Tablet: graph full width, inspector below or slide-over.
+- Mobile: graph should have a step-list fallback because canvas manipulation is difficult on small screens.
+
+### 6. Events and Information Flow
+
+What each element does:
+
+- Event trigger defines the incoming payload.
+- First node receives that payload.
+- Each node declares what it consumes and produces.
+- Edges represent data movement, not just execution order.
+- Data-flow strip names the path in plain language.
+
+Defense:
+
+- Users need to know what information is available to each step.
+- Discord, Telegram, email, and similar messages should normalize to generic events like `message.received` where possible.
+- Raw event names should be inspectable but not the default language.
+
+Does it need to be there:
+
+- Required for workflow trust.
+- Required for event-triggered tasks.
+
+Other ways to do it:
+
+- Hide payloads entirely. Simpler, but users cannot debug why a step lacks data.
+- Show raw JSON everywhere. Precise, but too technical.
+- Schema chips per edge. Strong future direction, but only useful after payload schemas are normalized.
+
+How other companies do it:
+
+- n8n exposes node input/output data in executions.
+- Zapier maps fields from prior steps into later steps.
+- Slack workflow variables expose outputs from earlier steps.
+
+Responsive rules:
+
+- Desktop can show graph plus compact flow strip.
+- Mobile should prioritize the linear data-flow strip over the freeform canvas.
+- Raw payload drawer should be copyable and collapsible.
+
+### 7. Draft Management
+
+What each element does:
+
+- Drafts appear in the sidebar and overview.
+- Draft detail opens the actual task/workflow editor.
+- Delete removes drafts after confirmation.
+- Duplicate creates a separate draft from an existing automation.
+- Publish/enable changes runtime state.
+
+Defense:
+
+- Drafts are work, not placeholders.
+- Users need to safely explore, duplicate, abandon, and resume ideas.
+- "What would you like to automate?" is an entry prompt, not a draft detail page.
+
+Does it need to be there:
+
+- Required: list, open, delete, continue.
+- Strongly useful: duplicate.
+- Optional: version history, publish comparison.
+
+Other ways to do it:
+
+- Auto-delete empty drafts. Reduces clutter, but risks losing intent.
+- Single draft per user. Simple, but blocks parallel work.
+- Hidden drafts only in editor. Keeps sidebar clean, but users cannot recover them easily.
+
+How other companies do it:
+
+- Zapier treats drafts and versions as explicit objects separate from published behavior.
+- n8n keeps workflows editable and inactive until activated.
+
+Responsive rules:
+
+- Draft rows should be compact and clearly marked with a yellow dot.
+- Delete must remain a confirmed destructive action.
+- Mobile should expose delete in an overflow menu, not as an accidental row tap.
+
+### 8. One Sidebar Agent
+
+What each element does:
+
+- The right sidebar chat is the only conversational assistant.
+- Page controls can prefill the chat with workflow/task-specific prompts.
+- The agent can generate, edit, explain, repair, duplicate, enable, disable, or inspect automations.
+
+Defense:
+
+- Two assistant panels create ambiguity and duplicated state.
+- One assistant makes all automation operations auditable in one place.
+- The editor should show the object; the chat should operate on it.
+
+Does it need to be there:
+
+- Required if conversational editing exists.
+
+Other ways to do it:
+
+- Inline assistant inside the graph. Useful as a launcher, but should still use the same conversation.
+- Modal assistant. Focused, but blocks the editor.
+- No chat. Cleaner surface, but loses the core AI-generated workflow advantage.
+
+How other companies do it:
+
+- n8n AI builder keeps AI creation close to the workflow editor.
+- AI coding products generally converge on one assistant surface with file/object context rather than multiple independent chats.
+
+Responsive rules:
+
+- Desktop: persistent right sidebar.
+- Tablet: collapsible right drawer.
+- Mobile: chat opens as a full-height sheet with clear return to editor.
+
+### 9. Nodes Catalog
+
+What each element does:
+
+- Nodes lists available primitives/actions for workflow construction.
+- It helps advanced users understand what can be used.
+- It should not be the overview content.
+
+Defense:
+
+- Node catalogs are important for builders, but they are not the user's primary mental model.
+- "Nodes" is clearer and shorter than "Node Catalog."
+- Showing node counts in the header suggests implementation detail instead of user progress.
+
+Does it need to be there:
+
+- Optional for most users, required for advanced editing and debugging.
+
+Other ways to do it:
+
+- Node picker only inside the workflow editor. Cleaner, but less discoverable.
+- Marketplace/integrations page. Better for connectors, too broad for workflow primitives.
+
+How other companies do it:
+
+- n8n has a node picker/catalog because it is a builder tool.
+- Zapier hides most primitive catalog concerns behind app/action selection.
+
+Responsive rules:
+
+- Desktop can show Nodes in the sidebar footer.
+- Mobile should expose nodes from the workflow editor, not global nav.
+
+### 10. Failures and Repair
+
+What each element does:
+
+- Failure row shows the blocked automation, cause, and one next action.
+- Possible actions: Connect account, Retry, Open workflow, Ask agent to fix.
+- Logs remain available behind a disclosure.
+
+Defense:
+
+- Users do not want logs first. They want repair.
+- Red should be reserved for actionable failures, not empty or paused state.
+- Credential/setup errors should be normalized enough to map to repair actions.
+
+Does it need to be there:
+
+- Required once automations can fail.
+
+Other ways to do it:
+
+- Full run log as default. Good for engineers, too much for normal users.
+- Toast-only errors. Easy to miss.
+- Email alerts only. Useful supplement, not a dashboard replacement.
+
+How other companies do it:
+
+- Slack exposes workflow activity and errors.
+- Zapier blocks publishing or highlights steps needing attention.
+- n8n execution logs are powerful but technical; Milady should surface repair first.
+
+Responsive rules:
+
+- Mobile failure rows should fit one line with a clear action button.
+- Details open in a sheet or drawer.
+
+## Implementation Pass
+
+Implemented now:
+
+- Added a top-level command input to the overview and create dialog.
+- Added prompt-shape inference: simple recurring prompts open a task draft form, complex/event/multi-step prompts generate workflow drafts.
+- Reworked overview toward a command center: Next, Running, Needs attention, Drafts, Recently changed, with task/workflow inventory below.
+- Replaced metric-card dashboard emphasis with compact status chips.
+- Preserved the graph and data-flow strip for workflows.
+- Kept drafts as real selectable/deletable items.
+
+Deliberately not implemented in this pass:
+
+- Full mobile step-list fallback for graph editing, because that needs a dedicated graph interaction pass.
+- Connector-specific failure repair actions, because credential/setup errors need normalized backend causes first.
+- True in-flight "Running" state, because the current frontend can only safely represent enabled/live automations until execution state is exposed.
+
+## Quality Bar
+
+The accepted UX should satisfy these checks:
+
+- A new user with no automations sees one sentence, one creation input, and useful examples.
+- A returning user sees what will happen next, what is live, what is broken, and what is unfinished.
+- A task can be created without understanding graphs.
+- A workflow can be generated from description and inspected as a graph.
+- Drafts can be opened and deleted.
+- Event-triggered automations show events as start conditions, not fake schedules.
+- The right sidebar is the only assistant chat.
+- UUIDs, room IDs, and raw backend details stay out of the default path.

--- a/packages/app-core/scripts/ensure-bundled-workspaces.mjs
+++ b/packages/app-core/scripts/ensure-bundled-workspaces.mjs
@@ -29,26 +29,9 @@ export const BUNDLED_WORKSPACE_BUILDS = [
     ),
     args: ["../../../scripts/build-bundled-agent-skills-artifact.mjs"],
   },
-  // NOTE: earlier revisions of this file (cherry-picked from the
-  // unmerged commit eb4846c50) tried to build 12 more workspace
-  // plugins — plugin-anthropic, plugin-cron, plugin-edge-tts,
-  // plugin-experience, plugin-local-embedding, plugin-ollama,
-  // plugin-openai, plugin-personality, plugin-plugin-manager,
-  // plugin-shell, plugin-sql, plugin-trust — so that their `dist/`
-  // declarations would be available for TypeScript resolution when
-  // `ELIZA_SKIP_LOCAL_UPSTREAMS=1`. In practice at least one of
-  // those plugins (plugin-anthropic) has a pre-existing
-  // `ModelType.TEXT_MEDIUM` compat bug against the current
-  // `@elizaos/core`, which makes the postinstall fail as soon as
-  // the anthropic build is attempted:
-  //
-  //   Error: index.ts(170,43): error TS2339: Property 'TEXT_MEDIUM'
-  //   does not exist on type '{...}'.
-  //
-  // Nothing we ship here consumes those plugins at build-time from
-  // source, so building them is a footgun. Keep only the two
-  // historically-bundled builds (plugin-agent-skills) that actually need to be on disk for
-  // downstream packaging to work.
+  // Only build workspaces that downstream packaging consumes directly. Building
+  // every locally-linked plugin during postinstall makes unrelated plugin
+  // compatibility bugs fail app setup.
 ];
 
 function runCommand(command, args, { cwd, env = process.env, label } = {}) {

--- a/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
+++ b/packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs
@@ -243,6 +243,124 @@ const emptyLocalInferenceHub = {
   hardware: emptyLocalInferenceHardware,
 };
 
+const emptyWalletConfig = {
+  evmAddress: null,
+  solanaAddress: null,
+  selectedRpcProviders: {
+    evm: "eliza-cloud",
+    bsc: "eliza-cloud",
+    solana: "eliza-cloud",
+  },
+  legacyCustomChains: [],
+  alchemyKeySet: false,
+  infuraKeySet: false,
+  ankrKeySet: false,
+  nodeRealBscRpcSet: false,
+  quickNodeBscRpcSet: false,
+  managedBscRpcReady: false,
+  cloudManagedAccess: false,
+  evmBalanceReady: false,
+  ethereumBalanceReady: false,
+  baseBalanceReady: false,
+  bscBalanceReady: false,
+  avalancheBalanceReady: false,
+  solanaBalanceReady: false,
+  heliusKeySet: false,
+  birdeyeKeySet: false,
+  evmChains: [],
+  walletSource: "none",
+  pluginEvmLoaded: false,
+  pluginEvmRequired: false,
+  executionReady: false,
+  executionBlockedReason: null,
+  evmSigningCapability: "none",
+  solanaSigningAvailable: false,
+  wallets: [],
+  primary: {
+    evm: "local",
+    solana: "local",
+  },
+};
+
+const emptyWalletBalances = {
+  evm: null,
+  solana: null,
+};
+
+const emptyWalletNfts = {
+  evm: [],
+  solana: null,
+};
+
+const emptyWalletTradingProfile = {
+  window: "30d",
+  source: "all",
+  generatedAt: new Date(0).toISOString(),
+  summary: {
+    totalSwaps: 0,
+    buyCount: 0,
+    sellCount: 0,
+    settledCount: 0,
+    successCount: 0,
+    revertedCount: 0,
+    tradeWinRate: null,
+    txSuccessRate: null,
+    winningTrades: 0,
+    evaluatedTrades: 0,
+    realizedPnlBnb: "0",
+    volumeBnb: "0",
+  },
+  pnlSeries: [],
+  tokenBreakdown: [],
+  recentSwaps: [],
+};
+
+const emptyWalletMarketSource = {
+  providerId: "coingecko",
+  providerName: "CoinGecko",
+  providerUrl: "https://www.coingecko.com",
+  available: false,
+  stale: false,
+  error: null,
+};
+
+const emptyWalletMarketOverview = {
+  generatedAt: new Date(0).toISOString(),
+  cacheTtlSeconds: 300,
+  stale: false,
+  sources: {
+    prices: emptyWalletMarketSource,
+    movers: emptyWalletMarketSource,
+    predictions: {
+      providerId: "polymarket",
+      providerName: "Polymarket",
+      providerUrl: "https://polymarket.com",
+      available: false,
+      stale: false,
+      error: null,
+    },
+  },
+  prices: [],
+  movers: [],
+  predictions: [],
+};
+
+const stubCharacter = {
+  name: "Chen",
+  username: "chen",
+  bio: ["A concise local assistant for UI smoke tests."],
+  system: "You are Chen, a concise assistant for UI smoke tests.",
+  adjectives: ["focused", "direct"],
+  topics: [],
+  style: {
+    all: [],
+    chat: [],
+    post: [],
+  },
+  messageExamples: [],
+  postExamples: [],
+};
+
 function parsePositiveInt(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -780,12 +898,62 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (req.method === "GET" && url.pathname === "/api/character") {
-    sendJson(req, res, 200, { character: {}, agentName: "Chen" });
+    sendJson(req, res, 200, { character: stubCharacter, agentName: "Chen" });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/character/history") {
+    sendJson(req, res, 200, { history: [], total: 0 });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/character/experiences") {
+    sendJson(req, res, 200, { data: [], total: 0 });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/relationships/activity") {
+    sendJson(req, res, 200, { activity: [] });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/knowledge/documents") {
+    sendJson(req, res, 200, {
+      documents: [],
+      total: 0,
+      limit: parsePositiveInt(url.searchParams.get("limit"), 100),
+      offset: parsePositiveInt(url.searchParams.get("offset"), 0),
+    });
     return;
   }
 
   if (req.method === "GET" && url.pathname === "/api/wallet/addresses") {
     sendJson(req, res, 200, { evmAddress: null, solanaAddress: null });
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/wallet/config") {
+    sendJson(req, res, 200, emptyWalletConfig);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/wallet/balances") {
+    sendJson(req, res, 200, emptyWalletBalances);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/wallet/nfts") {
+    sendJson(req, res, 200, emptyWalletNfts);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/wallet/trading/profile") {
+    sendJson(req, res, 200, emptyWalletTradingProfile);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/api/wallet/market-overview") {
+    sendJson(req, res, 200, emptyWalletMarketOverview);
     return;
   }
 

--- a/packages/app-core/scripts/release-check.test.ts
+++ b/packages/app-core/scripts/release-check.test.ts
@@ -4,6 +4,7 @@ import {
   findLocalPackHotspots,
   shouldSkipExactPackDryRun,
 } from "./lib/release-check-pack-dry-run";
+import { findNonWorkspaceDependencySpecs } from "./release-check";
 
 describe("release-check pack dry-run guard", () => {
   it("treats broad publish roots as pack hotspots", () => {
@@ -25,5 +26,39 @@ describe("release-check pack dry-run guard", () => {
     expect(
       shouldSkipExactPackDryRun(["dist"], { ELIZA_FORCE_PACK_DRY_RUN: "1" }),
     ).toBe(false);
+  });
+});
+
+describe("release-check cloud-agent template guard", () => {
+  it("accepts workspace-local elizaOS dependencies in source", () => {
+    expect(
+      findNonWorkspaceDependencySpecs(
+        {
+          dependencies: {
+            "@elizaos/core": "workspace:*",
+            "@elizaos/plugin-sql": "workspace:*",
+          },
+        },
+        ["@elizaos/core", "@elizaos/plugin-sql"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("rejects committed alpha pins in the source template", () => {
+    expect(
+      findNonWorkspaceDependencySpecs(
+        {
+          dependencies: {
+            "@elizaos/core": "2.0.0-alpha.341",
+          },
+        },
+        ["@elizaos/core"],
+      ),
+    ).toEqual([
+      {
+        name: "@elizaos/core",
+        specifier: "2.0.0-alpha.341",
+      },
+    ]);
   });
 });

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -450,7 +450,8 @@ function runBunPackDry(): PackResult[] {
     });
     return parseBunPackDryRunOutput(raw);
   } catch (bunError) {
-    const bunOutput = `${(bunError as { stdout?: string }).stdout ?? ""}\n${      (bunError as { stderr?: string }).stderr ?? ""
+    const bunOutput = `${(bunError as { stdout?: string }).stdout ?? ""}\n${
+      (bunError as { stderr?: string }).stderr ?? ""
     }`;
     if (
       bunOutput.includes("Duplicate package path") ||
@@ -567,6 +568,22 @@ export function findFloatingDependencySpecs(
   return dependencyNames.flatMap((name) => {
     const specifier = dependencies[name];
     if (!isExactVersionSpecifier(specifier)) {
+      return [{ name, specifier: specifier ?? "<missing>" }];
+    }
+
+    return [];
+  });
+}
+
+export function findNonWorkspaceDependencySpecs(
+  pkg: RootPackageJson,
+  dependencyNames: readonly string[],
+): Array<{ name: string; specifier: string }> {
+  const dependencies = pkg.dependencies ?? {};
+
+  return dependencyNames.flatMap((name) => {
+    const specifier = dependencies[name];
+    if (specifier !== "workspace:*") {
       return [{ name, specifier: specifier ?? "<missing>" }];
     }
 
@@ -749,23 +766,23 @@ function assertOrchestratorVersionPinned() {
   }
 }
 
-function assertCloudAgentTemplateDependenciesPinned() {
+function assertCloudAgentTemplateDependenciesUseWorkspace() {
   const cloudAgentPackage = JSON.parse(
     readFileSync(
       "eliza/packages/app-core/deploy/cloud-agent-template/package.json",
       "utf8",
     ),
   ) as RootPackageJson;
-  const floating = findFloatingDependencySpecs(
+  const nonWorkspace = findNonWorkspaceDependencySpecs(
     cloudAgentPackage,
     cloudAgentTemplateReleaseDependencies,
   );
 
-  if (floating.length > 0) {
+  if (nonWorkspace.length > 0) {
     console.error(
-      "release-check: eliza/packages/app-core/deploy/cloud-agent-template/package.json must pin release dependencies to exact versions.",
+      "release-check: eliza/packages/app-core/deploy/cloud-agent-template/package.json must use workspace:* for repo-local elizaOS dependencies. Materialize exact npm versions only at the deploy/publish boundary.",
     );
-    for (const dependency of floating) {
+    for (const dependency of nonWorkspace) {
       console.error(`  - ${dependency.name}: ${dependency.specifier}`);
     }
     process.exit(1);
@@ -901,7 +918,10 @@ function assertElectrobunConfigHasPostWrapSigner() {
 }
 
 function assertMacArtifactStagerLooksCorrect() {
-  const script = readElectrobunFile("scripts", "stage-macos-release-artifacts.sh");
+  const script = readElectrobunFile(
+    "scripts",
+    "stage-macos-release-artifacts.sh",
+  );
   const requiredSnippets = [
     'find -L "$ARTIFACTS_DIR" -maxdepth 1 -type f -name "*-macos-*.app.tar.zst"',
     "no macOS updater tarball found",
@@ -1305,7 +1325,7 @@ function main() {
   maybeValidateCdnAssets();
   assertBundledAgentOrchestratorInstallFix();
   assertOrchestratorVersionPinned();
-  assertCloudAgentTemplateDependenciesPinned();
+  assertCloudAgentTemplateDependenciesUseWorkspace();
   assertAgentDependenciesAlignedWithRootPins();
   const localHotspots = findLocalPackHotspots();
   if (shouldSkipExactPackDryRun(localHotspots)) {

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -274,69 +274,35 @@ function WalletChatGuideActions() {
   );
 }
 
-function MobileChatSurfaceSwitcher({
-  active,
-  onChange,
-  showRight,
-  t,
-}: {
-  active: MobileChatSurface;
-  onChange: (surface: MobileChatSurface) => void;
-  showRight: boolean;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}) {
-  const options: Array<{
-    icon: typeof PanelLeft;
-    label: string;
-    surface: MobileChatSurface;
-  }> = [
-    {
-      icon: PanelLeft,
-      label: t("conversations.chats", { defaultValue: "Chats" }),
-      surface: "left",
-    },
-    {
-      icon: MessagesSquare,
-      label: t("nav.chat", { defaultValue: "Chat" }),
-      surface: "center",
-    },
-    ...(showRight
-      ? [
-          {
-            icon: ListTodo,
-            label: t("taskseventspanel.Title", {
-              defaultValue: "Tasks & Events",
-            }),
-            surface: "right" as const,
-          },
-        ]
-      : []),
-  ];
+interface MobileChatSurfaceButtonProps {
+  active: boolean;
+  icon: typeof PanelLeft;
+  label: string;
+  onClick: () => void;
+  surface: MobileChatSurface;
+}
 
+function MobileChatSurfaceButton({
+  active,
+  icon: Icon,
+  label,
+  onClick,
+  surface,
+}: MobileChatSurfaceButtonProps) {
   return (
-    <div
-      className="inline-flex h-[2.375rem] items-center rounded-md border border-border/40 bg-card/55 p-0.5"
-      data-testid="chat-mobile-surface-switcher"
+    <button
+      type="button"
+      aria-label={label}
+      aria-current={active ? "page" : undefined}
+      title={label}
+      data-testid={`chat-mobile-surface-${surface}`}
+      onClick={onClick}
+      className={`inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/40 bg-card/55 text-muted shadow-sm transition-colors hover:text-txt ${
+        active ? "border-accent/70 bg-accent text-accent-fg" : ""
+      }`}
     >
-      {options.map((option) => (
-        <button
-          key={option.surface}
-          type="button"
-          aria-label={option.label}
-          aria-current={active === option.surface ? "page" : undefined}
-          title={option.label}
-          data-testid={`chat-mobile-surface-${option.surface}`}
-          onClick={() => onChange(option.surface)}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
-            active === option.surface
-              ? "bg-accent text-accent-fg"
-              : "text-muted hover:text-txt"
-          }`}
-        >
-          <option.icon className="h-4 w-4" aria-hidden />
-        </button>
-      ))}
-    </div>
+      <Icon className="h-4 w-4" aria-hidden />
+    </button>
   );
 }
 
@@ -715,18 +681,41 @@ export function App() {
   const isSettingsPage = tab === "settings" || tab === "voice";
   const isAppsToolPage = isAppsToolTab(tab);
   const isDesktopWorkspacePage = tab === "desktop";
-  const mobileChatControls = useMemo(
-    () =>
-      isChatMobileLayout ? (
-        <MobileChatSurfaceSwitcher
-          active={mobileChatSurface}
-          onChange={setMobileChatSurface}
-          showRight={isChat}
-          t={t}
+  const mobileChatControls = useMemo(() => {
+    if (!isChatMobileLayout) return null;
+
+    return {
+      center: (
+        <MobileChatSurfaceButton
+          active={mobileChatSurface === "center"}
+          icon={MessagesSquare}
+          label={t("nav.chat", { defaultValue: "Chat" })}
+          onClick={() => setMobileChatSurface("center")}
+          surface="center"
         />
-      ) : undefined,
-    [isChat, isChatMobileLayout, mobileChatSurface, t],
-  );
+      ),
+      left: (
+        <MobileChatSurfaceButton
+          active={mobileChatSurface === "left"}
+          icon={PanelLeft}
+          label={t("conversations.chats", { defaultValue: "Chats" })}
+          onClick={() => setMobileChatSurface("left")}
+          surface="left"
+        />
+      ),
+      right: isChat ? (
+        <MobileChatSurfaceButton
+          active={mobileChatSurface === "right"}
+          icon={ListTodo}
+          label={t("taskseventspanel.Title", {
+            defaultValue: "Tasks & Events",
+          })}
+          onClick={() => setMobileChatSurface("right")}
+          surface="right"
+        />
+      ) : null,
+    };
+  }, [isChat, isChatMobileLayout, mobileChatSurface, t]);
 
   // Keep hook order stable across onboarding/auth state transitions.
   // Otherwise React can throw when onboarding completes and the main shell mounts.
@@ -882,7 +871,9 @@ export function App() {
           className="flex flex-col flex-1 min-h-0 w-full font-body text-txt bg-bg"
         >
           <Header
-            mobileCenter={mobileChatControls}
+            mobileCenter={mobileChatControls?.center}
+            mobileLeft={mobileChatControls?.left}
+            pageRightExtras={mobileChatControls?.right}
             tasksEventsPanelOpen={isChat && !isChatMobileLayout}
           />
           <div className="flex flex-1 min-h-0 relative">

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -342,10 +342,17 @@ function TabContentView({
   children: ReactNode;
   chatScope?: PageScope;
 }) {
+  const { activeGameRunId, appsSubTab } = useApp();
+  const gameOwnsChat =
+    chatScope === "page-apps" &&
+    appsSubTab === "games" &&
+    activeGameRunId.trim().length > 0;
+
   return (
     <AppWorkspaceChrome
       testId="tab-content-view"
       chatScope={chatScope}
+      chatDisabled={gameOwnsChat}
       main={
         <div className="flex flex-col flex-1 min-h-0 min-w-0 w-full overflow-hidden">
           {children}

--- a/packages/app-core/src/App.tsx
+++ b/packages/app-core/src/App.tsx
@@ -7,18 +7,13 @@ import {
   ArrowDownLeft,
   ArrowLeftRight,
   Layers3,
+  ListTodo,
   MessagesSquare,
+  PanelLeft,
 } from "lucide-react";
 
 import "./components/chat/chat-source-registration";
-import {
-  Button,
-  DrawerSheet,
-  DrawerSheetContent,
-  DrawerSheetHeader,
-  DrawerSheetTitle,
-  ErrorBoundary,
-} from "@elizaos/ui";
+import { Button, ErrorBoundary } from "@elizaos/ui";
 import {
   type ComponentType,
   type LazyExoticComponent,
@@ -72,6 +67,7 @@ import type { FlaminaGuideTopic } from "./state/types";
 
 const CHAT_MOBILE_BREAKPOINT_PX = 820;
 const WALLET_CHAT_PREFILL_EVENT = "milady:chat:prefill";
+type MobileChatSurface = "left" | "center" | "right";
 
 type ExtractComponent<TValue> =
   TValue extends ComponentType<infer Props> ? ComponentType<Props> : never;
@@ -275,6 +271,72 @@ function WalletChatGuideActions() {
         </Button>
       ))}
     </>
+  );
+}
+
+function MobileChatSurfaceSwitcher({
+  active,
+  onChange,
+  showRight,
+  t,
+}: {
+  active: MobileChatSurface;
+  onChange: (surface: MobileChatSurface) => void;
+  showRight: boolean;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const options: Array<{
+    icon: typeof PanelLeft;
+    label: string;
+    surface: MobileChatSurface;
+  }> = [
+    {
+      icon: PanelLeft,
+      label: t("conversations.chats", { defaultValue: "Chats" }),
+      surface: "left",
+    },
+    {
+      icon: MessagesSquare,
+      label: t("nav.chat", { defaultValue: "Chat" }),
+      surface: "center",
+    },
+    ...(showRight
+      ? [
+          {
+            icon: ListTodo,
+            label: t("taskseventspanel.Title", {
+              defaultValue: "Tasks & Events",
+            }),
+            surface: "right" as const,
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <div
+      className="inline-flex h-[2.375rem] items-center rounded-md border border-border/40 bg-card/55 p-0.5"
+      data-testid="chat-mobile-surface-switcher"
+    >
+      {options.map((option) => (
+        <button
+          key={option.surface}
+          type="button"
+          aria-label={option.label}
+          aria-current={active === option.surface ? "page" : undefined}
+          title={option.label}
+          data-testid={`chat-mobile-surface-${option.surface}`}
+          onClick={() => onChange(option.surface)}
+          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
+            active === option.surface
+              ? "bg-accent text-accent-fg"
+              : "text-muted hover:text-txt"
+          }`}
+        >
+          <option.icon className="h-4 w-4" aria-hidden />
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -605,7 +667,6 @@ export function App() {
   const [settingsInitialSection, setSettingsInitialSection] = useState<
     string | null
   >(null);
-  const [tasksEventsPanelOpen, setTasksEventsPanelOpen] = useState(false);
   const [widgetsPanelCollapsed, setWidgetsPanelCollapsed] = useState(() => {
     if (typeof window === "undefined") return false;
     try {
@@ -637,7 +698,8 @@ export function App() {
       ? window.innerWidth < CHAT_MOBILE_BREAKPOINT_PX
       : false,
   );
-  const [mobileConversationsOpen, setMobileConversationsOpen] = useState(false);
+  const [mobileChatSurface, setMobileChatSurface] =
+    useState<MobileChatSurface>("center");
   const [desktopShuttingDown, setDesktopShuttingDown] = useState(false);
   const [characterHeaderActions, setCharacterHeaderActions] =
     useState<ReactNode | null>(null);
@@ -656,31 +718,14 @@ export function App() {
   const mobileChatControls = useMemo(
     () =>
       isChatMobileLayout ? (
-        <div className="flex items-center gap-2 w-max">
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`inline-flex h-[2.375rem] w-[2.375rem] min-w-[2.375rem] items-center justify-center rounded-none border-0 !bg-transparent p-0 text-muted shadow-none ring-0 transition-colors hover:!bg-transparent hover:text-txt active:!bg-transparent ${
-              mobileConversationsOpen
-                ? "text-accent"
-                : "text-muted hover:text-txt"
-            }`}
-            onClick={() => {
-              setTasksEventsPanelOpen(false);
-              setMobileConversationsOpen(true);
-            }}
-            aria-label={t("aria.openChannelsPanel", {
-              defaultValue: "Open channels panel",
-            })}
-          >
-            <MessagesSquare className="h-4 w-4" aria-hidden />
-            <span className="sr-only">
-              {t("conversations.channels", { defaultValue: "Channels" })}
-            </span>
-          </Button>
-        </div>
+        <MobileChatSurfaceSwitcher
+          active={mobileChatSurface}
+          onChange={setMobileChatSurface}
+          showRight={isChat}
+          t={t}
+        />
       ) : undefined,
-    [isChatMobileLayout, mobileConversationsOpen, t],
+    [isChat, isChatMobileLayout, mobileChatSurface, t],
   );
 
   // Keep hook order stable across onboarding/auth state transitions.
@@ -728,19 +773,18 @@ export function App() {
 
   useEffect(() => {
     if (!isChatMobileLayout) {
-      setMobileConversationsOpen(false);
-      setTasksEventsPanelOpen(false);
+      setMobileChatSurface("center");
     }
   }, [isChatMobileLayout]);
 
   useEffect(() => {
     if (!isChatWorkspace) {
-      setMobileConversationsOpen(false);
+      setMobileChatSurface("center");
     }
-    if (!isChat) {
-      setTasksEventsPanelOpen(false);
+    if (!isChat && mobileChatSurface === "right") {
+      setMobileChatSurface("center");
     }
-  }, [isChat, isChatWorkspace]);
+  }, [isChat, isChatWorkspace, mobileChatSurface]);
 
   useEffect(() => {
     if (isSettingsPage || settingsInitialSection === null) {
@@ -838,18 +882,8 @@ export function App() {
           className="flex flex-col flex-1 min-h-0 w-full font-body text-txt bg-bg"
         >
           <Header
-            mobileLeft={mobileChatControls}
-            tasksEventsPanelOpen={
-              isChat && (isChatMobileLayout ? tasksEventsPanelOpen : true)
-            }
-            onToggleTasksPanel={
-              isChat && isChatMobileLayout
-                ? () => {
-                    setMobileConversationsOpen(false);
-                    setTasksEventsPanelOpen((open) => !open);
-                  }
-                : undefined
-            }
+            mobileCenter={mobileChatControls}
+            tasksEventsPanelOpen={isChat && !isChatMobileLayout}
           />
           <div className="flex flex-1 min-h-0 relative">
             {!isChatMobileLayout && isChat ? (
@@ -859,54 +893,38 @@ export function App() {
               />
             ) : null}
             {isChatMobileLayout ? (
-              <>
-                <div className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden pt-2 px-2">
-                  {isChat && tasksEventsPanelOpen ? (
-                    <TasksEventsPanel
-                      open
-                      events={activityEvents}
-                      clearEvents={clearActivityEvents}
-                      mobile
+              <div
+                className={`flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden ${
+                  mobileChatSurface === "center" ? "px-2 pt-2" : ""
+                }`}
+              >
+                {mobileChatSurface === "left" ? (
+                  <ConversationsSidebar
+                    key="chat-sidebar-mobile"
+                    mobile
+                    onClose={() => setMobileChatSurface("center")}
+                  />
+                ) : mobileChatSurface === "right" && isChat ? (
+                  <TasksEventsPanel
+                    open
+                    events={activityEvents}
+                    clearEvents={clearActivityEvents}
+                    mobile
+                  />
+                ) : isChat ? (
+                  <>
+                    <DeferredSetupChecklist
+                      className="mb-3"
+                      onOpenTask={handleDeferredTaskOpen}
                     />
-                  ) : isChat ? (
-                    <>
-                      <DeferredSetupChecklist
-                        className="mb-3"
-                        onOpenTask={handleDeferredTaskOpen}
-                      />
-                      <ChatView />
-                    </>
-                  ) : (
-                    <LazyViewBoundary>
-                      <ConnectorsPageView />
-                    </LazyViewBoundary>
-                  )}
-                </div>
-
-                {mobileConversationsOpen && (
-                  <DrawerSheet
-                    open={mobileConversationsOpen}
-                    onOpenChange={setMobileConversationsOpen}
-                  >
-                    <DrawerSheetContent
-                      aria-describedby={undefined}
-                      className="h-[min(calc(100dvh-1rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),46rem)] p-0"
-                      showCloseButton
-                    >
-                      <DrawerSheetHeader className="sr-only">
-                        <DrawerSheetTitle>
-                          {t("conversations.chats")}
-                        </DrawerSheetTitle>
-                      </DrawerSheetHeader>
-                      <ConversationsSidebar
-                        key="chat-sidebar-mobile"
-                        mobile
-                        onClose={() => setMobileConversationsOpen(false)}
-                      />
-                    </DrawerSheetContent>
-                  </DrawerSheet>
+                    <ChatView />
+                  </>
+                ) : (
+                  <LazyViewBoundary>
+                    <ConnectorsPageView />
+                  </LazyViewBoundary>
                 )}
-              </>
+              </div>
             ) : (
               <>
                 <ConversationsSidebar key="chat-sidebar-desktop" />
@@ -1078,17 +1096,15 @@ export function App() {
       isAppsToolPage,
       isDesktopWorkspacePage,
       isChatMobileLayout,
-      mobileConversationsOpen,
+      mobileChatSurface,
       mobileChatControls,
       characterHeaderActions,
-      tasksEventsPanelOpen,
       handleDeferredTaskOpen,
       activityEvents,
       clearActivityEvents,
       customActionsPanelOpen,
       handleToggleWidgetsCollapsed,
       settingsInitialSection,
-      t,
       widgetsPanelCollapsed,
     ],
   );

--- a/packages/app-core/src/api/client-agent.ts
+++ b/packages/app-core/src/api/client-agent.ts
@@ -75,9 +75,9 @@ import type {
   TrainingStatus,
   TrainingTrajectoryDetail,
   TrainingTrajectoryList,
+  TriggerEventDispatchResponse,
   TriggerHealthSnapshot,
   TriggerLastStatus,
-  TriggerEventDispatchResponse,
   TriggerRunRecord,
   TriggerSummary,
   UpdateStatus,
@@ -398,6 +398,7 @@ declare module "./client-base" {
     getRelationshipsPerson(id: string): Promise<RelationshipsPersonDetail>;
     getRelationshipsActivity(
       limit?: number,
+      offset?: number,
     ): Promise<RelationshipsActivityResponse>;
     getRelationshipsCandidates(): Promise<RelationshipsMergeCandidate[]>;
     acceptRelationshipsCandidate(
@@ -1185,13 +1186,10 @@ ElizaClient.prototype.emitTriggerEvent = async function (
   eventKind,
   payload = {},
 ) {
-  return this.fetch(
-    `/api/triggers/events/${encodeURIComponent(eventKind)}`,
-    {
-      method: "POST",
-      body: JSON.stringify({ payload }),
-    },
-  );
+  return this.fetch(`/api/triggers/events/${encodeURIComponent(eventKind)}`, {
+    method: "POST",
+    body: JSON.stringify({ payload }),
+  });
 };
 
 ElizaClient.prototype.getTriggerHealth = async function (this: ElizaClient) {
@@ -1560,6 +1558,7 @@ ElizaClient.prototype.getRelationshipsGraph = async function (
   const params = new URLSearchParams();
   if (query?.search) params.set("search", query.search);
   if (query?.platform) params.set("platform", query.platform);
+  if (query?.scope) params.set("scope", query.scope);
   if (typeof query?.limit === "number")
     params.set("limit", String(query.limit));
   if (typeof query?.offset === "number")
@@ -1578,6 +1577,7 @@ ElizaClient.prototype.getRelationshipsPeople = async function (
   const params = new URLSearchParams();
   if (query?.search) params.set("search", query.search);
   if (query?.platform) params.set("platform", query.platform);
+  if (query?.scope) params.set("scope", query.scope);
   if (typeof query?.limit === "number")
     params.set("limit", String(query.limit));
   if (typeof query?.offset === "number")
@@ -1606,11 +1606,15 @@ ElizaClient.prototype.getRelationshipsPerson = async function (
 ElizaClient.prototype.getRelationshipsActivity = async function (
   this: ElizaClient,
   limit?,
+  offset?,
 ) {
   const params = new URLSearchParams();
   if (typeof limit === "number") params.set("limit", String(limit));
+  if (typeof offset === "number") params.set("offset", String(offset));
   const qs = params.toString();
-  return this.fetch(`/api/relationships/activity${qs ? `?${qs}` : ""}`);
+  return this.fetch<RelationshipsActivityResponse>(
+    `/api/relationships/activity${qs ? `?${qs}` : ""}`,
+  );
 };
 
 ElizaClient.prototype.getRelationshipsCandidates = async function (

--- a/packages/app-core/src/api/client-types-relationships.ts
+++ b/packages/app-core/src/api/client-types-relationships.ts
@@ -10,6 +10,8 @@ export interface RelationshipsIdentityHandle {
   entityId: string;
   platform: string;
   handle: string;
+  status?: string | null;
+  verified?: boolean | null;
 }
 
 export interface RelationshipsIdentitySummary {
@@ -154,12 +156,19 @@ export interface RelationshipsGraphStats {
   totalIdentities: number;
 }
 
+export interface RelationshipsMergeCandidateEvidence {
+  platform?: string;
+  handle?: string;
+  notes?: string;
+  identityIds?: string[];
+}
+
 export interface RelationshipsMergeCandidate {
   id: string;
   entityA: string;
   entityB: string;
   confidence: number;
-  evidence: Record<string, unknown>;
+  evidence: RelationshipsMergeCandidateEvidence;
   status: "pending" | "accepted" | "rejected";
   proposedAt: string;
   resolvedAt?: string;
@@ -183,5 +192,9 @@ export interface RelationshipsActivityItem {
 
 export interface RelationshipsActivityResponse {
   activity: RelationshipsActivityItem[];
+  total: number;
   count: number;
+  offset: number;
+  limit: number;
+  hasMore: boolean;
 }

--- a/packages/app-core/src/api/wallet-market-overview-route.test.ts
+++ b/packages/app-core/src/api/wallet-market-overview-route.test.ts
@@ -114,6 +114,19 @@ const coinGeckoPayload = [
   },
 ];
 
+const polymarketPayload = [
+  {
+    slug: "will-bitcoin-hit-150k-by-june-30-2026",
+    question: "Will Bitcoin hit $150k by June 30, 2026?",
+    outcomes: JSON.stringify(["Yes", "No"]),
+    outcomePrices: JSON.stringify(["0.0135", "0.9865"]),
+    volume24hr: "5821652.894196",
+    volume: "15734008.014241",
+    endDate: "2026-07-01T04:00:00Z",
+    image: "https://assets.example.com/btc-market.png",
+  },
+];
+
 const cloudPreviewPayload: WalletMarketOverviewResponse = {
   generatedAt: "2026-04-23T12:34:56.000Z",
   cacheTtlSeconds: 120,
@@ -167,13 +180,13 @@ const cloudPreviewPayload: WalletMarketOverviewResponse = {
   ],
   predictions: [
     {
-      id: "bitcoin-above-120k-by-2026",
-      slug: "bitcoin-above-120k-by-2026",
-      question: "Will Bitcoin trade above $120k by 2026?",
+      id: "preview-only-market",
+      slug: "preview-only-market",
+      question: "Preview-only market that should be replaced",
       highlightedOutcomeLabel: "Yes",
       highlightedOutcomeProbability: 0.62,
-      volume24hUsd: 1532450.9,
-      totalVolumeUsd: 10_400_000,
+      volume24hUsd: 25,
+      totalVolumeUsd: 50,
       endsAt: "2026-12-31T23:59:59.000Z",
       imageUrl: "https://assets.example.com/btc-market.png",
     },
@@ -195,10 +208,10 @@ describe("wallet-market-overview-route", () => {
     __resetWalletMarketOverviewCacheForTests();
   });
 
-  it("prefers the cloud preview feed when it is available", async () => {
-    fetchWithTimeoutGuardMock.mockResolvedValueOnce(
-      jsonResponse(cloudPreviewPayload),
-    );
+  it("replaces cloud preview predictions with the live Polymarket feed", async () => {
+    fetchWithTimeoutGuardMock
+      .mockResolvedValueOnce(jsonResponse(cloudPreviewPayload))
+      .mockResolvedValueOnce(jsonResponse(polymarketPayload));
 
     const response = await fetch(
       `${harness.baseUrl}/api/wallet/market-overview`,
@@ -206,15 +219,32 @@ describe("wallet-market-overview-route", () => {
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as WalletMarketOverviewResponse;
-    expect(body).toEqual(cloudPreviewPayload);
-    expect(fetchWithTimeoutGuardMock).toHaveBeenCalledTimes(1);
+    expect(body.prices).toEqual(cloudPreviewPayload.prices);
+    expect(body.movers).toEqual(cloudPreviewPayload.movers);
+    expect(body.predictions).toEqual([
+      {
+        id: "will-bitcoin-hit-150k-by-june-30-2026",
+        slug: "will-bitcoin-hit-150k-by-june-30-2026",
+        question: "Will Bitcoin hit $150k by June 30, 2026?",
+        highlightedOutcomeLabel: "Yes",
+        highlightedOutcomeProbability: 0.0135,
+        volume24hUsd: 5821652.894196,
+        totalVolumeUsd: 15734008.014241,
+        endsAt: "2026-07-01T04:00:00Z",
+        imageUrl: "https://assets.example.com/btc-market.png",
+      },
+    ]);
+    expect(fetchWithTimeoutGuardMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchWithTimeoutGuardMock.mock.calls[1]?.[0])).toContain(
+      "order=volume24hr",
+    );
   });
 
   it("falls back to direct feeds when the cloud preview is unavailable", async () => {
     fetchWithTimeoutGuardMock
       .mockRejectedValueOnce(new Error("Cloud preview responded 503"))
-      .mockResolvedValueOnce(jsonResponse(coinGeckoPayload))
-      .mockRejectedValueOnce(new Error("Polymarket responded 502"));
+      .mockResolvedValueOnce(jsonResponse(polymarketPayload))
+      .mockResolvedValueOnce(jsonResponse(coinGeckoPayload));
 
     const response = await fetch(
       `${harness.baseUrl}/api/wallet/market-overview`,
@@ -224,20 +254,21 @@ describe("wallet-market-overview-route", () => {
     const body = (await response.json()) as WalletMarketOverviewResponse;
     expect(body.prices).toHaveLength(3);
     expect(body.movers.length).toBeGreaterThan(0);
-    expect(body.predictions).toEqual([]);
+    expect(body.predictions[0]?.question).toBe(
+      "Will Bitcoin hit $150k by June 30, 2026?",
+    );
     expect(body.sources.prices.available).toBe(true);
-    expect(body.sources.predictions).toMatchObject({
-      available: false,
-      stale: false,
-      error: "Polymarket responded 502",
-    });
+    expect(body.sources.predictions.available).toBe(true);
+    expect(String(fetchWithTimeoutGuardMock.mock.calls[1]?.[0])).toContain(
+      "order=volume24hr",
+    );
   });
 
   it("returns 502 when every market feed fails", async () => {
     fetchWithTimeoutGuardMock
       .mockRejectedValueOnce(new Error("Cloud preview responded 503"))
-      .mockRejectedValueOnce(new Error("CoinGecko responded 429"))
-      .mockRejectedValueOnce(new Error("Polymarket responded 503"));
+      .mockRejectedValueOnce(new Error("Polymarket responded 503"))
+      .mockRejectedValueOnce(new Error("CoinGecko responded 429"));
 
     const response = await fetch(
       `${harness.baseUrl}/api/wallet/market-overview`,

--- a/packages/app-core/src/api/wallet-market-overview-route.ts
+++ b/packages/app-core/src/api/wallet-market-overview-route.ts
@@ -319,7 +319,7 @@ async function fetchPolymarketMarkets(): Promise<PolymarketMarketRecord[]> {
   const url = new URL("https://gamma-api.polymarket.com/markets");
   url.searchParams.set("active", "true");
   url.searchParams.set("closed", "false");
-  url.searchParams.set("order", "volume_24hr");
+  url.searchParams.set("order", "volume24hr");
   url.searchParams.set("ascending", "false");
   url.searchParams.set("limit", String(POLYMARKET_MARKET_LIMIT));
 
@@ -491,29 +491,52 @@ async function fetchCloudWalletMarketOverview(
 async function buildWalletMarketOverview(
   clientAddress: string,
 ): Promise<WalletMarketOverviewResponse> {
-  try {
-    return await fetchCloudWalletMarketOverview(clientAddress);
-  } catch (error) {
+  const [cloudPreviewResult, polymarketResult] = await Promise.allSettled([
+    fetchCloudWalletMarketOverview(clientAddress),
+    fetchPolymarketMarkets(),
+  ]);
+  const polymarketMarkets =
+    polymarketResult.status === "fulfilled" ? polymarketResult.value : [];
+  const polymarketError =
+    polymarketResult.status === "rejected"
+      ? marketOverviewErrorMessage(polymarketResult.reason)
+      : null;
+
+  if (cloudPreviewResult.status === "fulfilled") {
+    if (polymarketError) {
+      logger.warn(
+        `[WalletMarketOverviewRoute] Polymarket feed unavailable (${polymarketError})`,
+      );
+    }
+
+    return {
+      ...cloudPreviewResult.value,
+      sources: {
+        ...cloudPreviewResult.value.sources,
+        predictions: buildMarketOverviewSource(POLYMARKET_SOURCE, {
+          available: polymarketError === null,
+          stale: false,
+          error: polymarketError,
+        }),
+      },
+      predictions:
+        polymarketError === null ? buildPredictions(polymarketMarkets) : [],
+    };
+  }
+
+  {
+    const error = cloudPreviewResult.reason;
     logger.warn(
       `[WalletMarketOverviewRoute] Cloud preview unavailable (${marketOverviewErrorMessage(error)}); falling back to direct feeds`,
     );
   }
 
-  const [coinGeckoResult, polymarketResult] = await Promise.allSettled([
-    fetchCoinGeckoMarkets(),
-    fetchPolymarketMarkets(),
-  ]);
+  const [coinGeckoResult] = await Promise.allSettled([fetchCoinGeckoMarkets()]);
   const coinGeckoMarkets =
     coinGeckoResult.status === "fulfilled" ? coinGeckoResult.value : [];
-  const polymarketMarkets =
-    polymarketResult.status === "fulfilled" ? polymarketResult.value : [];
   const coinGeckoError =
     coinGeckoResult.status === "rejected"
       ? marketOverviewErrorMessage(coinGeckoResult.reason)
-      : null;
-  const polymarketError =
-    polymarketResult.status === "rejected"
-      ? marketOverviewErrorMessage(polymarketResult.reason)
       : null;
 
   if (coinGeckoError) {

--- a/packages/app-core/src/components/apps/GameView.tsx
+++ b/packages/app-core/src/components/apps/GameView.tsx
@@ -28,7 +28,11 @@ import { invokeDesktopBridgeRequest, isElectrobunRuntime } from "../../bridge";
 import { useBranding } from "../../config/branding";
 import { useMediaQuery } from "../../hooks";
 import { useApp } from "../../state";
-import { openExternalUrl } from "../../utils";
+import {
+  navigatePreOpenedWindow,
+  openExternalUrl,
+  preOpenWindow,
+} from "../../utils";
 import type { DesktopClickAuditItem } from "../../utils/desktop-workspace";
 import { formatTime } from "../../utils/format";
 import { getAppOperatorSurface } from "./surfaces/registry";
@@ -1217,8 +1221,13 @@ export function GameView() {
       );
       return;
     }
+    const popup = preOpenWindow();
     try {
-      await openExternalUrl(openableUrl);
+      if (popup) {
+        navigatePreOpenedWindow(popup, openableUrl);
+      } else {
+        await openExternalUrl(openableUrl);
+      }
     } catch {
       setActionNotice(
         t("gameview.PopupBlocked", {
@@ -1768,6 +1777,35 @@ export function GameView() {
       : isCompactLayout && mobileSurface === "chat"
         ? "chat"
         : "all";
+  const openInNewTabLabel = hasViewer
+    ? t("game.openInNewTab")
+    : "Open launch URL";
+  const renderOpenInNewTabButton = (
+    variant: "default" | "outline",
+    className?: string,
+  ) => {
+    if (!openableUrl || isElectrobun) {
+      return (
+        <Button
+          variant={variant}
+          size="sm"
+          className={className}
+          onClick={handleOpenInNewTab}
+          disabled={!openableUrl}
+        >
+          {openInNewTabLabel}
+        </Button>
+      );
+    }
+
+    return (
+      <Button asChild variant={variant} size="sm" className={className}>
+        <a href={openableUrl} target="_blank" rel="noreferrer">
+          {openInNewTabLabel}
+        </a>
+      </Button>
+    );
+  };
 
   const renderViewerPane = () => {
     if (!hasViewer) {
@@ -1793,14 +1831,7 @@ export function GameView() {
             watching without restarting the session.
           </div>
           <div className="flex flex-wrap justify-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void handleOpenInNewTab()}
-              disabled={!openableUrl}
-            >
-              {t("game.openInNewTab")}
-            </Button>
+            {renderOpenInNewTabButton("outline")}
           </div>
         </div>
       );
@@ -1938,15 +1969,7 @@ export function GameView() {
             {gameOverlayEnabled ? t("game.unpinOverlay") : t("game.keepOnTop")}
           </Button>
         ) : null}
-        <Button
-          variant="default"
-          size="sm"
-          className="h-7 text-xs shadow-sm"
-          onClick={handleOpenInNewTab}
-          disabled={!openableUrl}
-        >
-          {hasViewer ? t("game.openInNewTab") : "Open launch URL"}
-        </Button>
+        {renderOpenInNewTabButton("default", "h-7 text-xs shadow-sm")}
         <Button
           variant="default"
           size="sm"

--- a/packages/app-core/src/components/apps/GameView.tsx
+++ b/packages/app-core/src/components/apps/GameView.tsx
@@ -555,6 +555,7 @@ export function GameView() {
   const [attachingViewer, setAttachingViewer] = useState(false);
   const [detachingViewer, setDetachingViewer] = useState(false);
   const [showLogsPanel, setShowLogsPanel] = useState(false);
+  const [showDiagnostics, setShowDiagnostics] = useState(false);
   const [mobileSurface, setMobileSurface] = useState<
     "game" | "dashboard" | "chat"
   >("game");
@@ -1725,17 +1726,42 @@ export function GameView() {
     </div>
   );
 
-  const connectionStatusColor =
-    connectionStatus === "connected"
-      ? "text-ok border-ok"
-      : connectionStatus === "connecting"
-        ? "text-warn border-warn"
-        : "text-danger border-danger";
   const activeRunSummary =
     activeGameRun?.summary ??
     activeGameRun?.health.message ??
     activeSessionState?.summary ??
     null;
+  const gameStatusLabel =
+    connectionStatus !== "connected"
+      ? connectionStatus === "connecting"
+        ? "Starting"
+        : "Offline"
+      : activeGameRun?.health.state === "offline" ||
+          activeGameRun?.health.state === "degraded"
+        ? "Needs attention"
+        : "Live";
+  const gameStatusClass =
+    gameStatusLabel === "Live"
+      ? "border-ok/30 bg-ok/10 text-ok"
+      : gameStatusLabel === "Needs attention"
+        ? "border-warn/35 bg-warn/10 text-warn"
+        : "border-border/45 bg-bg-hover/70 text-muted-strong";
+  const diagnostics = [
+    { label: "Connection", value: connectionStatus },
+    {
+      label: "Viewer",
+      value: activeGameRun?.viewerAttachment ?? "unavailable",
+    },
+    { label: "Health", value: activeGameRun?.health.state ?? "unknown" },
+    {
+      label: "Chat",
+      value: activeGameRun?.chatAvailability ?? "unknown",
+    },
+    {
+      label: "Control",
+      value: activeGameRun?.controlAvailability ?? "unknown",
+    },
+  ];
   const operatorSurfaceFocus =
     isCompactLayout && mobileSurface === "dashboard"
       ? "dashboard"
@@ -1767,14 +1793,6 @@ export function GameView() {
             watching without restarting the session.
           </div>
           <div className="flex flex-wrap justify-center gap-2">
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => void handleAttachViewer()}
-              disabled={attachingViewer}
-            >
-              {attachingViewer ? "Reattaching..." : "Reattach viewer"}
-            </Button>
             <Button
               variant="outline"
               size="sm"
@@ -1825,40 +1843,24 @@ export function GameView() {
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex flex-wrap items-center gap-3 px-4 py-2 bg-card">
-        <span className="font-bold text-sm">
-          {activeGameDisplayName || activeGameApp}
-        </span>
-        <span
-          className={`text-2xs px-1.5 py-0.5 border ${connectionStatusColor}`}
-        >
-          {connectionStatus === "connected"
-            ? t("game.connected")
-            : connectionStatus === "connecting"
-              ? t("game.connecting")
-              : t("game.disconnected")}
-        </span>
-        <span className="text-2xs px-1.5 py-0.5 border border-border text-muted">
-          {activeGameRun?.viewerAttachment ?? "unavailable"}
-        </span>
-        <span className="text-2xs px-1.5 py-0.5 border border-border text-muted">
-          {activeGameRun?.health.state ?? "unknown"}
-        </span>
-        {activeGamePostMessageAuth ? (
-          <span className="text-2xs px-1.5 py-0.5 border border-border text-muted">
-            {t("gameview.postMessageAuth")}
-          </span>
-        ) : null}
-        <span className="flex-1" />
-        {activeSessionState?.status ? (
-          <span
-            data-testid="game-session-status"
-            className="max-w-56 truncate text-2xs px-1.5 py-0.5 border border-border text-muted"
-            title={activeSessionState.summary ?? activeSessionState.status}
-          >
-            {activeSessionState.summary ?? activeSessionState.status}
-          </span>
-        ) : null}
+      <div className="flex flex-wrap items-center gap-3 bg-card px-4 py-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-bold text-sm">
+              {activeGameDisplayName || activeGameApp}
+            </span>
+            <span
+              className={`rounded-full border px-2.5 py-1 text-2xs font-medium uppercase tracking-[0.14em] ${gameStatusClass}`}
+            >
+              {gameStatusLabel}
+            </span>
+          </div>
+          {activeRunSummary ? (
+            <div className="mt-1 max-w-3xl truncate text-xs-tight leading-5 text-muted-strong">
+              {activeRunSummary}
+            </div>
+          ) : null}
+        </div>
         {sessionControlAction ? (
           <Button
             variant="outline"
@@ -1885,15 +1887,17 @@ export function GameView() {
             className="h-7 text-xs shadow-sm hover:border-accent"
             onClick={() => setShowLogsPanel(!showLogsPanel)}
           >
-            {showLogsPanel
-              ? t("gameview.HideDashboard", {
-                  defaultValue: "Hide dashboard",
-                })
-              : t("gameview.ShowDashboard", {
-                  defaultValue: "Show dashboard",
-                })}
+            {showLogsPanel ? "Hide game chat" : "Show game chat"}
           </Button>
         ) : null}
+        <Button
+          variant={showDiagnostics ? "default" : "outline"}
+          size="sm"
+          className="h-7 text-xs shadow-sm hover:border-accent"
+          onClick={() => setShowDiagnostics((current) => !current)}
+        >
+          Details
+        </Button>
         {canAttachViewer ? (
           <Button
             variant="outline"
@@ -1964,9 +1968,27 @@ export function GameView() {
           {t("game.backToApps")}
         </Button>
       </div>
-      {activeRunSummary ? (
-        <div className="bg-card/70 px-4 py-2 text-xs-tight leading-5 text-muted-strong">
-          {activeRunSummary}
+      {showDiagnostics ? (
+        <div className="border-t border-border/30 bg-card/70 px-4 py-2 text-xs-tight leading-5 text-muted-strong">
+          <div className="flex flex-wrap gap-2">
+            {diagnostics.map((item) => (
+              <span
+                key={item.label}
+                className="rounded-full border border-border/35 bg-bg/65 px-2.5 py-1"
+              >
+                <span className="text-muted">{item.label}: </span>
+                {item.value}
+              </span>
+            ))}
+            {activeGamePostMessageAuth ? (
+              <span className="rounded-full border border-border/35 bg-bg/65 px-2.5 py-1">
+                {t("gameview.postMessageAuth")}
+              </span>
+            ) : null}
+          </div>
+          {activeGameRun?.health.message ? (
+            <div className="mt-2">{activeGameRun.health.message}</div>
+          ) : null}
         </div>
       ) : null}
       {dashboardPanelEnabled && isCompactLayout ? (
@@ -1990,7 +2012,7 @@ export function GameView() {
             onClick={() => setMobileSurface("dashboard")}
           >
             {t("gameview.MobileSurfaceDashboard", {
-              defaultValue: "Dashboard",
+              defaultValue: "Actions",
             })}
           </Button>
           <Button

--- a/packages/app-core/src/components/apps/surfaces/GameOperatorShell.tsx
+++ b/packages/app-core/src/components/apps/surfaces/GameOperatorShell.tsx
@@ -1,0 +1,252 @@
+import { Button, Input } from "@elizaos/ui";
+import type { FormEvent } from "react";
+
+export type GameOperatorEventTone =
+  | "user"
+  | "success"
+  | "info"
+  | "warning"
+  | "error";
+
+export interface GameOperatorEvent {
+  id: string;
+  label: string;
+  message: string;
+  tone?: GameOperatorEventTone;
+  timestamp?: string | number | null;
+}
+
+export interface GameOperatorAction {
+  id: string;
+  label: string;
+  command: string;
+  testId?: string;
+  active?: boolean;
+  disabled?: boolean;
+}
+
+export interface GameOperatorDetail {
+  label: string;
+  value: string;
+}
+
+export interface GameOperatorShellProps {
+  surfaceTestId: string;
+  title: string;
+  statusLabel: string;
+  statusTone?: "live" | "attention" | "idle";
+  objective: string | null;
+  detailItems?: GameOperatorDetail[];
+  primaryActions: GameOperatorAction[];
+  suggestedActions?: GameOperatorAction[];
+  events: GameOperatorEvent[];
+  emptyEventsLabel: string;
+  draft: string;
+  inputPlaceholder: string;
+  sendLabel?: string;
+  sendingLabel?: string;
+  canSend: boolean;
+  sending: boolean;
+  chatInputTestId: string;
+  chatSendTestId: string;
+  noticeTestId?: string;
+  variant?: "detail" | "live" | "running";
+  onDraftChange: (value: string) => void;
+  onSendDraft: () => void;
+  onCommand: (command: string) => void;
+}
+
+function toneClass(tone: GameOperatorEventTone = "info"): string {
+  if (tone === "user") return "border-accent/35 bg-accent/10 text-txt";
+  if (tone === "success") return "border-ok/30 bg-ok/10 text-txt";
+  if (tone === "warning") return "border-warn/35 bg-warn/10 text-txt";
+  if (tone === "error") return "border-danger/35 bg-danger/10 text-txt";
+  return "border-border/35 bg-bg/80 text-txt";
+}
+
+function statusClass(tone: GameOperatorShellProps["statusTone"]): string {
+  if (tone === "live") return "border-ok/30 bg-ok/10 text-ok";
+  if (tone === "attention") return "border-warn/35 bg-warn/10 text-warn";
+  return "border-border/45 bg-bg-hover/70 text-muted-strong";
+}
+
+function formatTimestamp(
+  value: string | number | null | undefined,
+): string | null {
+  if (value == null) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function GameOperatorShell({
+  surfaceTestId,
+  title,
+  statusLabel,
+  statusTone = "idle",
+  objective,
+  detailItems = [],
+  primaryActions,
+  suggestedActions = [],
+  events,
+  emptyEventsLabel,
+  draft,
+  inputPlaceholder,
+  sendLabel = "Send",
+  sendingLabel = "Sending",
+  canSend,
+  sending,
+  chatInputTestId,
+  chatSendTestId,
+  noticeTestId,
+  variant = "detail",
+  onDraftChange,
+  onSendDraft,
+  onCommand,
+}: GameOperatorShellProps) {
+  const latestEvent = events.at(-1) ?? null;
+  const visibleEvents = events.slice(-12);
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!draft.trim() || sending || !canSend) return;
+    onSendDraft();
+  };
+
+  return (
+    <section
+      className={`flex min-h-0 flex-col gap-3 ${
+        variant === "live" ? "h-full p-3" : ""
+      }`}
+      data-testid={surfaceTestId}
+    >
+      <div className="rounded-2xl border border-border/35 bg-card/74 p-3 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`inline-flex min-h-6 items-center rounded-full border px-2.5 py-1 text-2xs font-medium uppercase tracking-[0.14em] ${statusClass(
+              statusTone,
+            )}`}
+          >
+            {statusLabel}
+          </span>
+          <span className="text-xs font-semibold text-txt">{title}</span>
+        </div>
+        {objective ? (
+          <div className="mt-2 text-xs leading-5 text-muted-strong">
+            {objective}
+          </div>
+        ) : null}
+        {detailItems.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {detailItems.map((item) => (
+              <span
+                key={`${item.label}:${item.value}`}
+                className="rounded-full border border-border/35 bg-bg/65 px-2.5 py-1 text-2xs text-muted-strong"
+              >
+                <span className="text-muted">{item.label}: </span>
+                {item.value}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {primaryActions.map((item) => (
+          <Button
+            key={item.id}
+            type="button"
+            variant={item.active ? "default" : "outline"}
+            size="sm"
+            className="min-h-9 rounded-xl shadow-sm"
+            data-testid={item.testId}
+            disabled={!canSend || sending || item.disabled}
+            onClick={() => onCommand(item.command)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col rounded-2xl border border-border/35 bg-card/74 shadow-sm">
+        <div className="flex items-center justify-between gap-2 border-b border-border/30 px-3 py-2">
+          <div className="text-2xs font-semibold uppercase tracking-[0.18em] text-muted">
+            Game chat
+          </div>
+          {latestEvent && noticeTestId ? (
+            <div
+              className="max-w-44 truncate text-2xs text-muted-strong"
+              data-testid={noticeTestId}
+              title={latestEvent.message}
+            >
+              {latestEvent.message}
+            </div>
+          ) : null}
+        </div>
+        <div className="min-h-40 flex-1 space-y-2 overflow-y-auto p-3">
+          {visibleEvents.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-border/45 bg-bg/45 px-3 py-4 text-xs leading-5 text-muted-strong">
+              {emptyEventsLabel}
+            </div>
+          ) : (
+            visibleEvents.map((event) => {
+              const time = formatTimestamp(event.timestamp);
+              return (
+                <div
+                  key={event.id}
+                  className={`rounded-xl border px-3 py-2 text-xs leading-5 ${toneClass(
+                    event.tone,
+                  )}`}
+                >
+                  <div className="mb-1 flex items-center gap-2 text-2xs uppercase tracking-[0.14em] text-muted">
+                    <span>{event.label}</span>
+                    {time ? <span>{time}</span> : null}
+                  </div>
+                  <div>{event.message}</div>
+                </div>
+              );
+            })
+          )}
+        </div>
+        <form className="border-t border-border/30 p-3" onSubmit={handleSubmit}>
+          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+            <Input
+              value={draft}
+              onChange={(event) => onDraftChange(event.target.value)}
+              placeholder={inputPlaceholder}
+              className="min-h-10 rounded-xl"
+              data-testid={chatInputTestId}
+              disabled={!canSend}
+            />
+            <Button
+              type="submit"
+              className="min-h-10 rounded-xl px-4 shadow-sm"
+              data-testid={chatSendTestId}
+              disabled={!canSend || sending || !draft.trim()}
+            >
+              {sending ? sendingLabel : sendLabel}
+            </Button>
+          </div>
+          {suggestedActions.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {suggestedActions.map((item) => (
+                <Button
+                  key={item.id}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="min-h-8 rounded-xl px-3 shadow-sm"
+                  data-testid={item.testId}
+                  disabled={!canSend || sending || item.disabled}
+                  onClick={() => onCommand(item.command)}
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/packages/app-core/src/components/character/CharacterHubView.test.tsx
+++ b/packages/app-core/src/components/character/CharacterHubView.test.tsx
@@ -1,0 +1,291 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type {
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+  TextareaHTMLAttributes,
+} from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CharacterData, ExperienceRecord } from "../../api/client-types";
+
+const { clientMock, useAppMock } = vi.hoisted(() => ({
+  clientMock: {
+    deleteExperience: vi.fn(),
+    getRelationshipsActivity: vi.fn(),
+    listCharacterHistory: vi.fn(),
+    listExperiences: vi.fn(),
+    listKnowledgeDocuments: vi.fn(),
+    updateCharacter: vi.fn(),
+    updateExperience: vi.fn(),
+  },
+  useAppMock: vi.fn(),
+}));
+
+vi.mock("@elizaos/ui", () => {
+  const passThrough =
+    (Tag: "div" | "section" | "span" = "div") =>
+    ({
+      active: _active,
+      children,
+      ...props
+    }: HTMLAttributes<HTMLElement> & { active?: boolean }) => {
+      const Component = Tag;
+      return <Component {...props}>{children}</Component>;
+    };
+
+  const SidebarContent = {
+    Item: ({
+      active: _active,
+      children,
+      onClick,
+      ...props
+    }: HTMLAttributes<HTMLButtonElement> & { active?: boolean }) => (
+      <button type="button" onClick={onClick} {...props}>
+        {children}
+      </button>
+    ),
+    ItemBody: passThrough("span"),
+    ItemIcon: passThrough("span"),
+    ItemTitle: passThrough("span"),
+    SectionLabel: passThrough("div"),
+  };
+
+  return {
+    Button: ({
+      children,
+      size: _size,
+      variant: _variant,
+      ...props
+    }: ButtonHTMLAttributes<HTMLButtonElement> & {
+      size?: string;
+      variant?: string;
+    }) => <button {...props}>{children}</button>,
+    Input: (props: InputHTMLAttributes<HTMLInputElement>) => (
+      <input {...props} />
+    ),
+    PageLayout: ({
+      children,
+      sidebar,
+      ...props
+    }: {
+      children?: ReactNode;
+      sidebar?: ReactNode;
+      "data-testid"?: string;
+    }) => (
+      <main data-testid={props["data-testid"]}>
+        <aside>{sidebar}</aside>
+        {children}
+      </main>
+    ),
+    SidebarContent,
+    SidebarPanel: passThrough("section"),
+    SidebarScrollRegion: passThrough("div"),
+    Textarea: (props: TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+      <textarea {...props} />
+    ),
+  };
+});
+
+vi.mock("../../api/client", () => ({
+  client: clientMock,
+}));
+
+vi.mock("../../state/useApp", () => ({
+  useApp: () => useAppMock(),
+}));
+
+vi.mock("../pages/KnowledgeView", () => ({
+  KnowledgeView: () => <div>Knowledge view</div>,
+}));
+
+vi.mock("../pages/relationships/RelationshipsWorkspaceView", () => ({
+  RelationshipsWorkspaceView: () => <div>Relationships workspace</div>,
+}));
+
+vi.mock("../shared/AppPageSidebar", () => ({
+  AppPageSidebar: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("./CharacterEditorPanels", () => ({
+  CharacterExamplesPanel: () => <div>Examples panel</div>,
+  CharacterIdentityPanel: () => <div>Identity panel</div>,
+  CharacterStylePanel: () => <div>Style panel</div>,
+}));
+
+vi.mock("./CharacterOverviewSection", () => ({
+  CharacterOverviewSection: () => <div>Overview section</div>,
+}));
+
+vi.mock("./CharacterPersonalityTimeline", () => ({
+  CharacterPersonalityTimeline: () => <div>Personality timeline</div>,
+}));
+
+vi.mock("./CharacterRelationshipsSection", () => ({
+  CharacterRelationshipsSection: ({ children }: { children?: ReactNode }) => (
+    <section>{children}</section>
+  ),
+}));
+
+import { CharacterHubView } from "./CharacterHubView";
+
+const experience: ExperienceRecord = {
+  accessCount: 0,
+  action: "Asked for source token, destination token, amount, and slippage.",
+  confidence: 0.55,
+  context: "A user asked for a direct wallet swap without enough details.",
+  createdAt: "2026-04-20T12:00:00.000Z",
+  domain: "finance",
+  id: "exp-1",
+  importance: 0.92,
+  learning:
+    "Always collect complete swap parameters before preparing a wallet transaction.",
+  outcome: "negative",
+  result: "The user supplied the missing route details before execution.",
+  tags: ["wallet", "safety"],
+  type: "interaction",
+  updatedAt: "2026-04-21T12:00:00.000Z",
+};
+
+const character = {
+  bio: [],
+  messageExamples: [],
+  name: "Milady",
+  postExamples: [],
+  style: {
+    all: [],
+    chat: [],
+    post: [],
+  },
+} as CharacterData;
+
+function renderHub() {
+  return render(
+    <CharacterHubView
+      d={character}
+      bioText=""
+      normalizedMessageExamples={[]}
+      pendingStyleEntries={{}}
+      styleEntryDrafts={{}}
+      handleFieldEdit={() => {}}
+      applyFieldEdit={() => {}}
+      handlePendingStyleEntryChange={() => {}}
+      applyStyleEdit={() => {}}
+      handleStyleEntryDraftChange={() => {}}
+      characterSaving={false}
+      characterSaveSuccess={null}
+      characterSaveError={null}
+      hasPendingChanges={false}
+      onSave={async () => ({})}
+      onReset={() => {}}
+      canReset={false}
+    />,
+  );
+}
+
+describe("CharacterHubView experience tab", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/character/experience");
+    useAppMock.mockReturnValue({
+      setActionNotice: vi.fn(),
+      setTab: vi.fn(),
+      t: (key: string, options?: Record<string, unknown>) =>
+        String(options?.defaultValue ?? key),
+      tab: "character",
+    });
+    clientMock.listCharacterHistory.mockResolvedValue({ history: [] });
+    clientMock.getRelationshipsActivity.mockResolvedValue({ activity: [] });
+    clientMock.listKnowledgeDocuments.mockResolvedValue({
+      documents: [],
+      total: 0,
+    });
+    clientMock.listExperiences.mockResolvedValue({
+      experiences: [experience],
+      total: 1,
+    });
+    clientMock.updateCharacter.mockResolvedValue({
+      agentName: "Milady",
+      character,
+      ok: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    window.history.pushState(null, "", "/");
+  });
+
+  it("loads experiences when the character page opens directly to the Experience tab", async () => {
+    renderHub();
+
+    expect(screen.getByText("Loading experiences…")).toBeTruthy();
+
+    expect(
+      (await screen.findAllByText(experience.learning)).length,
+    ).toBeGreaterThan(0);
+    expect(clientMock.listExperiences).toHaveBeenCalledWith({ limit: 100 });
+    expect(screen.getByText("1 of 1 shown")).toBeTruthy();
+  });
+
+  it("saves review edits through the character experience API and deletes the reviewed item", async () => {
+    const updatedLearning =
+      "Require complete wallet swap instructions before drafting any transaction.";
+    clientMock.updateExperience.mockResolvedValue({
+      experience: {
+        ...experience,
+        confidence: 0.7,
+        importance: 0.88,
+        learning: updatedLearning,
+        tags: ["wallet", "safety", "review"],
+      },
+    });
+    clientMock.deleteExperience.mockResolvedValue({ ok: true });
+
+    renderHub();
+    await screen.findAllByText(experience.learning);
+
+    fireEvent.change(screen.getByLabelText("Learning"), {
+      target: { value: updatedLearning },
+    });
+    fireEvent.change(screen.getByLabelText("Importance"), {
+      target: { value: "0.88" },
+    });
+    fireEvent.change(screen.getByLabelText("Confidence"), {
+      target: { value: "0.7" },
+    });
+    fireEvent.change(screen.getByLabelText("Tags"), {
+      target: { value: "wallet, safety, review" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save review" }));
+
+    await waitFor(() => {
+      expect(clientMock.updateExperience).toHaveBeenCalledWith("exp-1", {
+        confidence: 0.7,
+        importance: 0.88,
+        learning: updatedLearning,
+        tags: ["wallet", "safety", "review"],
+      });
+    });
+    expect(
+      (await screen.findAllByText(updatedLearning)).length,
+    ).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(clientMock.deleteExperience).toHaveBeenCalledWith("exp-1");
+    });
+    expect(await screen.findByText("No experiences recorded yet.")).toBeTruthy();
+  });
+});

--- a/packages/app-core/src/components/conversations/ConversationsSidebar.test.tsx
+++ b/packages/app-core/src/components/conversations/ConversationsSidebar.test.tsx
@@ -200,6 +200,7 @@ vi.mock("@elizaos/ui", () => {
     SidebarPanel: passthrough,
     SidebarScrollRegion: passthrough,
     TooltipProvider: passthrough,
+    useIntervalWhenDocumentVisible: vi.fn(),
   };
 });
 

--- a/packages/app-core/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/app-core/src/components/conversations/ConversationsSidebar.tsx
@@ -728,6 +728,7 @@ export function ConversationsSidebar({
       <AppPageSidebar
         testId="conversations-sidebar"
         variant={mobile ? "mobile" : isGameModal ? "game-modal" : "default"}
+        className={mobile || isGameModal ? "!mt-0" : undefined}
         collapsible={!mobile && !isGameModal}
         collapsed={!mobile && !isGameModal ? sidebarCollapsed : undefined}
         onCollapsedChange={

--- a/packages/app-core/src/components/pages/AutomationRoomChatPane.tsx
+++ b/packages/app-core/src/components/pages/AutomationRoomChatPane.tsx
@@ -37,6 +37,26 @@ interface AutomationRoomChatPaneProps {
 const WORKFLOW_ACTION_KEYWORDS =
   /workflow|automation|cron|task|calendar|gmail|signal|telegram|discord|github|deploy|activate|deactivate|delete|create/i;
 
+async function getAutomationConversationMessages(
+  conversationId: string,
+): Promise<ConversationMessage[]> {
+  try {
+    const { messages } = await client.getConversationMessages(conversationId);
+    return messages;
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      status === 404 ||
+      message.toLowerCase().includes("not found") ||
+      message.includes("404")
+    ) {
+      throw error;
+    }
+    return [];
+  }
+}
+
 // ── Custom event shapes ──────────────────────────────────────────────────────
 
 interface WorkflowGeneratingDetail {
@@ -129,8 +149,9 @@ export function AutomationRoomChatPane({
         setConversationId(conversation.id);
         onConversationResolved?.(conversation);
 
-        const { messages: loadedMessages } =
-          await client.getConversationMessages(conversation.id);
+        const loadedMessages = await getAutomationConversationMessages(
+          conversation.id,
+        );
         if (cancelled) {
           return;
         }
@@ -152,8 +173,9 @@ export function AutomationRoomChatPane({
           }
           setConversationId(recreatedConversation.id);
           onConversationResolved?.(recreatedConversation);
-          const { messages: recreatedMessages } =
-            await client.getConversationMessages(recreatedConversation.id);
+          const recreatedMessages = await getAutomationConversationMessages(
+            recreatedConversation.id,
+          );
           if (!cancelled) {
             setMessages(recreatedMessages);
           }

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -22,6 +22,7 @@ import {
   Textarea,
 } from "@elizaos/ui";
 import {
+  ArrowRight,
   Calendar,
   CheckCircle2,
   ChevronDown,
@@ -34,7 +35,6 @@ import {
   GitBranch,
   Grid3x3,
   LayoutDashboard,
-  ArrowRight,
   type LucideIcon,
   Mail,
   Pause,
@@ -98,8 +98,8 @@ import {
   buildUpdateRequest,
   emptyForm,
   formFromTrigger,
-  humanizeEventKind,
   type HeartbeatTemplate,
+  humanizeEventKind,
   loadUserTemplates,
   localizedExecutionStatus,
   railMonogram,
@@ -155,8 +155,11 @@ const NODE_CLASS_ORDER = [
 
 const PAGE_CHAT_PREFILL_EVENT = "milady:chat:prefill";
 const DESCRIBE_WORKFLOW_PROMPT = "Describe your workflow";
+const DESCRIBE_AUTOMATION_PROMPT = "What should happen?";
 const WORKFLOW_PROMPT_PLACEHOLDER =
   "Describe the trigger and steps, e.g. when a GitHub issue opens, summarize it and post to Discord";
+const AUTOMATION_PROMPT_PLACEHOLDER =
+  "e.g. Every morning summarize my inbox, or when a GitHub issue opens, triage it";
 const AUTOMATIONS_OVERVIEW_VISIBILITY_EVENT =
   "milady:automations:overview-visibility";
 
@@ -205,6 +208,33 @@ function buildWorkflowCopyRequest(
     connections: workflow.connections ?? {},
     settings: {},
   };
+}
+
+function inferAutomationPromptKind(prompt: string): "task" | "workflow" {
+  const normalized = prompt.toLowerCase();
+  const looksScheduledTask =
+    /\b(every|daily|hourly|weekly|monthly|weekday|morning|evening|at \d{1,2})\b/.test(
+      normalized,
+    );
+  const looksWorkflow =
+    /\b(when|if|after|then|workflow|pipeline|webhook|event|triage|route|label|enrich|crm)\b/.test(
+      normalized,
+    ) ||
+    (normalized.includes(" and ") &&
+      /\b(send|post|create|update|reply|notify|summarize)\b/.test(normalized));
+
+  if (looksScheduledTask && !normalized.includes("when ")) return "task";
+  return looksWorkflow ? "workflow" : "task";
+}
+
+function titleFromAutomationPrompt(prompt: string): string {
+  const cleaned = prompt
+    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return "New task";
+  const title = cleaned.split(" ").slice(0, 7).join(" ");
+  return title.charAt(0).toUpperCase() + title.slice(1);
 }
 
 // Reads `#automations.trigger=<id>` from the URL hash. The LifeOps chat-sidebar
@@ -1385,11 +1415,13 @@ function CreateAutomationDialog({
   onOpenChange,
   onCreateTask,
   onCreateWorkflow,
+  onDescribeAutomation,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreateTask: () => void;
   onCreateWorkflow: () => void;
+  onDescribeAutomation: (prompt: string) => Promise<void> | void;
 }) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -1397,6 +1429,14 @@ function CreateAutomationDialog({
         <DialogHeader>
           <DialogTitle>Create automation</DialogTitle>
         </DialogHeader>
+
+        <AutomationCommandBar
+          autoFocus
+          onSubmit={async (prompt) => {
+            await onDescribeAutomation(prompt);
+            onOpenChange(false);
+          }}
+        />
 
         <div className="grid gap-3 sm:grid-cols-2">
           <button
@@ -2125,6 +2165,84 @@ function OverviewIdeaGrid({
   );
 }
 
+function AutomationCommandBar({
+  onSubmit,
+  autoFocus = false,
+}: {
+  onSubmit: (prompt: string) => Promise<void> | void;
+  autoFocus?: boolean;
+}) {
+  const [prompt, setPrompt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = useCallback(async () => {
+    const trimmed = prompt.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+      setPrompt("");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [onSubmit, prompt, submitting]);
+
+  return (
+    <div className="rounded-2xl border border-border/30 bg-bg/55 p-1.5 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <Input
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void submit();
+            }
+          }}
+          placeholder={AUTOMATION_PROMPT_PLACEHOLDER}
+          aria-label={DESCRIBE_AUTOMATION_PROMPT}
+          className="min-h-11 flex-1 border-0 bg-transparent px-4 text-sm shadow-none focus-visible:ring-0"
+          autoFocus={autoFocus}
+        />
+        <Button
+          variant="default"
+          size="sm"
+          className="h-10 shrink-0 rounded-xl px-4 text-sm"
+          disabled={submitting || prompt.trim().length === 0}
+          onClick={() => void submit()}
+        >
+          {submitting ? "Creating..." : "Create"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function AutomationStatusStrip({
+  entries,
+}: {
+  entries: Array<{
+    label: string;
+    value: number;
+    tone: "success" | "warning" | "muted" | "danger";
+  }>;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {entries.map((entry) => (
+        <div
+          key={entry.label}
+          className="inline-flex items-center gap-2 rounded-full border border-border/25 bg-bg/40 px-2.5 py-1 text-xs"
+        >
+          <StatusDot tone={entry.tone} />
+          <span className="font-medium text-txt">{entry.label}</span>
+          <span className="tabular-nums text-muted">{entry.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function formatRelativeFuture(
   targetMs: number,
   t?: (
@@ -2255,12 +2373,14 @@ function AutomationsDashboard({
   onSelectItem,
   onCreateTask,
   onCreateWorkflow,
+  onDescribeAutomation,
   onUseIdea,
 }: {
   items: AutomationItem[];
   onSelectItem: (item: AutomationItem) => void;
   onCreateTask: () => void;
   onCreateWorkflow: () => void;
+  onDescribeAutomation: (prompt: string) => Promise<void> | void;
   onUseIdea: (idea: AutomationExample) => void;
 }) {
   const { t, uiLanguage } = useAutomationsViewContext();
@@ -2296,6 +2416,17 @@ function AutomationsDashboard({
       ).slice(0, 6),
     [visibleItems],
   );
+  const liveItems = useMemo(
+    () =>
+      sortAutomationsByUpdatedAtDesc(
+        visibleItems.filter((item) => item.enabled && !item.isDraft),
+      ).slice(0, 5),
+    [visibleItems],
+  );
+  const recentItems = useMemo(
+    () => sortAutomationsByUpdatedAtDesc(visibleItems).slice(0, 6),
+    [visibleItems],
+  );
 
   const taskCount = visibleItems.filter(
     (item) => item.type !== "n8n_workflow",
@@ -2329,23 +2460,6 @@ function AutomationsDashboard({
         )
         .slice(0, 6),
     [scheduledEntries, now],
-  );
-
-  const recent = useMemo(
-    () =>
-      scheduledEntries
-        .filter(({ schedule }) => schedule.lastRunAtIso)
-        .sort((a, b) => {
-          const aTs = a.schedule.lastRunAtIso
-            ? Date.parse(a.schedule.lastRunAtIso)
-            : 0;
-          const bTs = b.schedule.lastRunAtIso
-            ? Date.parse(b.schedule.lastRunAtIso)
-            : 0;
-          return bTs - aTs;
-        })
-        .slice(0, 6),
-    [scheduledEntries],
   );
 
   const failures = useMemo(
@@ -2391,6 +2505,28 @@ function AutomationsDashboard({
 
     return next.slice(0, 6);
   }, [failures, t, uiLanguage]);
+  const statusEntries = [
+    {
+      label: "Live",
+      value: activeCount,
+      tone: activeCount > 0 ? "success" : "muted",
+    },
+    {
+      label: "Timed",
+      value: activeScheduleCount,
+      tone: activeScheduleCount > 0 ? "success" : "muted",
+    },
+    {
+      label: "Events",
+      value: activeEventCount,
+      tone: activeEventCount > 0 ? "success" : "muted",
+    },
+    {
+      label: "Attention",
+      value: attentionEntries.length,
+      tone: attentionEntries.length > 0 ? "danger" : "success",
+    },
+  ] satisfies Parameters<typeof AutomationStatusStrip>[0]["entries"];
 
   if (taskCount === 0 && workflowCount === 0) {
     return (
@@ -2410,6 +2546,7 @@ function AutomationsDashboard({
                 that run on a schedule or from an event.
               </p>
             </div>
+            <AutomationCommandBar onSubmit={onDescribeAutomation} autoFocus />
             <div className="flex flex-wrap gap-2">
               <Button variant="default" size="sm" onClick={onCreateTask}>
                 New task
@@ -2469,60 +2606,23 @@ function AutomationsDashboard({
     <div className="space-y-4 px-1 pt-4">
       <section className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
         <div className="rounded-xl border border-border/25 bg-[radial-gradient(circle_at_top_left,rgba(34,197,94,0.1),transparent_34%),radial-gradient(circle_at_top_right,rgba(56,189,248,0.12),transparent_30%),rgba(255,255,255,0.02)] px-4 py-4 sm:px-5">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <div className="inline-flex items-center gap-2 rounded-full border border-border/25 bg-bg/40 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted/70">
                 <LayoutDashboard className="h-3 w-3" aria-hidden />
                 Overview
               </div>
-              <h2 className="text-lg font-semibold text-txt">Automations</h2>
+              <AutomationStatusStrip entries={statusEntries} />
             </div>
-
+            <AutomationCommandBar onSubmit={onDescribeAutomation} />
             <div className="flex flex-wrap gap-2">
-              <Button variant="default" size="sm" onClick={onCreateTask}>
+              <Button variant="ghost" size="sm" onClick={onCreateTask}>
                 New task
               </Button>
-              <Button variant="outline" size="sm" onClick={onCreateWorkflow}>
+              <Button variant="ghost" size="sm" onClick={onCreateWorkflow}>
                 New workflow
               </Button>
             </div>
-          </div>
-
-          <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-            <OverviewMetricCard
-              label="Live"
-              value={<span className="tabular-nums">{activeCount}</span>}
-              detail={activeCount > 0 ? "Ready to run" : "Nothing enabled"}
-              tone={activeCount > 0 ? "ok" : "default"}
-            />
-            <OverviewMetricCard
-              label="Timed"
-              value={
-                <span className="tabular-nums">{activeScheduleCount}</span>
-              }
-              detail={
-                activeScheduleCount > 0
-                  ? "Schedules live"
-                  : "No timed runs"
-              }
-              tone={activeScheduleCount > 0 ? "ok" : "default"}
-            />
-            <OverviewMetricCard
-              label="Events"
-              value={<span className="tabular-nums">{activeEventCount}</span>}
-              detail={activeEventCount > 0 ? "Hooks live" : "No event hooks"}
-              tone={activeEventCount > 0 ? "ok" : "default"}
-            />
-            <OverviewMetricCard
-              label="Attention"
-              value={
-                <span className="tabular-nums">{attentionEntries.length}</span>
-              }
-              detail={
-                attentionEntries.length > 0 ? "Failed runs" : "Nothing urgent"
-              }
-              tone={attentionEntries.length > 0 ? "danger" : "ok"}
-            />
           </div>
         </div>
 
@@ -2597,65 +2697,82 @@ function AutomationsDashboard({
       ) : null}
 
       <div className="grid gap-4 xl:grid-cols-2">
-        <DetailSection title="Upcoming runs" className="h-full">
-          {upcoming.length > 0 ? (
+        <DetailSection title="Running" className="h-full">
+          {liveItems.length > 0 ? (
             <div className="divide-y divide-border/20">
-              {upcoming.map(({ key, item, schedule }) => (
+              {liveItems.map((item) => (
                 <OverviewListItem
-                  key={key}
+                  key={item.id}
                   onClick={() => onSelectItem(item)}
                   title={getOverviewDisplayTitle(item)}
                   badge={getAutomationGroupLabel(item)}
-                  meta={scheduleLabel(schedule, t, uiLanguage)}
-                  detail={formatDateTime(schedule.nextRunAtMs ?? null, {
-                    fallback: "—",
-                    locale: uiLanguage,
-                  })}
-                  trailing={
-                    schedule.nextRunAtMs
-                      ? formatRelativeFuture(schedule.nextRunAtMs, t)
-                      : "—"
+                  meta={
+                    item.schedules[0]
+                      ? scheduleLabel(item.schedules[0], t, uiLanguage)
+                      : "Manual or event"
                   }
+                  trailing={formatRelativePast(item.updatedAt, t)}
                   tone="success"
                 />
               ))}
             </div>
           ) : (
             <div className="px-3 py-4 text-xs-tight text-muted/70">
-              {scheduledEntries.length > 0 ? "None queued." : "No schedules."}
+              Nothing live.
             </div>
           )}
         </DetailSection>
 
-        <DetailSection title="Recent runs" className="h-full">
-          {recent.length > 0 ? (
+        <DetailSection title="Drafts" className="h-full">
+          {draftItems.length > 0 ? (
             <div className="divide-y divide-border/20">
-              {recent.map(({ key, item, schedule }) => {
-                const tone = toneForLastStatus(schedule.lastStatus);
-                return (
-                  <OverviewListItem
-                    key={key}
-                    onClick={() => onSelectItem(item)}
-                    title={getOverviewDisplayTitle(item)}
-                    badge={getAutomationGroupLabel(item)}
-                    meta={scheduleLabel(schedule, t, uiLanguage)}
-                    detail={formatDateTime(schedule.lastRunAtIso, {
-                      fallback: "—",
-                      locale: uiLanguage,
-                    })}
-                    trailing={formatRelativePast(schedule.lastRunAtIso, t)}
-                    tone={tone}
-                  />
-                );
-              })}
+              {draftItems.map((item) => (
+                <OverviewListItem
+                  key={item.id}
+                  onClick={() => onSelectItem(item)}
+                  title={getOverviewDisplayTitle(item)}
+                  badge={getAutomationGroupLabel(item)}
+                  meta="Continue"
+                  trailing={formatRelativePast(item.updatedAt, t)}
+                  tone="warning"
+                />
+              ))}
             </div>
           ) : (
             <div className="px-3 py-4 text-xs-tight text-muted/70">
-              No runs yet.
+              No drafts.
             </div>
           )}
         </DetailSection>
       </div>
+
+      <DetailSection title="Recently changed">
+        {recentItems.length > 0 ? (
+          <div className="grid divide-y divide-border/20 md:grid-cols-2 md:divide-x md:divide-y-0">
+            {recentItems.map((item) => (
+              <OverviewListItem
+                key={item.id}
+                onClick={() => onSelectItem(item)}
+                title={getOverviewDisplayTitle(item)}
+                badge={getAutomationGroupLabel(item)}
+                meta={
+                  item.schedules[0]
+                    ? scheduleLabel(item.schedules[0], t, uiLanguage)
+                    : item.isDraft
+                      ? "Draft"
+                      : "Manual or event"
+                }
+                trailing={formatRelativePast(item.updatedAt, t)}
+                tone={getAutomationStatusTone(item)}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="px-3 py-4 text-xs-tight text-muted/70">
+            No recent changes.
+          </div>
+        )}
+      </DetailSection>
 
       <div className="grid gap-4 xl:grid-cols-2">
         <DetailSection
@@ -3003,11 +3120,7 @@ function getWorkflowFlowNodes(workflow: N8nWorkflow | null): Array<{
     }));
 }
 
-function WorkflowDataFlowStrip({
-  workflow,
-}: {
-  workflow: N8nWorkflow | null;
-}) {
+function WorkflowDataFlowStrip({ workflow }: { workflow: N8nWorkflow | null }) {
   const flowNodes = getWorkflowFlowNodes(workflow);
   if (flowNodes.length === 0) {
     return (
@@ -4540,6 +4653,30 @@ function AutomationsLayout() {
     [openCreateTrigger, setForm, showAutomationsList],
   );
 
+  const handleDescribeAutomation = useCallback(
+    async (prompt: string) => {
+      const trimmed = prompt.trim();
+      if (!trimmed) return;
+
+      if (inferAutomationPromptKind(trimmed) === "workflow") {
+        await createWorkflowDraft({
+          title: titleFromAutomationPrompt(trimmed),
+          initialPrompt: trimmed,
+        });
+        return;
+      }
+
+      showAutomationsList();
+      openCreateTrigger();
+      setForm({
+        ...emptyForm,
+        displayName: titleFromAutomationPrompt(trimmed),
+        instructions: trimmed,
+      });
+    },
+    [createWorkflowDraft, openCreateTrigger, setForm, showAutomationsList],
+  );
+
   const handleRefreshWorkflows = useCallback(async () => {
     setPageNotice(null);
     const data = await refreshAutomationsWithDraftBinding(
@@ -5067,6 +5204,7 @@ function AutomationsLayout() {
             onSelectItem={selectItem}
             onCreateTask={handleZeroStateNewTask}
             onCreateWorkflow={() => void createWorkflowDraft()}
+            onDescribeAutomation={handleDescribeAutomation}
             onUseIdea={(idea) => {
               if (idea.kind === "workflow") {
                 void createWorkflowDraft({
@@ -5142,6 +5280,7 @@ function AutomationsLayout() {
           setCreateDialogMode(null);
           void createWorkflowDraft();
         }}
+        onDescribeAutomation={handleDescribeAutomation}
       />
       <WorkflowTemplatesModal
         open={templatesModalOpen}

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -1199,7 +1199,7 @@ function AutomationCollapsibleSection({
       data-testid={`automation-section-${sectionKey}`}
       className="group/section space-y-0"
     >
-      <div className="flex items-center gap-1 pr-1">
+      <div className="flex items-center gap-1">
         <button
           type="button"
           onClick={() => onToggleCollapsed(sectionKey)}
@@ -1221,16 +1221,18 @@ function AutomationCollapsibleSection({
             onClick={onAdd}
             aria-label={addLabel ?? "Add"}
             title={addLabel}
-            className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-transparent text-muted transition-colors hover:text-txt"
+            className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-[var(--radius-sm)] bg-transparent text-muted transition-colors hover:text-txt"
           >
             <Plus className="h-3.5 w-3.5" aria-hidden />
           </button>
         ) : null}
       </div>
       {collapsed ? null : count === 0 ? (
-        <div className="px-3 py-1 text-2xs text-muted/70">{emptyLabel}</div>
+        <div className="py-1 pl-8 pr-1 text-2xs text-muted/70">
+          {emptyLabel}
+        </div>
       ) : (
-        <div className="space-y-0">{children}</div>
+        <div className="space-y-0 pl-3 pr-0.5">{children}</div>
       )}
     </section>
   );
@@ -3916,7 +3918,7 @@ function AutomationSidebarItem({
       onClick={onClick}
       onDoubleClick={onDoubleClick}
       aria-current={selected ? "page" : undefined}
-      className={`group flex w-full min-w-0 items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left transition-colors ${
+      className={`group flex w-full min-w-0 items-center gap-1.5 rounded-[var(--radius-sm)] py-1 pl-2 pr-1.5 text-left transition-colors ${
         selected ? "bg-accent/15 text-txt" : "text-txt hover:bg-bg-muted/50"
       } ${item.system ? "opacity-60" : ""}`}
     >
@@ -3924,7 +3926,7 @@ function AutomationSidebarItem({
       <span className={`truncate text-xs-tight ${titleClass}`}>
         {getAutomationDisplayTitle(item)}
       </span>
-      <StatusDot tone={tone} />
+      <StatusDot tone={tone} className="ml-auto h-1.5 w-1.5 shrink-0" />
     </button>
   );
 }
@@ -5030,7 +5032,10 @@ function AutomationsLayout() {
         </SidebarContent.RailItem>
       ))}
     >
-      <SidebarScrollRegion className="px-1 pb-2 pt-0">
+      <SidebarScrollRegion
+        className="!px-0 !pb-2 !pt-0 [scrollbar-gutter:auto]"
+        style={{ scrollbarGutter: "auto" }}
+      >
         <SidebarPanel className="bg-transparent gap-0 p-0 shadow-none">
           {isLoading && (
             <div className="flex items-center gap-2 px-2 py-1.5 text-2xs text-muted">
@@ -5043,7 +5048,7 @@ function AutomationsLayout() {
             type="button"
             onClick={showOverview}
             aria-current={showDashboard ? "page" : undefined}
-            className={`mt-0.5 flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left text-xs-tight transition-colors ${
+            className={`mt-0 flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1 text-left text-xs-tight transition-colors ${
               showDashboard
                 ? "bg-accent/15 text-txt"
                 : "text-txt hover:bg-bg-muted/50"
@@ -5087,12 +5092,12 @@ function AutomationsLayout() {
 
             <AutomationCollapsibleSection
               sectionKey="agent-owned"
-              label="Agent Owned"
+              label="Internal"
               icon={<SquareTerminal className="h-3.5 w-3.5" aria-hidden />}
               count={agentOwnedItems.length}
               collapsed={collapsedSections.has("agent-owned")}
               onToggleCollapsed={toggleSectionCollapsed}
-              emptyLabel="No agent-owned automations"
+              emptyLabel="No internal automations"
             >
               {agentOwnedItems.map(renderItem)}
             </AutomationCollapsibleSection>

--- a/packages/app-core/src/components/pages/ChatModalView.tsx
+++ b/packages/app-core/src/components/pages/ChatModalView.tsx
@@ -48,7 +48,7 @@ export const ChatModalView = memo(function ChatModalView({
         >
           <DrawerSheetContent
             aria-describedby={undefined}
-            className="h-[min(calc(100dvh-1rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),36rem)] p-0"
+            className="!inset-0 !left-0 !right-0 !bottom-0 !top-0 !h-[100dvh] !max-h-none !rounded-none !border-0 p-0"
             data-chat-game-sidebar-overlay
             showCloseButton={false}
           >

--- a/packages/app-core/src/components/pages/ChatView.tsx
+++ b/packages/app-core/src/components/pages/ChatView.tsx
@@ -374,6 +374,7 @@ export function ChatView({
 
   // Auto-resize textarea
   useEffect(() => {
+    if (!isGameModal) return;
     const ta = textareaRef.current;
     if (!ta) return;
 
@@ -390,7 +391,7 @@ export function ChatView({
     ta.style.height = `${h}px`;
     ta.style.overflowY =
       ta.scrollHeight > CHAT_INPUT_MAX_HEIGHT_PX ? "auto" : "hidden";
-  }, [chatInput]);
+  }, [chatInput, isGameModal]);
 
   // Track composer height so the message layer bottom adjusts dynamically
   useEffect(() => {

--- a/packages/app-core/src/components/pages/InventoryView.tsx
+++ b/packages/app-core/src/components/pages/InventoryView.tsx
@@ -344,12 +344,6 @@ function formatMarketEndsAt(value: string | null): string | null {
   });
 }
 
-function formatMarketGeneratedAt(value: string): string | null {
-  const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) return null;
-  return formatRelativeTimestamp(timestamp);
-}
-
 function tradingProfileWindow(
   window: DashboardWindow,
 ): WalletTradingProfileWindow {
@@ -863,12 +857,6 @@ function MarketAvatar({
 }
 
 function MarketSourceBadge({ source }: { source: WalletMarketOverviewSource }) {
-  const statusLabel = source.available
-    ? source.stale
-      ? "Cached"
-      : "Live"
-    : "Unavailable";
-
   return (
     <a
       href={source.providerUrl}
@@ -876,21 +864,8 @@ function MarketSourceBadge({ source }: { source: WalletMarketOverviewSource }) {
       rel="noreferrer"
       className="transition-opacity hover:opacity-80"
     >
-      <span className="inline-flex items-center gap-2 rounded-full border border-border/35 bg-bg/45 px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted">
-        <span className="normal-case tracking-normal text-txt">
-          {source.providerName}
-        </span>
-        <span
-          className={cn(
-            source.available
-              ? source.stale
-                ? "text-warn"
-                : "text-ok"
-              : "text-danger",
-          )}
-        >
-          {statusLabel}
-        </span>
+      <span className="inline-flex items-center rounded-full border border-border/35 bg-bg/45 px-2.5 py-1 text-[0.68rem] font-semibold text-txt">
+        {source.providerName}
       </span>
     </a>
   );
@@ -1120,10 +1095,6 @@ function MarketPulseHero({
   loading: boolean;
   error: string | null;
 }) {
-  const updatedAtLabel = overview
-    ? formatMarketGeneratedAt(overview.generatedAt)
-    : null;
-
   return (
     <section className="space-y-6">
       <div className="max-w-2xl">
@@ -1135,21 +1106,6 @@ function MarketPulseHero({
             ? "Here's the latest cached market snapshot."
             : "Here's what the market looks like right now."}
         </p>
-        {overview ? (
-          <div className="mt-3 flex flex-wrap items-center gap-2 text-[0.68rem] font-semibold uppercase tracking-[0.08em] text-muted">
-            <span
-              className={cn(
-                "rounded-full border px-2.5 py-1",
-                overview.stale
-                  ? "border-warn/30 bg-warn/10 text-warn"
-                  : "border-ok/30 bg-ok/10 text-ok",
-              )}
-            >
-              {overview.stale ? "Cached snapshot" : "Live feeds"}
-            </span>
-            {updatedAtLabel ? <span>Updated {updatedAtLabel}</span> : null}
-          </div>
-        ) : null}
       </div>
 
       {overview ? (

--- a/packages/app-core/src/components/pages/InventoryView.tsx
+++ b/packages/app-core/src/components/pages/InventoryView.tsx
@@ -239,11 +239,6 @@ function hasClosedTradePnl(
   return (profile?.summary.evaluatedTrades ?? 0) > 0;
 }
 
-function shortAddress(address: string): string {
-  if (address.length <= 14) return address;
-  return `${address.slice(0, 6)}...${address.slice(-6)}`;
-}
-
 function clampWalletSidebarWidth(value: number): number {
   return Math.min(
     Math.max(value, WALLET_SIDEBAR_MIN_WIDTH),
@@ -867,11 +862,7 @@ function MarketAvatar({
   );
 }
 
-function MarketSourceBadge({
-  source,
-}: {
-  source: WalletMarketOverviewSource;
-}) {
+function MarketSourceBadge({ source }: { source: WalletMarketOverviewSource }) {
   const statusLabel = source.available
     ? source.stale
       ? "Cached"
@@ -932,7 +923,9 @@ function MarketDataUnavailable({
 }) {
   return (
     <div className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3">
-      <div className="text-sm font-semibold text-danger">{title} unavailable</div>
+      <div className="text-sm font-semibold text-danger">
+        {title} unavailable
+      </div>
       <div className="mt-1 text-xs text-danger/80">
         {source.error ?? `${source.providerName} did not return live data.`}
       </div>
@@ -1065,7 +1058,9 @@ function MarketPredictionList({
   source: WalletMarketOverviewSource;
 }) {
   if (!source.available) {
-    return <MarketDataUnavailable title="Popular predictions" source={source} />;
+    return (
+      <MarketDataUnavailable title="Popular predictions" source={source} />
+    );
   }
 
   if (predictions.length === 0) {
@@ -1357,11 +1352,11 @@ function SummaryChip({
 
 function WalletRailAddress({
   address,
-  chains,
+  label,
   emptyLabel,
 }: {
   address: string | null;
-  chains: string[];
+  label: string;
   emptyLabel: string;
 }) {
   const [copied, setCopied] = useState(false);
@@ -1377,7 +1372,7 @@ function WalletRailAddress({
   return (
     <button
       type="button"
-      className="flex w-full min-w-0 items-center justify-between gap-3 rounded-2xl border border-border/35 bg-bg/35 px-3.5 py-3 text-left transition-colors hover:bg-bg/55"
+      className="flex w-full min-w-0 items-center justify-between gap-3 py-1 text-left transition-colors hover:text-txt"
       onClick={handleCopy}
       disabled={!address}
       title={address ?? emptyLabel}
@@ -1386,15 +1381,8 @@ function WalletRailAddress({
       }
     >
       <span className="flex min-w-0 items-center gap-3">
-        <span className="flex w-11 shrink-0 justify-center -space-x-1.5">
-          {chains.map((chain) => (
-            <ChainLogoBadge
-              key={chain}
-              chain={chain}
-              size={18}
-              className="ring-1 ring-bg"
-            />
-          ))}
+        <span className="shrink-0 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted">
+          {label}
         </span>
         <span
           className={cn(
@@ -1402,7 +1390,7 @@ function WalletRailAddress({
             address ? "text-txt" : "text-muted",
           )}
         >
-          {address ? shortAddress(address) : emptyLabel}
+          {address ?? emptyLabel}
         </span>
       </span>
       {address ? (
@@ -1459,12 +1447,14 @@ function WalletRailRpcButton({
 
 function WalletRailAccount({
   addresses,
+  portfolioValueUsd,
   walletConfig,
   onOpenSettings,
   onRefresh,
   refreshing,
 }: {
   addresses: { evmAddress: string | null; solanaAddress: string | null };
+  portfolioValueUsd: number;
   walletConfig: WalletConfigStatus | null;
   onOpenSettings: () => void;
   onRefresh: () => void;
@@ -1473,15 +1463,20 @@ function WalletRailAccount({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="flex shrink-0 -space-x-1.5">
-          {SUPPORTED_WALLET_CHAINS.map((chain) => (
-            <ChainLogoBadge
-              key={chain}
-              chain={chain}
-              size={18}
-              className="ring-1 ring-bg"
-            />
-          ))}
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="font-mono text-xl font-semibold leading-none text-txt">
+            {formatUsd(portfolioValueUsd)}
+          </div>
+          <div className="flex shrink-0 -space-x-1.5">
+            {SUPPORTED_WALLET_CHAINS.map((chain) => (
+              <ChainLogoBadge
+                key={chain}
+                chain={chain}
+                size={18}
+                className="ring-1 ring-bg"
+              />
+            ))}
+          </div>
         </div>
         <div className="flex items-center gap-2">
           <WalletRailRpcButton
@@ -1506,12 +1501,12 @@ function WalletRailAccount({
       </div>
       <WalletRailAddress
         address={addresses.evmAddress}
-        chains={SUPPORTED_WALLET_CHAINS.filter((chain) => chain !== "solana")}
+        label="EVM"
         emptyLabel="No EVM address"
       />
       <WalletRailAddress
         address={addresses.solanaAddress}
-        chains={["solana"]}
+        label="SOL"
         emptyLabel="No Solana address"
       />
     </div>
@@ -1802,10 +1797,6 @@ function TokenRail({
   }, []);
   const headerContent = (
     <div className="space-y-4">
-      <div className="font-mono text-[2.35rem] font-semibold leading-none text-txt">
-        {formatUsd(totalUsd)}
-      </div>
-
       {visibleRows.length > 0 ? (
         <AssetAllocationStrip rows={visibleRows} compact />
       ) : null}
@@ -1894,6 +1885,7 @@ function TokenRail({
       <div className="shrink-0 px-4 pb-3 pt-0">
         <WalletRailAccount
           addresses={addresses}
+          portfolioValueUsd={totalUsd}
           walletConfig={walletConfig}
           onOpenSettings={onOpenRpcSettings}
           onRefresh={onRefresh}

--- a/packages/app-core/src/components/pages/InventoryView.tsx
+++ b/packages/app-core/src/components/pages/InventoryView.tsx
@@ -937,7 +937,7 @@ function MajorPriceCard({ snapshot }: { snapshot: WalletMarketPriceSnapshot }) {
   const isPositive = snapshot.change24hPct >= 0;
 
   return (
-    <div className="rounded-[26px] border border-border/30 bg-bg/40 p-4">
+    <div className="min-w-0 rounded-[26px] border border-border/30 bg-bg/40 p-4">
       <div className="flex items-center gap-3">
         <MarketAvatar imageUrl={snapshot.imageUrl} label={snapshot.symbol} />
         <div className="min-w-0">
@@ -949,13 +949,13 @@ function MajorPriceCard({ snapshot }: { snapshot: WalletMarketPriceSnapshot }) {
           </div>
         </div>
       </div>
-      <div className="mt-4 flex items-end justify-between gap-3">
-        <div className="font-mono text-xl font-semibold text-txt">
+      <div className="mt-4 flex flex-wrap items-end justify-between gap-x-3 gap-y-1">
+        <div className="min-w-0 font-mono text-lg font-semibold text-txt sm:text-xl">
           {formatMarketUsd(snapshot.priceUsd)}
         </div>
         <div
           className={cn(
-            "text-sm font-semibold",
+            "shrink-0 text-sm font-semibold",
             isPositive ? "text-ok" : "text-danger",
           )}
         >
@@ -982,7 +982,7 @@ function MarketPriceGrid({
   }
 
   return (
-    <div className="grid gap-3 md:grid-cols-3">
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,13.5rem),1fr))] gap-3">
       {prices.map((snapshot) => (
         <MajorPriceCard key={snapshot.id} snapshot={snapshot} />
       ))}
@@ -1193,7 +1193,7 @@ function MarketPulseHero({
           </div>
         </div>
       ) : loading ? (
-        <div className="mt-6 grid gap-3 md:grid-cols-3">
+        <div className="mt-6 grid grid-cols-[repeat(auto-fit,minmax(min(100%,13.5rem),1fr))] gap-3">
           {["btc", "eth", "sol"].map((placeholderId) => (
             <div
               key={placeholderId}

--- a/packages/app-core/src/components/pages/InventoryView.tsx
+++ b/packages/app-core/src/components/pages/InventoryView.tsx
@@ -1352,11 +1352,11 @@ function SummaryChip({
 
 function WalletRailAddress({
   address,
-  label,
+  chains,
   emptyLabel,
 }: {
   address: string | null;
-  label: string;
+  chains: string[];
   emptyLabel: string;
 }) {
   const [copied, setCopied] = useState(false);
@@ -1381,8 +1381,15 @@ function WalletRailAddress({
       }
     >
       <span className="flex min-w-0 items-center gap-3">
-        <span className="shrink-0 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-muted">
-          {label}
+        <span className="flex shrink-0 -space-x-1.5">
+          {chains.map((chain) => (
+            <ChainLogoBadge
+              key={chain}
+              chain={chain}
+              size={18}
+              className="ring-1 ring-bg"
+            />
+          ))}
         </span>
         <span
           className={cn(
@@ -1463,20 +1470,8 @@ function WalletRailAccount({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="font-mono text-xl font-semibold leading-none text-txt">
-            {formatUsd(portfolioValueUsd)}
-          </div>
-          <div className="flex shrink-0 -space-x-1.5">
-            {SUPPORTED_WALLET_CHAINS.map((chain) => (
-              <ChainLogoBadge
-                key={chain}
-                chain={chain}
-                size={18}
-                className="ring-1 ring-bg"
-              />
-            ))}
-          </div>
+        <div className="font-mono text-xl font-semibold leading-none text-txt">
+          {formatUsd(portfolioValueUsd)}
         </div>
         <div className="flex items-center gap-2">
           <WalletRailRpcButton
@@ -1501,12 +1496,12 @@ function WalletRailAccount({
       </div>
       <WalletRailAddress
         address={addresses.evmAddress}
-        label="EVM"
+        chains={SUPPORTED_WALLET_CHAINS.filter((chain) => chain !== "solana")}
         emptyLabel="No EVM address"
       />
       <WalletRailAddress
         address={addresses.solanaAddress}
-        label="SOL"
+        chains={["solana"]}
         emptyLabel="No Solana address"
       />
     </div>

--- a/packages/app-core/src/components/pages/PageScopedChatPane.test.tsx
+++ b/packages/app-core/src/components/pages/PageScopedChatPane.test.tsx
@@ -81,6 +81,33 @@ const conversation = {
   updatedAt: "2026-04-22T00:00:00.000Z",
 };
 
+let restoreTextareaScrollHeight: (() => void) | null = null;
+
+function mockTextareaScrollHeight(getScrollHeight: () => number): void {
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "scrollHeight",
+  );
+
+  restoreTextareaScrollHeight = () => {
+    if (originalScrollHeight) {
+      Object.defineProperty(
+        HTMLTextAreaElement.prototype,
+        "scrollHeight",
+        originalScrollHeight,
+      );
+    } else {
+      delete (HTMLTextAreaElement.prototype as { scrollHeight?: number })
+        .scrollHeight;
+    }
+  };
+
+  Object.defineProperty(HTMLTextAreaElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: getScrollHeight,
+  });
+}
+
 describe("PageScopedChatPane", () => {
   beforeEach(() => {
     clientMock.createConversation.mockReset();
@@ -118,6 +145,8 @@ describe("PageScopedChatPane", () => {
   });
 
   afterEach(() => {
+    restoreTextareaScrollHeight?.();
+    restoreTextareaScrollHeight = null;
     cleanup();
   });
 
@@ -193,18 +222,15 @@ describe("PageScopedChatPane", () => {
   });
 
   it("stacks multiline inline drafts above the footer controls", async () => {
+    let scrollHeight = 32;
+    mockTextareaScrollHeight(() => scrollHeight);
+
     render(<PageScopedChatPane scope="page-apps" />);
 
     await screen.findByTestId("page-scoped-chat-intro-page-apps");
 
     const composer = screen.getByTestId("page-scoped-chat-composer-page-apps");
     const textarea = screen.getByRole("textbox", { name: /apps/i });
-    let scrollHeight = 32;
-
-    Object.defineProperty(textarea, "scrollHeight", {
-      configurable: true,
-      get: () => scrollHeight,
-    });
 
     scrollHeight = 72;
     fireEvent.change(textarea, {
@@ -223,6 +249,42 @@ describe("PageScopedChatPane", () => {
     expect(
       screen.getByRole("button", { name: "Start voice input" }),
     ).toBeTruthy();
+  });
+
+  it("returns inline drafts to a single-line composer when the text fits", async () => {
+    let scrollHeight = 72;
+    mockTextareaScrollHeight(() => scrollHeight);
+
+    render(<PageScopedChatPane scope="page-apps" />);
+
+    await screen.findByTestId("page-scoped-chat-intro-page-apps");
+
+    const composer = screen.getByTestId("page-scoped-chat-composer-page-apps");
+    const textarea = screen.getByRole("textbox", { name: /apps/i });
+
+    fireEvent.change(textarea, {
+      target: {
+        value:
+          "PieChartPieChartPieChartPieChartPieChartPieChartPieChartPieChart",
+      },
+    });
+
+    await waitFor(() =>
+      expect(
+        composer.firstElementChild?.getAttribute("data-inline-layout"),
+      ).toBe("stacked"),
+    );
+
+    scrollHeight = 34;
+    fireEvent.change(textarea, {
+      target: { value: "can you block new s.google.com" },
+    });
+
+    await waitFor(() =>
+      expect(
+        composer.firstElementChild?.getAttribute("data-inline-layout"),
+      ).toBe("single-line"),
+    );
   });
 
   it("sends text and voice turns with page routing metadata", async () => {

--- a/packages/app-core/src/components/pages/PageScopedChatPane.tsx
+++ b/packages/app-core/src/components/pages/PageScopedChatPane.tsx
@@ -42,6 +42,17 @@ type PageScopedMessage = ConversationMessage & {
   images?: ImageAttachment[];
 };
 
+async function getPageScopedConversationMessages(
+  conversationId: string,
+): Promise<PageScopedMessage[]> {
+  try {
+    const { messages } = await client.getConversationMessages(conversationId);
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
 function readChatPrefillDetail(event: Event): ChatPrefillDetail | null {
   const detail = (event as CustomEvent<ChatPrefillDetail>).detail;
   if (!detail || typeof detail.text !== "string" || detail.text.length === 0) {
@@ -211,9 +222,7 @@ export function PageScopedChatPane({
         if (cancelled) return;
         setConversation(next);
         adapter?.onConversationResolved?.(next);
-        const { messages: history } = await client.getConversationMessages(
-          next.id,
-        );
+        const history = await getPageScopedConversationMessages(next.id);
         if (cancelled) return;
         setMessages(history);
       } catch (cause) {

--- a/packages/app-core/src/components/pages/RelationshipsGraphPanel.tsx
+++ b/packages/app-core/src/components/pages/RelationshipsGraphPanel.tsx
@@ -1,13 +1,39 @@
-import { useMemo, useState } from "react";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@elizaos/ui";
+import {
+  Crown,
+  Focus,
+  Link2,
+  Maximize2,
+  Minus,
+  Network,
+  Plus,
+  UserRound,
+} from "lucide-react";
+import {
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
 import type {
   RelationshipsGraphEdge,
   RelationshipsGraphSnapshot,
   RelationshipsPersonSummary,
 } from "../../api/client-types-relationships";
 
-const GRAPH_WIDTH = 960;
-const GRAPH_HEIGHT = 540;
-const GRAPH_PADDING = 56;
+const GRAPH_WIDTH = 1320;
+const GRAPH_HEIGHT = 760;
+const GRAPH_PADDING = 92;
+const MIN_ZOOM = 0.58;
+const MAX_ZOOM = 1.35;
+const ZOOM_STEP = 0.12;
 const MAX_GLOBAL_NODES = 28;
 const MAX_FOCUSED_NODES = 24;
 const MAX_DIRECT_NEIGHBORS = 12;
@@ -25,6 +51,14 @@ type VisibleGraph = {
   truncated: boolean;
 };
 
+const EDGE_COLORS = {
+  positive: "rgba(34, 197, 94, 0.64)",
+  neutral: "rgba(240, 185, 11, 0.48)",
+  negative: "rgba(239, 68, 68, 0.62)",
+} as const;
+
+type EdgeTone = keyof typeof EDGE_COLORS;
+
 function toTimestamp(value?: string): number {
   if (!value) return 0;
   const timestamp = Date.parse(value);
@@ -33,8 +67,8 @@ function toTimestamp(value?: string): number {
 
 function nodeRadius(person: RelationshipsPersonSummary): number {
   return Math.min(
-    42,
-    16 +
+    46,
+    18 +
       Math.sqrt(
         Math.max(
           1,
@@ -49,10 +83,28 @@ function shortLabel(value: string, maxLength = 18): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
+function edgeTone(sentiment: string): EdgeTone {
+  if (sentiment === "positive" || sentiment === "negative") return sentiment;
+  return "neutral";
+}
+
 function edgeColor(edge: RelationshipsGraphEdge): string {
-  if (edge.sentiment === "positive") return "rgba(73, 197, 122, 0.55)";
-  if (edge.sentiment === "negative") return "rgba(239, 68, 68, 0.5)";
-  return "rgba(240, 185, 11, 0.38)";
+  return EDGE_COLORS[edgeTone(edge.sentiment)];
+}
+
+function sentimentLabel(value: string): string {
+  if (value === "positive") return "Positive";
+  if (value === "negative") return "Negative";
+  return "Neutral";
+}
+
+function nodeInitials(value: string): string {
+  const words = value.trim().split(/\s+/).filter(Boolean);
+  const source =
+    words.length >= 2
+      ? `${words[0]?.charAt(0) ?? ""}${words[1]?.charAt(0) ?? ""}`
+      : value.trim().slice(0, 2);
+  return source.toUpperCase();
 }
 
 function rankPerson(person: RelationshipsPersonSummary): number {
@@ -99,19 +151,29 @@ function buildEdgeIndex(
   return index;
 }
 
+function buildVisibleGraph(
+  snapshot: RelationshipsGraphSnapshot,
+  included: Set<string>,
+  modeLabel: string,
+): VisibleGraph {
+  const people = snapshot.people.filter((person) =>
+    included.has(person.groupId),
+  );
+  return {
+    people,
+    relationships: snapshot.relationships.filter(
+      (edge) =>
+        included.has(edge.sourcePersonId) && included.has(edge.targetPersonId),
+    ),
+    modeLabel,
+    truncated: people.length < snapshot.people.length,
+  };
+}
+
 function selectVisibleGraph(
   snapshot: RelationshipsGraphSnapshot,
   selectedGroupId: string | null,
 ): VisibleGraph {
-  if (snapshot.people.length <= MAX_GLOBAL_NODES) {
-    return {
-      people: snapshot.people,
-      relationships: snapshot.relationships,
-      modeLabel: "Loaded relationship graph",
-      truncated: false,
-    };
-  }
-
   const edgeIndex = buildEdgeIndex(snapshot.relationships);
   const peopleById = new Map(
     snapshot.people.map((person) => [person.groupId, person]),
@@ -158,18 +220,19 @@ function selectVisibleGraph(
       included.add(person.groupId);
     }
 
-    const people = snapshot.people.filter((person) =>
-      included.has(person.groupId),
+    return buildVisibleGraph(
+      snapshot,
+      included,
+      `Focused on ${peopleById.get(selectedGroupId)?.displayName ?? "selected person"}`,
     );
+  }
+
+  if (snapshot.people.length <= MAX_GLOBAL_NODES) {
     return {
-      people,
-      relationships: snapshot.relationships.filter(
-        (edge) =>
-          included.has(edge.sourcePersonId) &&
-          included.has(edge.targetPersonId),
-      ),
-      modeLabel: "Selected neighborhood",
-      truncated: people.length < snapshot.people.length,
+      people: snapshot.people,
+      relationships: snapshot.relationships,
+      modeLabel: "All visible people",
+      truncated: false,
     };
   }
 
@@ -183,18 +246,7 @@ function selectVisibleGraph(
     included.add(edge.targetPersonId);
   }
 
-  const people = snapshot.people.filter((person) =>
-    included.has(person.groupId),
-  );
-  return {
-    people,
-    relationships: snapshot.relationships.filter(
-      (edge) =>
-        included.has(edge.sourcePersonId) && included.has(edge.targetPersonId),
-    ),
-    modeLabel: "Most connected subgraph",
-    truncated: people.length < snapshot.people.length,
-  };
+  return buildVisibleGraph(snapshot, included, "Most connected subgraph");
 }
 
 function buildConnectedComponents(
@@ -272,14 +324,14 @@ function layoutComponent(
 
   for (const person of componentPeople) {
     positions.set(person.groupId, {
-      x: center.x + (seededUnit(person.groupId, 1) - 0.5) * cellWidth * 0.5,
-      y: center.y + (seededUnit(person.groupId, 2) - 0.5) * cellHeight * 0.5,
+      x: center.x + (seededUnit(person.groupId, 1) - 0.5) * cellWidth * 0.68,
+      y: center.y + (seededUnit(person.groupId, 2) - 0.5) * cellHeight * 0.68,
       vx: 0,
       vy: 0,
     });
   }
 
-  for (let iteration = 0; iteration < 170; iteration += 1) {
+  for (let iteration = 0; iteration < 240; iteration += 1) {
     const forces = new Map<string, { x: number; y: number }>();
     for (const person of componentPeople) {
       forces.set(person.groupId, { x: 0, y: 0 });
@@ -308,8 +360,8 @@ function layoutComponent(
         const dx = rightPosition.x - leftPosition.x;
         const dy = rightPosition.y - leftPosition.y;
         const distance = Math.max(1, Math.hypot(dx, dy));
-        const minimumDistance = nodeRadius(left) + nodeRadius(right) + 24;
-        const repulsion = minimumDistance * minimumDistance * 0.42;
+        const minimumDistance = nodeRadius(left) + nodeRadius(right) + 52;
+        const repulsion = minimumDistance * minimumDistance * 0.8;
         const forceMagnitude = repulsion / (distance * distance);
         const fx = (dx / distance) * forceMagnitude;
         const fy = (dy / distance) * forceMagnitude;
@@ -339,8 +391,8 @@ function layoutComponent(
       const dy = targetPosition.y - sourcePosition.y;
       const distance = Math.max(1, Math.hypot(dx, dy));
       const idealDistance =
-        84 + Math.max(0, componentPeople.length - 6) * 4 - edge.strength * 16;
-      const springStrength = 0.012 + edge.strength * 0.028;
+        142 + Math.max(0, componentPeople.length - 6) * 7 - edge.strength * 18;
+      const springStrength = 0.006 + edge.strength * 0.018;
       const forceMagnitude = (distance - idealDistance) * springStrength;
       const fx = (dx / distance) * forceMagnitude;
       const fy = (dy / distance) * forceMagnitude;
@@ -357,8 +409,8 @@ function layoutComponent(
       if (!position || !force) {
         continue;
       }
-      force.x += (center.x - position.x) * 0.018;
-      force.y += (center.y - position.y) * 0.018;
+      force.x += (center.x - position.x) * 0.01;
+      force.y += (center.y - position.y) * 0.01;
 
       position.vx = (position.vx + force.x) * 0.86;
       position.vy = (position.vy + force.y) * 0.86;
@@ -380,10 +432,96 @@ function layoutComponent(
   );
 }
 
+function placeOnRing(
+  positions: Map<string, GraphPosition>,
+  people: RelationshipsPersonSummary[],
+  center: GraphPosition,
+  radius: number,
+  startAngle: number,
+) {
+  people.forEach((person, index) => {
+    const angle =
+      startAngle + (index / Math.max(people.length, 1)) * Math.PI * 2;
+    positions.set(person.groupId, {
+      x: center.x + Math.cos(angle) * radius,
+      y: center.y + Math.sin(angle) * radius,
+    });
+  });
+}
+
+function buildFocusedNodePositions(
+  people: RelationshipsPersonSummary[],
+  edges: RelationshipsGraphEdge[],
+  selectedGroupId: string,
+): Map<string, GraphPosition> | null {
+  const selected = people.find((person) => person.groupId === selectedGroupId);
+  if (!selected) {
+    return null;
+  }
+
+  const directEdges = sortEdges(
+    edges.filter(
+      (edge) =>
+        edge.sourcePersonId === selectedGroupId ||
+        edge.targetPersonId === selectedGroupId,
+    ),
+  );
+  const directIds = new Set(
+    directEdges.map((edge) => otherEndpoint(edge, selectedGroupId)),
+  );
+  const directPeople = directEdges
+    .map((edge) =>
+      people.find(
+        (person) => person.groupId === otherEndpoint(edge, selectedGroupId),
+      ),
+    )
+    .filter(
+      (person): person is RelationshipsPersonSummary => person !== undefined,
+    );
+  const remainingPeople = people
+    .filter(
+      (person) =>
+        person.groupId !== selectedGroupId && !directIds.has(person.groupId),
+    )
+    .sort((left, right) => rankPerson(right) - rankPerson(left));
+  const positions = new Map<string, GraphPosition>();
+  const center = { x: GRAPH_WIDTH / 2, y: GRAPH_HEIGHT / 2 };
+
+  positions.set(selectedGroupId, center);
+  placeOnRing(
+    positions,
+    directPeople,
+    center,
+    clamp(190 + directPeople.length * 5, 210, 292),
+    -Math.PI / 2,
+  );
+  placeOnRing(
+    positions,
+    remainingPeople,
+    center,
+    clamp(330 + remainingPeople.length * 2, 330, 360),
+    -Math.PI / 2 + Math.PI / Math.max(remainingPeople.length, 3),
+  );
+
+  return positions;
+}
+
 function buildNodePositions(
   people: RelationshipsPersonSummary[],
   edges: RelationshipsGraphEdge[],
+  selectedGroupId: string | null,
 ): Map<string, GraphPosition> {
+  if (selectedGroupId) {
+    const focusedPositions = buildFocusedNodePositions(
+      people,
+      edges,
+      selectedGroupId,
+    );
+    if (focusedPositions) {
+      return focusedPositions;
+    }
+  }
+
   const components = buildConnectedComponents(people, edges);
   const peopleById = new Map(people.map((person) => [person.groupId, person]));
   const componentCount = Math.max(components.length, 1);
@@ -428,27 +566,67 @@ function buildNodePositions(
   return positions;
 }
 
+function GraphIconButton({
+  label,
+  disabled = false,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 w-8 rounded-full p-0"
+          aria-label={label}
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 function GraphLegend() {
   return (
-    <div className="flex flex-wrap items-center gap-3 text-xs-tight text-muted">
+    <div className="flex flex-wrap items-center gap-2 text-xs-tight text-muted">
       <div className="flex items-center gap-1.5">
-        <span className="h-2.5 w-2.5 rounded-full bg-[rgba(240,185,11,0.9)]" />
+        <UserRound className="h-3.5 w-3.5 text-[rgba(240,185,11,0.9)]" />
         People
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="h-2.5 w-2.5 rounded-full border-2 border-[rgba(99,102,241,0.7)] bg-[rgba(99,102,241,0.15)]" />
+        <Crown className="h-3.5 w-3.5 text-[rgba(99,102,241,0.86)]" />
         Owner
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="h-[2px] w-6 bg-[rgba(73,197,122,0.48)]" />
+        <span
+          className="h-[2px] w-6 rounded-full"
+          style={{ backgroundColor: EDGE_COLORS.positive }}
+        />
         Positive
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="h-[2px] w-6 bg-[rgba(240,185,11,0.34)]" />
+        <span
+          className="h-[2px] w-6 rounded-full"
+          style={{ backgroundColor: EDGE_COLORS.neutral }}
+        />
         Neutral
       </div>
       <div className="flex items-center gap-1.5">
-        <span className="h-[2px] w-6 bg-[rgba(239,68,68,0.44)]" />
+        <span
+          className="h-[2px] w-6 rounded-full"
+          style={{ backgroundColor: EDGE_COLORS.negative }}
+        />
         Negative
       </div>
     </div>
@@ -463,7 +641,7 @@ type TooltipState =
 function GraphTooltip({ state }: { state: TooltipState }) {
   if (!state) return null;
 
-  const style: React.CSSProperties = {
+  const style: CSSProperties = {
     position: "absolute",
     left: state.x,
     top: state.y,
@@ -485,8 +663,8 @@ function GraphTooltip({ state }: { state: TooltipState }) {
         <div className="mt-1 space-y-0.5 text-xs-tight text-muted">
           <div>
             {person.memberEntityIds.length} identit
-            {person.memberEntityIds.length === 1 ? "y" : "ies"} ·{" "}
-            {person.relationshipCount} links · {person.factCount} facts
+            {person.memberEntityIds.length === 1 ? "y" : "ies"} /{" "}
+            {person.relationshipCount} links / {person.factCount} facts
           </div>
           {person.platforms.length > 0 ? (
             <div>{person.platforms.join(", ")}</div>
@@ -506,12 +684,12 @@ function GraphTooltip({ state }: { state: TooltipState }) {
       className="rounded-xl border border-border/40 bg-card/95 px-3 py-2.5 shadow-lg backdrop-blur-md"
     >
       <div className="text-sm font-semibold text-txt">
-        {edge.sourcePersonName} ↔ {edge.targetPersonName}
+        {edge.sourcePersonName} / {edge.targetPersonName}
       </div>
       <div className="mt-1 space-y-0.5 text-xs-tight text-muted">
         <div>
-          Strength {edge.strength.toFixed(2)} · {edge.sentiment} ·{" "}
-          {edge.interactionCount} interactions
+          Strength {edge.strength.toFixed(2)} / {sentimentLabel(edge.sentiment)}{" "}
+          / {edge.interactionCount} interactions
         </div>
         {edge.relationshipTypes.length > 0 ? (
           <div>{edge.relationshipTypes.join(", ")}</div>
@@ -525,53 +703,63 @@ export function RelationshipsGraphPanel({
   snapshot,
   selectedGroupId,
   compact = false,
-  onSelectGroupId,
+  onSelectPersonId,
 }: {
-  snapshot: RelationshipsGraphSnapshot | null;
+  snapshot: RelationshipsGraphSnapshot;
   selectedGroupId: string | null;
   compact?: boolean;
-  onSelectGroupId: (groupId: string) => void;
+  onSelectPersonId: (primaryEntityId: string) => void;
 }) {
   const [tooltip, setTooltip] = useState<TooltipState>(null);
+  const fittedZoom = compact ? 0.68 : 0.9;
+  const [zoom, setZoom] = useState(fittedZoom);
 
   const visibleGraph = useMemo(
-    () =>
-      snapshot && snapshot.people.length > 0
-        ? selectVisibleGraph(snapshot, selectedGroupId)
-        : null,
+    () => selectVisibleGraph(snapshot, selectedGroupId),
     [snapshot, selectedGroupId],
   );
 
   const positions = useMemo(
     () =>
-      visibleGraph
-        ? buildNodePositions(visibleGraph.people, visibleGraph.relationships)
-        : new Map<string, GraphPosition>(),
-    [visibleGraph],
+      buildNodePositions(
+        visibleGraph.people,
+        visibleGraph.relationships,
+        selectedGroupId,
+      ),
+    [selectedGroupId, visibleGraph],
   );
 
-  if (!snapshot || !visibleGraph || snapshot.people.length === 0) {
-    return (
-      <div className="flex min-h-[20rem] flex-col items-center justify-center rounded-2xl border border-border/28 bg-card/35 px-6 py-10 text-center">
-        <div className="text-sm font-semibold text-txt">
-          No identities match the current filters.
-        </div>
-        <p className="mt-2 max-w-lg text-sm leading-6 text-muted">
-          The graph will render once the relationships has people, identity
-          links, and relationships to visualize.
-        </p>
-      </div>
-    );
-  }
+  const directNeighborIds = useMemo(() => {
+    const ids = new Set<string>();
+    if (!visibleGraph || !selectedGroupId) {
+      return ids;
+    }
+    for (const edge of visibleGraph.relationships) {
+      if (
+        edge.sourcePersonId === selectedGroupId ||
+        edge.targetPersonId === selectedGroupId
+      ) {
+        ids.add(otherEndpoint(edge, selectedGroupId));
+      }
+    }
+    return ids;
+  }, [selectedGroupId, visibleGraph]);
+
+  const selectedPerson = useMemo(
+    () =>
+      visibleGraph.people.find(
+        (person) => person.groupId === selectedGroupId,
+      ) ?? null,
+    [selectedGroupId, visibleGraph],
+  );
 
   const showTooltipForNode = (
     person: RelationshipsPersonSummary,
-    event: React.MouseEvent,
+    event: MouseEvent,
   ) => {
-    const rect = (
-      event.currentTarget.closest("[data-graph-container]") as HTMLElement
-    )?.getBoundingClientRect();
-    if (!rect) return;
+    const container = event.currentTarget.closest("[data-graph-container]");
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
     setTooltip({
       kind: "node",
       person,
@@ -582,12 +770,11 @@ export function RelationshipsGraphPanel({
 
   const showTooltipForEdge = (
     edge: RelationshipsGraphEdge,
-    event: React.MouseEvent,
+    event: MouseEvent,
   ) => {
-    const rect = (
-      event.currentTarget.closest("[data-graph-container]") as HTMLElement
-    )?.getBoundingClientRect();
-    if (!rect) return;
+    const container = event.currentTarget.closest("[data-graph-container]");
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
     setTooltip({
       kind: "edge",
       edge,
@@ -597,203 +784,278 @@ export function RelationshipsGraphPanel({
   };
 
   const hideTooltip = () => setTooltip(null);
+  const zoomOut = () =>
+    setZoom((currentZoom) =>
+      clamp(Number((currentZoom - ZOOM_STEP).toFixed(2)), MIN_ZOOM, MAX_ZOOM),
+    );
+  const zoomIn = () =>
+    setZoom((currentZoom) =>
+      clamp(Number((currentZoom + ZOOM_STEP).toFixed(2)), MIN_ZOOM, MAX_ZOOM),
+    );
+  const fitGraph = () => setZoom(fittedZoom);
+  const actualSize = () => setZoom(1);
+  const zoomPercent = `${Math.round(zoom * 100)}%`;
+  const graphWidth = GRAPH_WIDTH * zoom;
+  const graphHeight = GRAPH_HEIGHT * zoom;
 
   return (
-    <div className={compact ? "space-y-3" : "space-y-4"}>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
-            Identity Graph
+    <TooltipProvider delayDuration={160} skipDelayDuration={80}>
+      <div className={compact ? "space-y-3" : "space-y-4"}>
+        <div
+          className={
+            compact
+              ? "flex flex-col gap-3"
+              : "flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between"
+          }
+        >
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-accent/24 bg-accent/10 text-accent">
+              <Network className="h-5 w-5" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
+                Relationship map
+              </div>
+              <div
+                className={`${compact ? "mt-1 text-lg" : "mt-2 text-xl"} font-semibold text-txt`}
+              >
+                {selectedPerson
+                  ? selectedPerson.displayName
+                  : "People and links"}
+              </div>
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted">
+                <span>{visibleGraph.modeLabel}</span>
+                {visibleGraph.truncated ? (
+                  <span>
+                    showing {visibleGraph.people.length} of{" "}
+                    {snapshot.stats.totalPeople}
+                  </span>
+                ) : null}
+                <span className="inline-flex items-center gap-1">
+                  <UserRound className="h-3.5 w-3.5" />
+                  {visibleGraph.people.length}
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  <Link2 className="h-3.5 w-3.5" />
+                  {visibleGraph.relationships.length}
+                </span>
+              </div>
+            </div>
           </div>
+
           <div
-            className={`${compact ? "mt-1 text-lg" : "mt-2 text-xl"} font-semibold text-txt`}
+            className={
+              compact
+                ? "flex flex-col gap-2"
+                : "flex flex-col gap-2 lg:items-end"
+            }
           >
-            Canonical people and cross-person relationships
-          </div>
-          <div className="mt-2 text-xs text-muted">
-            {visibleGraph.modeLabel}
-            {visibleGraph.truncated
-              ? ` · showing ${visibleGraph.people.length} of ${snapshot.stats.totalPeople}`
-              : null}
+            <GraphLegend />
+            <div className="flex flex-wrap items-center gap-2">
+              <GraphIconButton
+                label="Zoom out"
+                disabled={zoom <= MIN_ZOOM}
+                onClick={zoomOut}
+              >
+                <Minus className="h-4 w-4" />
+              </GraphIconButton>
+              <GraphIconButton label="Fit graph" onClick={fitGraph}>
+                <Focus className="h-4 w-4" />
+              </GraphIconButton>
+              <GraphIconButton label="Actual size" onClick={actualSize}>
+                <Maximize2 className="h-4 w-4" />
+              </GraphIconButton>
+              <GraphIconButton
+                label="Zoom in"
+                disabled={zoom >= MAX_ZOOM}
+                onClick={zoomIn}
+              >
+                <Plus className="h-4 w-4" />
+              </GraphIconButton>
+              <span className="min-w-12 text-right text-xs-tight font-semibold tabular-nums text-muted">
+                {zoomPercent}
+              </span>
+            </div>
           </div>
         </div>
-        <GraphLegend />
-      </div>
 
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: graph container handles tooltip dismiss on mouse leave */}
-      <div
-        className="relative overflow-hidden rounded-3xl border border-border/26 bg-[radial-gradient(circle_at_top,rgba(240,185,11,0.12),transparent_42%),linear-gradient(180deg,color-mix(in_srgb,var(--card)_92%,transparent),color-mix(in_srgb,var(--bg)_97%,transparent))]"
-        data-graph-container
-        onMouseLeave={hideTooltip}
-      >
-        <GraphTooltip state={tooltip} />
-        <svg
-          viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`}
-          className={`${compact ? "h-[20rem]" : "h-[30rem]"} w-full`}
-          role="img"
-          aria-label="Relationships graph"
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: graph container handles tooltip dismiss on mouse leave */}
+        <div
+          className={`${compact ? "max-h-[34rem]" : "max-h-[42rem]"} relative overflow-auto rounded-2xl border border-border/26 bg-[radial-gradient(circle_at_top,rgba(240,185,11,0.12),transparent_42%),linear-gradient(180deg,color-mix(in_srgb,var(--card)_92%,transparent),color-mix(in_srgb,var(--bg)_97%,transparent))]`}
+          data-graph-container
+          onMouseLeave={hideTooltip}
         >
-          <defs>
-            <radialGradient
-              id="relationships-node-fill"
-              cx="50%"
-              cy="35%"
-              r="70%"
-            >
-              <stop offset="0%" stopColor="rgba(255,240,199,0.92)" />
-              <stop offset="100%" stopColor="rgba(240,185,11,0.86)" />
-            </radialGradient>
-            <radialGradient
-              id="relationships-owner-fill"
-              cx="50%"
-              cy="35%"
-              r="70%"
-            >
-              <stop offset="0%" stopColor="rgba(199,210,255,0.94)" />
-              <stop offset="100%" stopColor="rgba(99,102,241,0.82)" />
-            </radialGradient>
-          </defs>
+          <GraphTooltip state={tooltip} />
+          <svg
+            viewBox={`0 0 ${GRAPH_WIDTH} ${GRAPH_HEIGHT}`}
+            className="block max-w-none"
+            style={{ width: graphWidth, height: graphHeight }}
+            role="img"
+            aria-label="Relationships graph"
+          >
+            <defs>
+              <radialGradient
+                id="relationships-node-fill"
+                cx="50%"
+                cy="35%"
+                r="70%"
+              >
+                <stop offset="0%" stopColor="rgba(255,240,199,0.96)" />
+                <stop offset="100%" stopColor="rgba(240,185,11,0.9)" />
+              </radialGradient>
+              <radialGradient
+                id="relationships-owner-fill"
+                cx="50%"
+                cy="35%"
+                r="70%"
+              >
+                <stop offset="0%" stopColor="rgba(199,210,255,0.98)" />
+                <stop offset="100%" stopColor="rgba(99,102,241,0.86)" />
+              </radialGradient>
+            </defs>
 
-          {visibleGraph.relationships.map((edge) => {
-            const source = positions.get(edge.sourcePersonId);
-            const target = positions.get(edge.targetPersonId);
-            if (!source || !target) {
-              return null;
-            }
-            const midX = (source.x + target.x) / 2;
-            const midY = (source.y + target.y) / 2;
-            return (
-              <g key={edge.id}>
-                <line
-                  x1={source.x}
-                  y1={source.y}
-                  x2={target.x}
-                  y2={target.y}
-                  stroke={edgeColor(edge)}
-                  strokeWidth={Math.max(1.5, edge.strength * 7)}
-                  strokeLinecap="round"
-                  opacity={0.9}
-                />
-                {/* biome-ignore lint/a11y/noStaticElementInteractions: SVG edge hover for tooltip display only */}
-                <line
-                  x1={source.x}
-                  y1={source.y}
-                  x2={target.x}
-                  y2={target.y}
-                  stroke="transparent"
-                  strokeWidth={16}
-                  className="cursor-pointer"
-                  onMouseEnter={(e) => {
-                    const rect = (
-                      e.currentTarget.closest(
-                        "[data-graph-container]",
-                      ) as HTMLElement
-                    )?.getBoundingClientRect();
-                    if (rect) {
-                      setTooltip({
-                        kind: "edge",
-                        edge,
-                        x: (midX / GRAPH_WIDTH) * rect.width,
-                        y: (midY / GRAPH_HEIGHT) * rect.height,
-                      });
-                    }
-                  }}
-                  onMouseMove={(e) => showTooltipForEdge(edge, e)}
-                  onMouseLeave={hideTooltip}
-                />
-              </g>
-            );
-          })}
-
-          {visibleGraph.people.map((person) => {
-            const position = positions.get(person.groupId);
-            if (!position) {
-              return null;
-            }
-            const radius = nodeRadius(person);
-            const selected = selectedGroupId === person.groupId;
-            const isOwner = person.isOwner;
-            return (
-              <g key={person.groupId}>
-                <g
-                  transform={`translate(${position.x}, ${position.y})`}
-                  className="pointer-events-none"
-                >
-                  {/* Selection halo */}
-                  <circle
-                    r={radius + (selected ? 10 : 0)}
-                    fill={selected ? "rgba(240,185,11,0.12)" : "transparent"}
-                    stroke={selected ? "rgba(240,185,11,0.34)" : "transparent"}
-                    strokeWidth={selected ? 2 : 0}
-                  />
-                  {/* Owner outer ring */}
-                  {isOwner && !selected ? (
-                    <circle
-                      r={radius + 5}
-                      fill="transparent"
-                      stroke="rgba(99,102,241,0.4)"
-                      strokeWidth={2}
-                      strokeDasharray="4 3"
-                    />
-                  ) : null}
-                  {/* Main node */}
-                  <circle
-                    r={radius}
-                    fill={
-                      isOwner
-                        ? "url(#relationships-owner-fill)"
-                        : "url(#relationships-node-fill)"
-                    }
-                    stroke={
-                      selected
-                        ? "rgba(255,255,255,0.92)"
-                        : isOwner
-                          ? "rgba(99,102,241,0.7)"
-                          : "rgba(28,34,43,0.55)"
-                    }
-                    strokeWidth={selected ? 3 : isOwner ? 2.5 : 1.5}
-                  />
-                  <text
-                    textAnchor="middle"
-                    y={-3}
-                    className={`text-xs font-semibold ${isOwner ? "fill-white" : "fill-black"}`}
-                  >
-                    {shortLabel(person.displayName, 15)}
-                  </text>
-                  <text
-                    textAnchor="middle"
-                    y={12}
-                    className={`text-3xs font-medium ${isOwner ? "fill-white/70" : "fill-black/70"}`}
-                  >
-                    {shortLabel(
-                      person.relationshipCount > 0
-                        ? `${person.relationshipCount} links`
-                        : `${person.memberEntityIds.length} identities`,
-                      18,
+            {visibleGraph.relationships.map((edge) => {
+              const source = positions.get(edge.sourcePersonId);
+              const target = positions.get(edge.targetPersonId);
+              if (!source || !target) {
+                return null;
+              }
+              const touchesSelected =
+                selectedGroupId !== null &&
+                (edge.sourcePersonId === selectedGroupId ||
+                  edge.targetPersonId === selectedGroupId);
+              return (
+                <g key={edge.id}>
+                  <line
+                    x1={source.x}
+                    y1={source.y}
+                    x2={target.x}
+                    y2={target.y}
+                    stroke={edgeColor(edge)}
+                    strokeWidth={Math.max(
+                      touchesSelected ? 3 : 1.5,
+                      edge.strength * (touchesSelected ? 8 : 5.5),
                     )}
-                  </text>
-                </g>
-                <foreignObject
-                  x={position.x - radius - 12}
-                  y={position.y - radius - 12}
-                  width={(radius + 12) * 2}
-                  height={(radius + 12) * 2}
-                >
-                  <button
-                    type="button"
-                    onClick={() => onSelectGroupId(person.groupId)}
-                    onMouseEnter={(e) => showTooltipForNode(person, e)}
-                    onMouseMove={(e) => showTooltipForNode(person, e)}
-                    onMouseLeave={hideTooltip}
-                    className="h-full w-full rounded-full bg-transparent"
-                    aria-label={`Select ${person.displayName}`}
+                    strokeLinecap="round"
+                    opacity={
+                      selectedGroupId ? (touchesSelected ? 0.95 : 0.24) : 0.78
+                    }
                   />
-                </foreignObject>
-              </g>
-            );
-          })}
-        </svg>
+                  {/* biome-ignore lint/a11y/noStaticElementInteractions: SVG edge hover for tooltip display only */}
+                  <line
+                    x1={source.x}
+                    y1={source.y}
+                    x2={target.x}
+                    y2={target.y}
+                    stroke="transparent"
+                    strokeWidth={18}
+                    className="cursor-pointer"
+                    onMouseEnter={(event) => showTooltipForEdge(edge, event)}
+                    onMouseMove={(event) => showTooltipForEdge(edge, event)}
+                    onMouseLeave={hideTooltip}
+                  />
+                </g>
+              );
+            })}
+
+            {visibleGraph.people.map((person) => {
+              const position = positions.get(person.groupId);
+              if (!position) {
+                return null;
+              }
+              const selected = selectedGroupId === person.groupId;
+              const directlyConnected = directNeighborIds.has(person.groupId);
+              const muted =
+                selectedGroupId !== null && !selected && !directlyConnected;
+              const radius = nodeRadius(person) + (selected ? 6 : 0);
+              const isOwner = person.isOwner;
+              return (
+                <g key={person.groupId}>
+                  <g
+                    transform={`translate(${position.x}, ${position.y})`}
+                    className="pointer-events-none"
+                    opacity={muted ? 0.52 : 1}
+                  >
+                    <circle
+                      r={radius + (selected ? 18 : directlyConnected ? 8 : 0)}
+                      fill="transparent"
+                      stroke={
+                        selected
+                          ? "rgba(240,185,11,0.52)"
+                          : directlyConnected
+                            ? "rgba(34,197,94,0.38)"
+                            : "transparent"
+                      }
+                      strokeWidth={selected ? 3 : directlyConnected ? 2 : 0}
+                    />
+                    {isOwner ? (
+                      <circle
+                        r={radius + 11}
+                        fill="transparent"
+                        stroke="rgba(99,102,241,0.56)"
+                        strokeWidth={2}
+                        strokeDasharray="5 4"
+                      />
+                    ) : null}
+                    <circle
+                      r={radius}
+                      fill={
+                        isOwner
+                          ? "url(#relationships-owner-fill)"
+                          : "url(#relationships-node-fill)"
+                      }
+                      stroke={
+                        selected
+                          ? "rgba(255,255,255,0.96)"
+                          : isOwner
+                            ? "rgba(99,102,241,0.78)"
+                            : "rgba(28,34,43,0.56)"
+                      }
+                      strokeWidth={selected ? 3.5 : isOwner ? 2.5 : 1.5}
+                    />
+                    <text
+                      textAnchor="middle"
+                      y={5}
+                      className={`text-sm font-semibold ${isOwner ? "fill-white" : "fill-black"}`}
+                    >
+                      {nodeInitials(person.displayName)}
+                    </text>
+                    <text
+                      textAnchor="middle"
+                      y={radius + 24}
+                      className="text-xs font-semibold"
+                      fill="var(--txt)"
+                      stroke="rgba(255,255,255,0.82)"
+                      strokeWidth={4}
+                      paintOrder="stroke"
+                    >
+                      {shortLabel(person.displayName, 19)}
+                    </text>
+                  </g>
+                  <foreignObject
+                    x={position.x - 90}
+                    y={position.y - radius - 18}
+                    width={180}
+                    height={radius + 72}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onSelectPersonId(person.primaryEntityId)}
+                      onMouseEnter={(event) =>
+                        showTooltipForNode(person, event)
+                      }
+                      onMouseMove={(event) => showTooltipForNode(person, event)}
+                      onMouseLeave={hideTooltip}
+                      className="h-full w-full rounded-2xl bg-transparent"
+                      aria-label={`Select ${person.displayName}`}
+                    />
+                  </foreignObject>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 }

--- a/packages/app-core/src/components/pages/relationships/RelationshipsActivityFeed.tsx
+++ b/packages/app-core/src/components/pages/relationships/RelationshipsActivityFeed.tsx
@@ -1,31 +1,89 @@
-import { useEffect, useState } from "react";
+import { Button } from "@elizaos/ui";
+import { Fingerprint, Link2, Tags } from "lucide-react";
+import { type ComponentType, useEffect, useState } from "react";
 import { client } from "../../../api/client";
 import type { RelationshipsActivityItem } from "../../../api/client-types-relationships";
 import { formatDateTime } from "../../../utils/format";
 
-const ACTIVITY_TYPE_COLORS: Record<string, { bg: string; fg: string }> = {
-  relationship: { bg: "rgba(99, 102, 241, 0.15)", fg: "rgb(99, 102, 241)" },
-  fact: { bg: "rgba(34, 197, 94, 0.15)", fg: "rgb(34, 197, 94)" },
-  identity: { bg: "rgba(168, 85, 247, 0.15)", fg: "rgb(168, 85, 247)" },
+type ActivityType = RelationshipsActivityItem["type"];
+
+const ACTIVITY_TYPE_STYLES: Record<
+  ActivityType,
+  { bg: string; fg: string; icon: ComponentType<{ className?: string }> }
+> = {
+  relationship: {
+    bg: "rgba(99, 102, 241, 0.15)",
+    fg: "rgb(99, 102, 241)",
+    icon: Link2,
+  },
+  fact: {
+    bg: "rgba(34, 197, 94, 0.15)",
+    fg: "rgb(34, 197, 94)",
+    icon: Tags,
+  },
+  identity: {
+    bg: "rgba(168, 85, 247, 0.15)",
+    fg: "rgb(168, 85, 247)",
+    icon: Fingerprint,
+  },
 };
+
+const ACTIVITY_PAGE_SIZE = 25;
 
 export function RelationshipsActivityFeed() {
   const [activity, setActivity] = useState<RelationshipsActivityItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
+    setError(null);
     void client
-      .getRelationshipsActivity(50)
-      .then((response) => setActivity(response.activity))
+      .getRelationshipsActivity(ACTIVITY_PAGE_SIZE, 0)
+      .then((response) => {
+        if (!cancelled) {
+          setActivity(response.activity);
+          setHasMore(response.hasMore);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Failed to load activity feed.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadMore = () => {
+    setLoadingMore(true);
+    setError(null);
+    void client
+      .getRelationshipsActivity(ACTIVITY_PAGE_SIZE, activity.length)
+      .then((response) => {
+        setActivity((current) => [...current, ...response.activity]);
+        setHasMore(response.hasMore);
+      })
       .catch((err) =>
         setError(
           err instanceof Error ? err.message : "Failed to load activity feed.",
         ),
       )
-      .finally(() => setLoading(false));
-  }, []);
+      .finally(() => setLoadingMore(false));
+  };
 
   if (loading) {
     return (
@@ -42,19 +100,14 @@ export function RelationshipsActivityFeed() {
   }
 
   if (activity.length === 0) {
-    return (
-      <p className="px-4 py-3 text-sm text-muted">
-        No relationship activity yet. Events will appear as the agent extracts
-        relationships, identities, and facts from conversations.
-      </p>
-    );
+    return <p className="px-4 py-3 text-sm text-muted">No activity.</p>;
   }
 
   return (
     <div className="space-y-2">
       {activity.map((item) => {
-        const color =
-          ACTIVITY_TYPE_COLORS[item.type] ?? ACTIVITY_TYPE_COLORS.relationship;
+        const style = ACTIVITY_TYPE_STYLES[item.type];
+        const ActivityIcon = style.icon;
         return (
           <div
             key={`${item.personId}-${item.type}-${item.timestamp ?? "none"}-${item.summary}`}
@@ -62,9 +115,10 @@ export function RelationshipsActivityFeed() {
           >
             <div className="flex flex-wrap items-center gap-2">
               <span
-                className="inline-flex items-center rounded-full px-2 py-0.5 text-2xs font-semibold uppercase tracking-[0.12em]"
-                style={{ backgroundColor: color.bg, color: color.fg }}
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-semibold uppercase tracking-[0.12em]"
+                style={{ backgroundColor: style.bg, color: style.fg }}
               >
+                <ActivityIcon className="h-3 w-3" />
                 {item.type}
               </span>
               {item.timestamp ? (
@@ -82,6 +136,18 @@ export function RelationshipsActivityFeed() {
           </div>
         );
       })}
+      {hasMore ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 rounded-lg px-3"
+          disabled={loadingMore}
+          onClick={loadMore}
+        >
+          {loadingMore ? "Loading..." : "Load more"}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/packages/app-core/src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx
+++ b/packages/app-core/src/components/pages/relationships/RelationshipsCandidateMergesPanel.tsx
@@ -17,7 +17,7 @@ export function RelationshipsCandidateMergesPanel({
 }) {
   const [pending, setPending] = useState<Set<string>>(new Set());
   const [errors, setErrors] = useState<Map<string, string>>(new Map());
-  const candidates = graph.candidateMerges ?? [];
+  const candidates = graph.candidateMerges;
 
   if (candidates.length === 0) {
     return null;
@@ -94,9 +94,8 @@ export function RelationshipsCandidateMergesPanel({
         {candidates.map((candidate) => {
           const isPending = pending.has(candidate.id);
           const errorMessage = errors.get(candidate.id) ?? null;
-          const evidenceCount = Array.isArray(candidate.evidence.identityIds)
-            ? candidate.evidence.identityIds.length
-            : 0;
+          const evidenceCount = candidate.evidence.identityIds?.length ?? 0;
+          const evidenceText = evidenceSummary(candidate);
           return (
             <div
               key={candidate.id}
@@ -108,7 +107,9 @@ export function RelationshipsCandidateMergesPanel({
                 </MetaPill>
                 <MetaPill compact>{evidenceCount} evidence</MetaPill>
                 <MetaPill compact>
-                  {formatDateTime(candidate.proposedAt, { fallback: "n/a" })}
+                  {formatDateTime(candidate.proposedAt, {
+                    fallback: "No date",
+                  })}
                 </MetaPill>
               </div>
               <div className="mt-2 text-sm font-semibold text-txt">
@@ -116,9 +117,11 @@ export function RelationshipsCandidateMergesPanel({
                 <span className="text-muted">↔</span>{" "}
                 {personLabel(graph, candidate.entityB)}
               </div>
-              <div className="mt-1 text-xs leading-5 text-muted">
-                {evidenceSummary(candidate)}
-              </div>
+              {evidenceText !== "No evidence" ? (
+                <div className="mt-1 text-xs leading-5 text-muted">
+                  {evidenceText}
+                </div>
+              ) : null}
               {errorMessage ? (
                 <div className="mt-2 text-xs text-danger">{errorMessage}</div>
               ) : null}

--- a/packages/app-core/src/components/pages/relationships/RelationshipsPersonPanels.tsx
+++ b/packages/app-core/src/components/pages/relationships/RelationshipsPersonPanels.tsx
@@ -1,5 +1,17 @@
 import { Button, MetaPill, PagePanel } from "@elizaos/ui";
-import type { ReactNode } from "react";
+import {
+  CalendarClock,
+  Crown,
+  Fingerprint,
+  Globe2,
+  Link2,
+  Mail,
+  MessageCircle,
+  Phone,
+  Tags,
+  UserRound,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
 import type {
   RelationshipsGraphEdge,
   RelationshipsPersonDetail,
@@ -8,15 +20,12 @@ import type {
 import { formatDateTime } from "../../../utils/format";
 import { RelationshipsIdentityCluster } from "../RelationshipsIdentityCluster";
 import {
-  buildAdditionalHighlights,
   profilePrimaryValue,
   profileSourceLabel,
-  type RelationshipsPersonSupplementalDetail,
   topContacts,
 } from "./relationships-utils";
 
-type RelationshipsDisplayPerson = RelationshipsPersonDetail &
-  RelationshipsPersonSupplementalDetail;
+type RelationshipsDisplayPerson = RelationshipsPersonDetail;
 
 const PANEL_PREVIEW_LIMIT = 4;
 const CONVERSATION_PREVIEW_LIMIT = 2;
@@ -73,22 +82,13 @@ function listValue(values: string[], fallback: string): string {
 }
 
 function personSummary(person: RelationshipsDisplayPerson): string {
-  if (person.headline?.trim()) {
-    return person.headline.trim();
-  }
-  if (person.bio?.trim()) {
-    return person.bio.trim();
-  }
-  if (person.notes?.trim()) {
-    return person.notes.trim();
-  }
   if (person.isOwner) {
-    return "Canonical owner profile for app chat and linked connectors.";
+    return "Primary owner profile for app chat and linked connectors.";
   }
   if (person.aliases.length > 0) {
     return `Known as ${person.aliases.join(", ")}.`;
   }
-  return "No alternate aliases have been confirmed yet.";
+  return "No alternate aliases recorded.";
 }
 
 function relationshipCounterpartName(
@@ -98,6 +98,31 @@ function relationshipCounterpartName(
   return relationship.sourcePersonId === groupId
     ? relationship.targetPersonName
     : relationship.sourcePersonName;
+}
+
+function sentimentClasses(sentiment: string): string {
+  if (sentiment === "positive") {
+    return "border-success/28 bg-success/10 text-success";
+  }
+  if (sentiment === "negative") {
+    return "border-danger/28 bg-danger/10 text-danger";
+  }
+  return "border-warning/28 bg-warning/10 text-warning";
+}
+
+function DetailLabel({
+  icon: Icon,
+  children,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs-tight uppercase tracking-[0.14em] text-muted/70">
+      <Icon className="h-3.5 w-3.5 text-accent" />
+      {children}
+    </div>
+  );
 }
 
 function ProfileCard({
@@ -130,7 +155,7 @@ function ProfileCard({
             <div className="text-2xs font-semibold uppercase tracking-[0.12em] text-muted/70">
               {profileSourceLabel(profile.source)}
             </div>
-            {profile.canonical ? <MetaPill compact>Canonical</MetaPill> : null}
+            {profile.canonical ? <MetaPill compact>Primary</MetaPill> : null}
           </div>
           <div className="mt-1 text-sm font-semibold text-txt">
             {primaryValue}
@@ -158,7 +183,8 @@ export function RelationshipsPersonSummaryPanel({
   const avatarUrl = resolvePrimaryAvatar(person);
   const contacts = topContacts(person);
   const hasProfiles = person.profiles.length > 0;
-  const additionalHighlights = buildAdditionalHighlights(person);
+  const hasCategories = person.categories.length > 0;
+  const hasTags = person.tags.length > 0;
 
   return (
     <PagePanel variant="padded" className={compact ? "space-y-3" : "space-y-4"}>
@@ -173,7 +199,7 @@ export function RelationshipsPersonSummaryPanel({
           ) : null}
           <div className="min-w-0">
             <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
-              Canonical person
+              Person
             </div>
             <div
               className={`${compact ? "mt-1 text-xl" : "mt-2 text-[1.75rem]"} break-words font-semibold leading-tight text-txt`}
@@ -186,12 +212,24 @@ export function RelationshipsPersonSummaryPanel({
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          {person.isOwner ? <MetaPill compact>Owner</MetaPill> : null}
+          {person.isOwner ? (
+            <MetaPill compact>
+              <Crown className="mr-1 h-3.5 w-3.5" />
+              Owner
+            </MetaPill>
+          ) : null}
           <MetaPill compact>
+            <Fingerprint className="mr-1 h-3.5 w-3.5" />
             {person.memberEntityIds.length} identities
           </MetaPill>
-          <MetaPill compact>{person.factCount} facts</MetaPill>
-          <MetaPill compact>{person.relationshipCount} links</MetaPill>
+          <MetaPill compact>
+            <Tags className="mr-1 h-3.5 w-3.5" />
+            {person.factCount} facts
+          </MetaPill>
+          <MetaPill compact>
+            <Link2 className="mr-1 h-3.5 w-3.5" />
+            {person.relationshipCount} links
+          </MetaPill>
           {onViewMemories ? (
             <Button
               type="button"
@@ -215,73 +253,55 @@ export function RelationshipsPersonSummaryPanel({
       >
         <div className="grid gap-3 sm:grid-cols-2">
           <PagePanel variant="inset" className="px-4 py-4">
-            <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-              Platforms
-            </div>
+            <DetailLabel icon={UserRound}>Platforms</DetailLabel>
             <div className="mt-2 text-sm font-semibold text-txt">
               {listValue(person.platforms, "No linked platforms")}
             </div>
           </PagePanel>
           <PagePanel variant="inset" className="px-4 py-4">
-            <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-              Last interaction
-            </div>
+            <DetailLabel icon={CalendarClock}>Last interaction</DetailLabel>
             <div className="mt-2 text-sm font-semibold text-txt">
-              {formatDateTime(person.lastInteractionAt, { fallback: "n/a" })}
-            </div>
-          </PagePanel>
-          <PagePanel variant="inset" className="px-4 py-4">
-            <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-              Categories
-            </div>
-            <div className="mt-2 text-sm font-semibold text-txt">
-              {listValue(person.categories, "No categories")}
-            </div>
-          </PagePanel>
-          <PagePanel variant="inset" className="px-4 py-4">
-            <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-              Tags
-            </div>
-            <div className="mt-2 text-sm font-semibold text-txt">
-              {listValue(person.tags, "No tags")}
+              {formatDateTime(person.lastInteractionAt, {
+                fallback: "No date",
+              })}
             </div>
           </PagePanel>
 
-          {additionalHighlights.length > 0 ? (
+          {hasCategories || hasTags ? (
             <PagePanel variant="surface" className="sm:col-span-2 px-4 py-4">
-              <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-                Additional context
-              </div>
-              <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                {additionalHighlights.map((row) => (
-                  <div
-                    key={`${row.label}:${row.value}`}
-                    className="rounded-xl border border-border/24 bg-card/35 px-3 py-3"
-                  >
-                    <div className="text-2xs font-semibold uppercase tracking-[0.12em] text-muted/70">
-                      {row.label}
-                    </div>
-                    <div className="mt-1 text-sm font-semibold text-txt">
-                      {row.value}
-                    </div>
-                  </div>
+              <DetailLabel icon={Tags}>Labels</DetailLabel>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {person.categories.map((category) => (
+                  <MetaPill key={`category:${category}`} compact>
+                    {category}
+                  </MetaPill>
+                ))}
+                {person.tags.map((tag) => (
+                  <MetaPill key={`tag:${tag}`} compact>
+                    {tag}
+                  </MetaPill>
                 ))}
               </div>
             </PagePanel>
           ) : null}
 
-          <PagePanel variant="surface" className="sm:col-span-2 px-4 py-4">
-            <div className="text-xs-tight uppercase tracking-[0.14em] text-muted/70">
-              Reachability
-            </div>
-            {contacts.length > 0 ? (
+          {contacts.length > 0 ? (
+            <PagePanel variant="surface" className="sm:col-span-2 px-4 py-4">
+              <DetailLabel icon={Mail}>Reachability</DetailLabel>
               <div className="mt-3 grid gap-2 sm:grid-cols-2">
                 {contacts.map((contact) => (
                   <div
                     key={`${contact.label}:${contact.value}`}
                     className="rounded-xl border border-border/24 bg-card/35 px-3 py-3"
                   >
-                    <div className="text-2xs font-semibold uppercase tracking-[0.12em] text-muted/70">
+                    <div className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.12em] text-muted/70">
+                      {contact.label === "Phone" ? (
+                        <Phone className="h-3 w-3 text-accent" />
+                      ) : contact.label === "Website" ? (
+                        <Globe2 className="h-3 w-3 text-accent" />
+                      ) : (
+                        <Mail className="h-3 w-3 text-accent" />
+                      )}
                       {contact.label}
                     </div>
                     <div className="mt-1 text-sm font-semibold text-txt">
@@ -290,12 +310,8 @@ export function RelationshipsPersonSummaryPanel({
                   </div>
                 ))}
               </div>
-            ) : (
-              <p className="mt-3 text-sm leading-6 text-muted">
-                No direct contact channels are stored for this person yet.
-              </p>
-            )}
-          </PagePanel>
+            </PagePanel>
+          ) : null}
 
           {hasProfiles && !compact ? <ProfilesPanel person={person} /> : null}
         </div>
@@ -376,9 +392,9 @@ export function RelationshipsFactsPanel({
         </div>
         <div className="mt-2 text-xs text-muted">
           {fact.lastReinforced
-            ? `Reinforced ${formatDateTime(fact.lastReinforced, { fallback: "n/a" })}`
+            ? `Reinforced ${formatDateTime(fact.lastReinforced, { fallback: "No date" })}`
             : formatDateTime(fact.updatedAt, {
-                fallback: "No timestamp",
+                fallback: "No date",
               })}
         </div>
         {fact.provenance?.source ? (
@@ -397,17 +413,12 @@ export function RelationshipsFactsPanel({
           <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
             Facts
           </div>
-          <div className="mt-2 text-lg font-semibold text-txt">
-            Stored claims and memory-backed notes
-          </div>
         </div>
         <MetaPill compact>{person.facts.length}</MetaPill>
       </div>
 
       {person.facts.length === 0 ? (
-        <p className="mt-4 text-sm leading-6 text-muted">
-          No facts have been extracted for this person yet.
-        </p>
+        <p className="mt-4 text-sm leading-6 text-muted">No facts extracted.</p>
       ) : (
         <div className="mt-4 space-y-3">
           {shownFacts.map(renderFact)}
@@ -435,20 +446,31 @@ export function RelationshipsConnectionsPanel({
       className="rounded-xl border border-border/24 bg-card/32 px-3.5 py-3"
     >
       <div className="flex flex-wrap items-center gap-2">
-        <MetaPill compact>{relationship.strength.toFixed(2)}</MetaPill>
-        <MetaPill compact>{relationship.sentiment}</MetaPill>
-        <MetaPill compact>{relationship.interactionCount} msgs</MetaPill>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold uppercase tracking-[0.12em] ${sentimentClasses(relationship.sentiment)}`}
+        >
+          <span className="h-1.5 w-1.5 rounded-full bg-current" />
+          {relationship.sentiment || "neutral"}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full border border-border/24 bg-card/36 px-2 py-0.5 text-2xs font-semibold text-muted">
+          <Link2 className="h-3 w-3" />
+          {Math.round(relationship.strength * 100)}%
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full border border-border/24 bg-card/36 px-2 py-0.5 text-2xs font-semibold text-muted">
+          <MessageCircle className="h-3 w-3" />
+          {relationship.interactionCount}
+        </span>
       </div>
       <div className="mt-2 text-sm font-semibold text-txt">
         {relationshipCounterpartName(relationship, person.groupId)}
       </div>
       <div className="mt-1 text-xs uppercase tracking-[0.12em] text-muted/70">
-        {relationship.relationshipTypes.join(" • ") || "unknown"}
+        {relationship.relationshipTypes.join(" • ") || "Unlabeled"}
       </div>
       <div className="mt-2 text-xs text-muted">
         Last interaction{" "}
         {formatDateTime(relationship.lastInteractionAt, {
-          fallback: "n/a",
+          fallback: "No date",
         })}
       </div>
     </div>
@@ -461,17 +483,13 @@ export function RelationshipsConnectionsPanel({
           <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
             Relationships
           </div>
-          <div className="mt-2 text-lg font-semibold text-txt">
-            Strongest adjacent people in the graph
-          </div>
         </div>
         <MetaPill compact>{person.relationships.length}</MetaPill>
       </div>
 
       {person.relationships.length === 0 ? (
         <p className="mt-4 text-sm leading-6 text-muted">
-          No cross-person relationship edges have been aggregated for this
-          identity group yet.
+          No relationships recorded.
         </p>
       ) : (
         <div className="mt-4 space-y-3">
@@ -510,7 +528,7 @@ export function RelationshipsConversationsPanel({
         </div>
         <div className="shrink-0 text-xs-tight text-muted">
           {formatDateTime(conversation.lastActivityAt, {
-            fallback: "n/a",
+            fallback: "No date",
           })}
         </div>
       </div>
@@ -545,16 +563,13 @@ export function RelationshipsConversationsPanel({
           <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
             Recent conversations
           </div>
-          <div className="mt-2 text-lg font-semibold text-txt">
-            Latest room snippets linked to this person
-          </div>
         </div>
         <MetaPill compact>{person.recentConversations.length}</MetaPill>
       </div>
 
       {person.recentConversations.length === 0 ? (
         <p className="mt-4 text-sm leading-6 text-muted">
-          No recent room snippets are available for this person yet.
+          No conversations linked.
         </p>
       ) : (
         <div className="mt-4 grid gap-4 xl:grid-cols-2">
@@ -603,7 +618,7 @@ export function RelationshipsRelevantMemoriesPanel({
         {boundedText(memory.text)}
       </div>
       <div className="mt-2 text-xs text-muted">
-        {formatDateTime(memory.createdAt, { fallback: "No timestamp" })}
+        {formatDateTime(memory.createdAt, { fallback: "No date" })}
       </div>
     </div>
   );
@@ -615,16 +630,13 @@ export function RelationshipsRelevantMemoriesPanel({
           <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
             Relevant memories
           </div>
-          <div className="mt-2 text-lg font-semibold text-txt">
-            Message memories tied to this person
-          </div>
         </div>
         <MetaPill compact>{person.relevantMemories.length}</MetaPill>
       </div>
 
       {person.relevantMemories.length === 0 ? (
         <p className="mt-4 text-sm leading-6 text-muted">
-          No relevant memories are attached to this person yet.
+          No relevant memories.
         </p>
       ) : (
         <div className="mt-4 space-y-3">
@@ -674,7 +686,7 @@ export function RelationshipsUserPreferencesPanel({
       ) : null}
       <div className="mt-2 text-xs text-muted">
         {formatDateTime(preference.createdAt, {
-          fallback: "No timestamp",
+          fallback: "No date",
         })}
       </div>
     </div>
@@ -685,10 +697,7 @@ export function RelationshipsUserPreferencesPanel({
       <div className="flex items-center justify-between gap-3">
         <div>
           <div className="text-xs-tight font-semibold uppercase tracking-[0.16em] text-muted/70">
-            User personality preferences
-          </div>
-          <div className="mt-2 text-lg font-semibold text-txt">
-            User-scoped guidance learned from interactions
+            Preferences
           </div>
         </div>
         <MetaPill compact>{person.userPersonalityPreferences.length}</MetaPill>
@@ -696,8 +705,7 @@ export function RelationshipsUserPreferencesPanel({
 
       {person.userPersonalityPreferences.length === 0 ? (
         <p className="mt-4 text-sm leading-6 text-muted">
-          No user-scoped personality preferences have been learned for this
-          person yet.
+          No preferences learned.
         </p>
       ) : (
         <div className="mt-4 space-y-3">

--- a/packages/app-core/src/components/pages/relationships/RelationshipsSidebar.tsx
+++ b/packages/app-core/src/components/pages/relationships/RelationshipsSidebar.tsx
@@ -1,10 +1,10 @@
 import {
-  MetaPill,
   SidebarContent,
   SidebarHeader,
   SidebarPanel,
   SidebarScrollRegion,
 } from "@elizaos/ui";
+import { Crown, Fingerprint, Link2 } from "lucide-react";
 import type { RelationshipsGraphSnapshot } from "../../../api/client-types-relationships";
 import { AppPageSidebar } from "../../shared/AppPageSidebar";
 import { summarizeHandles } from "./relationships-utils";
@@ -58,18 +58,32 @@ export function RelationshipsSidebar({
                     {person.displayName.charAt(0).toUpperCase()}
                   </SidebarContent.ItemIcon>
                   <span className="min-w-0 flex-1 text-left">
-                    <SidebarContent.ItemTitle>
-                      {person.displayName}
-                    </SidebarContent.ItemTitle>
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <SidebarContent.ItemTitle>
+                        {person.displayName}
+                      </SidebarContent.ItemTitle>
+                      {person.isOwner ? (
+                        <Crown className="h-3.5 w-3.5 shrink-0 text-accent" />
+                      ) : null}
+                    </span>
                     <SidebarContent.ItemDescription>
                       {person.isOwner
-                        ? `Owner · ${summarizeHandles(person) || person.platforms.join(" • ") || "Canonical profile"}`
+                        ? `Owner · ${summarizeHandles(person) || person.platforms.join(" • ") || "Primary profile"}`
                         : summarizeHandles(person) ||
                           person.platforms.join(" • ") ||
-                          "No handles yet"}
+                          "No linked handles"}
                     </SidebarContent.ItemDescription>
                   </span>
-                  <MetaPill compact>{person.memberEntityIds.length}</MetaPill>
+                  <span className="flex shrink-0 flex-col items-end gap-1 text-2xs font-semibold text-muted">
+                    <span className="inline-flex items-center gap-1">
+                      <Fingerprint className="h-3 w-3 text-accent" />
+                      {person.memberEntityIds.length}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <Link2 className="h-3 w-3 text-muted" />
+                      {person.relationshipCount}
+                    </span>
+                  </span>
                 </SidebarContent.Item>
               );
             })}

--- a/packages/app-core/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
+++ b/packages/app-core/src/components/pages/relationships/RelationshipsWorkspaceView.tsx
@@ -1,5 +1,15 @@
-import { Button, MetaPill, PageLayout, PagePanel } from "@elizaos/ui";
+import { Button, PageLayout, PagePanel } from "@elizaos/ui";
 import {
+  Filter,
+  Fingerprint,
+  Link2,
+  RefreshCw,
+  Search,
+  UserRound,
+  X,
+} from "lucide-react";
+import {
+  type ComponentType,
   type ReactNode,
   useCallback,
   useDeferredValue,
@@ -12,7 +22,7 @@ import type {
   RelationshipsGraphSnapshot,
   RelationshipsPersonDetail,
 } from "../../../api/client-types-relationships";
-import { useApp } from "../../../state";
+import { useApp } from "../../../state/useApp";
 import { RelationshipsGraphPanel } from "../RelationshipsGraphPanel";
 import { RelationshipsActivityFeed } from "./RelationshipsActivityFeed";
 import { RelationshipsCandidateMergesPanel } from "./RelationshipsCandidateMergesPanel";
@@ -30,6 +40,24 @@ import {
   platformOptions,
   sortPeople,
 } from "./relationships-utils";
+
+function ToolbarMetric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  label: string;
+  value: number | string;
+}) {
+  return (
+    <div className="inline-flex h-9 items-center gap-2 rounded-full border border-border/28 bg-card/42 px-3 text-sm text-muted-strong">
+      <Icon className="h-4 w-4 text-accent" />
+      <span className="font-semibold tabular-nums text-txt">{value}</span>
+      <span>{label}</span>
+    </div>
+  );
+}
 
 export function RelationshipsWorkspaceView({
   contentHeader,
@@ -50,21 +78,29 @@ export function RelationshipsWorkspaceView({
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [detail, setDetail] = useState<RelationshipsPersonDetail | null>(null);
-  const previousDetail = useRef<RelationshipsPersonDetail | null>(null);
+  const graphRequestId = useRef(0);
   const deferredSearch = useDeferredValue(search);
 
   const loadGraph = useCallback(
     async (query = buildRelationshipsGraphQuery("", "all")) => {
+      const requestId = graphRequestId.current + 1;
+      graphRequestId.current = requestId;
       setGraphLoading(true);
       setGraphError(null);
 
       try {
         const snapshot = await client.getRelationshipsGraph(query);
+        if (requestId !== graphRequestId.current) {
+          return;
+        }
         setGraph({
           ...snapshot,
           people: sortPeople(snapshot.people),
         });
       } catch (error) {
+        if (requestId !== graphRequestId.current) {
+          return;
+        }
         setGraphError(
           error instanceof Error
             ? error.message
@@ -72,7 +108,9 @@ export function RelationshipsWorkspaceView({
         );
         setGraph(null);
       } finally {
-        setGraphLoading(false);
+        if (requestId === graphRequestId.current) {
+          setGraphLoading(false);
+        }
       }
     },
     [],
@@ -93,24 +131,18 @@ export function RelationshipsWorkspaceView({
       (person) => person.primaryEntityId === selectedPersonId,
     );
     if (!stillSelected) {
-      setSelectedPersonId(graph.people[0]?.primaryEntityId ?? null);
+      setSelectedPersonId(graph.people[0].primaryEntityId);
     }
   }, [graph, selectedPersonId]);
 
-  const detailRef = useRef(detail);
-  detailRef.current = detail;
-
   useEffect(() => {
     if (!selectedPersonId) {
-      previousDetail.current = null;
       setDetail(null);
       return;
     }
 
     let cancelled = false;
-    if (detailRef.current) {
-      previousDetail.current = detailRef.current;
-    }
+    setDetail(null);
     setDetailLoading(true);
     setDetailError(null);
 
@@ -119,13 +151,11 @@ export function RelationshipsWorkspaceView({
       .then((person) => {
         if (!cancelled) {
           setDetail(person);
-          previousDetail.current = null;
         }
       })
       .catch((err) => {
         if (!cancelled) {
           setDetail(null);
-          previousDetail.current = null;
           setDetailError(
             err instanceof Error
               ? err.message
@@ -150,10 +180,6 @@ export function RelationshipsWorkspaceView({
       (person) => person.primaryEntityId === selectedPersonId,
     ) ?? null;
   const selectedGroupId = selectedSummary?.groupId ?? null;
-  const displayDetail =
-    detail ?? (detailLoading ? previousDetail.current : null);
-  const isStaleDetail =
-    detailLoading && !detail && previousDetail.current !== null;
   const handleViewMemories =
     onViewMemories ??
     (() => {
@@ -166,72 +192,110 @@ export function RelationshipsWorkspaceView({
 
   const toolbar = (
     <PagePanel variant="surface" className="px-3 py-3">
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap">
-          <MetaPill compact>{graph?.stats.totalPeople ?? 0} people</MetaPill>
-          <MetaPill compact>
-            {graph?.stats.totalRelationships ?? 0} links
-          </MetaPill>
-          <MetaPill compact>
-            {graph?.stats.totalIdentities ?? 0} identities
-          </MetaPill>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap gap-2">
+          <ToolbarMetric
+            icon={UserRound}
+            label="people"
+            value={
+              graph
+                ? graph.stats.totalPeople
+                : graphLoading || graphError
+                  ? "..."
+                  : 0
+            }
+          />
+          <ToolbarMetric
+            icon={Link2}
+            label="links"
+            value={
+              graph
+                ? graph.stats.totalRelationships
+                : graphLoading || graphError
+                  ? "..."
+                  : 0
+            }
+          />
+          <ToolbarMetric
+            icon={Fingerprint}
+            label="identities"
+            value={
+              graph
+                ? graph.stats.totalIdentities
+                : graphLoading || graphError
+                  ? "..."
+                  : 0
+            }
+          />
         </div>
 
-        <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row lg:max-w-3xl">
+        <div
+          className={
+            embedded
+              ? "grid min-w-0 gap-2 md:grid-cols-[minmax(16rem,1fr)_minmax(12rem,14rem)_auto]"
+              : "flex min-w-0 flex-col gap-2 sm:flex-row sm:justify-end"
+          }
+        >
           {embedded ? (
             <>
               <label className="sr-only" htmlFor="relationships-search">
                 Search people, aliases, handles
               </label>
               <div className="relative min-w-0 flex-1">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
                 <input
                   id="relationships-search"
                   value={search}
                   onChange={(event) => setSearch(event.target.value)}
                   placeholder="Search people, aliases, handles"
                   aria-label="Search people, aliases, handles"
-                  className="h-9 w-full rounded-lg border border-border/35 bg-card/45 px-3 pr-16 text-sm text-txt outline-none transition focus:border-accent/55"
+                  className="h-9 w-full rounded-lg border border-border/35 bg-card/45 pl-9 pr-10 text-sm text-txt outline-none transition focus:border-accent/55"
                 />
                 {search ? (
-                  <Button
+                  <button
                     type="button"
-                    size="sm"
-                    variant="ghost"
-                    className="absolute right-1 top-1 h-7 rounded-md px-2 text-2xs"
+                    className="absolute right-1.5 top-1.5 inline-flex h-6 w-6 items-center justify-center rounded-md text-muted transition hover:bg-bg-hover hover:text-txt"
                     onClick={() => setSearch("")}
+                    aria-label="Clear relationship search"
                   >
-                    Clear
-                  </Button>
+                    <X className="h-3.5 w-3.5" />
+                  </button>
                 ) : null}
               </div>
             </>
           ) : null}
 
-          <label className="sr-only" htmlFor="relationships-platform">
-            Platform filter
-          </label>
-          <select
-            id="relationships-platform"
-            value={platform}
-            onChange={(event) => setPlatform(event.target.value)}
-            aria-label="Platform filter"
-            className="h-9 rounded-lg border border-border/35 bg-card/45 px-3 text-sm text-txt outline-none transition focus:border-accent/55"
-          >
-            <option value="all">All platforms</option>
-            {platforms.map((entry) => (
-              <option key={entry} value={entry}>
-                {entry}
-              </option>
-            ))}
-          </select>
+          <div className="relative min-w-0">
+            <label className="sr-only" htmlFor="relationships-platform">
+              Platform filter
+            </label>
+            <Filter className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+            <select
+              id="relationships-platform"
+              value={platform}
+              onChange={(event) => setPlatform(event.target.value)}
+              aria-label="Platform filter"
+              className="h-9 w-full rounded-lg border border-border/35 bg-card/45 pl-9 pr-8 text-sm text-txt outline-none transition focus:border-accent/55"
+            >
+              <option value="all">All platforms</option>
+              {platforms.map((entry) => (
+                <option key={entry} value={entry}>
+                  {entry}
+                </option>
+              ))}
+            </select>
+          </div>
 
           <Button
             type="button"
             size="sm"
             variant="outline"
-            className="h-9 shrink-0 rounded-lg px-3"
+            className="h-9 shrink-0 gap-2 rounded-lg px-3"
             onClick={refreshGraph}
           >
+            <RefreshCw
+              className={`h-4 w-4 ${graphLoading ? "animate-spin" : ""}`}
+            />
             {graphLoading ? "Refreshing..." : "Refresh"}
           </Button>
         </div>
@@ -245,18 +309,20 @@ export function RelationshipsWorkspaceView({
       data-testid={embedded ? "relationships-embedded-view" : undefined}
     >
       {toolbar}
-      {graphError ? (
-        <div className="rounded-xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-          {graphError}
-        </div>
-      ) : null}
       {detailError ? (
         <div className="rounded-xl border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning">
           {detailError}
         </div>
       ) : null}
 
-      {!graph && graphLoading ? (
+      {graphError && !graph ? (
+        <PagePanel.Empty
+          variant="panel"
+          className={embedded ? "min-h-[18rem]" : "min-h-[24rem]"}
+          title="Relationships failed to load"
+          description={graphError}
+        />
+      ) : !graph && graphLoading ? (
         <PagePanel.Loading
           heading={t("common.loading", { defaultValue: "Loading..." })}
         />
@@ -277,10 +343,15 @@ export function RelationshipsWorkspaceView({
         />
       ) : (
         <>
+          {graphError ? (
+            <div className="rounded-xl border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
+              {graphError}
+            </div>
+          ) : null}
           <div
             className={
               embedded
-                ? "grid min-h-0 gap-3 xl:grid-cols-[minmax(0,1.25fr)_minmax(20rem,0.75fr)]"
+                ? "grid min-h-0 gap-3"
                 : "grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1.35fr)_minmax(22rem,0.65fr)]"
             }
           >
@@ -289,27 +360,14 @@ export function RelationshipsWorkspaceView({
                 snapshot={graph}
                 selectedGroupId={selectedGroupId}
                 compact={embedded}
-                onSelectGroupId={(groupId) => {
-                  const person = graph.people.find(
-                    (entry) => entry.groupId === groupId,
-                  );
-                  if (person) {
-                    setSelectedPersonId(person.primaryEntityId);
-                  }
-                }}
+                onSelectPersonId={setSelectedPersonId}
               />
             </PagePanel>
 
-            {displayDetail ? (
-              <div
-                className={
-                  isStaleDetail
-                    ? "pointer-events-none opacity-50 transition-opacity duration-200"
-                    : "transition-opacity duration-200"
-                }
-              >
+            {detail ? (
+              <div className="transition-opacity duration-200">
                 <RelationshipsPersonSummaryPanel
-                  person={displayDetail}
+                  person={detail}
                   compact={embedded}
                   onViewMemories={handleViewMemories}
                 />
@@ -325,17 +383,15 @@ export function RelationshipsWorkspaceView({
             )}
           </div>
 
-          {displayDetail ? (
-            <div
-              className={`grid gap-3 xl:grid-cols-2 ${isStaleDetail ? "pointer-events-none opacity-50 transition-opacity duration-200" : "transition-opacity duration-200"}`}
-            >
-              <RelationshipsFactsPanel person={displayDetail} />
-              <RelationshipsConnectionsPanel person={displayDetail} />
+          {detail ? (
+            <div className="grid gap-3 transition-opacity duration-200 xl:grid-cols-2">
+              <RelationshipsFactsPanel person={detail} />
+              <RelationshipsConnectionsPanel person={detail} />
               <div className="xl:col-span-2">
-                <RelationshipsConversationsPanel person={displayDetail} />
+                <RelationshipsConversationsPanel person={detail} />
               </div>
-              <RelationshipsRelevantMemoriesPanel person={displayDetail} />
-              <RelationshipsUserPreferencesPanel person={displayDetail} />
+              <RelationshipsRelevantMemoriesPanel person={detail} />
+              <RelationshipsUserPreferencesPanel person={detail} />
             </div>
           ) : null}
 

--- a/packages/app-core/src/components/pages/relationships/relationships-utils.ts
+++ b/packages/app-core/src/components/pages/relationships/relationships-utils.ts
@@ -6,18 +6,6 @@ import type {
   RelationshipsPersonSummary,
 } from "../../../api/client-types-relationships";
 
-export const RELATIONSHIPS_TOOLBAR_BUTTON_CLASS =
-  "h-8 rounded-full px-3.5 text-2xs font-semibold tracking-[0.12em] border border-border/32 bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_84%,transparent),color-mix(in_srgb,var(--bg)_95%,transparent))] text-muted-strong shadow-[inset_0_1px_0_rgba(255,255,255,0.14),0_14px_20px_-18px_rgba(15,23,42,0.14)] backdrop-blur-md transition-[border-color,background-color,color,transform,box-shadow] duration-200 hover:border-border/46 hover:bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_90%,transparent),color-mix(in_srgb,var(--bg)_97%,transparent))] hover:text-txt hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.16),0_16px_22px_-18px_rgba(15,23,42,0.16)] active:scale-95 disabled:hover:border-border/32 disabled:hover:bg-[linear-gradient(180deg,color-mix(in_srgb,var(--card)_84%,transparent),color-mix(in_srgb,var(--bg)_95%,transparent))] disabled:hover:text-muted-strong";
-
-export type RelationshipsPersonSupplementalDetail = {
-  headline?: string | null;
-  bio?: string | null;
-  notes?: string | null;
-  occupations?: string[];
-  locations?: string[];
-  organizations?: string[];
-};
-
 type PersonContactRow = {
   label: string;
   value: string;
@@ -91,25 +79,6 @@ export function topContacts(
   return rows;
 }
 
-export function buildAdditionalHighlights(
-  person: RelationshipsPersonDetail & RelationshipsPersonSupplementalDetail,
-): PersonContactRow[] {
-  const rows: PersonContactRow[] = [];
-  if (person.organizations?.length) {
-    rows.push({
-      label: "Organizations",
-      value: person.organizations.join(", "),
-    });
-  }
-  if (person.occupations?.length) {
-    rows.push({ label: "Roles", value: person.occupations.join(", ") });
-  }
-  if (person.locations?.length) {
-    rows.push({ label: "Locations", value: person.locations.join(", ") });
-  }
-  return rows;
-}
-
 export function profileSourceLabel(source: string): string {
   switch (source) {
     case "client_chat":
@@ -158,27 +127,15 @@ export function evidenceSummary(
   candidate: RelationshipsMergeCandidate,
 ): string {
   const parts: string[] = [];
-  const platform =
-    typeof candidate.evidence.platform === "string"
-      ? candidate.evidence.platform
-      : null;
-  const handle =
-    typeof candidate.evidence.handle === "string"
-      ? candidate.evidence.handle
-      : null;
+  const { platform, handle, notes, identityIds } = candidate.evidence;
   if (platform && handle) {
     parts.push(`${platform}:${handle}`);
   } else if (platform) {
     parts.push(platform);
   }
-  const notes =
-    typeof candidate.evidence.notes === "string"
-      ? candidate.evidence.notes
-      : null;
   if (notes) parts.push(notes);
-  const ids = candidate.evidence.identityIds;
-  if (Array.isArray(ids) && ids.length > 0) {
-    parts.push(`${ids.length} identity refs`);
+  if (identityIds && identityIds.length > 0) {
+    parts.push(`${identityIds.length} identities`);
   }
-  return parts.join(" · ") || "no evidence summary";
+  return parts.join(" · ") || "No evidence";
 }

--- a/packages/app-core/src/components/shell/Header.tsx
+++ b/packages/app-core/src/components/shell/Header.tsx
@@ -64,6 +64,7 @@ const MOBILE_BOTTOM_NAV_BUTTON_ACTIVE_CLASSNAME =
   "text-accent after:opacity-100";
 
 interface HeaderProps {
+  mobileCenter?: ReactNode;
   mobileLeft?: ReactNode;
   pageRightExtras?: ReactNode;
   transparent?: boolean;
@@ -83,6 +84,7 @@ function shouldShowMacDesktopTitleBar(): boolean {
 }
 
 export function Header({
+  mobileCenter,
   mobileLeft,
   pageRightExtras,
   transparent: _transparent = false,
@@ -408,14 +410,21 @@ export function Header({
                   {mobileLeft}
                 </div>
                 <div
-                  className="pointer-events-none h-[2.375rem] min-w-0"
+                  className={
+                    mobileCenter
+                      ? "flex h-[2.375rem] min-w-0 items-center justify-center"
+                      : "pointer-events-none h-[2.375rem] min-w-0"
+                  }
                   data-testid={
                     showMacDesktopTitleBar
                       ? "desktop-window-titlebar-drag-zone"
                       : undefined
                   }
-                  aria-hidden="true"
-                />
+                  data-no-camera-drag={mobileCenter ? "true" : undefined}
+                  aria-hidden={mobileCenter ? undefined : "true"}
+                >
+                  {mobileCenter}
+                </div>
                 <div
                   className="flex min-w-0 items-center justify-end gap-1"
                   data-no-camera-drag="true"

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
@@ -149,20 +149,25 @@ describe("AppWorkspaceChrome", () => {
     expect(screen.queryByTestId("mobile-chat")).toBeNull();
     expect(screen.queryByTestId("mobile-shell-chat-resize-handle")).toBeNull();
 
-    fireEvent.click(screen.getByTestId("mobile-shell-chat-expand"));
+    expect(
+      screen.getByTestId("app-workspace-mobile-pane-switcher"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("app-workspace-mobile-pane-chat"));
 
     const openSidebar = screen.getByTestId("mobile-shell-chat-sidebar");
-    expect(openSidebar.className).toContain("fixed");
+    expect(openSidebar.className).toContain("w-full");
+    expect(openSidebar.className).toContain("flex-1");
     expect(openSidebar.getAttribute("style") ?? "").not.toContain("width");
-    expect(screen.getByTestId("mobile-shell-chat-backdrop")).toBeTruthy();
+    expect(screen.queryByTestId("mobile-shell-chat-backdrop")).toBeNull();
     expect(screen.getByTestId("mobile-chat")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Close page chat" }));
+    fireEvent.click(screen.getByTestId("app-workspace-mobile-pane-main"));
 
     const closedSidebar = screen.getByTestId("mobile-shell-chat-sidebar");
     expect(closedSidebar.getAttribute("data-collapsed")).not.toBeNull();
     expect(screen.queryByTestId("mobile-chat")).toBeNull();
-    expect(screen.getByTestId("mobile-shell-chat-expand")).toBeTruthy();
+    expect(screen.getByTestId("app-workspace-mobile-pane-chat")).toBeTruthy();
   });
 
   it("lets main-pane content open chat through the workspace chrome context", () => {
@@ -197,7 +202,12 @@ describe("AppWorkspaceChrome", () => {
     fireEvent.click(screen.getByTestId("main-open-chat"));
 
     expect(screen.getByTestId("main-chat")).toBeTruthy();
-    expect(screen.getByTestId("main-chat-shell-chat-backdrop")).toBeTruthy();
+    expect(screen.queryByTestId("main-chat-shell-chat-backdrop")).toBeNull();
+    expect(
+      screen
+        .getByTestId("app-workspace-mobile-pane-chat")
+        .getAttribute("aria-current"),
+    ).toBe("page");
   });
 
   it("lets chat content own the collapse control row", () => {

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
@@ -156,6 +156,13 @@ describe("AppWorkspaceChrome", () => {
     expect(openSidebar.getAttribute("style") ?? "").not.toContain("width");
     expect(screen.getByTestId("mobile-shell-chat-backdrop")).toBeTruthy();
     expect(screen.getByTestId("mobile-chat")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close page chat" }));
+
+    const closedSidebar = screen.getByTestId("mobile-shell-chat-sidebar");
+    expect(closedSidebar.getAttribute("data-collapsed")).not.toBeNull();
+    expect(screen.queryByTestId("mobile-chat")).toBeNull();
+    expect(screen.getByTestId("mobile-shell-chat-expand")).toBeTruthy();
   });
 
   it("lets main-pane content open chat through the workspace chrome context", () => {

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
+import { useWorkspaceMobileSidebarControls } from "@elizaos/ui";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AppWorkspaceChrome,
@@ -168,6 +169,117 @@ describe("AppWorkspaceChrome", () => {
     expect(closedSidebar.getAttribute("data-collapsed")).not.toBeNull();
     expect(screen.queryByTestId("mobile-chat")).toBeNull();
     expect(screen.getByTestId("app-workspace-mobile-pane-chat")).toBeTruthy();
+  });
+
+  it("splits mobile controls into left sidebar, content, and right chat", async () => {
+    useMediaQueryMock.mockImplementation(
+      (query: string) => query === "(max-width: 639px)",
+    );
+
+    function RegisteredSidebar() {
+      const controls = useWorkspaceMobileSidebarControls();
+      const [open, setOpen] = useState(false);
+
+      useEffect(() => {
+        return controls?.register({
+          id: "test-sidebar",
+          label: "Test sidebar",
+          open,
+          setOpen,
+        });
+      }, [controls, open]);
+
+      return (
+        <div data-testid={open ? "registered-sidebar-open" : "main-content"}>
+          {open ? "Sidebar" : "Main"}
+        </div>
+      );
+    }
+
+    render(
+      <AppWorkspaceChrome
+        testId="three-pane-shell"
+        main={<RegisteredSidebar />}
+        chat={<div data-testid="three-pane-chat">Chat content</div>}
+      />,
+    );
+
+    const leftButton = await screen.findByTestId(
+      "app-workspace-mobile-pane-left",
+    );
+    expect(screen.getByTestId("app-workspace-mobile-pane-main")).toBeTruthy();
+    expect(screen.getByTestId("app-workspace-mobile-pane-chat")).toBeTruthy();
+
+    fireEvent.click(leftButton);
+
+    expect(screen.getByTestId("registered-sidebar-open")).toBeTruthy();
+    expect(leftButton.getAttribute("aria-current")).toBe("page");
+
+    fireEvent.click(screen.getByTestId("app-workspace-mobile-pane-main"));
+
+    expect(screen.getByTestId("main-content")).toBeTruthy();
+    expect(
+      screen
+        .getByTestId("app-workspace-mobile-pane-main")
+        .getAttribute("aria-current"),
+    ).toBe("page");
+
+    fireEvent.click(screen.getByTestId("app-workspace-mobile-pane-chat"));
+
+    expect(screen.getByTestId("three-pane-chat")).toBeTruthy();
+    expect(screen.queryByTestId("registered-sidebar-open")).toBeNull();
+    expect(
+      screen
+        .getByTestId("app-workspace-mobile-pane-chat")
+        .getAttribute("aria-current"),
+    ).toBe("page");
+  });
+
+  it("omits the mobile right pane button when chat is disabled", async () => {
+    useMediaQueryMock.mockImplementation(
+      (query: string) => query === "(max-width: 639px)",
+    );
+
+    function RegisteredSidebar() {
+      const controls = useWorkspaceMobileSidebarControls();
+      const [open, setOpen] = useState(false);
+
+      useEffect(() => {
+        return controls?.register({
+          id: "disabled-chat-sidebar",
+          open,
+          setOpen,
+        });
+      }, [controls, open]);
+
+      return (
+        <div data-testid={open ? "disabled-chat-sidebar-open" : "main-only"}>
+          {open ? "Sidebar" : "Main"}
+        </div>
+      );
+    }
+
+    render(
+      <AppWorkspaceChrome
+        chatDisabled
+        testId="disabled-chat-shell"
+        main={<RegisteredSidebar />}
+      />,
+    );
+
+    const leftButton = await screen.findByTestId(
+      "app-workspace-mobile-pane-left",
+    );
+
+    expect(screen.getByTestId("app-workspace-mobile-pane-main")).toBeTruthy();
+    expect(screen.queryByTestId("app-workspace-mobile-pane-chat")).toBeNull();
+
+    fireEvent.click(leftButton);
+    expect(screen.getByTestId("disabled-chat-sidebar-open")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("app-workspace-mobile-pane-main"));
+    expect(screen.getByTestId("main-only")).toBeTruthy();
+    expect(screen.queryByTestId("disabled-chat-shell-chat-sidebar")).toBeNull();
   });
 
   it("lets main-pane content open chat through the workspace chrome context", () => {

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.test.tsx
@@ -114,6 +114,22 @@ describe("AppWorkspaceChrome", () => {
     expect(expandButton.className).not.toContain("border-border/40");
   });
 
+  it("omits the right chat rail when the main surface owns chat", () => {
+    render(
+      <AppWorkspaceChrome
+        testId="game-shell"
+        chatScope="page-apps"
+        chatDisabled
+        main={<div data-testid="game-main">Game content</div>}
+      />,
+    );
+
+    expect(screen.getByTestId("game-main")).toBeTruthy();
+    expect(screen.queryByTestId("page-scoped-chat")).toBeNull();
+    expect(screen.queryByTestId("game-shell-chat-sidebar")).toBeNull();
+    expect(screen.queryByTestId("game-shell-chat-collapse")).toBeNull();
+  });
+
   it("does not reserve right-chat width on mobile until the user opens it", () => {
     useMediaQueryMock.mockImplementation(
       (query: string) => query === "(max-width: 639px)",

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
@@ -143,6 +143,8 @@ export interface AppWorkspaceChromeProps {
   chatDefaultCollapsed?: boolean;
   /** Hide the default bottom-right collapse control when chat content owns it. */
   hideCollapseButton?: boolean;
+  /** Disable the right chat rail for focused surfaces that own their own chat. */
+  chatDisabled?: boolean;
   /** data-testid applied to the root element. */
   testId?: string;
 }
@@ -181,6 +183,7 @@ export function AppWorkspaceChrome({
   onToggleChat,
   chatDefaultCollapsed = false,
   hideCollapseButton = false,
+  chatDisabled = false,
   testId = "app-workspace-chrome",
 }: AppWorkspaceChromeProps): JSX.Element {
   const isControlled = chatCollapsedProp !== undefined;
@@ -329,8 +332,7 @@ export function AppWorkspaceChrome({
           </div>
         </div>
 
-        {/* Collapsible right-side chat sidebar */}
-        {effectiveCollapsed ? (
+        {chatDisabled ? null : effectiveCollapsed ? (
           <aside
             className="w-0 min-w-0 shrink-0"
             data-testid={`${testId}-chat-sidebar`}

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
@@ -1,4 +1,4 @@
-import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { Maximize2, PanelRightClose, PanelRightOpen } from "lucide-react";
 import type React from "react";
 import {
   createContext,
@@ -95,6 +95,50 @@ function AppWorkspaceChatDockToggleButton({
         <PanelRightClose className="h-3.5 w-3.5" aria-hidden />
       )}
     </button>
+  );
+}
+
+function MobileWorkspacePaneSwitcher({
+  chatOpen,
+  onChat,
+  onMain,
+}: {
+  chatOpen: boolean;
+  onChat: () => void;
+  onMain: () => void;
+}): JSX.Element {
+  return (
+    <div
+      className="flex shrink-0 justify-center border-b border-border/35 bg-bg/92 px-2 py-1.5"
+      data-testid="app-workspace-mobile-pane-switcher"
+    >
+      <div className="inline-flex h-[2.375rem] items-center rounded-md border border-border/40 bg-card/55 p-0.5">
+        <button
+          type="button"
+          aria-label="Show main pane"
+          aria-current={!chatOpen ? "page" : undefined}
+          data-testid="app-workspace-mobile-pane-main"
+          onClick={onMain}
+          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
+            !chatOpen ? "bg-accent text-accent-fg" : "text-muted hover:text-txt"
+          }`}
+        >
+          <Maximize2 className="h-4 w-4" aria-hidden />
+        </button>
+        <button
+          type="button"
+          aria-label="Show page chat"
+          aria-current={chatOpen ? "page" : undefined}
+          data-testid="app-workspace-mobile-pane-chat"
+          onClick={onChat}
+          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
+            chatOpen ? "bg-accent text-accent-fg" : "text-muted hover:text-txt"
+          }`}
+        >
+          <PanelRightOpen className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -322,10 +366,24 @@ export function AppWorkspaceChrome({
   return (
     <AppWorkspaceChatChromeContext.Provider value={chatChromeContextValue}>
       <div
-        className="flex min-h-0 min-w-0 w-full flex-1 bg-bg pb-[var(--eliza-mobile-nav-offset,0px)]"
+        className={`flex min-h-0 min-w-0 w-full flex-1 bg-bg pb-[var(--eliza-mobile-nav-offset,0px)] ${
+          isMobileViewport ? "flex-col" : ""
+        }`}
         data-testid={testId}
       >
-        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {isMobileViewport && !chatDisabled ? (
+          <MobileWorkspacePaneSwitcher
+            chatOpen={!effectiveCollapsed}
+            onChat={() => handleToggle(false)}
+            onMain={() => handleToggle(true)}
+          />
+        ) : null}
+
+        <div
+          className={`relative min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${
+            isMobileViewport && !effectiveCollapsed ? "hidden" : "flex"
+          }`}
+        >
           {nav}
           <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
             {main}
@@ -338,17 +396,7 @@ export function AppWorkspaceChrome({
             data-testid={`${testId}-chat-sidebar`}
             data-collapsed
           >
-            {isMobileViewport ? (
-              <button
-                type="button"
-                data-testid={`${testId}-chat-expand`}
-                className="fixed right-2 top-[var(--safe-area-top,0px)] z-50 inline-flex h-[2.375rem] w-[2.375rem] items-center justify-center rounded-md border border-transparent bg-transparent text-muted transition-colors hover:text-txt"
-                aria-label="Open page chat"
-                onClick={() => handleToggle(false)}
-              >
-                <PanelRightOpen className="h-4 w-4" />
-              </button>
-            ) : (
+            {isMobileViewport ? null : (
               <AppWorkspaceChatDockToggleButton
                 collapsed
                 testId={`${testId}-chat-expand`}
@@ -358,45 +406,21 @@ export function AppWorkspaceChrome({
         ) : (
           <>
             {isMobileViewport ? (
-              <button
-                type="button"
-                className="fixed inset-x-0 z-40 bg-bg/65 backdrop-blur-[2px]"
-                style={{
-                  top: "calc(var(--safe-area-top, 0px) + 2.375rem)",
-                  bottom: "calc(3.625rem + var(--safe-area-bottom, 0px))",
-                }}
-                aria-label="Dismiss page chat"
-                onClick={() => handleToggle(true)}
-                data-testid={`${testId}-chat-backdrop`}
-              />
+              <aside
+                className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-bg"
+                data-testid={`${testId}-chat-sidebar`}
+              >
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                  {chatContent}
+                </div>
+              </aside>
             ) : null}
-            <aside
-              className={
-                isMobileViewport
-                  ? "fixed right-0 z-50 flex w-[min(24rem,92vw)] max-w-[calc(100vw-1rem)] flex-col overflow-hidden bg-bg shadow-2xl"
-                  : "relative flex shrink-0 flex-col overflow-hidden bg-bg"
-              }
-              style={
-                isMobileViewport
-                  ? {
-                      top: "calc(var(--safe-area-top, 0px) + 2.375rem)",
-                      bottom: "calc(3.625rem + var(--safe-area-bottom, 0px))",
-                    }
-                  : { width: `${chatWidth}px`, minWidth: `${chatWidth}px` }
-              }
-              data-testid={`${testId}-chat-sidebar`}
-            >
-              {isMobileViewport ? (
-                <button
-                  type="button"
-                  className="absolute right-2 top-2 z-20 inline-flex h-8 w-8 items-center justify-center rounded-md border border-border/18 bg-bg/90 text-muted shadow-sm backdrop-blur transition-colors hover:bg-bg-muted/80 hover:text-txt"
-                  aria-label="Close page chat"
-                  onClick={() => handleToggle(true)}
-                >
-                  <PanelRightClose className="h-4 w-4" aria-hidden />
-                </button>
-              ) : null}
-              {isMobileViewport ? null : (
+            {!isMobileViewport ? (
+              <aside
+                className="relative flex shrink-0 flex-col overflow-hidden bg-bg"
+                style={{ width: `${chatWidth}px`, minWidth: `${chatWidth}px` }}
+                data-testid={`${testId}-chat-sidebar`}
+              >
                 <hr
                   aria-label="Resize chat"
                   aria-orientation="vertical"
@@ -408,13 +432,11 @@ export function AppWorkspaceChrome({
                   onPointerDown={handleResizePointerDown}
                   className="absolute inset-y-0 left-0 z-20 m-0 h-full w-3 -translate-x-1/2 cursor-col-resize touch-none select-none border-0 bg-transparent transition-colors hover:bg-accent/20"
                 />
-              )}
-              <div
-                className={`flex min-h-0 flex-1 flex-col overflow-hidden ${isMobileViewport ? "pt-9" : ""}`}
-              >
-                {chatContent}
-              </div>
-            </aside>
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                  {chatContent}
+                </div>
+              </aside>
+            ) : null}
             {!isMobileViewport && !hideCollapseButton ? (
               <AppWorkspaceChatDockToggleButton
                 collapsed={false}

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
@@ -365,7 +365,7 @@ export function AppWorkspaceChrome({
                   top: "calc(var(--safe-area-top, 0px) + 2.375rem)",
                   bottom: "calc(3.625rem + var(--safe-area-bottom, 0px))",
                 }}
-                aria-label="Close page chat"
+                aria-label="Dismiss page chat"
                 onClick={() => handleToggle(true)}
                 data-testid={`${testId}-chat-backdrop`}
               />
@@ -386,6 +386,16 @@ export function AppWorkspaceChrome({
               }
               data-testid={`${testId}-chat-sidebar`}
             >
+              {isMobileViewport ? (
+                <button
+                  type="button"
+                  className="absolute right-2 top-2 z-20 inline-flex h-8 w-8 items-center justify-center rounded-md border border-border/18 bg-bg/90 text-muted shadow-sm backdrop-blur transition-colors hover:bg-bg-muted/80 hover:text-txt"
+                  aria-label="Close page chat"
+                  onClick={() => handleToggle(true)}
+                >
+                  <PanelRightClose className="h-4 w-4" aria-hidden />
+                </button>
+              ) : null}
               {isMobileViewport ? null : (
                 <hr
                   aria-label="Resize chat"
@@ -399,7 +409,9 @@ export function AppWorkspaceChrome({
                   className="absolute inset-y-0 left-0 z-20 m-0 h-full w-3 -translate-x-1/2 cursor-col-resize touch-none select-none border-0 bg-transparent transition-colors hover:bg-accent/20"
                 />
               )}
-              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div
+                className={`flex min-h-0 flex-1 flex-col overflow-hidden ${isMobileViewport ? "pt-9" : ""}`}
+              >
                 {chatContent}
               </div>
             </aside>

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
@@ -1,4 +1,14 @@
-import { Maximize2, PanelRightClose, PanelRightOpen } from "lucide-react";
+import {
+  type WorkspaceMobileSidebarControl,
+  type WorkspaceMobileSidebarControls,
+  WorkspaceMobileSidebarControlsContext,
+} from "@elizaos/ui";
+import {
+  LayoutDashboard,
+  PanelLeftOpen,
+  PanelRightClose,
+  PanelRightOpen,
+} from "lucide-react";
 import type React from "react";
 import {
   createContext,
@@ -99,44 +109,84 @@ function AppWorkspaceChatDockToggleButton({
 }
 
 function MobileWorkspacePaneSwitcher({
+  chatAvailable,
   chatOpen,
+  sidebar,
   onChat,
   onMain,
+  onSidebar,
 }: {
+  chatAvailable: boolean;
   chatOpen: boolean;
+  sidebar: WorkspaceMobileSidebarControl | null;
   onChat: () => void;
   onMain: () => void;
+  onSidebar: () => void;
 }): JSX.Element {
+  const sidebarOpen = sidebar?.open ?? false;
+  const mainOpen = !sidebarOpen && (!chatAvailable || !chatOpen);
+  const baseButtonClassName =
+    "inline-flex h-9 w-9 items-center justify-center rounded-md border border-border/40 bg-card/55 text-muted shadow-sm transition-colors hover:text-txt";
+  const activeButtonClassName =
+    "border-accent/70 bg-accent text-accent-fg hover:text-accent-fg";
+
   return (
     <div
-      className="flex shrink-0 justify-center border-b border-border/35 bg-bg/92 px-2 py-1.5"
+      className="grid shrink-0 grid-cols-[1fr_auto_1fr] items-center border-b border-border/35 bg-bg/92 px-2 py-1.5"
       data-testid="app-workspace-mobile-pane-switcher"
     >
-      <div className="inline-flex h-[2.375rem] items-center rounded-md border border-border/40 bg-card/55 p-0.5">
+      <div className="flex min-w-0 justify-start">
+        {sidebar ? (
+          <button
+            type="button"
+            aria-label="Show left sidebar"
+            aria-current={sidebarOpen ? "page" : undefined}
+            title="Show left sidebar"
+            data-testid="app-workspace-mobile-pane-left"
+            onClick={onSidebar}
+            className={`${baseButtonClassName} ${
+              sidebarOpen ? activeButtonClassName : ""
+            }`}
+          >
+            <PanelLeftOpen className="h-4 w-4" aria-hidden />
+          </button>
+        ) : (
+          <span className="h-9 w-9" aria-hidden />
+        )}
+      </div>
+      <div className="flex min-w-0 justify-center">
         <button
           type="button"
-          aria-label="Show main pane"
-          aria-current={!chatOpen ? "page" : undefined}
+          aria-label="Show content"
+          aria-current={mainOpen ? "page" : undefined}
+          title="Show content"
           data-testid="app-workspace-mobile-pane-main"
           onClick={onMain}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
-            !chatOpen ? "bg-accent text-accent-fg" : "text-muted hover:text-txt"
+          className={`${baseButtonClassName} ${
+            mainOpen ? activeButtonClassName : ""
           }`}
         >
-          <Maximize2 className="h-4 w-4" aria-hidden />
+          <LayoutDashboard className="h-4 w-4" aria-hidden />
         </button>
-        <button
-          type="button"
-          aria-label="Show page chat"
-          aria-current={chatOpen ? "page" : undefined}
-          data-testid="app-workspace-mobile-pane-chat"
-          onClick={onChat}
-          className={`inline-flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] transition-colors ${
-            chatOpen ? "bg-accent text-accent-fg" : "text-muted hover:text-txt"
-          }`}
-        >
-          <PanelRightOpen className="h-4 w-4" aria-hidden />
-        </button>
+      </div>
+      <div className="flex min-w-0 justify-end">
+        {chatAvailable ? (
+          <button
+            type="button"
+            aria-label="Show page chat"
+            aria-current={chatOpen ? "page" : undefined}
+            title="Show page chat"
+            data-testid="app-workspace-mobile-pane-chat"
+            onClick={onChat}
+            className={`${baseButtonClassName} ${
+              chatOpen ? activeButtonClassName : ""
+            }`}
+          >
+            <PanelRightOpen className="h-4 w-4" aria-hidden />
+          </button>
+        ) : (
+          <span className="h-9 w-9" aria-hidden />
+        )}
       </div>
     </div>
   );
@@ -233,6 +283,8 @@ export function AppWorkspaceChrome({
   const isControlled = chatCollapsedProp !== undefined;
   const isMobileViewport = useMediaQuery(WORKSPACE_MOBILE_MEDIA_QUERY);
   const [mobileChatOpen, setMobileChatOpen] = useState(false);
+  const [mobileSidebarControl, setMobileSidebarControl] =
+    useState<WorkspaceMobileSidebarControl | null>(null);
 
   const [internalCollapsed, setInternalCollapsed] = useState<boolean>(() =>
     isControlled
@@ -252,12 +304,17 @@ export function AppWorkspaceChrome({
   const collapsed = isControlled
     ? (chatCollapsedProp ?? false)
     : internalCollapsed;
-  const effectiveCollapsed = isMobileViewport ? !mobileChatOpen : collapsed;
+  const effectiveCollapsed = chatDisabled
+    ? true
+    : isMobileViewport
+      ? !mobileChatOpen
+      : collapsed;
 
   const handleToggle = useCallback(
     (next: boolean) => {
       if (isMobileViewport) {
-        setMobileChatOpen(!next);
+        mobileSidebarControl?.setOpen(false);
+        setMobileChatOpen(chatDisabled ? false : !next);
         return;
       }
       if (isControlled) {
@@ -274,8 +331,43 @@ export function AppWorkspaceChrome({
         }
       }
     },
-    [isControlled, isMobileViewport, onToggleChat],
+    [
+      chatDisabled,
+      isControlled,
+      isMobileViewport,
+      mobileSidebarControl,
+      onToggleChat,
+    ],
   );
+
+  const registerMobileSidebar = useCallback<
+    WorkspaceMobileSidebarControls["register"]
+  >((control) => {
+    setMobileSidebarControl(control);
+    return () => {
+      setMobileSidebarControl((current) =>
+        current?.id === control.id ? null : current,
+      );
+    };
+  }, []);
+
+  const mobileSidebarControlsValue = useMemo<WorkspaceMobileSidebarControls>(
+    () => ({
+      register: registerMobileSidebar,
+    }),
+    [registerMobileSidebar],
+  );
+
+  const handleOpenMobileSidebar = useCallback(() => {
+    if (!mobileSidebarControl) return;
+    setMobileChatOpen(false);
+    mobileSidebarControl.setOpen(true);
+  }, [mobileSidebarControl]);
+
+  const handleOpenMobileMain = useCallback(() => {
+    mobileSidebarControl?.setOpen(false);
+    handleToggle(true);
+  }, [handleToggle, mobileSidebarControl]);
 
   useEffect(() => {
     if (!isMobileViewport) {
@@ -364,88 +456,99 @@ export function AppWorkspaceChrome({
     ));
 
   return (
-    <AppWorkspaceChatChromeContext.Provider value={chatChromeContextValue}>
-      <div
-        className={`flex min-h-0 min-w-0 w-full flex-1 bg-bg pb-[var(--eliza-mobile-nav-offset,0px)] ${
-          isMobileViewport ? "flex-col" : ""
-        }`}
-        data-testid={testId}
-      >
-        {isMobileViewport && !chatDisabled ? (
-          <MobileWorkspacePaneSwitcher
-            chatOpen={!effectiveCollapsed}
-            onChat={() => handleToggle(false)}
-            onMain={() => handleToggle(true)}
-          />
-        ) : null}
-
+    <WorkspaceMobileSidebarControlsContext.Provider
+      value={mobileSidebarControlsValue}
+    >
+      <AppWorkspaceChatChromeContext.Provider value={chatChromeContextValue}>
         <div
-          className={`relative min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${
-            isMobileViewport && !effectiveCollapsed ? "hidden" : "flex"
+          className={`flex min-h-0 min-w-0 w-full flex-1 bg-bg pb-[var(--eliza-mobile-nav-offset,0px)] ${
+            isMobileViewport ? "flex-col" : ""
           }`}
+          data-testid={testId}
         >
-          {nav}
-          <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-            {main}
-          </div>
-        </div>
+          {isMobileViewport &&
+          (!chatDisabled || mobileSidebarControl !== null) ? (
+            <MobileWorkspacePaneSwitcher
+              chatAvailable={!chatDisabled}
+              chatOpen={!effectiveCollapsed}
+              sidebar={mobileSidebarControl}
+              onChat={() => handleToggle(false)}
+              onMain={handleOpenMobileMain}
+              onSidebar={handleOpenMobileSidebar}
+            />
+          ) : null}
 
-        {chatDisabled ? null : effectiveCollapsed ? (
-          <aside
-            className="w-0 min-w-0 shrink-0"
-            data-testid={`${testId}-chat-sidebar`}
-            data-collapsed
+          <div
+            className={`relative min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${
+              isMobileViewport && !effectiveCollapsed ? "hidden" : "flex"
+            }`}
           >
-            {isMobileViewport ? null : (
-              <AppWorkspaceChatDockToggleButton
-                collapsed
-                testId={`${testId}-chat-expand`}
-              />
-            )}
-          </aside>
-        ) : (
-          <>
-            {isMobileViewport ? (
-              <aside
-                className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-bg"
-                data-testid={`${testId}-chat-sidebar`}
-              >
-                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                  {chatContent}
-                </div>
-              </aside>
-            ) : null}
-            {!isMobileViewport ? (
-              <aside
-                className="relative flex shrink-0 flex-col overflow-hidden bg-bg"
-                style={{ width: `${chatWidth}px`, minWidth: `${chatWidth}px` }}
-                data-testid={`${testId}-chat-sidebar`}
-              >
-                <hr
-                  aria-label="Resize chat"
-                  aria-orientation="vertical"
-                  aria-valuemin={0}
-                  aria-valuemax={100}
-                  aria-valuenow={50}
-                  tabIndex={0}
-                  data-testid={`${testId}-chat-resize-handle`}
-                  onPointerDown={handleResizePointerDown}
-                  className="absolute inset-y-0 left-0 z-20 m-0 h-full w-3 -translate-x-1/2 cursor-col-resize touch-none select-none border-0 bg-transparent transition-colors hover:bg-accent/20"
+            {nav}
+            <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+              {main}
+            </div>
+          </div>
+
+          {chatDisabled ? null : effectiveCollapsed ? (
+            <aside
+              className="w-0 min-w-0 shrink-0"
+              data-testid={`${testId}-chat-sidebar`}
+              data-collapsed
+            >
+              {isMobileViewport ? null : (
+                <AppWorkspaceChatDockToggleButton
+                  collapsed
+                  testId={`${testId}-chat-expand`}
                 />
-                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                  {chatContent}
-                </div>
-              </aside>
-            ) : null}
-            {!isMobileViewport && !hideCollapseButton ? (
-              <AppWorkspaceChatDockToggleButton
-                collapsed={false}
-                testId={`${testId}-chat-collapse`}
-              />
-            ) : null}
-          </>
-        )}
-      </div>
-    </AppWorkspaceChatChromeContext.Provider>
+              )}
+            </aside>
+          ) : (
+            <>
+              {isMobileViewport ? (
+                <aside
+                  className="flex min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden bg-bg"
+                  data-testid={`${testId}-chat-sidebar`}
+                >
+                  <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                    {chatContent}
+                  </div>
+                </aside>
+              ) : null}
+              {!isMobileViewport ? (
+                <aside
+                  className="relative flex shrink-0 flex-col overflow-hidden bg-bg"
+                  style={{
+                    width: `${chatWidth}px`,
+                    minWidth: `${chatWidth}px`,
+                  }}
+                  data-testid={`${testId}-chat-sidebar`}
+                >
+                  <hr
+                    aria-label="Resize chat"
+                    aria-orientation="vertical"
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={50}
+                    tabIndex={0}
+                    data-testid={`${testId}-chat-resize-handle`}
+                    onPointerDown={handleResizePointerDown}
+                    className="absolute inset-y-0 left-0 z-20 m-0 h-full w-3 -translate-x-1/2 cursor-col-resize touch-none select-none border-0 bg-transparent transition-colors hover:bg-accent/20"
+                  />
+                  <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                    {chatContent}
+                  </div>
+                </aside>
+              ) : null}
+              {!isMobileViewport && !hideCollapseButton ? (
+                <AppWorkspaceChatDockToggleButton
+                  collapsed={false}
+                  testId={`${testId}-chat-collapse`}
+                />
+              ) : null}
+            </>
+          )}
+        </div>
+      </AppWorkspaceChatChromeContext.Provider>
+    </WorkspaceMobileSidebarControlsContext.Provider>
   );
 }

--- a/packages/app-core/src/i18n/locales/en.json
+++ b/packages/app-core/src/i18n/locales/en.json
@@ -1117,7 +1117,7 @@
   "gameview.LaunchGpuDiagnostics": "Launch GPU Diagnostics",
   "gameview.LogLoadFailed": "Failed to load logs: {{message}}",
   "gameview.MobileSurfaceChat": "Chat",
-  "gameview.MobileSurfaceDashboard": "Dashboard",
+  "gameview.MobileSurfaceDashboard": "Actions",
   "gameview.MobileSurfaceGame": "Game",
   "gameview.NativeGameActionFailed": "Native game action failed.",
   "gameview.NativeGameStateRefreshed": "Native game state refreshed.",

--- a/packages/app-core/test/live-agent/experience-capture.real.e2e.test.ts
+++ b/packages/app-core/test/live-agent/experience-capture.real.e2e.test.ts
@@ -9,6 +9,11 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { experienceEvaluator } from "../../../typescript/src/features/advanced-capabilities/experience/evaluators/experienceEvaluator.ts";
 import { ExperienceService } from "../../../typescript/src/features/advanced-capabilities/experience/service.ts";
+import {
+  type Experience,
+  ExperienceType,
+  OutcomeType,
+} from "../../../typescript/src/features/advanced-capabilities/experience/types.ts";
 
 type Extraction = {
   type: string;
@@ -37,6 +42,32 @@ type RuntimeHarness = {
   getService: (serviceType: string) => ExperienceService | null;
   getSetting: (key: string) => string | undefined;
   queueExtraction: (extractions: Extraction[]) => void;
+};
+
+type ExpectedRecordedExperience = Partial<
+  Pick<
+    Experience,
+    | "action"
+    | "confidence"
+    | "context"
+    | "domain"
+    | "importance"
+    | "learning"
+    | "outcome"
+    | "result"
+    | "tags"
+    | "type"
+  >
+>;
+
+type ExtractionScenario = {
+  name: string;
+  recentTexts: string[];
+  extraction: Extraction[];
+  expectedRecordedDelta: number;
+  expectedExperiences?: ExpectedRecordedExperience[];
+  triggerEntityId?: UUID;
+  messageCountBeforeTrigger?: string;
 };
 
 function nextUuid(label: string): UUID {
@@ -189,15 +220,10 @@ async function seedConversation(
 async function runExtractionCase(
   runtime: RuntimeHarness,
   service: ExperienceService,
-  options: {
-    recentTexts: string[];
-    extraction: Extraction[];
-    expectedRecordedDelta: number;
-    triggerEntityId?: UUID;
-    messageCountBeforeTrigger?: string;
-  },
-): Promise<void> {
+  options: Omit<ExtractionScenario, "name">,
+): Promise<Experience[]> {
   const before = await service.listExperiences({ limit: 100 });
+  const beforeIds = new Set(before.map((experience) => experience.id));
   const roomId = nextUuid("experience-room");
   const triggerEntityId = options.triggerEntityId ?? runtime.agentId;
   const recentMessages = await seedConversation(
@@ -226,7 +252,7 @@ async function runExtractionCase(
   if (!shouldRun) {
     const after = await service.listExperiences({ limit: 100 });
     expect(after).toHaveLength(before.length);
-    return;
+    return [];
   }
 
   if (options.recentTexts.length >= 3) {
@@ -237,6 +263,59 @@ async function runExtractionCase(
 
   const after = await service.listExperiences({ limit: 100 });
   expect(after).toHaveLength(before.length + options.expectedRecordedDelta);
+  const recorded = after.filter((experience) => !beforeIds.has(experience.id));
+  expect(recorded).toHaveLength(options.expectedRecordedDelta);
+
+  if (options.expectedExperiences) {
+    expect(recorded).toHaveLength(options.expectedExperiences.length);
+    for (const [index, expected] of options.expectedExperiences.entries()) {
+      const actual = recorded[index];
+      expect(
+        actual,
+        `expected recorded experience at index ${index}`,
+      ).toBeTruthy();
+      if (!actual) continue;
+      expectExperienceToMatch(actual, expected);
+    }
+  }
+
+  return recorded;
+}
+
+function expectExperienceToMatch(
+  actual: Experience,
+  expected: ExpectedRecordedExperience,
+): void {
+  if (expected.action !== undefined) {
+    expect(actual.action).toBe(expected.action);
+  }
+  if (expected.confidence !== undefined) {
+    expect(actual.confidence).toBe(expected.confidence);
+  }
+  if (expected.context !== undefined) {
+    expect(actual.context).toBe(expected.context);
+  }
+  if (expected.domain !== undefined) {
+    expect(actual.domain).toBe(expected.domain);
+  }
+  if (expected.importance !== undefined) {
+    expect(actual.importance).toBe(expected.importance);
+  }
+  if (expected.learning !== undefined) {
+    expect(actual.learning).toBe(expected.learning);
+  }
+  if (expected.outcome !== undefined) {
+    expect(actual.outcome).toBe(expected.outcome);
+  }
+  if (expected.result !== undefined) {
+    expect(actual.result).toBe(expected.result);
+  }
+  if (expected.tags !== undefined) {
+    expect(actual.tags).toEqual(expected.tags);
+  }
+  if (expected.type !== undefined) {
+    expect(actual.type).toBe(expected.type);
+  }
 }
 
 describe("Experience Capture E2E", () => {
@@ -254,134 +333,232 @@ describe("Experience Capture E2E", () => {
     await experienceService.stop();
   });
 
-  it("records expected experiences, skips non-experiences, and retrieves the right result 3/3 times", async () => {
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "Let me run the Python script.",
-        "It failed with ModuleNotFoundError for pandas.",
-        "Installing dependencies fixed it and the script completed.",
-      ],
-      extraction: [
-        {
-          type: "CORRECTION",
-          learning:
-            "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
-          context: "Debugging a local Python script failure.",
-          confidence: 0.92,
-        },
-      ],
-      expectedRecordedDelta: 1,
-    });
+  it("runs extraction scenarios, verifies recorded fields, skips non-experiences, and retrieves the right result 3/3 times", async () => {
+    const formedScenarios: ExtractionScenario[] = [
+      {
+        name: "dependency correction",
+        recentTexts: [
+          "Let me run the Python script.",
+          "It failed with ModuleNotFoundError for pandas.",
+          "Installing dependencies fixed it and the script completed.",
+        ],
+        extraction: [
+          {
+            type: "CORRECTION",
+            learning:
+              "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
+            context: "Debugging a local Python script failure.",
+            confidence: 0.92,
+          },
+        ],
+        expectedRecordedDelta: 1,
+        expectedExperiences: [
+          {
+            action: "pattern_recognition",
+            confidence: 0.9,
+            context: "Debugging a local Python script failure.",
+            domain: "shell",
+            importance: 0.8,
+            learning:
+              "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
+            outcome: OutcomeType.POSITIVE,
+            result:
+              "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
+            tags: ["extracted", "novel", ExperienceType.CORRECTION],
+            type: ExperienceType.CORRECTION,
+          },
+        ],
+      },
+      {
+        name: "terminal discovery",
+        recentTexts: [
+          "I need to inspect API output quickly from the terminal.",
+          "jq is installed here and can parse JSON cleanly.",
+          "Using jq made the payload inspection much faster.",
+        ],
+        extraction: [
+          {
+            type: "DISCOVERY",
+            learning:
+              "Use jq to parse JSON responses directly in the terminal when inspecting API output.",
+            context: "Inspecting API payloads from the CLI.",
+            confidence: 0.9,
+          },
+        ],
+        expectedRecordedDelta: 1,
+        expectedExperiences: [
+          {
+            action: "pattern_recognition",
+            confidence: 0.9,
+            context: "Inspecting API payloads from the CLI.",
+            domain: "shell",
+            importance: 0.8,
+            learning:
+              "Use jq to parse JSON responses directly in the terminal when inspecting API output.",
+            outcome: OutcomeType.NEUTRAL,
+            result:
+              "Use jq to parse JSON responses directly in the terminal when inspecting API output.",
+            tags: ["extracted", "novel", ExperienceType.DISCOVERY],
+            type: ExperienceType.DISCOVERY,
+          },
+        ],
+      },
+      {
+        name: "environment restart learning",
+        recentTexts: [
+          "I changed an environment variable for the dev server.",
+          "The app still showed stale values until I restarted it.",
+          "Restarting the dev server picked up the new environment variable.",
+        ],
+        extraction: [
+          {
+            type: "LEARNING",
+            learning:
+              "Restart the dev server after changing environment variables so the new values are loaded.",
+            context: "Local development after environment changes.",
+            confidence: 0.88,
+          },
+        ],
+        expectedRecordedDelta: 1,
+        expectedExperiences: [
+          {
+            action: "pattern_recognition",
+            confidence: 0.88,
+            context: "Local development after environment changes.",
+            domain: "coding",
+            importance: 0.8,
+            learning:
+              "Restart the dev server after changing environment variables so the new values are loaded.",
+            outcome: OutcomeType.NEUTRAL,
+            result:
+              "Restart the dev server after changing environment variables so the new values are loaded.",
+            tags: ["extracted", "novel", ExperienceType.LEARNING],
+            type: ExperienceType.LEARNING,
+          },
+        ],
+      },
+      {
+        name: "sensitive-context sanitization",
+        recentTexts: [
+          "I almost included /Users/shawwalters/secrets.env in notes.",
+          "The debug output included 10.20.30.40 and shaw@example.com.",
+          "I redacted them before using the note.",
+        ],
+        extraction: [
+          {
+            type: "LEARNING",
+            learning:
+              "Redact /Users/shawwalters/secrets.env and shaw@example.com before saving debug notes.",
+            context:
+              "Debugging from /Users/shawwalters/project with shaw@example.com and 10.20.30.40.",
+            confidence: 0.93,
+          },
+        ],
+        expectedRecordedDelta: 1,
+        expectedExperiences: [
+          {
+            action: "pattern_recognition",
+            confidence: 0.9,
+            context:
+              "Debugging from /Users/[USER]/project with [EMAIL] and [IP].",
+            domain: "coding",
+            importance: 0.8,
+            learning:
+              "Redact /Users/[USER]/secrets.env and [EMAIL] before saving debug notes.",
+            outcome: OutcomeType.NEUTRAL,
+            result:
+              "Redact /Users/shawwalters/secrets.env and shaw@example.com before saving debug notes.",
+            tags: ["extracted", "novel", ExperienceType.LEARNING],
+            type: ExperienceType.LEARNING,
+          },
+        ],
+      },
+    ];
 
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "I need to inspect API output quickly from the terminal.",
-        "jq is installed here and can parse JSON cleanly.",
-        "Using jq made the payload inspection much faster.",
-      ],
-      extraction: [
-        {
-          type: "DISCOVERY",
-          learning:
-            "Use jq to parse JSON responses directly in the terminal when inspecting API output.",
-          context: "Inspecting API payloads from the CLI.",
-          confidence: 0.9,
-        },
-      ],
-      expectedRecordedDelta: 1,
-    });
+    const skippedScenarios: ExtractionScenario[] = [
+      {
+        name: "low confidence hunch",
+        recentTexts: [
+          "A user asked me to remember a weak hunch.",
+          "I think it might matter later, but I am not sure.",
+          "This is too uncertain to record confidently.",
+        ],
+        extraction: [
+          {
+            type: "LEARNING",
+            learning: "Maybe this uncertain hunch matters later.",
+            context: "A low-confidence conversation snippet.",
+            confidence: 0.2,
+          },
+        ],
+        expectedRecordedDelta: 0,
+      },
+      {
+        name: "user-authored trigger",
+        recentTexts: [
+          "The user sent a message about pandas dependencies.",
+          "This was a user-authored note, not an agent-authored message.",
+          "The evaluator should not run on user messages.",
+        ],
+        triggerEntityId: nextUuid("experience-user"),
+        extraction: [
+          {
+            type: "LEARNING",
+            learning:
+              "This should never be recorded because the trigger is not from the agent.",
+            context: "User-authored message should not trigger extraction.",
+            confidence: 0.99,
+          },
+        ],
+        expectedRecordedDelta: 0,
+      },
+      {
+        name: "duplicate dependency correction",
+        recentTexts: [
+          "I saw the pandas ModuleNotFoundError again.",
+          "Installing the dependency fixed the same Python script.",
+          "This is the same lesson as before.",
+        ],
+        extraction: [
+          {
+            type: "CORRECTION",
+            learning:
+              "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
+            context: "Revisiting the same dependency fix.",
+            confidence: 0.95,
+          },
+        ],
+        expectedRecordedDelta: 0,
+      },
+      {
+        name: "conversation too short",
+        recentTexts: [
+          "Only one message exists here.",
+          "Two messages are not enough for extraction.",
+        ],
+        extraction: [
+          {
+            type: "LEARNING",
+            learning:
+              "This should not record because there are fewer than three messages.",
+            context: "Conversation too short.",
+            confidence: 0.99,
+          },
+        ],
+        expectedRecordedDelta: 0,
+      },
+    ];
 
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "I changed an environment variable for the dev server.",
-        "The app still showed stale values until I restarted it.",
-        "Restarting the dev server picked up the new environment variable.",
-      ],
-      extraction: [
-        {
-          type: "LEARNING",
-          learning:
-            "Restart the dev server after changing environment variables so the new values are loaded.",
-          context: "Local development after environment changes.",
-          confidence: 0.88,
-        },
-      ],
-      expectedRecordedDelta: 1,
-    });
+    for (const scenario of formedScenarios) {
+      await runExtractionCase(runtime, experienceService, scenario);
+    }
 
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "A user asked me to remember a weak hunch.",
-        "I think it might matter later, but I am not sure.",
-        "This is too uncertain to record confidently.",
-      ],
-      extraction: [
-        {
-          type: "LEARNING",
-          learning: "Maybe this uncertain hunch matters later.",
-          context: "A low-confidence conversation snippet.",
-          confidence: 0.2,
-        },
-      ],
-      expectedRecordedDelta: 0,
-    });
-
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "The user sent a message about pandas dependencies.",
-        "This was a user-authored note, not an agent-authored message.",
-        "The evaluator should not run on user messages.",
-      ],
-      triggerEntityId: nextUuid("experience-user"),
-      extraction: [
-        {
-          type: "LEARNING",
-          learning:
-            "This should never be recorded because the trigger is not from the agent.",
-          context: "User-authored message should not trigger extraction.",
-          confidence: 0.99,
-        },
-      ],
-      expectedRecordedDelta: 0,
-    });
-
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "I saw the pandas ModuleNotFoundError again.",
-        "Installing the dependency fixed the same Python script.",
-        "This is the same lesson as before.",
-      ],
-      extraction: [
-        {
-          type: "CORRECTION",
-          learning:
-            "Install dependencies before rerunning Python scripts after ModuleNotFoundError for pandas.",
-          context: "Revisiting the same dependency fix.",
-          confidence: 0.95,
-        },
-      ],
-      expectedRecordedDelta: 0,
-    });
-
-    await runExtractionCase(runtime, experienceService, {
-      recentTexts: [
-        "Only one message exists here.",
-        "Two messages are not enough for extraction.",
-      ],
-      extraction: [
-        {
-          type: "LEARNING",
-          learning:
-            "This should not record because there are fewer than three messages.",
-          context: "Conversation too short.",
-          confidence: 0.99,
-        },
-      ],
-      expectedRecordedDelta: 0,
-    });
+    for (const scenario of skippedScenarios) {
+      await runExtractionCase(runtime, experienceService, scenario);
+    }
 
     const allExperiences = await experienceService.listExperiences({ limit: 20 });
-    expect(allExperiences).toHaveLength(3);
+    expect(allExperiences).toHaveLength(formedScenarios.length);
 
     const retrievalCases = [
       {

--- a/packages/benchmarks/experience/README.md
+++ b/packages/benchmarks/experience/README.md
@@ -1,6 +1,6 @@
-# Experience Plugin Benchmark
+# Experience Benchmark
 
-Benchmark suite for evaluating the ElizaOS experience plugin's retrieval quality, reranking correctness, and learning cycle effectiveness.
+Benchmark suite for evaluating the built-in advanced capabilities experience service retrieval quality, reranking correctness, and learning cycle effectiveness.
 
 ## What it tests
 
@@ -56,10 +56,6 @@ The `ExperienceGenerator` creates realistic experiences using domain-specific te
 - **Ground truth clusters**: each experience is tagged with a cluster for precision/recall evaluation
 - **Reproducible**: seeded random generation for deterministic results
 
-## Cross-language coverage
+## Runtime coverage
 
-The experience plugin is implemented in three languages. This benchmark tests the Python implementation directly, but the same reranking algorithm (similarity 70% + quality 30%) is implemented identically in:
-
-- **TypeScript** (`plugins/plugin-experience/typescript/service.ts`) — uses vector embeddings + cosine similarity
-- **Python** (`plugins/plugin-experience/python/elizaos_plugin_experience/service.py`) — uses token overlap + Jaccard similarity
-- **Rust** (`plugins/plugin-experience/rust/src/service.rs`) — uses token overlap + Jaccard similarity
+The runtime experience service is built into advanced capabilities in TypeScript (`packages/typescript/src/features/advanced-capabilities/experience/service.ts`) and uses embeddings with reranking. This benchmark uses a local Python in-memory model (`elizaos_experience_bench/service.py`) so retrieval, reranking, and learning-cycle checks remain runnable without a separate experience plugin checkout.

--- a/packages/benchmarks/experience/elizaos_experience_bench/baselines.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/baselines.py
@@ -14,8 +14,7 @@ import random
 import re
 import time
 
-from elizaos_plugin_experience.service import ExperienceService
-from elizaos_plugin_experience.types import Experience
+from elizaos_experience_bench.service import Experience, ExperienceService
 
 
 class PerfectExperienceService(ExperienceService):

--- a/packages/benchmarks/experience/elizaos_experience_bench/eliza_plugin.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/eliza_plugin.py
@@ -56,16 +56,7 @@ if TYPE_CHECKING:
     from elizaos.types.components import HandlerCallback
     from elizaos.types.runtime import IAgentRuntime
 
-import sys
-from pathlib import Path
-
-sys.path.insert(
-    0,
-    str(Path(__file__).resolve().parents[3] / "plugins" / "plugin-experience" / "python"),
-)
-
-from elizaos_plugin_experience.service import ExperienceService
-from elizaos_plugin_experience.types import ExperienceQuery
+from elizaos_experience_bench.service import ExperienceQuery, ExperienceService
 
 
 # ============================================================================

--- a/packages/benchmarks/experience/elizaos_experience_bench/eliza_runner.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/eliza_runner.py
@@ -41,16 +41,7 @@ if TYPE_CHECKING:
     from elizaos.types.plugin import Plugin
     from elizaos.types.runtime import IAgentRuntime
 
-import sys
-from pathlib import Path
-
-sys.path.insert(
-    0,
-    str(Path(__file__).resolve().parents[3] / "plugins" / "plugin-experience" / "python"),
-)
-
-from elizaos_plugin_experience.service import ExperienceService
-from elizaos_plugin_experience.types import ExperienceQuery
+from elizaos_experience_bench.service import ExperienceQuery, ExperienceService
 
 
 # ============================================================================

--- a/packages/benchmarks/experience/elizaos_experience_bench/evaluators/hard_cases.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/evaluators/hard_cases.py
@@ -7,14 +7,9 @@ Reports per-category pass rates split by tier (jaccard vs semantic).
 
 from __future__ import annotations
 
-import sys
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[4] / "plugins" / "plugin-experience" / "python"))
-
-from elizaos_plugin_experience.service import ExperienceService
 
 from elizaos_experience_bench.hard_cases import (
     ALL_HARD_CASES,
@@ -23,6 +18,7 @@ from elizaos_experience_bench.hard_cases import (
     HardCase,
     get_all_cases,
 )
+from elizaos_experience_bench.service import ExperienceService
 
 ServiceFactory = Callable[[], ExperienceService]
 

--- a/packages/benchmarks/experience/elizaos_experience_bench/evaluators/learning.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/evaluators/learning.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-import sys
 import time
 from collections.abc import Callable
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[4] / "plugins" / "plugin-experience" / "python"))
-
-from elizaos_plugin_experience.service import ExperienceService
-from elizaos_plugin_experience.types import ExperienceQuery
-
 from elizaos_experience_bench.generator import GeneratedExperience, LearningScenario
+from elizaos_experience_bench.service import ExperienceQuery, ExperienceService
 from elizaos_experience_bench.types import LearningCycleMetrics
 
 ServiceFactory = Callable[[], ExperienceService]

--- a/packages/benchmarks/experience/elizaos_experience_bench/evaluators/reranking.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/evaluators/reranking.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[4] / "plugins" / "plugin-experience" / "python"))
-
-from elizaos_plugin_experience.service import ExperienceService
+from elizaos_experience_bench.service import ExperienceService
 
 ServiceFactory = Callable[[], ExperienceService]
 

--- a/packages/benchmarks/experience/elizaos_experience_bench/evaluators/retrieval.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/evaluators/retrieval.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-import sys
 import time
 from collections.abc import Callable
 
-sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parents[4] / "plugins" / "plugin-experience" / "python"))
-
-from elizaos_plugin_experience.service import ExperienceService
-from elizaos_plugin_experience.types import ExperienceQuery
-
 from elizaos_experience_bench.generator import GeneratedExperience, RetrievalQuery
+from elizaos_experience_bench.service import ExperienceQuery, ExperienceService
 from elizaos_experience_bench.types import RetrievalMetrics
 
 ServiceFactory = Callable[[], ExperienceService]

--- a/packages/benchmarks/experience/elizaos_experience_bench/service.py
+++ b/packages/benchmarks/experience/elizaos_experience_bench/service.py
@@ -1,0 +1,297 @@
+"""Local benchmark model of the built-in experience service.
+
+The runtime implementation lives in TypeScript under advanced capabilities.
+This Python model keeps the benchmark runnable without depending on the
+removed external plugin package layout.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+ExperienceType: TypeAlias = str
+OutcomeType: TypeAlias = str
+
+_TOKEN_RE = re.compile(r"[a-z0-9_]+")
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "before",
+    "by",
+    "for",
+    "from",
+    "how",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "what",
+    "when",
+    "with",
+}
+_SYNONYM_GROUPS = {
+    "debug": {"debugging", "troubleshooting", "diagnosing", "investigating"},
+    "fix": {"fix", "resolve", "repair", "patch", "solve", "handle"},
+    "install": {"install", "installed", "set", "setup", "configure", "add"},
+    "optimize": {"optimize", "improve", "speed", "enhance"},
+    "deploy": {"deploy", "deploying", "deployment", "release", "ship", "launch"},
+    "check": {"check", "verify", "inspect", "examine", "validate"},
+    "error": {"error", "bug", "issue", "problem", "fault"},
+    "test": {"test", "tests", "testing", "suite", "verify", "validate", "check"},
+    "reduce": {"reduce", "reduced", "minimize", "decrease", "lower"},
+    "cache": {"cache", "caching", "store", "buffer", "memoize"},
+    "query": {"query", "queries", "search", "lookup", "fetch"},
+    "monitor": {"monitor", "monitoring", "track", "observe", "watch"},
+    "failure": {"failure", "failures", "crash", "breakdown", "outage"},
+    "performance": {"performance", "speed", "efficiency", "throughput"},
+    "dependency": {"dependency", "dependencies", "requirement", "prerequisite", "library"},
+    "connection": {"connection", "connections", "link", "session", "socket"},
+    "memory": {"memory", "ram", "heap", "allocation"},
+}
+_CANONICAL_TOKEN = {
+    token: canonical
+    for canonical, tokens in _SYNONYM_GROUPS.items()
+    for token in tokens | {canonical}
+}
+
+
+@dataclass
+class Experience:
+    id: str
+    agent_id: str
+    context: str
+    action: str
+    result: str
+    learning: str
+    domain: str = "general"
+    tags: list[str] = field(default_factory=list)
+    type: ExperienceType = "learning"
+    outcome: OutcomeType = "neutral"
+    confidence: float = 0.5
+    importance: float = 0.5
+    created_at: int = 0
+    updated_at: int = 0
+    last_accessed_at: int | None = None
+    access_count: int = 0
+    related_experiences: list[str] = field(default_factory=list)
+    supersedes: str | None = None
+    previous_belief: str | None = None
+    corrected_belief: str | None = None
+
+
+@dataclass
+class ExperienceQuery:
+    query: str | None = None
+    type: ExperienceType | list[ExperienceType] | None = None
+    outcome: OutcomeType | list[OutcomeType] | None = None
+    domain: str | list[str] | None = None
+    tags: list[str] | None = None
+    min_importance: float | None = None
+    min_confidence: float | None = None
+    time_range: dict[str, int] | None = None
+    limit: int = 10
+    include_related: bool = False
+
+
+class ExperienceService:
+    """In-memory benchmark service matching the public experience operations."""
+
+    def __init__(self) -> None:
+        self._experiences: dict[str, Experience] = {}
+
+    @property
+    def experience_count(self) -> int:
+        return len(self._experiences)
+
+    def record_experience(
+        self,
+        *,
+        agent_id: str,
+        context: str = "",
+        action: str = "",
+        result: str = "",
+        learning: str = "",
+        domain: str = "general",
+        tags: list[str] | None = None,
+        confidence: float = 0.5,
+        importance: float = 0.5,
+        created_at: int | None = None,
+        type: ExperienceType = "learning",
+        outcome: OutcomeType = "neutral",
+        related_experiences: list[str] | None = None,
+        supersedes: str | None = None,
+        previous_belief: str | None = None,
+        corrected_belief: str | None = None,
+    ) -> Experience:
+        now_ms = int(time.time() * 1000)
+        created = created_at if created_at is not None else now_ms
+        experience = Experience(
+            id=str(uuid.uuid4()),
+            agent_id=agent_id,
+            type=type,
+            outcome=outcome,
+            context=context,
+            action=action,
+            result=result,
+            learning=learning,
+            domain=domain,
+            tags=list(tags or []),
+            confidence=_clamp(confidence),
+            importance=_clamp(importance),
+            created_at=created,
+            updated_at=now_ms,
+            last_accessed_at=now_ms,
+            related_experiences=list(related_experiences or []),
+            supersedes=supersedes,
+            previous_belief=previous_belief,
+            corrected_belief=corrected_belief,
+        )
+        self._experiences[experience.id] = experience
+        return experience
+
+    def query_experiences(self, query: ExperienceQuery) -> list[Experience]:
+        limit = max(1, query.limit)
+        if query.query:
+            candidates = self._apply_filters(list(self._experiences.values()), query)
+            results = self.find_similar_experiences(query.query, limit=limit, candidates=candidates)
+        else:
+            results = self._apply_filters(list(self._experiences.values()), query)
+            results.sort(
+                key=lambda exp: (_decayed_confidence(exp) * exp.importance, exp.created_at),
+                reverse=True,
+            )
+            results = results[:limit]
+
+        if query.include_related:
+            seen = {exp.id for exp in results}
+            for exp in list(results):
+                for related_id in exp.related_experiences:
+                    related = self._experiences.get(related_id)
+                    if related and related.id not in seen:
+                        results.append(related)
+                        seen.add(related.id)
+
+        _touch(results)
+        return results
+
+    def find_similar_experiences(
+        self,
+        text: str,
+        *,
+        limit: int = 5,
+        candidates: list[Experience] | None = None,
+    ) -> list[Experience]:
+        query_tokens = _tokenize(text)
+        if not query_tokens:
+            return []
+
+        pool = candidates if candidates is not None else list(self._experiences.values())
+        scored: list[tuple[Experience, float]] = []
+        now_ms = int(time.time() * 1000)
+
+        for exp in pool:
+            exp_tokens = _tokenize(
+                " ".join([exp.context, exp.action, exp.result, exp.learning, exp.domain, *exp.tags])
+            )
+            if not exp_tokens:
+                continue
+
+            intersection = query_tokens & exp_tokens
+            if not intersection:
+                continue
+
+            coverage = len(intersection) / len(query_tokens)
+            jaccard = len(intersection) / len(query_tokens | exp_tokens)
+            recency = 1 / (1 + max(0, (now_ms - exp.created_at) / 86_400_000) / 30)
+            access = min(1.0, math.log2(exp.access_count + 1) / math.log2(10))
+            quality = (
+                _decayed_confidence(exp) * 0.45
+                + exp.importance * 0.35
+                + recency * 0.12
+                + access * 0.08
+            )
+            score = coverage * 0.62 + jaccard * 0.14 + quality * 0.24
+            scored.append((exp, score))
+
+        scored.sort(key=lambda item: item[1], reverse=True)
+        results = [exp for exp, _score in scored[: max(1, limit)]]
+        _touch(results)
+        return results
+
+    def _apply_filters(
+        self,
+        candidates: list[Experience],
+        query: ExperienceQuery,
+    ) -> list[Experience]:
+        results = candidates
+
+        if query.type:
+            values = set(query.type if isinstance(query.type, list) else [query.type])
+            results = [exp for exp in results if exp.type in values]
+        if query.outcome:
+            values = set(query.outcome if isinstance(query.outcome, list) else [query.outcome])
+            results = [exp for exp in results if exp.outcome in values]
+        if query.domain:
+            values = set(query.domain if isinstance(query.domain, list) else [query.domain])
+            results = [exp for exp in results if exp.domain in values]
+        if query.tags:
+            tags = set(query.tags)
+            results = [exp for exp in results if tags & set(exp.tags)]
+        if query.min_importance is not None:
+            results = [exp for exp in results if exp.importance >= query.min_importance]
+        if query.min_confidence is not None:
+            results = [exp for exp in results if _decayed_confidence(exp) >= query.min_confidence]
+        if query.time_range:
+            start = query.time_range.get("start")
+            end = query.time_range.get("end")
+            if start is not None:
+                results = [exp for exp in results if exp.created_at >= start]
+            if end is not None:
+                results = [exp for exp in results if exp.created_at <= end]
+
+        return results
+
+
+def _tokenize(text: str) -> set[str]:
+    tokens: set[str] = set()
+    for raw in _TOKEN_RE.findall(text.lower()):
+        if raw in _STOPWORDS:
+            continue
+        token = raw[:-1] if len(raw) > 4 and raw.endswith("s") else raw
+        tokens.add(_CANONICAL_TOKEN.get(token, token))
+    return tokens
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _decayed_confidence(exp: Experience) -> float:
+    age_ms = max(0, int(time.time() * 1000) - exp.created_at)
+    grace_ms = 7 * 24 * 60 * 60 * 1000
+    if age_ms < grace_ms:
+        return exp.confidence
+    half_life_ms = 30 * 24 * 60 * 60 * 1000
+    decayed = exp.confidence * (0.5 ** ((age_ms - grace_ms) / half_life_ms))
+    return max(0.1, decayed)
+
+
+def _touch(experiences: list[Experience]) -> None:
+    now_ms = int(time.time() * 1000)
+    for exp in experiences:
+        exp.access_count += 1
+        exp.last_accessed_at = now_ms

--- a/packages/benchmarks/experience/run_benchmark.py
+++ b/packages/benchmarks/experience/run_benchmark.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 # Add paths
 sys.path.insert(0, str(Path(__file__).parent))
-sys.path.insert(0, str(Path(__file__).parent.parent.parent / "plugins" / "plugin-experience" / "python"))
 
 from elizaos_experience_bench.runner import ExperienceBenchmarkRunner
 from elizaos_experience_bench.types import BenchmarkConfig, BenchmarkMode

--- a/packages/benchmarks/experience/tests/conftest.py
+++ b/packages/benchmarks/experience/tests/conftest.py
@@ -5,11 +5,9 @@ from pathlib import Path
 
 import pytest
 
-# Add benchmark and plugin paths
+# Add benchmark package path.
 benchmark_root = Path(__file__).resolve().parents[1]
-plugin_root = Path(__file__).resolve().parents[3] / "plugins" / "plugin-experience" / "python"
 sys.path.insert(0, str(benchmark_root))
-sys.path.insert(0, str(plugin_root))
 
 from elizaos_experience_bench.generator import ExperienceGenerator
 

--- a/packages/benchmarks/experience/tests/test_baselines.py
+++ b/packages/benchmarks/experience/tests/test_baselines.py
@@ -15,7 +15,7 @@ from elizaos_experience_bench.evaluators.retrieval import RetrievalEvaluator
 from elizaos_experience_bench.evaluators.reranking import RerankingEvaluator
 from elizaos_experience_bench.evaluators.learning import LearningCycleEvaluator
 from elizaos_experience_bench.generator import ExperienceGenerator
-from elizaos_plugin_experience.service import ExperienceService
+from elizaos_experience_bench.service import ExperienceService
 
 
 # ---------------------------------------------------------------------------

--- a/packages/benchmarks/experience/tests/test_evaluators.py
+++ b/packages/benchmarks/experience/tests/test_evaluators.py
@@ -6,7 +6,7 @@ from elizaos_experience_bench.evaluators.reranking import RerankingEvaluator
 from elizaos_experience_bench.evaluators.retrieval import RetrievalEvaluator
 from elizaos_experience_bench.evaluators.learning import LearningCycleEvaluator
 from elizaos_experience_bench.generator import ExperienceGenerator
-from elizaos_plugin_experience.service import ExperienceService
+from elizaos_experience_bench.service import ExperienceQuery, ExperienceService
 
 
 def test_reranking_evaluator():
@@ -86,7 +86,6 @@ def test_retrieval_at_scale():
     assert svc.experience_count == 5000
 
     # Measure query latency
-    from elizaos_plugin_experience.types import ExperienceQuery
     latencies: list[float] = []
     for q in queries:
         t0 = time.time()

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -15,6 +15,7 @@ import {
   type PointerEvent,
   type RefObject,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -23,6 +24,68 @@ import { Button } from "../../ui/button";
 import { Textarea } from "../../ui/textarea";
 import type { ChatVariant } from "./chat-types";
 import { CreateTaskPopover } from "./create-task-popover";
+
+const INLINE_TEXTAREA_MIN_HEIGHT_PX = 32;
+const INLINE_TEXTAREA_MAX_HEIGHT_PX = 128;
+const INLINE_STACKED_INLINE_PADDING_PX = 12;
+
+const inlineTextareaClass =
+  "block h-8 max-h-[128px] min-h-0 w-full min-w-0 resize-none overflow-y-hidden appearance-none rounded-none border-0 bg-transparent px-2 py-[6px] text-sm leading-5 text-txt shadow-none outline-none ring-0 placeholder:text-muted/60 focus:!border-0 focus:!outline-none focus:!ring-0 focus-visible:!border-0 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0 focus-visible:!shadow-none";
+
+const inlineMeasureTextareaClass = `${inlineTextareaClass} pointer-events-none fixed left-0 top-0 z-[-1] opacity-0`;
+
+const chatComposerFocusResetClass =
+  "[&_button:focus]:!outline-none [&_button:focus-visible]:!outline-none [&_button:focus-visible]:!ring-0 [&_button:focus-visible]:!ring-offset-0 [&_button:focus-visible]:!shadow-none [&_textarea:focus]:!outline-none [&_textarea:focus-visible]:!outline-none [&_textarea:focus-visible]:!ring-0 [&_textarea:focus-visible]:!ring-offset-0 [&_textarea:focus-visible]:!shadow-none";
+
+type InlineTextareaMeasurement = {
+  scrollHeight: number;
+  wraps: boolean;
+};
+
+function getTextareaVerticalPadding(textarea: HTMLTextAreaElement): number {
+  const styles = window.getComputedStyle(textarea);
+  const paddingTop = Number.parseFloat(styles.paddingTop);
+  const paddingBottom = Number.parseFloat(styles.paddingBottom);
+  const verticalPadding = paddingTop + paddingBottom;
+  if (
+    Number.isFinite(paddingTop) &&
+    Number.isFinite(paddingBottom) &&
+    verticalPadding > 0
+  ) {
+    return verticalPadding;
+  }
+  return 12;
+}
+
+function getTextareaLineHeight(textarea: HTMLTextAreaElement): number {
+  const lineHeight = Number.parseFloat(
+    window.getComputedStyle(textarea).lineHeight,
+  );
+  return Number.isFinite(lineHeight) && lineHeight > 0 ? lineHeight : 20;
+}
+
+function measureInlineTextarea(
+  textarea: HTMLTextAreaElement,
+  value: string,
+  width: number,
+): InlineTextareaMeasurement {
+  textarea.value = value.endsWith("\n") ? `${value} ` : value || " ";
+  textarea.style.width = `${Math.max(1, width)}px`;
+  textarea.style.height = "auto";
+  textarea.style.overflowY = "hidden";
+
+  const scrollHeight = textarea.scrollHeight;
+  const contentHeight = Math.max(
+    0,
+    scrollHeight - getTextareaVerticalPadding(textarea),
+  );
+  const lineHeight = getTextareaLineHeight(textarea);
+
+  return {
+    scrollHeight,
+    wraps: contentHeight > lineHeight * 1.25,
+  };
+}
 
 export interface ChatComposerVoiceState {
   assistantTtsQuality?: "enhanced" | "standard";
@@ -95,6 +158,10 @@ export function ChatComposer({
     () => typeof window !== "undefined" && window.innerWidth < 310,
   );
   const [isInlineMultiline, setIsInlineMultiline] = useState(false);
+  const [inlineMeasureVersion, setInlineMeasureVersion] = useState(0);
+  const inlineRootRef = useRef<HTMLDivElement | null>(null);
+  const inlineMeasureRef = useRef<HTMLTextAreaElement | null>(null);
+  const lastInlineSingleLineWidthRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return;
@@ -142,9 +209,6 @@ export function ChatComposer({
           ? t("chat.listening")
           : inputPlaceholder
       : inputPlaceholder;
-  const inlineTextareaClass = isInlineMultiline
-    ? "block h-8 max-h-[128px] min-h-0 w-full min-w-0 resize-none overflow-y-hidden appearance-none rounded-none border-0 bg-transparent px-2 py-[6px] text-sm leading-5 text-txt shadow-none outline-none ring-0 placeholder:text-muted/60 focus:border-0 focus:outline-none focus:ring-0 focus-visible:border-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-none"
-    : "block h-8 max-h-[128px] min-h-0 w-full min-w-0 resize-none overflow-y-hidden appearance-none rounded-none border-0 bg-transparent px-1 py-[5px] text-sm leading-5 text-txt shadow-none outline-none ring-0 placeholder:text-muted/60 focus:border-0 focus:outline-none focus:ring-0 focus-visible:border-0 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:shadow-none";
 
   useEffect(() => {
     return () => {
@@ -155,28 +219,86 @@ export function ChatComposer({
     };
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: chatInput changes must rerun inline textarea autosizing.
   useEffect(() => {
+    if (!isInline) return;
+    const root = inlineRootRef.current;
+    if (!root || typeof ResizeObserver === "undefined") return;
+
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setInlineMeasureVersion((version) => version + 1);
+      });
+    });
+    observer.observe(root);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [isInline]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: inlineMeasureVersion is a ResizeObserver tick that reruns measurement after width changes.
+  useLayoutEffect(() => {
     if (!isInline) {
       setIsInlineMultiline(false);
+      lastInlineSingleLineWidthRef.current = null;
       return;
     }
     const textarea = textareaRef.current;
-    if (!textarea) return;
+    const measureTextarea = inlineMeasureRef.current;
+    const root = inlineRootRef.current;
+    if (!textarea || !measureTextarea || !root) return;
 
-    const minHeight = 32;
-    const maxHeight = 128;
+    const measuredSingleLineWidth =
+      textarea.clientWidth > 0 ? textarea.clientWidth : null;
+    const currentSingleLineWidth = isInlineMultiline
+      ? lastInlineSingleLineWidthRef.current
+      : measuredSingleLineWidth;
+    if (!isInlineMultiline && measuredSingleLineWidth) {
+      lastInlineSingleLineWidthRef.current = measuredSingleLineWidth;
+    }
 
-    textarea.style.height = "auto";
-    const nextHeight = Math.min(
-      Math.max(textarea.scrollHeight, minHeight),
-      maxHeight,
+    const decisionWidth =
+      currentSingleLineWidth ??
+      Math.max(1, root.clientWidth - INLINE_STACKED_INLINE_PADDING_PX);
+    const stackedWidth = Math.max(
+      1,
+      root.clientWidth - INLINE_STACKED_INLINE_PADDING_PX,
     );
+    const decision = measureInlineTextarea(
+      measureTextarea,
+      chatInput,
+      decisionWidth,
+    );
+    const nextIsInlineMultiline = chatInput.includes("\n") || decision.wraps;
+    const heightMeasurement = nextIsInlineMultiline
+      ? measureInlineTextarea(measureTextarea, chatInput, stackedWidth)
+      : decision;
+    const nextHeight = nextIsInlineMultiline
+      ? Math.min(
+          Math.max(
+            heightMeasurement.scrollHeight,
+            INLINE_TEXTAREA_MIN_HEIGHT_PX,
+          ),
+          INLINE_TEXTAREA_MAX_HEIGHT_PX,
+        )
+      : INLINE_TEXTAREA_MIN_HEIGHT_PX;
+
     textarea.style.height = `${nextHeight}px`;
     textarea.style.overflowY =
-      textarea.scrollHeight > maxHeight ? "auto" : "hidden";
-    setIsInlineMultiline(nextHeight > minHeight);
-  }, [chatInput, isInline, textareaRef]);
+      heightMeasurement.scrollHeight > INLINE_TEXTAREA_MAX_HEIGHT_PX
+        ? "auto"
+        : "hidden";
+    setIsInlineMultiline(nextIsInlineMultiline);
+  }, [
+    chatInput,
+    inlineMeasureVersion,
+    isInline,
+    isInlineMultiline,
+    textareaRef,
+  ]);
 
   const startPushToTalk = () => {
     if (isComposerLocked || voice.isListening) return;
@@ -394,13 +516,25 @@ export function ChatComposer({
 
     return (
       <div
+        ref={inlineRootRef}
+        data-chat-composer="true"
         data-inline-layout={isInlineMultiline ? "stacked" : "single-line"}
         className={
           isInlineMultiline
-            ? "flex min-h-[64px] flex-col gap-1 rounded-[22px] border border-border/35 bg-card/45 px-1.5 py-1.5"
-            : "flex min-h-[40px] items-center gap-1 rounded-full border border-border/35 bg-card/45 px-1 py-1"
+            ? `flex min-h-[64px] flex-col gap-1 rounded-[22px] border border-border/35 bg-card/45 px-1.5 py-1.5 ${chatComposerFocusResetClass}`
+            : `flex min-h-[40px] items-center gap-1 rounded-full border border-border/35 bg-card/45 px-1 py-1 ${chatComposerFocusResetClass}`
         }
       >
+        <textarea
+          ref={inlineMeasureRef}
+          aria-hidden="true"
+          className={inlineMeasureTextareaClass}
+          data-chat-composer-measure="true"
+          readOnly
+          rows={1}
+          tabIndex={-1}
+          value={chatInput}
+        />
         {isInlineMultiline ? (
           <>
             {inlineTextarea}
@@ -425,10 +559,11 @@ export function ChatComposer({
 
   return (
     <div
+      data-chat-composer="true"
       className={
         isGameModal
-          ? "relative flex w-full items-end gap-2 transition-all max-[380px]:gap-1.5"
-          : "flex items-center gap-1.5 sm:gap-2"
+          ? `relative flex w-full items-end gap-2 transition-all max-[380px]:gap-1.5 ${chatComposerFocusResetClass}`
+          : `flex items-center gap-1.5 sm:gap-2 ${chatComposerFocusResetClass}`
       }
     >
       {!isGameModal && !hideAttachButton ? (

--- a/packages/ui/src/layouts/page-layout/page-layout-mobile-drawer.tsx
+++ b/packages/ui/src/layouts/page-layout/page-layout-mobile-drawer.tsx
@@ -36,7 +36,7 @@ export function PageLayoutMobileDrawer({
       {!mobileSidebarOpen ? (
         <div
           className="pointer-events-none fixed left-2 z-40 md:hidden"
-          style={{ top: "var(--safe-area-top, 0px)" }}
+          style={{ top: "calc(var(--safe-area-top, 0px) + 2.75rem)" }}
         >
           <div className="pointer-events-auto">
             <Button
@@ -47,6 +47,7 @@ export function PageLayoutMobileDrawer({
                 "h-[2.375rem] max-w-[min(11rem,calc(100vw-5.5rem))] rounded-full border-border/40 bg-card/92 px-3 text-sm font-semibold text-txt shadow-sm backdrop-blur-md",
                 mobileSidebarTriggerClassName,
               )}
+              data-testid="page-layout-mobile-sidebar-trigger"
               onClick={() => onMobileSidebarOpenChange(true)}
             >
               <PanelLeftOpen className="h-4 w-4 shrink-0" />
@@ -61,7 +62,8 @@ export function PageLayoutMobileDrawer({
       >
         <DrawerSheetContent
           aria-describedby={undefined}
-          className="h-[min(calc(100dvh-1rem-var(--safe-area-top,0px)-var(--safe-area-bottom,0px)),46rem)] p-0"
+          className="!inset-0 !left-0 !right-0 !bottom-0 !top-0 !h-[100dvh] !max-h-none !rounded-none !border-0 p-0"
+          data-testid="page-layout-mobile-sidebar-drawer"
           showCloseButton={false}
         >
           <DrawerSheetHeader className="sr-only">

--- a/packages/ui/src/layouts/page-layout/page-layout-mobile-drawer.tsx
+++ b/packages/ui/src/layouts/page-layout/page-layout-mobile-drawer.tsx
@@ -2,13 +2,8 @@ import { PanelLeftOpen } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "../../components/ui/button";
-import {
-  DrawerSheet,
-  DrawerSheetContent,
-  DrawerSheetHeader,
-  DrawerSheetTitle,
-} from "../../components/ui/drawer-sheet";
 import { cn } from "../../lib/utils";
+import { useWorkspaceMobileSidebarControls } from "../workspace-layout/workspace-mobile-sidebar-controls";
 import type { PageLayoutMobileDrawerProps } from "./page-layout-types";
 
 export function PageLayoutMobileDrawer({
@@ -19,7 +14,8 @@ export function PageLayoutMobileDrawer({
   onMobileSidebarOpenChange,
   sidebar,
 }: PageLayoutMobileDrawerProps) {
-  if (isDesktop) return null;
+  const controls = useWorkspaceMobileSidebarControls();
+  const sidebarId = React.useId();
 
   const mobileSidebarElement = React.cloneElement(sidebar, {
     className: cn("!mt-0 !h-full !w-full !min-w-0", sidebar.props.className),
@@ -31,9 +27,29 @@ export function PageLayoutMobileDrawer({
   const drawerLabel =
     sidebar.props.mobileTitle ?? mobileSidebarLabel ?? "Browse";
 
+  React.useEffect(() => {
+    if (!controls || isDesktop) return undefined;
+
+    return controls.register({
+      id: sidebarId,
+      label: drawerLabel,
+      open: mobileSidebarOpen,
+      setOpen: onMobileSidebarOpenChange,
+    });
+  }, [
+    controls,
+    drawerLabel,
+    isDesktop,
+    mobileSidebarOpen,
+    onMobileSidebarOpenChange,
+    sidebarId,
+  ]);
+
+  if (isDesktop) return null;
+
   return (
     <>
-      {!mobileSidebarOpen ? (
+      {!mobileSidebarOpen && !controls ? (
         <div
           className="pointer-events-none fixed left-2 z-40 md:hidden"
           style={{ top: "calc(var(--safe-area-top, 0px) + 2.75rem)" }}
@@ -56,22 +72,15 @@ export function PageLayoutMobileDrawer({
           </div>
         </div>
       ) : null}
-      <DrawerSheet
-        open={mobileSidebarOpen}
-        onOpenChange={onMobileSidebarOpenChange}
-      >
-        <DrawerSheetContent
-          aria-describedby={undefined}
-          className="!inset-0 !left-0 !right-0 !bottom-0 !top-0 !h-[100dvh] !max-h-none !rounded-none !border-0 p-0"
+      {mobileSidebarOpen ? (
+        <section
+          className="flex min-h-0 w-full flex-1 overflow-hidden"
           data-testid="page-layout-mobile-sidebar-drawer"
-          showCloseButton={false}
+          aria-label={typeof drawerLabel === "string" ? drawerLabel : undefined}
         >
-          <DrawerSheetHeader className="sr-only">
-            <DrawerSheetTitle>{drawerLabel}</DrawerSheetTitle>
-          </DrawerSheetHeader>
           {mobileSidebarElement}
-        </DrawerSheetContent>
-      </DrawerSheet>
+        </section>
+      ) : null}
     </>
   );
 }

--- a/packages/ui/src/layouts/workspace-layout/index.ts
+++ b/packages/ui/src/layouts/workspace-layout/index.ts
@@ -1,2 +1,3 @@
 export * from "./workspace-layout";
 export * from "./workspace-layout-types";
+export * from "./workspace-mobile-sidebar-controls";

--- a/packages/ui/src/layouts/workspace-layout/workspace-layout.tsx
+++ b/packages/ui/src/layouts/workspace-layout/workspace-layout.tsx
@@ -72,6 +72,9 @@ export function WorkspaceLayout({
 }: WorkspaceLayoutProps) {
   const isDesktop = useWorkspaceLayoutDesktopMode();
   const [mobileSidebarOpen, setMobileSidebarOpen] = React.useState(false);
+  const showMobileSidebarPane = Boolean(
+    sidebar && !isDesktop && mobileSidebarOpen,
+  );
 
   React.useEffect(() => {
     if (isDesktop) {
@@ -132,10 +135,12 @@ export function WorkspaceLayout({
         <main
           ref={(node) => assignRef(contentRef, node)}
           className={cn(
-            "chat-native-scrollbar relative flex min-w-0 flex-1 flex-col overflow-y-auto bg-transparent",
+            "chat-native-scrollbar relative flex min-w-0 flex-1 flex-col bg-transparent",
+            showMobileSidebarPane ? "overflow-hidden" : "overflow-y-auto",
             contentPadding &&
+              !showMobileSidebarPane &&
               "px-4 pb-4 pt-2 sm:px-6 sm:pb-6 sm:pt-3 lg:px-7 lg:pb-7 lg:pt-4",
-            contentClassName,
+            !showMobileSidebarPane && contentClassName,
           )}
         >
           {sidebar ? (
@@ -149,12 +154,17 @@ export function WorkspaceLayout({
             />
           ) : null}
 
-          {contentHeader && headerPlacement === "inside" ? headerElement : null}
+          {contentHeader &&
+          headerPlacement === "inside" &&
+          !showMobileSidebarPane
+            ? headerElement
+            : null}
 
           <div
             className={cn(
               "flex w-full min-h-0 flex-1 flex-col",
               contentInnerClassName,
+              showMobileSidebarPane && "hidden",
             )}
           >
             {children}

--- a/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.tsx
+++ b/packages/ui/src/layouts/workspace-layout/workspace-mobile-sidebar-controls.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+export interface WorkspaceMobileSidebarControl {
+  id: string;
+  label?: React.ReactNode;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+}
+
+export interface WorkspaceMobileSidebarControls {
+  register: (control: WorkspaceMobileSidebarControl) => () => void;
+}
+
+export const WorkspaceMobileSidebarControlsContext =
+  React.createContext<WorkspaceMobileSidebarControls | null>(null);
+
+export function useWorkspaceMobileSidebarControls(): WorkspaceMobileSidebarControls | null {
+  return React.useContext(WorkspaceMobileSidebarControlsContext);
+}

--- a/scripts/fix-workspace-deps.mjs
+++ b/scripts/fix-workspace-deps.mjs
@@ -1,42 +1,45 @@
 #!/usr/bin/env node
+
 /**
  * fix-workspace-deps.mjs
  *
- * Manages workspace dependency references in the monorepo. Two modes:
+ * Enforces workspace dependency references in the monorepo. Two modes:
  *
- *   LOCAL mode (default):
+ *   SOURCE mode (default):
  *     Rewrites every workspace dependency to "workspace:*" so bun resolves
- *     to the local package. Use this for local development.
+ *     to the local package. This is the committed source state.
  *
  *   RESTORE mode (--restore):
- *     Reads the original version strings from a git ref and puts them back,
- *     reversing the workspace:* conversion WITHOUT touching other changes.
- *     Use this before committing so the repo doesn't ship workspace:* refs.
+ *     Reads old version strings from a git ref and puts them back, reversing
+ *     the workspace:* conversion WITHOUT touching other changes. Use only for
+ *     explicit publish/deploy compatibility work that needs registry specs.
  *
  * Usage:
- *   node scripts/fix-workspace-deps.mjs                  # set workspace:* (local dev)
+ *   node scripts/fix-workspace-deps.mjs                  # set workspace:*
  *   node scripts/fix-workspace-deps.mjs --check          # CI — exit 1 if any need fixing
  *   node scripts/fix-workspace-deps.mjs --restore        # restore from HEAD
  *   node scripts/fix-workspace-deps.mjs --restore --ref HEAD~3  # restore from specific ref
  *
  * Workflow:
- *   1. Pull/clone — package.json files have proper versioned refs
- *   2. `bun run fix-deps` — switches to workspace:* for local dev
- *   3. Develop…
- *   4. `bun run fix-deps:restore` — restores original versions from HEAD
- *   5. Commit your changes
- *   6. `bun run fix-deps` again — back to workspace:* for more dev
+ *   1. Pull/clone
+ *   2. `bun run fix-deps:check` verifies local packages use workspace:*
+ *   3. `bun run fix-deps` repairs drift if a manifest picked up a registry pin
+ *   4. Publish/deploy tooling materializes exact npm versions at the boundary
  *
- * Git submodule plugins (plugins/*) use `alpha` in the repo until you run
- * `bun run dev` (see scripts/dev.mjs + plugin-submodules-dev.mjs). That flow
- * inits submodules, adds their typescript/ paths to workspaces, then runs this script.
- * `bun run plugin-submodules:restore` runs fix-deps --restore, strips those workspaces,
- * and resets each submodule's typescript/package.json.
+ * Git submodule plugins (plugins/*) can drift to registry pins from their
+ * standalone repos. The dev flow adds their typescript/ paths to workspaces and
+ * runs this script so the checked-out monorepo graph stays workspace-local.
  */
 
-import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from "node:fs";
-import { join, resolve, relative } from "node:path";
 import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, relative, resolve } from "node:path";
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -80,11 +83,16 @@ function expandPattern(pattern) {
       // Glob segment — list the directory and match
       if (!existsSync(base) || !statSync(base).isDirectory()) return;
       const regex = new RegExp(
-        "^" + segment.replace(/\*/g, ".*").replace(/\?/g, ".") + "$"
+        "^" + segment.replace(/\*/g, ".*").replace(/\?/g, ".") + "$",
       );
       for (const entry of readdirSync(base)) {
         // Never walk into node_modules, dist, or hidden directories
-        if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+        if (
+          entry === "node_modules" ||
+          entry === "dist" ||
+          entry.startsWith(".")
+        )
+          continue;
         if (regex.test(entry)) {
           const full = join(base, entry);
           if (statSync(full).isDirectory()) {
@@ -139,7 +147,11 @@ const isWorkspacePackage = (depName) => nameToDir.has(depName);
 if (!QUIET) {
   console.log(`Workspace packages: ${nameToDir.size}`);
   console.log(`Package.json files to scan: ${workspaceDirs.length}`);
-  const mode = RESTORE_MODE ? "restore (from git)" : CHECK_MODE ? "check (read-only)" : "fix (→ workspace:*)";
+  const mode = RESTORE_MODE
+    ? "restore (from git)"
+    : CHECK_MODE
+      ? "check (read-only)"
+      : "fix (→ workspace:*)";
   console.log(`Mode: ${mode}\n`);
 }
 
@@ -148,7 +160,11 @@ if (!QUIET) {
 function gitShowFile(ref, filePath) {
   const relPath = relative(ROOT, filePath);
   try {
-    return execFileSync("git", ["show", `${ref}:${relPath}`], { cwd: ROOT, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+    return execFileSync("git", ["show", `${ref}:${relPath}`], {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
   } catch {
     return null; // file doesn't exist at that ref
   }
@@ -204,7 +220,9 @@ if (RESTORE_MODE) {
 
         if (oldVersion && oldVersion !== "workspace:*") {
           if (!QUIET) {
-            console.log(`  restore  ${rel}  ${section}.${depName}: "workspace:*" → "${oldVersion}"`);
+            console.log(
+              `  restore  ${rel}  ${section}.${depName}: "workspace:*" → "${oldVersion}"`,
+            );
           }
           pkg[section][depName] = oldVersion;
           changed = true;
@@ -213,7 +231,9 @@ if (RESTORE_MODE) {
           // Dep didn't exist at the old ref — it was added by us. Keep workspace:*
           // but warn so the developer can set a proper version.
           if (!QUIET) {
-            console.log(`  new      ${rel}  ${section}.${depName}: "workspace:*" (no original — set version manually)`);
+            console.log(
+              `  new      ${rel}  ${section}.${depName}: "workspace:*" (no original — set version manually)`,
+            );
           }
           newDepCount++;
         } else {
@@ -231,12 +251,17 @@ if (RESTORE_MODE) {
   console.log("");
   const parts = [];
   if (restoreCount > 0) parts.push(`${restoreCount} dep(s) restored`);
-  if (newDepCount > 0) parts.push(`${newDepCount} new dep(s) left as workspace:* (set versions manually)`);
+  if (newDepCount > 0)
+    parts.push(
+      `${newDepCount} new dep(s) left as workspace:* (set versions manually)`,
+    );
   if (skipCount > 0) parts.push(`${skipCount} already correct`);
   if (parts.length > 0) {
     console.log(`Done: ${parts.join(", ")}.`);
   } else {
-    console.log(`Nothing to restore — no workspace:* refs found for workspace packages.`);
+    console.log(
+      `Nothing to restore — no workspace:* refs found for workspace packages.`,
+    );
   }
   if (restoreCount > 0) {
     console.log(`\nRemember to run \`bun install\` to update the lockfile.`);
@@ -284,10 +309,14 @@ for (const dir of workspaceDirs) {
       if (depVersion === "workspace:*") continue;
 
       if (CHECK_MODE) {
-        issues.push(`${rel}  ${section}.${depName}: "${depVersion}" (should be "workspace:*")`);
+        issues.push(
+          `${rel}  ${section}.${depName}: "${depVersion}" (should be "workspace:*")`,
+        );
       } else {
         if (!QUIET) {
-          console.log(`  fix  ${rel}  ${section}.${depName}: "${depVersion}" → "workspace:*"`);
+          console.log(
+            `  fix  ${rel}  ${section}.${depName}: "${depVersion}" → "workspace:*"`,
+          );
         }
         pkg[section][depName] = "workspace:*";
         changed = true;
@@ -325,10 +354,14 @@ for (const dir of workspaceDirs) {
     for (const [depName, depVersion] of Object.entries(pkg[section])) {
       if (depVersion === "workspace:*" && !nameToDir.has(depName)) {
         if (CHECK_MODE) {
-          danglingIssues.push(`${rel}  ${section}.${depName}: "workspace:*" references nonexistent package`);
+          danglingIssues.push(
+            `${rel}  ${section}.${depName}: "workspace:*" references nonexistent package`,
+          );
         } else {
           if (!QUIET) {
-            console.log(`  rm   ${rel}  ${section}.${depName}: "workspace:*" (package not in workspace)`);
+            console.log(
+              `  rm   ${rel}  ${section}.${depName}: "workspace:*" (package not in workspace)`,
+            );
           }
           delete pkg[section][depName];
           changed = true;
@@ -356,7 +389,9 @@ if (CHECK_MODE) {
     console.log(`\nRun \`node scripts/fix-workspace-deps.mjs\` to fix them.`);
     process.exit(1);
   } else {
-    console.log(`OK: all ${nameToDir.size} workspace packages use correct references.`);
+    console.log(
+      `OK: all ${nameToDir.size} workspace packages use correct references.`,
+    );
   }
 } else {
   const parts = [];
@@ -365,6 +400,8 @@ if (CHECK_MODE) {
   if (parts.length > 0) {
     console.log(`Done: ${parts.join(", ")}.`);
   } else {
-    console.log(`All workspace references are already correct. Nothing to fix.`);
+    console.log(
+      `All workspace references are already correct. Nothing to fix.`,
+    );
   }
 }

--- a/scripts/plugin-submodules-dev.mjs
+++ b/scripts/plugin-submodules-dev.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
+
 /**
  * plugin-submodules-dev.mjs
  *
  * Git submodule plugins (plugins/*) are optional for local development.
- * The repo can stay on registry versions (`alpha`, semver) until you link them for editing.
+ * When linked into this monorepo, their local @elizaos/* dependencies should
+ * resolve through workspace:* like the rest of the source graph.
  *
  *   DEV (default — no flag, or `--dev`):
  *     1. `git submodule update --init` for each configured path
@@ -21,7 +23,7 @@
  *     3. `git checkout -- typescript/package.json` inside each submodule (reset submodule trees)
  *
  * Pair with:
- *   - `bun run fix-deps` / `bun run fix-deps:restore` for the rest of the monorepo
+ *   - `bun run fix-deps` for the rest of the monorepo
  *   - `scripts/replace-workspace-versions.js` for publish (Lerna)
  *
  * Usage:
@@ -31,9 +33,9 @@
  *   node scripts/plugin-submodules-dev.mjs --quiet
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
-import { join, resolve, relative } from "node:path";
 import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const DEV = !process.argv.includes("--restore");
@@ -43,145 +45,148 @@ const QUIET = process.argv.includes("--quiet");
 const INSTALL_STAMP = join(ROOT, ".eliza", "plugin-dev-needs-install");
 
 function touchInstallStamp() {
-	mkdirSync(join(ROOT, ".eliza"), { recursive: true });
-	writeFileSync(INSTALL_STAMP, `${Date.now()}\n`);
+  mkdirSync(join(ROOT, ".eliza"), { recursive: true });
+  writeFileSync(INSTALL_STAMP, `${Date.now()}\n`);
 }
 
 /** Submodules under plugins/ and their Bun workspace path (typescript package). */
 const PLUGIN_SUBMODULES = [
-	{
-		submodulePath: "plugins/plugin-sql",
-		workspaceEntry: "plugins/plugin-sql/typescript",
-		packageName: "@elizaos/plugin-sql",
-	},
-	{
-		submodulePath: "plugins/plugin-ollama",
-		workspaceEntry: "plugins/plugin-ollama/typescript",
-		packageName: "@elizaos/plugin-ollama",
-	},
-	{
-		submodulePath: "plugins/plugin-local-ai",
-		workspaceEntry: "plugins/plugin-local-ai/typescript",
-		packageName: "@elizaos/plugin-local-ai",
-	},
+  {
+    submodulePath: "plugins/plugin-sql",
+    workspaceEntry: "plugins/plugin-sql/typescript",
+    packageName: "@elizaos/plugin-sql",
+  },
+  {
+    submodulePath: "plugins/plugin-ollama",
+    workspaceEntry: "plugins/plugin-ollama/typescript",
+    packageName: "@elizaos/plugin-ollama",
+  },
+  {
+    submodulePath: "plugins/plugin-local-ai",
+    workspaceEntry: "plugins/plugin-local-ai/typescript",
+    packageName: "@elizaos/plugin-local-ai",
+  },
 ];
 
 /** Registry dist-tag when these packages are not linked from submodules. */
 const PLUGIN_REGISTRY_TAG = "alpha";
 
-const ROOT_AND_AGENT_PKG = [join(ROOT, "package.json"), join(ROOT, "agent", "package.json")];
+const ROOT_AND_AGENT_PKG = [
+  join(ROOT, "package.json"),
+  join(ROOT, "agent", "package.json"),
+];
 
 const FIX_DEPS_SCRIPT = join(ROOT, "scripts", "fix-workspace-deps.mjs");
 
 function log(...args) {
-	if (!QUIET) console.log(...args);
+  if (!QUIET) console.log(...args);
 }
 
 function readRootPackage() {
-	const p = join(ROOT, "package.json");
-	const raw = readFileSync(p, "utf8");
-	return { path: p, raw, pkg: JSON.parse(raw) };
-// Note: reads file once, storing raw data for both returning and parsing efficiency
+  const p = join(ROOT, "package.json");
+  const raw = readFileSync(p, "utf8");
+  return { path: p, raw, pkg: JSON.parse(raw) };
+  // Note: reads file once, storing raw data for both returning and parsing efficiency
 }
 
 function writePackageJson(path, raw, pkg) {
-	const indent = raw.match(/^(\s+)"/m)?.[1] || "  ";
-	writeFileSync(path, `${JSON.stringify(pkg, null, indent)}\n`);
+  const indent = raw.match(/^(\s+)"/m)?.[1] || "  ";
+  writeFileSync(path, `${JSON.stringify(pkg, null, indent)}\n`);
 }
 
 function ensureWorkspaces() {
-	const { path, raw, pkg } = readRootPackage();
-	const ws = pkg.workspaces;
-	if (!Array.isArray(ws)) {
-		throw new Error("package.json: missing workspaces array");
-	}
-	let changed = false;
-	for (const { workspaceEntry } of PLUGIN_SUBMODULES) {
-		if (!ws.includes(workspaceEntry)) {
-			ws.push(workspaceEntry);
-			log(`  workspaces  + ${workspaceEntry}`);
-			changed = true;
-		}
-	}
-	if (changed) {
-		writePackageJson(path, raw, pkg);
-	}
-	return changed;
+  const { path, raw, pkg } = readRootPackage();
+  const ws = pkg.workspaces;
+  if (!Array.isArray(ws)) {
+    throw new Error("package.json: missing workspaces array");
+  }
+  let changed = false;
+  for (const { workspaceEntry } of PLUGIN_SUBMODULES) {
+    if (!ws.includes(workspaceEntry)) {
+      ws.push(workspaceEntry);
+      log(`  workspaces  + ${workspaceEntry}`);
+      changed = true;
+    }
+  }
+  if (changed) {
+    writePackageJson(path, raw, pkg);
+  }
+  return changed;
 }
 
 function pluginPackagesPresent() {
-	return PLUGIN_SUBMODULES.every(({ workspaceEntry }) =>
-		existsSync(join(ROOT, workspaceEntry, "package.json")),
-	);
+  return PLUGIN_SUBMODULES.every(({ workspaceEntry }) =>
+    existsSync(join(ROOT, workspaceEntry, "package.json")),
+  );
 }
 
 function stripWorkspaces() {
-	const { path, raw, pkg } = readRootPackage();
-	const ws = pkg.workspaces;
-	if (!Array.isArray(ws)) return false;
-	const remove = new Set(PLUGIN_SUBMODULES.map((p) => p.workspaceEntry));
-	const next = ws.filter((e) => !remove.has(e));
-	if (next.length === ws.length) return false;
-	for (const e of ws) {
-		if (remove.has(e)) log(`  workspaces  − ${e}`);
-	}
-	pkg.workspaces = next;
-	writePackageJson(path, raw, pkg);
-	return true;
+  const { path, raw, pkg } = readRootPackage();
+  const ws = pkg.workspaces;
+  if (!Array.isArray(ws)) return false;
+  const remove = new Set(PLUGIN_SUBMODULES.map((p) => p.workspaceEntry));
+  const next = ws.filter((e) => !remove.has(e));
+  if (next.length === ws.length) return false;
+  for (const e of ws) {
+    if (remove.has(e)) log(`  workspaces  − ${e}`);
+  }
+  pkg.workspaces = next;
+  writePackageJson(path, raw, pkg);
+  return true;
 }
 
 function removeSelfDependencies() {
-	const sections = ["dependencies", "devDependencies", "peerDependencies"];
-	let any = false;
-	for (const { workspaceEntry } of PLUGIN_SUBMODULES) {
-		const pkgPath = join(ROOT, workspaceEntry, "package.json");
-		if (!existsSync(pkgPath)) {
-			log(`  skip  (no file) ${relative(ROOT, pkgPath)}`);
-			continue;
-		}
-		const raw = readFileSync(pkgPath, "utf8");
-		let pkg;
-		try {
-			pkg = JSON.parse(raw);
-		} catch {
-			continue;
-		}
-		const name = pkg.name;
-		if (!name) continue;
-		const indent = raw.match(/^(\s+)"/m)?.[1] || "  ";
-		let changed = false;
-		for (const sec of sections) {
-			if (!pkg[sec]?.[name]) continue;
-			delete pkg[sec][name];
-			log(`  self-dep  rm  ${relative(ROOT, pkgPath)}  ${sec}.${name}`);
-			changed = true;
-		}
-		if (changed) {
-			writePackageJson(pkgPath, raw, pkg);
-			any = true;
-		}
-	}
-	return any;
+  const sections = ["dependencies", "devDependencies", "peerDependencies"];
+  let any = false;
+  for (const { workspaceEntry } of PLUGIN_SUBMODULES) {
+    const pkgPath = join(ROOT, workspaceEntry, "package.json");
+    if (!existsSync(pkgPath)) {
+      log(`  skip  (no file) ${relative(ROOT, pkgPath)}`);
+      continue;
+    }
+    const raw = readFileSync(pkgPath, "utf8");
+    let pkg;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    const name = pkg.name;
+    if (!name) continue;
+    const indent = raw.match(/^(\s+)"/m)?.[1] || "  ";
+    let changed = false;
+    for (const sec of sections) {
+      if (!pkg[sec]?.[name]) continue;
+      delete pkg[sec][name];
+      log(`  self-dep  rm  ${relative(ROOT, pkgPath)}  ${sec}.${name}`);
+      changed = true;
+    }
+    if (changed) {
+      writePackageJson(pkgPath, raw, pkg);
+      any = true;
+    }
+  }
+  return any;
 }
 
 /** @returns {boolean} true if `git submodule update` ran successfully (new checkouts may need `bun install`). */
 function submoduleInit() {
-	if (pluginPackagesPresent()) {
-		log("  submodules  already present (skip git submodule update)");
-		return false;
-	}
-	const paths = PLUGIN_SUBMODULES.map((p) => p.submodulePath);
-	try {
-		execFileSync(
-			"git",
-			["submodule", "update", "--init", "--recursive", ...paths],
-			{ cwd: ROOT, stdio: QUIET ? "pipe" : "inherit" },
-		);
-		return true;
-	} catch {
-		log("  warning: git submodule update failed (network or .gitmodules).");
-		return false;
-	}
+  if (pluginPackagesPresent()) {
+    log("  submodules  already present (skip git submodule update)");
+    return false;
+  }
+  const paths = PLUGIN_SUBMODULES.map((p) => p.submodulePath);
+  try {
+    execFileSync(
+      "git",
+      ["submodule", "update", "--init", "--recursive", ...paths],
+      { cwd: ROOT, stdio: QUIET ? "pipe" : "inherit" },
+    );
+    return true;
+  } catch {
+    log("  warning: git submodule update failed (network or .gitmodules).");
+    return false;
+  }
 }
 
 /**
@@ -189,101 +194,105 @@ function submoduleInit() {
  * Force registry tag for known submodule plugin names on root + agent only.
  */
 function fallbackPluginDepsToRegistry() {
-	const names = new Set(PLUGIN_SUBMODULES.map((plugin) => plugin.packageName));
-	for (const path of ROOT_AND_AGENT_PKG) {
-		if (!existsSync(path)) continue;
-		const raw = readFileSync(path, "utf8");
-		let pkg;
-		try {
-			pkg = JSON.parse(raw);
-		} catch {
-			continue;
-		}
-		let changed = false;
-		if (!pkg.dependencies) continue;
-		for (const name of names) {
-			if (pkg.dependencies[name] === "workspace:*") {
-				pkg.dependencies[name] = PLUGIN_REGISTRY_TAG;
-				log(`  fallback  ${relative(ROOT, path)}  dependencies.${name} → "${PLUGIN_REGISTRY_TAG}"`);
-				changed = true;
-			}
-		}
-		if (changed) {
-			writePackageJson(path, raw, pkg);
-		}
-	}
+  const names = new Set(PLUGIN_SUBMODULES.map((plugin) => plugin.packageName));
+  for (const path of ROOT_AND_AGENT_PKG) {
+    if (!existsSync(path)) continue;
+    const raw = readFileSync(path, "utf8");
+    let pkg;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    let changed = false;
+    if (!pkg.dependencies) continue;
+    for (const name of names) {
+      if (pkg.dependencies[name] === "workspace:*") {
+        pkg.dependencies[name] = PLUGIN_REGISTRY_TAG;
+        log(
+          `  fallback  ${relative(ROOT, path)}  dependencies.${name} → "${PLUGIN_REGISTRY_TAG}"`,
+        );
+        changed = true;
+      }
+    }
+    if (changed) {
+      writePackageJson(path, raw, pkg);
+    }
+  }
 }
 
 function resetSubmodulePackageJson() {
-	for (const { submodulePath } of PLUGIN_SUBMODULES) {
-		const abs = join(ROOT, submodulePath);
-		if (!existsSync(join(abs, ".git"))) {
-			// not checked out or not a submodule worktree
-			continue;
-		}
-		try {
-			execFileSync(
-				"git",
-				["checkout", "--", "typescript/package.json"],
-				{ cwd: abs, stdio: QUIET ? "pipe" : "inherit" },
-			);
-			log(`  reset  ${submodulePath}/typescript/package.json`);
-		} catch {
-			log(`  skip reset  ${submodulePath} (no typescript/package.json in index?)`);
-		}
-	}
+  for (const { submodulePath } of PLUGIN_SUBMODULES) {
+    const abs = join(ROOT, submodulePath);
+    if (!existsSync(join(abs, ".git"))) {
+      // not checked out or not a submodule worktree
+      continue;
+    }
+    try {
+      execFileSync("git", ["checkout", "--", "typescript/package.json"], {
+        cwd: abs,
+        stdio: QUIET ? "pipe" : "inherit",
+      });
+      log(`  reset  ${submodulePath}/typescript/package.json`);
+    } catch {
+      log(
+        `  skip reset  ${submodulePath} (no typescript/package.json in index?)`,
+      );
+    }
+  }
 }
 
 function runFixWorkspaceDeps(args = []) {
-	const extra =
-		QUIET && !args.includes("--quiet") ? ["--quiet"] : [];
-	execFileSync(process.execPath, [FIX_DEPS_SCRIPT, ...args, ...extra], {
-		cwd: ROOT,
-		stdio: QUIET ? "pipe" : "inherit",
-	});
+  const extra = QUIET && !args.includes("--quiet") ? ["--quiet"] : [];
+  execFileSync(process.execPath, [FIX_DEPS_SCRIPT, ...args, ...extra], {
+    cwd: ROOT,
+    stdio: QUIET ? "pipe" : "inherit",
+  });
 }
 
 /** True if fix-workspace-deps --check passes (no rewrites needed). */
 function fixWorkspaceDepsCheckPasses() {
-	const extra = QUIET ? ["--quiet"] : [];
-	try {
-		execFileSync(process.execPath, [FIX_DEPS_SCRIPT, "--check", ...extra], {
-			cwd: ROOT,
-			stdio: "pipe",
-		});
-		return true;
-	} catch {
-		return false;
-	}
+  const extra = QUIET ? ["--quiet"] : [];
+  try {
+    execFileSync(process.execPath, [FIX_DEPS_SCRIPT, "--check", ...extra], {
+      cwd: ROOT,
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ── main ────────────────────────────────────────────────────────────────────
 
 if (DEV) {
-	log("plugin-submodules-dev: dev (link submodules for local editing)\n");
-	let mutated = submoduleInit();
-	if (!pluginPackagesPresent()) {
-		throw new Error(
-			"Plugin submodules are unavailable; aborting workspace/dependency rewrites.",
-		);
-	}
-	mutated = ensureWorkspaces() || mutated;
-	mutated = removeSelfDependencies() || mutated;
+  log("plugin-submodules-dev: dev (link submodules for local editing)\n");
+  let mutated = submoduleInit();
+  if (!pluginPackagesPresent()) {
+    throw new Error(
+      "Plugin submodules are unavailable; aborting workspace/dependency rewrites.",
+    );
+  }
+  mutated = ensureWorkspaces() || mutated;
+  mutated = removeSelfDependencies() || mutated;
 
-	if (fixWorkspaceDepsCheckPasses()) {
-		log("\nfix-workspace-deps: already satisfied (skip)\n");
-	} else {
-		log("\nRunning fix-workspace-deps.mjs …\n");
-		runFixWorkspaceDeps();
-		mutated = true;
-	}
+  if (fixWorkspaceDepsCheckPasses()) {
+    log("\nfix-workspace-deps: already satisfied (skip)\n");
+  } else {
+    log("\nRunning fix-workspace-deps.mjs …\n");
+    runFixWorkspaceDeps();
+    mutated = true;
+  }
 
-	if (mutated) {
-		touchInstallStamp();
-	} else {
-		log("No package.json / workspace changes — already linked for local dev.\n");
-	}
-	process.exit(0);
+  if (mutated) {
+    touchInstallStamp();
+  } else {
+    log(
+      "No package.json / workspace changes — already linked for local dev.\n",
+    );
+  }
+  process.exit(0);
 }
 
 // RESTORE


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles several related improvements: wrapping Discord message metadata enrichment in try-catch for resilience, a new `parseActivityInteger` helper that enforces proper pagination validation on the relationships activity endpoint, paginated load-more in the activity feed UI, a mobile chat surface redesign (drawer → inline panel switcher), popup-blocker avoidance in `GameView`, and a policy change that keeps `workspace:*` as the committed source state for monorepo deps (materializing exact npm versions only at the Docker deploy boundary).

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 quality/style issues that do not block production behavior.

The core runtime fixes (try-catch around Discord enrichment, pagination validation) are correct and defensive. The workspace:* policy change and Dockerfile refactor appear intentional and internally consistent. The two remaining P2 findings (missing cancellation guard in loadMore, implicit @elizaos/core transitive resolution in Docker) are worth a follow-up but do not block the PR.

packages/app-core/deploy/Dockerfile.cloud (verify @elizaos/core resolves transitively after pruning) and packages/app-core/src/components/pages/relationships/RelationshipsActivityFeed.tsx (loadMore unmount guard)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent/src/api/conversation-routes.ts | Discord message metadata enrichment wrapped in try-catch for resilience; `cacheDiscordAvatarForRuntime` is now a best-effort operation only |
| packages/agent/src/api/relationships-routes.ts | New `parseActivityInteger` helper validates pagination params and returns 400 for invalid/negative values — clean improvement over the old loose parseInt calls |
| packages/app-core/deploy/Dockerfile.cloud | Refactored inline one-liner to readable heredoc script; materializes workspace:* deps for cloud-agent-template at build time; `@elizaos/core` removed from ALLOW set — agent's workspace:* reference will be pruned, relying on transitive resolution |
| packages/app-core/deploy/cloud-agent-template/package.json | Dependencies changed from pinned registry versions to workspace:* — materialized to exact versions at Docker deploy boundary via Dockerfile.cloud script |
| packages/app-core/src/components/pages/relationships/RelationshipsActivityFeed.tsx | Pagination and icon improvements; initial load uses cancellation guard but `loadMore` does not — state updates can fire on unmounted component |
| packages/app-core/src/App.tsx | Mobile chat surface navigation redesigned from a drawer-based to inline panel switching (left/center/right surfaces); simplifies state from two booleans to one enum |
| packages/app-core/src/components/apps/GameView.tsx | Added `preOpenWindow`/`navigatePreOpenedWindow` to avoid popup-blocker for external URLs; new diagnostics panel and improved game status labeling |
| packages/app-core/src/api/client-agent.ts | Added `offset` param to `getRelationshipsActivity` and `scope` param to graph/people queries; explicit return type added to activity fetch |
| packages/app-core/src/api/client-types-relationships.ts | Added pagination metadata (total, offset, limit, hasMore) to RelationshipsActivityResponse and typed merge candidate evidence |
| packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx | Added `chatDisabled` prop, mobile pane switcher component, and workspace sidebar control registration — enables game views to own their chat surface |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Server as relationships-routes
    participant DB

    Client->>Server: GET /api/relationships/activity?limit=25&offset=0
    Server->>Server: parseActivityInteger(limit, 50, {min:1, max:100})
    Server->>Server: parseActivityInteger(offset, 0, {min:0})
    alt invalid params
        Server-->>Client: 400 Invalid pagination
    else valid params
        Server->>DB: query activity (limit, offset)
        DB-->>Server: rows + total count
        Server-->>Client: {activity[], total, count, offset, limit, hasMore}
    end
    Client->>Client: render page 1
    Client->>Server: GET /api/relationships/activity?limit=25&offset=25
    Server->>DB: query activity (limit=25, offset=25)
    DB-->>Server: rows + total count
    Server-->>Client: {activity[], hasMore}
    Client->>Client: append to activity list
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/agent/src/api/conversation-routes.ts`, line 977-1048 ([link](https://github.com/elizaos/eliza/blob/f46104cc5378ba2d142f0ffdeb5c6c7ef6953900/packages/agent/src/api/conversation-routes.ts#L977-L1048)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`cacheDiscordAvatarForRuntime` silently skipped on profile errors**

   Previously `cacheDiscordAvatarForRuntime` was called unconditionally after profile enrichment. Now it only runs if the entire try-block succeeds. If `resolveStoredDiscordEntityProfile` or `resolveDiscordMessageAuthorProfile` throws, `message.avatarUrl` is never updated — the message ships with a raw CDN URL rather than a cached one. This is intentional as a resilience fix, but worth documenting explicitly so future callers know avatar caching is best-effort.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor: remove wallet market status ta..."](https://github.com/elizaos/eliza/commit/f46104cc5378ba2d142f0ffdeb5c6c7ef6953900) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29565457)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->