### PR TITLE
fix(message): stop leaking internal mechanism words in transient-failure replies

### DIFF
--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -6439,7 +6439,6 @@ Output ONLY the continuation, starting immediately after the last character abov
 		responseId: UUID,
 		stage: string,
 	): Promise<StrategyResult> {
-		const failure = getStructuredOutputFailure(state);
 		const recentMessages =
 			typeof state.values?.recentMessages === "string" &&
 			state.values.recentMessages.trim().length > 0
@@ -6449,34 +6448,28 @@ Output ONLY the continuation, starting immediately after the last character abov
 					: typeof message.content.text === "string"
 						? message.content.text
 						: "(unavailable)";
-		const actionResults = Array.isArray(state.data?.actionResults)
-			? state.data.actionResults
-			: [];
 		const failurePrompt = [
-			"You are recovering from an internal structured-output failure while responding to a user.",
-			"Write the next user-facing reply in plain language.",
+			"You hit a transient model error and have to send a short user-facing reply.",
+			"Write a one or two sentence reply in plain language.",
 			"",
-			"Rules:",
-			"- Explain what failed and why using only the diagnostics below.",
-			"- Mention any completed or failed actions if action results are available.",
-			"- Be transparent, concise, and avoid inventing causes.",
-			"- If the model returned malformed XML, TOON, or JSON, say that clearly.",
-			"- Suggest the most useful next step for the user.",
-			"- Return only the reply text. No XML, JSON, TOON, bullet labels, or <think>.",
-			"",
-			`Failure Stage: ${stage}`,
-			"",
-			"Structured Failure Diagnostics:",
-			summarizeStructuredOutputFailure(failure),
+			"Hard rules:",
+			"- Stay in character. Keep your usual voice and tone.",
+			"- NEVER mention internal mechanism words such as: planner, action_planner,",
+			"  XML, TOON, JSON, schema, structured output, model, retries, sonnet,",
+			"  opus, claude, anthropic, prompt, parse, parser, xml plan, decision",
+			"  loop, runtime, dispatch, or hand off. The user does not know or care",
+			"  what those are.",
+			"- Do not use em-dashes or en-dashes. Use a plain hyphen, period, or comma.",
+			"- Just acknowledge that something went wrong and suggest a retry.",
+			'  Examples: "something flaked, try again in a sec",',
+			'  "weird hiccup, give me another shot in a moment",',
+			'  "got stuck on my end, retry that?"',
+			"- If the user already gave a clear command and you can plausibly act,",
+			"  acknowledge it and offer to take the action directly. Keep it short.",
+			"- Return only the reply text. No labels, no XML, no JSON, no <think>.",
 			"",
 			"Recent Conversation:",
 			recentMessages,
-			"",
-			"Action Results So Far:",
-			typeof state.values?.actionResults === "string" &&
-			state.values.actionResults.trim().length > 0
-				? state.values.actionResults
-				: "No action results available.",
 			"",
 			"Reply:",
 		].join("\n");
@@ -6527,18 +6520,13 @@ Output ONLY the continuation, starting immediately after the last character abov
 		}
 
 		if (!replyText) {
-			const failureReason =
-				failure?.parseError ??
-				failure?.issues?.[0] ??
-				"the model returned output that did not match the required format";
-			replyText = [
-				`I hit an internal parsing error while ${stage}.`,
-				`Reason: ${failureReason}.`,
-				summarizeActionResultsForUser(actionResults),
-				"Please try again or ask me to retry the last step.",
-			]
-				.filter(Boolean)
-				.join(" ");
+			// Last-ditch fallback when every model call above also failed.
+			// Voice-neutral so any character can ship this default; characters
+			// can override with their own phrasing via
+			// character.templates.transientFailureReply.
+			replyText =
+				runtime.character.templates?.transientFailureReply ||
+				"Something went wrong on my end. Please try again.";
 		}
 
 		replyText = truncateToCompleteSentence(replyText.trim(), 2000);


### PR DESCRIPTION
## Summary

`buildStructuredFailureReply` previously instructed the recovery model to *"Explain what failed and why using only the diagnostics below"* and fed it raw structured-output diagnostics plus action-result summaries. The resulting replies leaked internal terminology users have no business seeing. Observed live in discord when the planner hit transient Anthropic errors:

> *"planner blew up again. the action_planner call to sonnet-4-6 failed all 4 retries with a generic anthropic 'unexpected error', so no xml plan came back and i couldn't commit to a real action this turn. the doomscroll task is already queued from my earlier ack, it just can't hand off through the planner right now."*

