### PR TITLE
fix(agent): deliver swarm synthesis to the triggering room

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -3,6 +3,9 @@
  */
 
 import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   SwarmEvent,
   TaskCompletionSummary,
@@ -209,8 +212,8 @@ export function wireCodingAgentSwarmSynthesis(st: ServerState): boolean {
   if (!st.runtime) return false;
   const coordinator = getCoordinatorFromRuntime(st.runtime);
   if (!coordinator?.setSwarmCompleteCallback) return false;
-  coordinator.setSwarmCompleteCallback(async () => {
-    // Deliberately no-op -- synthesis happens via the streamer instead.
+  coordinator.setSwarmCompleteCallback(async (payload) => {
+    await handleSwarmSynthesis(st, payload);
   });
   return true;
 }
@@ -228,6 +231,8 @@ export async function handleSwarmSynthesis(
       originalTask: string;
       status: string;
       completionSummary: string;
+      roomId?: string | null;
+      workdir?: string;
     }>;
     total: number;
     completed: number;
@@ -252,7 +257,27 @@ export async function handleSwarmSynthesis(
   const resultText = await buildSynthesisResultText(payload);
   logger.info("[swarm-synthesis] Synthesis generated, routing to user");
   await routeMessage(resultText, "swarm_synthesis");
-  await routeSynthesisToConnector(runtime, resultText);
+  // coordinator.sourceRoomId is declared on the interface but never assigned
+  // by the orchestrator, so without a fallback the connector route is dead.
+  // Pick the most recently terminal task's roomId: that's the task whose
+  // completion fired this swarm_complete, and whose room is waiting for an
+  // answer. Naively taking "first task with a roomId" leaks results into
+  // stale rooms when the coordinator carries tasks across rooms.
+  const terminalStatuses = new Set(["completed", "stopped", "errored"]);
+  let fallbackRoomId: string | null = null;
+  for (let i = payload.tasks.length - 1; i >= 0; i--) {
+    const candidate = payload.tasks[i];
+    if (typeof candidate.roomId !== "string" || !candidate.roomId) continue;
+    if (terminalStatuses.has(candidate.status)) {
+      fallbackRoomId = candidate.roomId;
+      break;
+    }
+    // Track last-seen room as a fallback if no terminal task carries one.
+    if (!fallbackRoomId) {
+      fallbackRoomId = candidate.roomId;
+    }
+  }
+  await routeSynthesisToConnector(runtime, resultText, fallbackRoomId);
 }
 
 async function buildSynthesisResultText(payload: {
@@ -260,19 +285,30 @@ async function buildSynthesisResultText(payload: {
     originalTask: string;
     completionSummary: string;
     status: string;
+    workdir?: string;
   }>;
   total: number;
 }): Promise<string> {
   const parts = await Promise.all(payload.tasks.map(buildTaskResultLine));
   return parts.length === 1
-    ? `done -- ${parts[0]}`
-    : `done -- ${payload.total} tasks:\n${parts.map((p) => `- ${p}`).join("\n")}`;
+    ? parts[0]
+    : `${payload.total} tasks:\n${parts.map((p) => `- ${p}`).join("\n")}`;
 }
 
 async function buildTaskResultLine(task: {
   originalTask: string;
   completionSummary: string;
+  workdir?: string;
 }): Promise<string> {
+  // Prefer the agent's actual final assistant message: that's the real
+  // deliverable (news brief, code summary, URL, etc.). The coordinator's
+  // completionSummary is a meta-judgment about whether the task finished,
+  // not the content the agent produced. Only fall through if the jsonl
+  // can't be read.
+  if (task.workdir) {
+    const finalText = await readAgentFinalAssistantMessage(task.workdir);
+    if (finalText) return finalText;
+  }
   if (task.completionSummary) return task.completionSummary;
   const portMatch = task.originalTask.match(/port\s+(\d+)/i);
   const port = portMatch?.[1];
@@ -282,6 +318,70 @@ async function buildTaskResultLine(task: {
     return `built and serving at http://${host}:${port}`;
   }
   return `built the files but server isn't running on port ${port} yet`;
+}
+
+async function readAgentFinalAssistantMessage(
+  workdir: string,
+): Promise<string | null> {
+  try {
+    // claude-code persists each session under a project directory whose name
+    // is the workdir with both "/" and "." replaced by "-" (so a hidden
+    // path like /home/u/.milady/workspaces/<id> becomes
+    // -home-u--milady-workspaces-<id>).
+    const sanitized = workdir.replace(/[/.]/g, "-");
+    const projectDir = path.join(
+      os.homedir(),
+      ".claude",
+      "projects",
+      sanitized,
+    );
+    const entries = await fs.readdir(projectDir, { withFileTypes: true });
+    const jsonls = entries.filter(
+      (e) => e.isFile() && e.name.endsWith(".jsonl"),
+    );
+    if (jsonls.length === 0) return null;
+    const stats = await Promise.all(
+      jsonls.map(async (e) => ({
+        name: e.name,
+        mtime: (await fs.stat(path.join(projectDir, e.name))).mtimeMs,
+      })),
+    );
+    stats.sort((a, b) => b.mtime - a.mtime);
+    const newest = path.join(projectDir, stats[0].name);
+    const raw = await fs.readFile(newest, "utf8");
+    let lastText = "";
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as Record<string, unknown>;
+        if (obj.type !== "assistant") continue;
+        const message = obj.message as Record<string, unknown> | undefined;
+        if (!message || message.role !== "assistant") continue;
+        const content = message.content;
+        if (typeof content === "string") {
+          lastText = content;
+        } else if (Array.isArray(content)) {
+          for (const part of content) {
+            if (
+              part &&
+              typeof part === "object" &&
+              (part as Record<string, unknown>).type === "text" &&
+              typeof (part as Record<string, unknown>).text === "string"
+            ) {
+              lastText = (part as Record<string, string>).text;
+            }
+          }
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    const collapsed = lastText.trim();
+    return collapsed.length > 0 ? collapsed : null;
+  } catch {
+    return null;
+  }
 }
 
 async function isPortServing(port: string): Promise<boolean> {
@@ -298,9 +398,10 @@ async function isPortServing(port: string): Promise<boolean> {
 async function routeSynthesisToConnector(
   runtime: AgentRuntime,
   resultText: string,
+  fallbackRoomId: string | null = null,
 ): Promise<void> {
   const coordinator = getCoordinatorFromRuntime(runtime);
-  const sourceRoomId = coordinator?.sourceRoomId;
+  const sourceRoomId = coordinator?.sourceRoomId ?? fallbackRoomId;
   if (!sourceRoomId) return;
   try {
     const room = await runtime.getRoom(sourceRoomId as UUID);


### PR DESCRIPTION
## Summary

The swarm synthesis path was broken in three stacked ways. When a task agent finished its work (opens a PR, builds a page, fetches data, etc.), nothing was posted back to the triggering room — the agent silently dropped its final result on the floor.

### 1. `setSwarmCompleteCallback` was a no-op

`wireCodingAgentSwarmSynthesis` installed a deliberate no-op with a comment claiming *"synthesis happens via the streamer instead."* In practice `handleSwarmSynthesis` (defined in the same file) is never called anywhere in the repo. Task agents completed, `swarm_complete` fired, the callback ran, returned — no user-facing message was ever emitted.

**Fix:** wire the callback to `await handleSwarmSynthesis(st, payload)`.

### 2. `routeSynthesisToConnector` gated on a field that's never assigned

The connector-routing path early-returns when `coordinator.sourceRoomId` is null. That field is declared on the coordinator interface but **never assigned anywhere in the orchestrator**, so the path was always dead.

**Fix:** thread a `fallbackRoomId` parameter through `routeSynthesisToConnector`. Derive it from the most recently terminal task in the payload — the task whose completion fired `swarm_complete`, and whose room is waiting for an answer. Naively taking *"first task with a roomId"* leaked results into stale rooms when the coordinator carried tasks across rooms. `coordinator.sourceRoomId` is still preferred when set, so any future direct assignment still wins.

### 3. Synthesis rendered a meta-summary instead of the actual result

`buildTaskResultLine` used the coordinator's `completionSummary` as the user-facing output. That's a meta-judgment about *whether* the task finished ("The agent delivered a complete evening news brief with 7 headlines..."), not the content the agent produced. The real deliverable — the brief itself, the PR URL line, the built page URL — was sitting unread in the task agent's `claude-code` session transcript.

**Fix:** read the newest `.jsonl` at `~/.claude/projects/<sanitized-workdir>/` and return the last assistant message as the primary synthesis content. Only fall through to `completionSummary` (and then to port-heuristic text) when the jsonl can't be read. The workdir sanitizer replaces both `/` and `.` with `-` so hidden paths like `/home/u/.milady/workspaces/<id>` resolve to their matching project directory.

## Changes

One file: `packages/agent/src/api/server-helpers-swarm.ts` (+107, -6).

- `wireCodingAgentSwarmSynthesis` now invokes `handleSwarmSynthesis`
- `handleSwarmSynthesis` payload carries per-task `roomId` and `workdir`
- `routeSynthesisToConnector` accepts an optional `fallbackRoomId`
- New `readAgentFinalAssistantMessage(workdir)` helper reads the agent's final message from its claude-code transcript
- `buildTaskResultLine` prefers the agent's real output over the coordinator's meta-summary

## Test plan

- [x] Verified end-to-end on a real Discord-triggered delegation: user prompt → planner picks SPAWN_AGENT → task agent completes → synthesis posts the actual deliverable into the originating Discord room. Log shows:
  ```
  [swarm-synthesis] Generating synthesis for 1 tasks (1 completed, 0 stopped, 0 errored)
  [swarm-synthesis] Synthesis generated, routing to user
  [swarm-synthesis] Routed result to discord room <uuid>
  ```
- [x] Multi-task swarm where some tasks span different rooms: synthesis lands in the correct (most recently terminal) room, not in a stale room from a sibling task.
- [x] `tsc --noEmit` clean in `packages/agent`.

## Compatibility notes

- Behavior for turns where `coordinator.sourceRoomId` is actually set (any downstream consumer that populates it): unchanged — still preferred over the fallback.
- Behavior when the jsonl isn't readable (non-claude task agents, race at early-kill time, etc.): falls back to existing `completionSummary` / port-heuristic path, so no regression vs. pre-patch rendering.
- Net effect for users relying on the synthesis NOT running (none observed, but noting it): they now get a post-task message where they previously got silence. If that's desired behavior for some deployment, it should be guarded explicitly rather than left to a silent-drop bug.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three stacked bugs preventing swarm synthesis results from ever reaching the triggering room: (1) the `swarm_complete` callback was a deliberate no-op, (2) `routeSynthesisToConnector` gated on `coordinator.sourceRoomId` which was never assigned, and (3) the rendered output was a meta-judgment string instead of the agent's actual deliverable. The fix wires the callback, derives a `fallbackRoomId` from the most-recently terminal task, and reads the agent's final assistant message from its claude-code JSONL transcript.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only P2 findings (content concatenation and message-length cap), no logic-breaking bugs introduced.

All findings are P2 quality/robustness suggestions. The core fixes are well-reasoned, the fallback-room selection logic is correct, error paths fall through to pre-existing behaviour, and the PR was verified end-to-end.

packages/agent/src/api/server-helpers-swarm.ts — the readAgentFinalAssistantMessage JSONL parser (multi-part content handling and connector size limits).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/api/server-helpers-swarm.ts | Fixes three stacked swarm-synthesis bugs: no-op callback, dead connector route, and meta-summary vs. real deliverable; introduces `readAgentFinalAssistantMessage` to read from claude-code JSONL transcripts; minor issues with multi-part content blocks being overwritten instead of concatenated, and no truncation guard before forwarding potentially large outputs to connectors with character limits. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User (Discord/etc.)
    participant Coordinator as SwarmCoordinator
    participant Synthesis as handleSwarmSynthesis
    participant JSONL as claude-code JSONL
    participant WebUI as Web UI (routeMessage)
    participant Connector as Connector (Discord room)

    User->>Coordinator: trigger task (roomId attached)
    Coordinator->>Coordinator: task agent runs, writes JSONL
    Coordinator->>Synthesis: swarm_complete(payload{tasks[roomId, workdir]})
    Synthesis->>JSONL: readAgentFinalAssistantMessage(workdir)
    JSONL-->>Synthesis: last assistant text (real deliverable)
    Synthesis->>WebUI: routeMessage(resultText, swarm_synthesis)
    Note over Synthesis: derive fallbackRoomId from most-recently terminal task
    Synthesis->>Connector: routeSynthesisToConnector(runtime, resultText, fallbackRoomId)
    Connector-->>User: synthesis posted to originating room
```

<sub>Reviews (3): Last reviewed commit: ["fix(agent): deliver swarm synthesis to t..."](https://github.com/elizaos/eliza/commit/ec11c3fb790b0d59cb2ac4fdb8d51aa7fecab0c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29566007)</sub>

<!-- /greptile_comment -->