### PR TITLE
fix(auth): distinguish Claude Code CLI credentials from in-app OAuth

### DIFF
--- a/packages/agent/src/auth/credentials.ts
+++ b/packages/agent/src/auth/credentials.ts
@@ -187,11 +187,19 @@ function hasCodexCliSubscriptionAuth(): boolean {
  * awaited without `await` — silently marking every user as
  * "configured: true".
  */
+export type SubscriptionCredentialSource =
+  | "app"
+  | "claude-code-cli"
+  | "setup-token"
+  | "codex-cli"
+  | null;
+
 export function getSubscriptionStatus(): Array<{
   provider: SubscriptionProvider;
   configured: boolean;
   valid: boolean;
   expiresAt: number | null;
+  source: SubscriptionCredentialSource;
 }> {
   const providers: SubscriptionProvider[] = [
     "anthropic-subscription",
@@ -206,14 +214,17 @@ export function getSubscriptionStatus(): Array<{
     const claudeBlob =
       provider === "anthropic-subscription" ? readClaudeCodeOAuthBlob() : null;
     let importedClaudeAuth: string | null = null;
+    let claudeSource: SubscriptionCredentialSource = null;
     if (provider === "anthropic-subscription") {
       if (claudeBlob?.accessToken) {
         // Blob exists with a parsed accessToken — the user has Claude
         // Code installed and authenticated. Expiry is validated
         // below via the `valid` field.
         importedClaudeAuth = claudeBlob.accessToken;
+        claudeSource = "claude-code-cli";
       } else {
         importedClaudeAuth = readConfiguredAnthropicSetupToken();
+        if (importedClaudeAuth) claudeSource = "setup-token";
       }
     }
     const importedCodexAuth =
@@ -231,6 +242,18 @@ export function getSubscriptionStatus(): Array<{
       ? blobExpiresAt === null || blobExpiresAt > Date.now()
       : false;
 
+    // App-owned credentials take priority over system/CLI sources —
+    // they represent an explicit in-app OAuth, and they're the only
+    // source the DELETE /api/subscription/{provider} route can clear.
+    let source: SubscriptionCredentialSource = null;
+    if (stored !== null) {
+      source = "app";
+    } else if (provider === "anthropic-subscription" && claudeSource) {
+      source = claudeSource;
+    } else if (importedCodexAuth) {
+      source = "codex-cli";
+    }
+
     return {
       provider,
       configured:
@@ -241,6 +264,7 @@ export function getSubscriptionStatus(): Array<{
           ? blobValid
           : Boolean(importedCodexAuth),
       expiresAt: stored?.credentials.expires ?? blobExpiresAt,
+      source,
     };
   });
 }

--- a/packages/app-core/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.tsx
@@ -150,9 +150,16 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
       configured: boolean;
       valid: boolean;
       expiresAt: number | null;
+      source?:
+        | "app"
+        | "claude-code-cli"
+        | "setup-token"
+        | "codex-cli"
+        | null;
     }>
   >([]);
   const [anthropicConnected, setAnthropicConnected] = useState(false);
+  const [anthropicCliDetected, setAnthropicCliDetected] = useState(false);
   const [openaiConnected, setOpenaiConnected] = useState(false);
 
   const hasManualSelection = useRef(false);
@@ -289,7 +296,22 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
       (s) =>
         s.provider === "openai-subscription" || s.provider === "openai-codex",
     );
-    setAnthropicConnected(Boolean(anthStatus?.configured && anthStatus?.valid));
+    // Only treat as "connected" when credentials were linked via the in-app
+    // OAuth flow (source === "app"). Claude Code CLI credentials detected on
+    // the machine are surfaced separately — the app can't disconnect them.
+    const anthAppConnected = Boolean(
+      anthStatus?.configured &&
+        anthStatus?.valid &&
+        anthStatus?.source === "app",
+    );
+    setAnthropicConnected(anthAppConnected);
+    setAnthropicCliDetected(
+      Boolean(
+        anthStatus?.configured &&
+          anthStatus?.valid &&
+          anthStatus?.source === "claude-code-cli",
+      ),
+    );
     setOpenaiConnected(Boolean(oaiStatus?.configured && oaiStatus?.valid));
   }, [subscriptionStatus]);
 