That reply leaks "planner", "action_planner", "sonnet-4-6", "anthropic", "xml plan", "hand off through the planner". The user doesn't know or care what any of those are.

## Fix

Rewrite the prompt so the recovery model:
- Stays in character (uses the character's voice + tone)
- Avoids naming internal mechanism words (planner, action_planner, XML, TOON, JSON, schema, model names, retries, runtime, dispatch, hand off)
- Avoids em/en dashes (easy way for the model to sound like a shipping-log paraphrase instead of the character)
- Just acknowledges something flaked and suggests a retry
- Optionally offers to act directly on a clear command if it can

The hard-fallback string used when every model retry also fails is now a voice-neutral default `"Something went wrong on my end. Please try again."` and is overridable per character via `character.templates.transientFailureReply` (following the existing pattern used for `messageHandlerTemplate`, `multiStepDecisionTemplate`, `replyTemplate`, etc.).

## Changes

One file: `packages/typescript/src/services/message.ts` (+24, −36, net −12).

- Prompt rewritten around character voice + mechanism-word ban list
- Hard-fallback uses `character.templates?.transientFailureReply` with a neutral default
- Removed now-unused `failure` and `actionResults` locals + dependency on `summarizeStructuredOutputFailure` / `summarizeActionResultsForUser` inside this function (those helpers remain used elsewhere)

## Test plan

- [x] Verified on the bot with a character that has its own voice config: transient-failure replies stay in that voice, don't mention planner/XML/etc.
- [x] Verified the neutral fallback ("Something went wrong on my end. Please try again.") is what gets used when every model retry also fails (simulated by rejecting all model calls in the replay).
- [x] `tsc --noEmit` clean in `packages/typescript`.

## Compatibility

- `character.templates.transientFailureReply` is a new optional template key. Characters that don't define it get the neutral default. Backwards-compatible.
- The diagnostic information that used to flow into the user-facing text is still logged via `runtime.logger` on the failure path. Debuggability is preserved; only the user-facing surface is cleaned up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the `buildStructuredFailureReply` prompt in `packages/typescript/src/services/message.ts` to prevent internal terminology (planner, XML, model names, etc.) from surfacing in user-facing transient-failure replies. It also replaces the hard-coded fallback string with a voice-neutral default that can be overridden per character via `character.templates.transientFailureReply`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; change is scoped to one function and backwards-compatible.

Only P2 findings remain. No logic regressions introduced; removal of unused locals is clean.

packages/typescript/src/services/message.ts — the `thought` field and `transientFailureReply` template handling are the two areas worth a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Rewrites `buildStructuredFailureReply` prompt to avoid leaking internal terms; removes `failure`/`actionResults` locals; adds `character.templates.transientFailureReply` override for the hard fallback. One P2 inconsistency: the new template key is consumed as a raw string while the PR documentation implies it follows the template-engine pattern (no `{{var}}` substitution occurs). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildStructuredFailureReply called] --> B[Build failurePrompt\ncharacter-voice + ban-list rules\n+ recentMessages]
    B --> C{Try models in order:\nTEXT_LARGE → RESPONSE_HANDLER\n→ TEXT_SMALL → TEXT_NANO}
    C -- success --> D[Clean response\nstrip think tags\nparse if structured]
    D --> E{replyText non-empty?}
    E -- yes --> F[truncateToCompleteSentence]
    C -- all fail --> G{character.templates\n.transientFailureReply?}
    E -- no --> G
    G -- defined --> H[Use character override]
    G -- not defined --> I[Hard fallback: Something went wrong on my end.]
    H --> F
    I --> F
    F --> J[Build responseContent\nactions: REPLY]
    J --> K[Return StrategyResult]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/typescript/src/services/message.ts`, line 6530 ([link](https://github.com/elizaos/eliza/blob/a7fff9578353e294754fa5eed7fd2df4c9ec803a/packages/typescript/src/services/message.ts#L6530)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale internal-terminology in `thought` field**

   The `thought` field still embeds raw internal terms ("structured-output failure", the raw `stage` string) that the rest of this PR is deliberately hiding from users. While `thought` is not rendered in chat today, it is persisted in `responseMessages` and may surface in debug UIs, evaluators, or logged memory. A neutral description keeps this consistent with the spirit of the fix.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(message): stop leaking internal mech..."](https://github.com/elizaos/eliza/commit/2cc5ef20d8898962e2e6486fc9474f51517b94b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29670247)</sub>

<!-- /greptile_comment -->