### PR TITLE
fix(message): tolerate malformed planner action XML

### DIFF
--- a/packages/typescript/src/services/message.test.ts
+++ b/packages/typescript/src/services/message.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, State } from "../types";
 import { stringToUuid } from "../utils";
-import { DefaultMessageService } from "./message.ts";
+import { DefaultMessageService, extractPlannerActionNames } from "./message.ts";
 
 // Tests for DISABLE_MEMORY_CREATION and ALLOW_MEMORY_SOURCE_IDS logic
 describe("MessageService memory persistence logic", () => {
@@ -72,6 +72,69 @@ describe("MessageService memory persistence logic", () => {
 			const correctResult = !disableMemoryCreation || memorySourceAllowed;
 			expect(correctResult).toBe(true); // Correctly allows whitelisted source
 		});
+	});
+});
+
+describe("extractPlannerActionNames — tolerant of malformed action XML", () => {
+	// Production observation (2026-04-25): the planner LLM occasionally emits
+	// an unclosed <action> wrapper around a well-formed <name>X</name>, e.g.:
+	//   <actions><action><name>REPLY</name></actions>
+	// The closing </action> is missing, so the strict regex used to fall
+	// through to "return trimmed" and the entire XML chunk became the action
+	// identifier. That never matches a registered action and the bot logs
+	// "Dropping unknown planner action" then stays silent. The fix tolerates
+	// these malformed shapes by extracting the inner <name>X</name>.
+
+	it("extracts name from canonical <action><name>X</name></action>", () => {
+		expect(
+			extractPlannerActionNames({
+				actions: "<action><name>REPLY</name></action>",
+			}),
+		).toEqual(["REPLY"]);
+	});
+
+	it("extracts name from flat <action>X</action>", () => {
+		expect(
+			extractPlannerActionNames({
+				actions: "<action>REPLY</action>",
+			}),
+		).toEqual(["REPLY"]);
+	});
+
+	it("recovers REPLY when the closing </action> is missing", () => {
+		expect(
+			extractPlannerActionNames({
+				actions: "<action><name>REPLY</name>",
+			}),
+		).toEqual(["REPLY"]);
+	});
+
+	it("recovers when extra trailing content follows the name", () => {
+		expect(
+			extractPlannerActionNames({
+				actions: "<action><name>REPLY</name>garbage trail",
+			}),
+		).toEqual(["REPLY"]);
+	});
+
+	it("returns empty when the actions field is empty", () => {
+		expect(extractPlannerActionNames({ actions: "" })).toEqual([]);
+	});
+
+	it("treats unmatched non-action text as a literal identifier", () => {
+		// Plain comma-separated list still works
+		expect(
+			extractPlannerActionNames({ actions: "REPLY,STOP" }),
+		).toEqual(["REPLY", "STOP"]);
+	});
+
+	it("handles multiple well-formed action blocks", () => {
+		expect(
+			extractPlannerActionNames({
+				actions:
+					"<action><name>SPAWN_AGENT</name></action><action><name>REPLY</name></action>",
+			}),
+		).toEqual(["SPAWN_AGENT", "REPLY"]);
 	});
 });
 

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -1175,21 +1175,36 @@ function unwrapPlannerIdentifier(value: string): string {
 	}
 
 	const actionMatch = trimmed.match(/^<action\b[^>]*>([\s\S]*?)<\/action>$/i);
