### PR TITLE
fix(message): cap action results rendered in the planner prompt

### DIFF
--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -2630,21 +2630,42 @@ function shouldWaitForUserAfterIncompleteReflection(
 	});
 }
 
+// Cap how many recent action results we render into the planner prompt.
+// Prior turns' results accumulate without bound otherwise; in long-running
+// channels the planner template grows past the per-account long-context
+// gate (~200K input tokens on subscription tiers) and every turn fails
+// until history rolls off. Eight is enough for the planner to recognize
+// patterns ("we just spawned an agent, don't spawn another") without
+// dragging in entire session histories.
+const MAX_PROMPTED_ACTION_RESULTS = 8;
+
 function formatActionResultsForPrompt(actionResults: ActionResult[]): string {
 	if (actionResults.length === 0) {
 		return "No action results available.";
 	}
 
+	const rendered =
+		actionResults.length > MAX_PROMPTED_ACTION_RESULTS
+			? actionResults.slice(-MAX_PROMPTED_ACTION_RESULTS)
+			: actionResults;
+	const truncatedCount = actionResults.length - rendered.length;
+	const omittedNote =
+		truncatedCount > 0
+			? [`(${truncatedCount} earlier action result(s) omitted.)`]
+			: [];
+
 	return [
 		"# Action Results",
-		...actionResults.map((result, index) => {
+		...omittedNote,
+		...rendered.map((result, index) => {
 			const actionNameValue = result.data?.actionName;
 			const actionName =
 				typeof actionNameValue === "string"
 					? actionNameValue
 					: "Unknown Action";
+			const displayIndex = truncatedCount + index + 1;
 			const lines = [
-				`${index + 1}. ${actionName} - ${result.success === false ? "failed" : "succeeded"}`,
+				`${displayIndex}. ${actionName} - ${result.success === false ? "failed" : "succeeded"}`,
 			];
 			if (typeof result.text === "string" && result.text.trim()) {
 				lines.push(`Output: ${result.text.trim().slice(0, 2000)}`);


### PR DESCRIPTION
## Summary

`multiStepDecisionTemplate` interpolates `{{actionResults}}` via `formatActionResultsForPrompt`, which rendered the complete action-results history with no upper bound. In a long-running room this grows continuously: each entry is up to 2KB of output plus 1KB of error text, so a channel with many delegated actions (swarm spawns, search calls, etc.) builds a planner prompt that crosses the per-account long-context gate (~200K input tokens on subscription tiers). Once past that threshold, every turn fails with `"Extra usage is required for long context requests"` until history rolls off naturally.

Symptom observed live: the same user prompt succeeds in a quiet test channel (~500KB planner request) but fails repeatedly in an active channel (~1MB planner request, 429s on every retry).

## Fix

Cap the render to the 8 most recent action results. Include a one-line note (`"(N earlier action result(s) omitted.)"`) when the list was truncated so the model knows prior context existed without seeing the full content. The planner still sees enough near-term history to recognize patterns ("we just spawned an agent, don't spawn another") without carrying the entire session.

No change for turns with ≤ 8 results.

## Changes

One file: `packages/typescript/src/services/message.ts` (+23, −2).

- New constant `MAX_PROMPTED_ACTION_RESULTS = 8` with a comment explaining why
- `formatActionResultsForPrompt` slices to the tail before rendering, preserves absolute index numbering across the truncation note

## Test plan

- [x] Verified live: same prompt that previously 429'd in a long-running channel now completes with a clean planner response. No change in a fresh channel.
- [x] `tsc --noEmit` clean in `packages/typescript`.

## Compatibility / tunability

- The cap is a compile-time constant for now. If reviewers prefer a runtime knob (env var or character setting), that's a straightforward follow-up — the point of this PR is just to not send unbounded history into the planner in the first place.
- The truncation note preserves index numbering so later entries still correspond to their "real" position in the full result list. Helpful if a downstream consumer ever parses the prompt back.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps the number of action results rendered into the planner prompt (`multiStepDecisionTemplate`) at 8, preventing unbounded token growth in long-running channels that was triggering rate-limit errors. The fix is a clean, minimal change: a module-level constant with a clear explanatory comment, correct tail-slicing, preserved absolute index numbering, and an omission note for the model.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix is logically correct and the only gap is missing unit tests for the new truncation path.

No P0 or P1 issues found. The single P2 finding (no unit tests for the new slicing/renumbering logic) does not affect correctness or safety. Score of 4 reflects P2-only findings.

No files require special attention beyond the missing test coverage for formatActionResultsForPrompt.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds MAX_PROMPTED_ACTION_RESULTS=8 cap to formatActionResultsForPrompt; slicing, index renumbering, and omission note are all logically correct. No tests added for the new behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[actionResults array] --> B{length greater than 8?}
    B -- No --> C[rendered = all results\ntruncatedCount = 0]
    B -- Yes --> D[rendered = last 8 results\ntruncatedCount = length - 8]
    C --> G[Build prompt string]
    D --> F[prepend omission note:\nN earlier results omitted]
    F --> G
    G --> H[Return formatted Action Results\nwith preserved absolute index numbers]
    H --> I[Injected into multiStepDecisionTemplate\nvia withActionResults]
```

<sub>Reviews (1): Last reviewed commit: ["fix(message): cap action results rendere..."](https://github.com/elizaos/eliza/commit/7fa9cd573ac4d9c84a1fe13e33f537b9e398afd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29670140)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->