### PR TITLE
fix(message): drop passive bookkeeping actions when delegation owns the turn

### DIFF
--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -2350,6 +2350,15 @@ export function shouldEmitPlannerPreamble(
 	);
 }
 
+// Actions that are passive bookkeeping / chitchat. Safe to drop when a
+// turn-owning action (one that sets suppressPostActionContinuation = true,
+// e.g. SPAWN_AGENT) is also picked for the same turn. Keeping them around
+// alongside explicit delegation produces duplicate user-visible noise:
+// "Created task X" message followed by the actual delegated result.
+const PASSIVE_TURN_ACTIONS = new Set(
+	["REPLY", "MANAGE_TASKS"].map(normalizeActionIdentifier),
+);
+
 export function stripReplyWhenActionOwnsTurn(
 	runtime: Pick<IAgentRuntime, "actions" | "logger">,
 	actions: readonly string[] | null | undefined,
@@ -2358,18 +2367,17 @@ export function stripReplyWhenActionOwnsTurn(
 		return Array.isArray(actions) ? [...actions] : [];
 	}
 
-	const normalizedReply = normalizeActionIdentifier("REPLY");
-	const hasReply = actions.some(
-		(action) => normalizeActionIdentifier(action) === normalizedReply,
+	const hasPassive = actions.some((action) =>
+		PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
 	);
-	if (!hasReply) {
+	if (!hasPassive) {
 		return [...actions];
 	}
 
 	const actionLookup = buildRuntimeActionLookup(runtime);
 	const ownedActions = actions.filter((action) => {
 		const normalized = normalizeActionIdentifier(action);
-		if (!normalized || normalized === normalizedReply) {
+		if (!normalized || PASSIVE_TURN_ACTIONS.has(normalized)) {
 			return false;
 		}
 		return (
@@ -2382,16 +2390,16 @@ export function stripReplyWhenActionOwnsTurn(
 	}
 
 	const filtered = actions.filter(
-		(action) => normalizeActionIdentifier(action) !== normalizedReply,
+		(action) => !PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
 	);
 	runtime.logger.info(
 		{
 			src: "service:message",
 			originalActions: actions,
 			filteredActions: filtered,
-			replySuppressedBy: ownedActions,
+			suppressedBy: ownedActions,
 		},
-		"Dropped REPLY because another selected action already owns the turn",
+		"Dropped passive actions because another selected action already owns the turn",
 	);
 	return filtered.length > 0 ? filtered : ["REPLY"];
 }


### PR DESCRIPTION
## Summary

`stripReplyWhenActionOwnsTurn` previously only suppressed `REPLY` when another action with `suppressPostActionContinuation = true` (e.g. `SPAWN_AGENT`) was selected for the same turn. The planner commonly also picks `MANAGE_TASKS` (operation=create) alongside `SPAWN_AGENT` for delegation prompts ("build me a tip calculator", "send a PR to eliza", etc.). `MANAGE_TASKS` is not suppressed by the current logic, so the user gets a noisy `"Created task <name>."` confirmation followed moments later by the real delegated result from synthesis — two messages for one intent.

## Fix

Generalize the dedup. Define `PASSIVE_TURN_ACTIONS = { REPLY, MANAGE_TASKS }` and drop all members of that set when a turn-owning action (one with `suppressPostActionContinuation = true`) is also picked.

- Same fall-back behavior: returns `["REPLY"]` when everything was passive and the drop would leave the action list empty
- No-op for turns that don't include a passive action (no behavior change for the common cases)
- Log message adjusted from "Dropped REPLY" to "Dropped passive actions" to match the broader scope

## Changes

One file: `packages/typescript/src/services/message.ts` (+16, −8).

- New constant `PASSIVE_TURN_ACTIONS` with a comment explaining why MANAGE_TASKS joins REPLY in the set
- `stripReplyWhenActionOwnsTurn` consults the set instead of the hardcoded `normalizedReply` comparison

## Test plan

- [x] Verified live on a Discord-triggered delegation: `"remilio open a pr on milady-ai/milady that renames X"` previously produced `"Created task X"` followed by the PR URL. After patch, only the real result posts. Log line: `"Dropped passive actions because another selected action already owns the turn (originalActions=['REPLY','MANAGE_TASKS','SPAWN_AGENT'], filteredActions=['SPAWN_AGENT'], suppressedBy=['SPAWN_AGENT'])"`.
- [x] Normal MANAGE_TASKS-only turns (create/update/delete) continue to work — the dedup only engages when a turn-owning action is present.
- [x] `tsc --noEmit` clean in `packages/typescript`.

## Compatibility / design notes

- If a deployment intentionally wants both the task confirmation AND the delegated result, this PR changes that behavior. No such deployment is observed upstream; the existing dedup of `REPLY` already chose the "one message per turn" policy. This extends that policy to MANAGE_TASKS' equivalent confirmation.
- If reviewers prefer the set be opt-in per-action (e.g. a new `Action.isPassiveTurnAction` flag instead of the hardcoded name list), that's a reasonable follow-up. Going with the explicit name list here because it matches the existing `suppressPostActionContinuation` pattern's shape — both are "this action modifies turn dispatch behavior" declared at the usage site.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Widens the existing \"one message per turn\" dedup in `stripReplyWhenActionOwnsTurn`: a new module-level `PASSIVE_TURN_ACTIONS` set (`REPLY` + `MANAGE_TASKS`) replaces the previous hardcoded `REPLY`-only comparison, suppressing the noisy `\"Created task X.\"` confirmation that preceded the real delegated result on delegation turns. Fall-back and no-op paths are preserved exactly as before.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct for all current action configurations.

Only P2 findings remain; the core filtering logic is sound, the fall-back path is preserved, and MANAGE_TASKS has no suppressPostActionContinuation today so no action type is misclassified.

No files require special attention; the single changed file is straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Generalises REPLY-only dedup to a PASSIVE_TURN_ACTIONS set that also includes MANAGE_TASKS; logic is correct for current codebase, with minor naming mismatch on the exported function. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["stripReplyWhenActionOwnsTurn(actions)"] --> B{actions null\nor length ≤ 1?}
    B -- yes --> C[return actions copy]
    B -- no --> D{any action in\nPASSIVE_TURN_ACTIONS?\nREPLY · MANAGE_TASKS}
    D -- no --> E[return actions copy]
    D -- yes --> F[build ownedActions\nnon-passive + suppressPostActionContinuation=true]
    F --> G{ownedActions\nempty?}
    G -- yes --> H[return actions copy\nno turn owner found]
    G -- no --> I[filtered = actions minus PASSIVE_TURN_ACTIONS]
    I --> J[log Dropped passive actions]
    J --> K{filtered\nempty?}
    K -- yes --> L[return REPLY fallback]
    K -- no --> M[return filtered]
```

<sub>Reviews (2): Last reviewed commit: ["fix(message): drop passive bookkeeping a..."](https://github.com/elizaos/eliza/commit/379d33989933035c1eda94ac8c92ef7bf0c8d8fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29670196)</sub>

<!-- /greptile_comment -->