-	if (!actionMatch) {
-		return trimmed;
+	if (actionMatch) {
+		const inner = actionMatch[1].trim();
+		if (!inner) {
+			return "";
+		}
+
+		const nestedNameMatch = inner.match(/<name\b[^>]*>([\s\S]*?)<\/name>/i);
+		if (nestedNameMatch) {
+			return nestedNameMatch[1].trim();
+		}
+
+		return /<[A-Za-z][^>]*>/.test(inner) ? trimmed : inner;
 	}
 
-	const inner = actionMatch[1].trim();
-	if (!inner) {
-		return "";
+	// Tolerate malformed planner output where the closing </action> is missing
+	// or extra content trails the action body. Symptom in prod logs:
+	//   "Dropping unknown planner action (actionName=<action><name>REPLY</name>)"
+	// The planner LLM occasionally emits an unclosed <action> wrapper around a
+	// well-formed <name>X</name>. Falling through to "return trimmed" treats
+	// the whole XML chunk as the action identifier, which then fails to match
+	// any registered action and the bot goes silent. If the input begins with
+	// <action> and contains a <name>X</name>, prefer that name.
+	if (/^<action\b[^>]*>/i.test(trimmed)) {
+		const looseNameMatch = trimmed.match(/<name\b[^>]*>([\s\S]*?)<\/name>/i);
+		if (looseNameMatch) {
+			return looseNameMatch[1].trim();
+		}
 	}
 
-	const nestedNameMatch = inner.match(/<name\b[^>]*>([\s\S]*?)<\/name>/i);
-	if (nestedNameMatch) {
-		return nestedNameMatch[1].trim();
-	}
-
-	return /<[A-Za-z][^>]*>/.test(inner) ? trimmed : inner;
+	return trimmed;
 }
 
 const PLANNER_ACTION_ALIASES = new Map(


### PR DESCRIPTION
## Summary

The planner LLM occasionally emits an unclosed `<action>` wrapper around a well-formed `<name>X</name>`, e.g.:

```xml
<actions><action><name>REPLY</name></actions>
```

(closing `</action>` is missing). The strict `<action>...</action>` regex in `unwrapPlannerIdentifier` falls through to "return trimmed" and the entire XML chunk becomes the action identifier. That never matches a registered action, the bot logs `Dropping unknown planner action`, and the user sees silence — even though `shouldRespond` already decided to engage.

## Symptom

Production log line, observed live in the milady server (2026-04-25 02:41 UTC) on a real user prompt:

```
Warn  Dropping unknown planner action (actionName=<action><name>REPLY</name>)
```

The bot stayed silent for ~2 minutes before a retry path eventually recovered. In a quieter test channel the same prompt produced no reply at all within the test window.

## Fix

`packages/typescript/src/services/message.ts` — one fall-through branch added in `unwrapPlannerIdentifier`. When the input begins with `<action>` and contains a `<name>X</name>` somewhere inside, prefer that name even if the wrapper is unclosed or has trailing content.

The strict patterns still take precedence — this is purely a defensive fallback added before the bare `return trimmed`. No behavior change for canonical inputs.

## Tests

`packages/typescript/src/services/message.test.ts` — new `describe` block with 7 cases through the exported `extractPlannerActionNames`:

- canonical `<action><name>X</name></action>`
- flat `<action>X</action>`
- **missing closing `</action>` (the bug)**
- trailing garbage after the name
- empty actions field
- comma-separated literal identifiers
- multiple well-formed action blocks

All pass; full `vitest` and `tsc --noEmit` clean in `packages/typescript`.

## Live verification

Bot was restaged with this fix applied on top of `develop` + 4 other in-flight fixes (#7090, #7095, #7097, #7098). 10/10 webhook test scenarios passed cleanly, including the two REPLY-type prompts ("tell me a joke", "what year is it") that silently dropped on the immediately previous run without this patch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a defensive fallback in `unwrapPlannerIdentifier` so that malformed planner XML like `<action><name>REPLY</name>` (missing closing `</action>`) is recovered by extracting the inner `<name>` content, instead of falling through to return the whole XML chunk as the action identifier. The fix is narrow, well-commented, strictly additive (strict patterns still win), and covered by 7 targeted test cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted defensive fallback with no behavior change on canonical inputs and full test coverage.

The change is strictly additive: the two existing strict regex branches (bare `<name>` and closed `<action>`) still take precedence. The new branch only fires when both fail but the input still looks like a malformed `<action>` block with an inner `<name>`. Seven test cases exercise all relevant shapes, tsc and vitest both pass, and the production symptom is directly reproduced and fixed by the tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds a loose `<action>` + `<name>` fallback branch in `unwrapPlannerIdentifier` before the bare `return trimmed`; all canonical paths are unchanged and still take precedence. |
| packages/typescript/src/services/message.test.ts | Exports `extractPlannerActionNames` for testing and adds a focused describe block with 7 cases covering canonical, flat, unclosed, trailing-garbage, empty, comma-separated, and multi-action inputs. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["extractPlannerActionNames(parsedXml)"] --> B{actions is string?}
    B -- No --> Z["return []"]
    B -- Yes --> C{contains &lt;action&gt; tag?}
    C -- No --> G["comma-split → unwrapPlannerIdentifier each"]
    C -- Yes --> D["matchAll strict &lt;action&gt;...&lt;/action&gt; regex"]
    D --> E{any matches?}
    E -- Yes --> F["extract &lt;name&gt; or full match per entry → return names"]
    E -- No (malformed / unclosed) --> G
    G --> H["unwrapPlannerIdentifier(value)"]
    H --> I{starts with &lt;name&gt;...&lt;/name&gt;?}
    I -- Yes --> J["return inner name ✓"]
    I -- No --> K{strict &lt;action&gt;...&lt;/action&gt; match?}
    K -- Yes --> L{has nested &lt;name&gt;?}
    L -- Yes --> M["return nested name ✓"]
    L -- No --> N{inner has XML tags?}
    N -- Yes --> O["return trimmed (original)"]
    N -- No --> P["return inner text ✓"]
    K -- No --> Q{"NEW: starts with &lt;action&gt; AND contains &lt;name&gt;X&lt;/name&gt;?"}
    Q -- Yes --> R["return extracted name ✓ (fixes missing &lt;/action&gt; bug)"]
    Q -- No --> S["return trimmed (original)"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(message): tolerate malformed planner..."](https://github.com/elizaos/eliza/commit/542494d5d4105894c2eef717241912840e70789a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29689379)</sub>

<!-- /greptile_comment -->