### PR TITLE
fix(agent): stop workbench task list from leaking runtime scheduler tasks

### DIFF
--- a/packages/agent/src/actions/manage-tasks.ts
+++ b/packages/agent/src/actions/manage-tasks.ts
@@ -51,6 +51,20 @@ const TASK_INTENT_TERMS: string[] = [
   "check off",
 ];
 
+const LIST_INTENT_TERMS: string[] = [
+  "list tasks",
+  "show tasks",
+  "my tasks",
+  "what are my tasks",
+  "task list",
+];
+
+export function looksLikeListTaskIntent(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return findKeywordTermMatch(trimmed, LIST_INTENT_TERMS) !== undefined;
+}
+
 interface TaskExtraction {
   operation?: string;
   name?: string;
@@ -182,6 +196,17 @@ export const manageTasksAction: Action = {
 
       // ── LIST ──
       if (operation === "list") {
+        // Defensive: validate may admit this turn based on recent messages,
+        // and the LLM extractor occasionally classifies vague prompts as
+        // "list" by default. Require the current message to actually look
+        // like a list request before dumping tasks into chat.
+        if (!looksLikeListTaskIntent(text)) {
+          return {
+            success: false,
+            text: "",
+            error: "list operation requires explicit task-listing intent",
+          };
+        }
         if (workbenchTasks.length === 0) {
           const msg = "You have no tasks right now.";
           if (callback)

--- a/packages/agent/src/api/workbench-helpers.ts
+++ b/packages/agent/src/api/workbench-helpers.ts
@@ -107,6 +107,12 @@ export function isWorkbenchTodoTask(task: Task): boolean {
 }
 
 export function toWorkbenchTask(task: Task): WorkbenchTaskView | null {
+  // Only surface tasks that were explicitly created as workbench items.
+  // The runtime's batch-queue util (EMBEDDING_DRAIN, PROACTIVE_AGENT,
+  // LIFEOPS_SCHEDULER, heartbeat, ...) registers system ticks in the same
+  // task table; without this tag check those system tasks leaked into
+  // the user-facing task list and (worse) into LIST_TASKS replies.
+  if (!task.tags?.includes(WORKBENCH_TASK_TAG)) return null;
   if (readTriggerConfig(task) || isWorkbenchTodoTask(task)) return null;
   const id = normalizeTaskId(task);
   if (!id) return null;


### PR DESCRIPTION
## Summary

Two stacked issues caused the agent to dump its internal task table into chat whenever the planner picked `MANAGE_TASKS` with `operation=list`. A prompt like *"doomscroll the web for me"* or any vague phrase could produce a Discord reply listing 100+ `EMBEDDING_DRAIN` ticks alongside `PROACTIVE_AGENT`, `LIFEOPS_SCHEDULER`, and `heartbeat` entries.

### 1. `toWorkbenchTask` filter was permissive

`workbench-helpers.ts:109` excluded only trigger configs and todo tasks. The runtime's `utils/batch-queue` util (used for drain / queue tasks like `EMBEDDING_DRAIN`) registers system ticks as elizaOS `Task` records in the same table. Those have no trigger config and are not todos, so they sailed through and appeared in the user-facing workbench list.

The CREATE side of `MANAGE_TASKS` already tags user-created tasks with `WORKBENCH_TASK_TAG`. Make the filter inclusive and require that tag, matching the convention.

### 2. `MANAGE_TASKS` list operation fired without explicit list intent

`manage-tasks.ts` `validate` admits the action when `looksLikeTaskIntent` matches either the current message or any of the last 4 room messages. That lookback handles *"yes, list them"* follow-ups intentionally. Combined with `TEXT_SMALL` extraction occasionally classifying vague prompts as `operation=list`, though, the action could fire on a message that did not ask for a task list at all.

Add a defensive guard at the top of the LIST branch using a tighter `LIST_INTENT_TERMS` subset (`list tasks`, `show tasks`, `my tasks`, `what are my tasks`, `task list`). If the current message does not match list intent, the action returns `success=false` with an error and nothing is sent to chat.

## Changes

- `packages/agent/src/api/workbench-helpers.ts` (+6): `toWorkbenchTask` requires `WORKBENCH_TASK_TAG`
- `packages/agent/src/actions/manage-tasks.ts` (+25): new `LIST_INTENT_TERMS` + `looksLikeListTaskIntent` helper, guard in LIST branch

Total: 2 files, +31, −0.

## Test plan

- [x] Verified live on the bot: prior to patch, a `"doomscroll the web"` prompt produced a Discord reply listing 100+ EMBEDDING_DRAIN ticks. After patch, the same prompt routes through the planner to `SPAWN_AGENT` (the right action), and no system tasks appear in any user-visible surface.
- [x] Manual regression: explicit list prompts (`"list my tasks"`, `"show tasks"`) still work and show only user-created tasks tagged with `WORKBENCH_TASK_TAG`.
- [x] `tsc --noEmit` clean in `packages/agent`.

## Compatibility notes

- The filter tightening is backwards-compatible with the CREATE path, which already tags user tasks. Any task that was intentionally created without `WORKBENCH_TASK_TAG` (e.g. by a plugin that forgot the tag) will stop appearing in the workbench list. That's the same behavior those tasks would have gotten if they had been correctly filed as a todo or trigger.
- The LIST intent guard only suppresses the `list` branch when the current message doesn't match list intent. The `create`, `complete`, `delete`, `update` branches are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related issues that caused internal runtime scheduler tasks (e.g. `EMBEDDING_DRAIN`, `heartbeat`) to leak into user-facing workbench task lists. `toWorkbenchTask` now gates on `WORKBENCH_TASK_TAG` as an inclusive pre-filter, and a new `looksLikeListTaskIntent` guard prevents the `LIST` branch from firing when the LLM extractor misclassifies a vague prompt as `operation=list`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — both changes are additive guards with no behavior change on the happy path.

No P0 or P1 issues found. The tag-based filter is backwards-compatible with the existing CREATE path (which already applies the tag), and the LIST intent guard only suppresses misclassified list operations without touching other branches. Previously flagged concerns (silent no-op on unrecognized list phrasing, redundant readTriggerConfig check) are P2-level and have already been discussed in prior review threads.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/actions/manage-tasks.ts | Adds LIST_INTENT_TERMS constant and looksLikeListTaskIntent guard in the LIST branch to prevent vague prompts (misclassified as "list" by the LLM extractor) from dumping tasks into chat; other operations are unaffected. |
| packages/agent/src/api/workbench-helpers.ts | toWorkbenchTask now requires WORKBENCH_TASK_TAG as an inclusive pre-filter, preventing runtime system tasks (EMBEDDING_DRAIN, heartbeat, etc.) from leaking into the user-facing workbench list; existing defensive checks are retained. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant validate as manageTasksAction.validate
    participant handler as manageTasksAction.handler
    participant LLM as TEXT_SMALL (extraction)
    participant DB as Runtime Task Table
    participant toWT as toWorkbenchTask

    User->>validate: message text
    validate->>validate: looksLikeTaskIntent(text) OR recent messages match
    validate-->>handler: true (admitted)

    handler->>DB: getTasks({ agentIds })
    DB-->>handler: all tasks (system + workbench)

    handler->>toWT: filter each task
    toWT->>toWT: task.tags.includes(WORKBENCH_TASK_TAG)?
    Note over toWT: NEW: system tasks (EMBEDDING_DRAIN, heartbeat, etc.) excluded here
    toWT-->>handler: workbenchTasks (tag-filtered)

    handler->>LLM: extractionPrompt(text, taskList)
    LLM-->>handler: operation = list (may be misclassified)

    alt operation === list
        handler->>handler: looksLikeListTaskIntent(text)?
        Note over handler: NEW guard — requires explicit list phrasing on current message
        alt intent detected
            handler-->>User: Your tasks: [workbench tasks only]
        else intent NOT detected
            handler-->>User: (silent — success:false, no callback)
        end
    else other operation
        handler-->>User: create/complete/delete/update result
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(agent): stop workbench task list fro..."](https://github.com/elizaos/eliza/commit/87575ff1f7c363f00fe7b5ad12200642ff5d45f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29670078)</sub>

<!-- /greptile_comment -->