@@ -787,6 +809,7 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
           subscriptionStatus={subscriptionStatus}
           anthropicConnected={anthropicConnected}
           setAnthropicConnected={setAnthropicConnected}
+          anthropicCliDetected={anthropicCliDetected}
           openaiConnected={openaiConnected}
           setOpenaiConnected={setOpenaiConnected}
           handleSelectSubscription={handleSelectSubscription}

--- a/packages/app-core/src/components/settings/SubscriptionStatus.tsx
+++ b/packages/app-core/src/components/settings/SubscriptionStatus.tsx
@@ -34,9 +34,22 @@ export interface SubscriptionStatusProps {
     configured: boolean;
     valid: boolean;
     expiresAt: number | null;
+    source?:
+      | "app"
+      | "claude-code-cli"
+      | "setup-token"
+      | "codex-cli"
+      | null;
   }>;
   anthropicConnected: boolean;
   setAnthropicConnected: (v: boolean) => void;
+  /**
+   * True when Claude Code CLI credentials exist on this machine but the user
+   * has NOT linked their subscription via the in-app OAuth flow. In this
+   * state the panel shows a read-only notice and hides the Disconnect
+   * button — the app can't clear CLI-owned credentials.
+   */
+  anthropicCliDetected: boolean;
   openaiConnected: boolean;
   setOpenaiConnected: (v: boolean) => void;
   handleSelectSubscription: (
@@ -49,6 +62,15 @@ export interface SubscriptionStatusProps {
 interface SubscriptionProviderPanelProps {
   providerId: SubscriptionProviderSelectionId;
   connected: boolean;
+  /**
+   * Whether this panel owns credentials it can actually delete via
+   * `DELETE /api/subscription/{provider}`. When false (e.g. Claude Code CLI
+   * credentials detected on disk), the Disconnect button is hidden since
+   * clicking it would be a no-op and just confuse the user.
+   */
+  canDisconnect?: boolean;
+  /** Optional notice rendered below the header (e.g. for CLI-detected state). */
+  externalNotice?: ReactNode;
   configuredButInvalid: boolean;
   titleConnected: string;
   titleDisconnected: string;
@@ -92,6 +114,8 @@ function StatusDot({ connected }: { connected: boolean }) {
 
 function SubscriptionProviderPanel({
   connected,
+  canDisconnect = true,
+  externalNotice,
   configuredButInvalid,
   titleConnected,
   titleDisconnected,
@@ -130,7 +154,7 @@ function SubscriptionProviderPanel({
             {connected ? titleConnected : titleDisconnected}
           </span>
         </div>
-        {connected && (
+        {connected && canDisconnect && (
           <Button
             variant="outline"
             size="sm"
@@ -146,6 +170,8 @@ function SubscriptionProviderPanel({
       </div>
 
       {warningBanner}
+
+      {externalNotice}
 
       {configuredButInvalid && (
         <div className="text-xs text-warn">{invalidWarning}</div>
@@ -216,6 +242,7 @@ export function SubscriptionStatus({
   subscriptionStatus,
   anthropicConnected,
   setAnthropicConnected,
+  anthropicCliDetected,
   openaiConnected,
   setOpenaiConnected,
   handleSelectSubscription,
@@ -551,11 +578,27 @@ export function SubscriptionStatus({
         <SubscriptionProviderPanel
           providerId="anthropic-subscription"
           connected={anthropicConnected}
+          externalNotice={
+            anthropicCliDetected && !anthropicConnected ? (
+              <div className="rounded-lg border border-border/40 bg-card/40 px-2.5 py-2 text-xs leading-relaxed">
+                <div className="font-semibold">
+                  {t("subscriptionstatus.ClaudeCodeCliDetectedTitle")}
+                </div>
+                <p className="mt-1 text-muted">
+                  {t("subscriptionstatus.ClaudeCodeCliDetectedBody")}
+                </p>
+              </div>
+            ) : undefined
+          }
           configuredButInvalid={Boolean(
             anthropicStatus?.configured && !anthropicStatus.valid,
           )}
           titleConnected={t("subscriptionstatus.ConnectedToClaudeSubscription")}
-          titleDisconnected={t("subscriptionstatus.ClaudeSubscriptionTitle")}
+          titleDisconnected={
+            anthropicCliDetected
+              ? t("subscriptionstatus.ClaudeCodeCliDetectedTitle")
+              : t("subscriptionstatus.ClaudeSubscriptionTitle")
+          }
           loginLabel={t("onboarding.loginWithAnthropic")}
           loginHint={t("subscriptionstatus.RequiresClaudePro")}
           connectedSummary={t("subscriptionstatus.YourClaudeSubscrip")}

--- a/packages/app-core/src/i18n/locales/en.json
+++ b/packages/app-core/src/i18n/locales/en.json
@@ -2418,6 +2418,8 @@
   "subscriptionstatus.CallbackUrlMissingCode": "Callback URL is missing the ?code= parameter.",
   "subscriptionstatus.ChatGPTSubscription": "ChatGPT subscription credentials are expired or invalid. Reconnect\n              to continue.",
   "subscriptionstatus.ChatGPTSubscriptionTitle": "ChatGPT Subscription",
+  "subscriptionstatus.ClaudeCodeCliDetectedBody": "Signed in via the Claude Code CLI on this machine. To sign out, run `claude logout` in a terminal — the app can't clear CLI credentials. Connect in-app below to link this account to Milady explicitly.",
+  "subscriptionstatus.ClaudeCodeCliDetectedTitle": "Claude Code CLI detected",
   "subscriptionstatus.ClaudeSubscription": "Claude subscription credentials are expired or invalid. Reconnect\n              to continue.",
   "subscriptionstatus.ClaudeSubscriptionTitle": "Claude Subscription",
   "subscriptionstatus.ClaudeTosWarning": "Claude subscriptions can only be used through the Claude Code CLI (Anthropic TOS). Your subscription will power task agents but not the main agent runtime. For the main agent, use Eliza Cloud, a direct Anthropic API key, or another provider.",

--- a/packages/shared/src/contracts/onboarding.ts
+++ b/packages/shared/src/contracts/onboarding.ts
@@ -518,11 +518,19 @@ export interface OnboardingLlmPersistenceSelection
   remoteApiBase?: string;
   remoteAccessToken?: string;
 }
+export type SubscriptionCredentialSource =
+  | "app"
+  | "claude-code-cli"
+  | "setup-token"
+  | "codex-cli"
+  | null;
+
 export interface SubscriptionProviderStatus {
   provider: string;
   configured: boolean;
   valid: boolean;
   expiresAt: number | null;
+  source: SubscriptionCredentialSource;
 }
 
 export interface SubscriptionStatusResponse {


### PR DESCRIPTION
## Problem
When the Claude Code CLI is installed and authenticated on the user's machine, the Anthropic subscription panel in Settings → AI Models incorrectly reports "Connected to Claude Subscription" with an active Disconnect button — even though the user never ran the in-app OAuth flow. Clicking Disconnect is a no-op: it only clears app-owned credentials (`~/.eliza/auth/anthropic-subscription.json`), never the CLI's (`~/.claude/.credentials.json` or the macOS keychain entry). Status re-fetches, sees the CLI blob, UI stays "Connected". Phantom state the user can't dismiss.

## Fix
Surface the credential source on `GET /api/subscription/status`:

```ts
source: "app" | "claude-code-cli" | "setup-token" | "codex-cli" | null

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a phantom \"Connected\" state for Anthropic subscriptions by surfacing a `source` field (`"app" | "claude-code-cli" | "setup-token" | "codex-cli"`) on the subscription status endpoint and gating the UI's connected/disconnect affordances on that source. The credential-priority logic in `getSubscriptionStatus` is sound and the CLI-detected banner path works correctly.

- **P1 regression**: Users authenticated via `source === \"setup-token\"` now fall through both the `anthAppConnected` and `anthropicCliDetected` branches in `ProviderSwitcher`, causing the panel to render a \"Disconnected\" state with a login button even when the subscription is valid. Previously `configured && valid` was sufficient to show \"Connected\".

<h3>Confidence Score: 3/5</h3>

The fix is correct for the CLI case but introduces a UI regression for setup-token users who will see a misleading disconnected state

One P1 logic regression (setup-token users silently appear disconnected) pulls the score below the P1 ceiling of 4; the rest of the changes are well-reasoned and correctly implemented

packages/app-core/src/components/settings/ProviderSwitcher.tsx — the useEffect that computes anthropicConnected/anthropicCliDetected needs a third branch for source==="setup-token"

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/settings/ProviderSwitcher.tsx | Introduces anthropicCliDetected state and gates anthropicConnected on source==="app", but setup-token users (source==="setup-token") are now silently treated as disconnected with no UI explanation — a regression from prior behavior |
| packages/agent/src/auth/credentials.ts | Adds SubscriptionCredentialSource type and populates source field in getSubscriptionStatus(); logic is correct for app/cli/setup-token/codex-cli prioritization, but the type is duplicated rather than imported from the shared contract |
| packages/app-core/src/components/settings/SubscriptionStatus.tsx | Adds canDisconnect/externalNotice props to SubscriptionProviderPanel and renders a CLI-detected notice; canDisconnect defaults to true correctly (only relevant when connected=true, which requires source==="app") |
| packages/shared/src/contracts/onboarding.ts | Adds SubscriptionCredentialSource type and source field to SubscriptionProviderStatus; duplicates the type definition that also lives in packages/agent/src/auth/credentials.ts |
| packages/app-core/src/i18n/locales/en.json | Adds two new i18n keys for the CLI-detected banner; body text hardcodes "Milady" which may be namespace-specific |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["GET /api/subscription/status"] --> B["getSubscriptionStatus()"]
    B --> C{"stored != null\n(~/.eliza/auth/…)"}
    C -- "yes" --> D["source = 'app'"]
    C -- "no" --> E{"claudeBlob?.accessToken"}
    E -- "yes" --> F["claudeSource = 'claude-code-cli'"]
    E -- "no" --> G{"readConfiguredAnthropicSetupToken()"}
    G -- "found" --> H["claudeSource = 'setup-token'"]
    G -- "not found" --> I["claudeSource = null"]
    F --> J["source = 'claude-code-cli'"]
    H --> K["source = 'setup-token'"]
    I --> L["source = null"]
    D & J & K & L --> M["ProviderSwitcher useEffect"]
    M --> N{"source === 'app'"}
    N -- "yes" --> O["anthropicConnected = true\nanthropicCliDetected = false\n✅ Disconnect shown"]
    N -- "no" --> P{"source === 'claude-code-cli'"}
    P -- "yes" --> Q["anthropicConnected = false\nanthropicCliDetected = true\n✅ CLI notice shown"]
    P -- "no" --> R["anthropicConnected = false\nanthropicCliDetected = false\n⚠️ 'Disconnected' shown\neven for setup-token users"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(auth): distinguish Claude Code CLI c..."](https://github.com/elizaos/eliza/commit/58cf63a9b03bed4e8b26b638c2d65c12d6e013d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29619682)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->