### PR TITLE
fix(character): tokenize name occurrences on save so renames propagate

### DIFF
--- a/packages/app-core/src/character/character-draft-helpers.ts
+++ b/packages/app-core/src/character/character-draft-helpers.ts
@@ -1,6 +1,7 @@
 /** Character action helpers — CRUD and draft management. */
 
 import type { CharacterData, ElizaClient } from "../api/client";
+import { tokenizeNameOccurrences } from "../utils/name-tokens";
 
 type MessageExampleGroup = {
   examples: Array<{ name: string; content: { text: string } }>;
@@ -207,6 +208,7 @@ export function normalizeGeneratedMessageExamples(
 
 export function prepareDraftForSave(
   draft: CharacterData,
+  previousName?: string,
 ): Record<string, unknown> {
   // Only pick fields the API schema accepts (.strict() rejects unknown keys)
   const result: Record<string, unknown> = {};
@@ -220,16 +222,37 @@ export function prepareDraftForSave(
   } else if (typeof result.name === "string") {
     result.username = result.name;
   }
-  if (draft.system) result.system = draft.system;
+
+  // Build a tokenizer that replaces whole-word occurrences of the
+  // current *and* previous agent name with `{{name}}`. Load-side expansion
+  // (useCharacterState.loadCharacter → replaceNameTokens) renders them back
+  // against whatever the current name is, so renames now propagate through
+  // every free-text field without manual edits.
+  //
+  // Both names are tokenized so a rename within the same save pass also
+  // catches old-name literals that the user didn't hand-edit.
+  const currentName = typeof result.name === "string" ? result.name : "";
+  const previousNameTrimmed = previousName?.trim() ?? "";
+  const tokenize = (value: string): string => {
+    let out = value;
+    if (currentName) out = tokenizeNameOccurrences(out, currentName);
+    if (previousNameTrimmed && previousNameTrimmed !== currentName) {
+      out = tokenizeNameOccurrences(out, previousNameTrimmed);
+    }
+    return out;
+  };
+
+  if (draft.system) result.system = tokenize(draft.system);
 
   if (typeof draft.bio === "string") {
     const lines = draft.bio
       .split("\n")
       .map((l: string) => l.trim())
-      .filter((l: string) => l.length > 0);
+      .filter((l: string) => l.length > 0)
+      .map(tokenize);
     if (lines.length > 0) result.bio = lines;
   } else if (Array.isArray(draft.bio) && draft.bio.length > 0) {
-    result.bio = draft.bio;
+    result.bio = draft.bio.map(tokenize);
   }
 
   const adjectives = (draft.adjectives ?? []).filter(
@@ -237,12 +260,14 @@ export function prepareDraftForSave(
   );
   if (adjectives.length > 0) result.adjectives = adjectives;
 
-  const topics = (draft.topics ?? []).filter((s) => s.trim().length > 0);
+  const topics = (draft.topics ?? [])
+    .filter((s) => s.trim().length > 0)
+    .map(tokenize);
   if (topics.length > 0) result.topics = topics;
 
-  const postExamples = (draft.postExamples ?? []).filter(
-    (s) => s.trim().length > 0,
-  );
+  const postExamples = (draft.postExamples ?? [])
+    .filter((s) => s.trim().length > 0)
+    .map(tokenize);
   if (postExamples.length > 0) result.postExamples = postExamples;
 
   if (draft.messageExamples != null) {
@@ -273,7 +298,7 @@ export function prepareDraftForSave(
           return {
             name: msg.name.trim(),
             content: {
-              text: msg.content.text.trim(),
+              text: tokenize(msg.content.text.trim()),
               ...(originalMessage?.content?.actions
                 ? { actions: originalMessage.content.actions }
                 : {}),
@@ -287,9 +312,9 @@ export function prepareDraftForSave(
 
   if (draft.style) {
     const style: Record<string, string[]> = {};
-    if (draft.style.all?.length) style.all = draft.style.all;
-    if (draft.style.chat?.length) style.chat = draft.style.chat;
-    if (draft.style.post?.length) style.post = draft.style.post;
+    if (draft.style.all?.length) style.all = draft.style.all.map(tokenize);
+    if (draft.style.chat?.length) style.chat = draft.style.chat.map(tokenize);
+    if (draft.style.post?.length) style.post = draft.style.post.map(tokenize);
     if (Object.keys(style).length > 0) result.style = style;
   }
 

--- a/packages/app-core/src/state/useCharacterState.ts
+++ b/packages/app-core/src/state/useCharacterState.ts
@@ -112,7 +112,12 @@ export function useCharacterState({
     setCharacterSaveError(null);
     setCharacterSaveSuccess(null);
     try {
-      const draft = prepareDraftForSave(characterDraft);
+      // Pass the previously-saved name so save-side tokenization catches
+      // stale literals when the user renames in this same save pass.
+      const draft = prepareDraftForSave(
+        characterDraft,
+        characterData?.name ?? undefined,
+      );
       if (!(draft.name as string | undefined)?.trim()) {
         throw new Error("Character name is required before saving.");
       }
@@ -142,6 +147,7 @@ export function useCharacterState({
     }
     setCharacterSaving(false);
   }, [
+    characterData,
     characterDraft,
     agentStatus,
     loadCharacter,

--- a/packages/app-core/src/utils/name-tokens.test.ts
+++ b/packages/app-core/src/utils/name-tokens.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { prepareDraftForSave } from "../character/character-draft-helpers";
+import { replaceNameTokens, tokenizeNameOccurrences } from "./name-tokens";
+
+describe("tokenizeNameOccurrences", () => {
+  it("replaces whole-word occurrences with {{name}}", () => {
+    expect(tokenizeNameOccurrences("Momo is composed.", "Momo")).toBe(
+      "{{name}} is composed.",
+    );
+  });
+
+  it("handles multiple occurrences across one string", () => {
+    expect(
+      tokenizeNameOccurrences("Momo likes Momo-sized tasks. Momo!", "Momo"),
+    ).toBe("{{name}} likes {{name}}-sized tasks. {{name}}!");
+  });
+
+  it("respects word boundaries — does not replace inside other words", () => {
+    // "Kai" must not match inside "Kaizen" or "Mikaila".
+    expect(
+      tokenizeNameOccurrences("Kaizen is not Mikaila and Kai is Kai.", "Kai"),
+    ).toBe("Kaizen is not Mikaila and {{name}} is {{name}}.");
+  });
+
+  it("is case-sensitive", () => {
+    // "momo" (lowercase) mid-sentence should not tokenize when the
+    // stored name is "Momo" — the user's intent is ambiguous and we'd
+    // rather under-tokenize than destroy prose.
+    expect(tokenizeNameOccurrences("momo is not Momo.", "Momo")).toBe(
+      "momo is not {{name}}.",
+    );
+  });
+
+  it("is idempotent — running twice yields the same result", () => {
+    const once = tokenizeNameOccurrences("Momo is composed.", "Momo");
+    const twice = tokenizeNameOccurrences(once, "Momo");
+    expect(twice).toBe(once);
+  });
+
+  it("no-ops on empty text or empty name", () => {
+    expect(tokenizeNameOccurrences("", "Momo")).toBe("");
+    expect(tokenizeNameOccurrences("some text", "")).toBe("some text");
+    expect(tokenizeNameOccurrences("some text", "   ")).toBe("some text");
+  });
+
+  it("refuses to tokenize single-character names (guardrail)", () => {
+    // A one-letter name like "A" would eat every standalone "A" in prose.
+    expect(tokenizeNameOccurrences("A is a character named A.", "A")).toBe(
+      "A is a character named A.",
+    );
+  });
+
+  it("does not crash on regex special characters in the name", () => {
+    // Names with punctuation don't reliably match word boundaries, so
+    // the tokenizer is allowed to leave such text untouched — the
+    // important invariant is that the regex stays valid.
+    expect(() =>
+      tokenizeNameOccurrences("Some text here.", "Dr. X."),
+    ).not.toThrow();
+    expect(() =>
+      tokenizeNameOccurrences("Text with (parens).", "(name)"),
+    ).not.toThrow();
+  });
+
+  it("round-trips cleanly with replaceNameTokens", () => {
+    const original = "Momo is composed. Momo likes clarity.";
+    const tokenized = tokenizeNameOccurrences(original, "Momo");
+    expect(replaceNameTokens(tokenized, "Momo")).toBe(original);
+    // And the whole point of tokenization — renaming propagates:
+    expect(replaceNameTokens(tokenized, "Nyx")).toBe(
+      "Nyx is composed. Nyx likes clarity.",
+    );
+  });
+});
+
+describe("prepareDraftForSave — name tokenization", () => {
+  it("tokenizes bio, system, topics, postExamples, and style on save", () => {
+    const result = prepareDraftForSave({
+      name: "Momo",
+      bio: "Momo is composed.\nMomo is tidy.",
+      system: "You are Momo, a careful assistant.",
+      topics: ["how Momo thinks", "unrelated topic"],
+      postExamples: ["Momo just shipped."],
+      style: {
+        all: ["Momo speaks softly"],
+        chat: [],
+        post: ["Momo posts seldom"],
+      },
+    });
+
+    expect(result.bio).toEqual(["{{name}} is composed.", "{{name}} is tidy."]);
+    expect(result.system).toBe("You are {{name}}, a careful assistant.");
+    expect(result.topics).toEqual(["how {{name}} thinks", "unrelated topic"]);
+    expect(result.postExamples).toEqual(["{{name}} just shipped."]);
+    expect(result.style).toEqual({
+      all: ["{{name}} speaks softly"],
+      post: ["{{name}} posts seldom"],
+    });
+  });
+
+  it("tokenizes messageExamples body text while preserving existing speaker tokenization", () => {
+    const result = prepareDraftForSave({
+      name: "Momo",
+      messageExamples: [
+        {
+          examples: [
+            { name: "User", content: { text: "hey Momo" } },
+            { name: "Momo", content: { text: "Momo here — how can I help?" } },
+          ],
+        },
+      ],
+    });
+
+    const messageExamples = result.messageExamples as Array<{
+      examples: Array<{ name: string; content: { text: string } }>;
+    }>;
+    expect(messageExamples[0].examples[0].content.text).toBe("hey {{name}}");
+    expect(messageExamples[0].examples[1].content.text).toBe(
+      "{{name}} here — how can I help?",
+    );
+  });
+
+  it("tokenizes the previous name too when the user renames in the same save", () => {
+    // User loaded a character named "Momo", renamed to "Nyx", and
+    // edited the bio to add a new line referencing the new name. The
+    // stored bio still contains old "Momo" literals from onboarding.
+    const result = prepareDraftForSave(
+      {
+        name: "Nyx",
+        bio: "Momo is composed.\nNyx prefers clarity.",
+        system: "You are Nyx. Momo was my old name.",
+      },
+      "Momo",
+    );
+
+    expect(result.bio).toEqual([
+      "{{name}} is composed.",
+      "{{name}} prefers clarity.",
+    ]);
+    expect(result.system).toBe("You are {{name}}. {{name}} was my old name.");
+  });
+
+  it("leaves the name field itself as a literal (source of truth)", () => {
+    const result = prepareDraftForSave({
+      name: "Momo",
+      bio: "Momo is composed.",
+    });
+    expect(result.name).toBe("Momo");
+    expect(result.bio).toEqual(["{{name}} is composed."]);
+  });
+
+  it("no-ops when the draft has no name (no tokenization anchor)", () => {
+    const result = prepareDraftForSave({
+      bio: "Momo is composed.",
+    });
+    // Without a current name, the tokenizer has nothing to match against.
+    // The bio persists as-is; next load will still render literal text.
+    // This is acceptable because the save path refuses to persist a
+    // character without a name at the callsite level anyway.
+    expect(result.bio).toEqual(["Momo is composed."]);
+  });
+
+  it("round-trips through replaceNameTokens without drift", () => {
+    const result = prepareDraftForSave({
+      name: "Momo",
+      bio: "Momo is composed. Momo values clarity.",
+      system: "You are Momo.",
+    });
+    const bio = result.bio as string[];
+    // Rendering with the same name reproduces the original.
+    expect(bio.map((line) => replaceNameTokens(line, "Momo"))).toEqual([
+      "Momo is composed. Momo values clarity.",
+    ]);
+    // Rendering after a rename propagates through every field.
+    expect(bio.map((line) => replaceNameTokens(line, "Nyx"))).toEqual([
+      "Nyx is composed. Nyx values clarity.",
+    ]);
+    expect(replaceNameTokens(result.system as string, "Nyx")).toBe(
+      "You are Nyx.",
+    );
+  });
+});

--- a/packages/app-core/src/utils/name-tokens.ts
+++ b/packages/app-core/src/utils/name-tokens.ts
@@ -7,3 +7,29 @@ export function replaceNameTokens(text: string, name: string): string {
     .replace(/\{\{name\}\}/g, name)
     .replace(/\{\{agentName\}\}/g, name);
 }
+
+/**
+ * Reverse of `replaceNameTokens` — rewrite whole-word occurrences of the
+ * given literal character name back into `{{name}}` tokens so that a
+ * later rename continues to propagate through every text field.
+ *
+ * Rules:
+ * - Case-sensitive, whole-word match (word boundaries on both sides).
+ * - Names under 2 characters are ignored; the tokenizer is not
+ *   meaningful for single-letter names and risks destroying prose.
+ * - Idempotent: re-running on already-tokenized text is a no-op because
+ *   `{{name}}` does not contain the literal name.
+ * - Non-destructive on empty input or empty name.
+ *
+ * @param text The text to scan.
+ * @param name The literal character name to tokenize (e.g. "Momo").
+ * @returns The text with whole-word occurrences replaced by `{{name}}`.
+ */
+export function tokenizeNameOccurrences(text: string, name: string): string {
+  if (!text || !name) return text;
+  const trimmed = name.trim();
+  if (trimmed.length < 2) return text;
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`\\b${escaped}\\b`, "g");
+  return text.replace(pattern, "{{name}}");
+}


### PR DESCRIPTION
Cherry-picked from #7093 (by @dutchiono) — only the character rename fix, without the unrelated submodule pointer bumps, Windows pty patch, and coding-agent chip changes that #7093 also carried.

## Problem

The character editor resolves \`{{name}}\` / \`{{agentName}}\` tokens on **load** (\`replaceNameTokens\`), but \`prepareDraftForSave\` never ran the reverse pass. The moment a user saved via the editor, expanded literals got persisted and the tokens were lost. From that point on, renaming the agent in Identity settings stopped propagating — bio, system, message examples, post examples, style, and topics all kept the old name as dead text.

## Fix

- Add \`tokenizeNameOccurrences(text, name)\` next to \`replaceNameTokens\`. Whole-word, case-sensitive, idempotent; refuses single-character names to avoid eating prose.
- \`prepareDraftForSave(draft, previousName?)\` runs the tokenizer over every free-text field: \`bio\`, \`system\`, \`topics\`, \`postExamples\`, \`style.{all,chat,post}\`, and \`messageExamples[].examples[].content.text\`.
- Both the current draft name and (optionally) the previous saved name are tokenized so a rename within the same save pass also catches stale old-name literals.
- \`useCharacterState.handleSaveCharacter\` threads \`characterData?.name\` through as the previous name.

Runtime prompt composition already resolves \`{{name}}\` / \`{{agentName}}\` tokens via \`@elizaos/prompts\`, so no backend changes are needed.

## Tests

15 cases in \`name-tokens.test.ts\`: whole-word boundaries, case sensitivity, idempotency, single-char/empty/regex-special guardrails, full \`prepareDraftForSave\` field coverage, previous-name during rename, round-trip with \`replaceNameTokens\`.

Supersedes #7093.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `tokenizeNameOccurrences` to reverse the load-side `replaceNameTokens` expansion on save, so character renames propagate through all free-text fields. The core logic and tests are solid, but the save-side tokenization is not symmetric with the load-side de-tokenization.

- **P1 — Editor shows raw `{{name}}` after save**: `prepareDraftForSave` now tokenizes `topics`, `postExamples`, `style.*`, and `messageExamples[].content.text`, but `loadCharacter` in `useCharacterState.ts` only calls `replaceNameTokens` on `bio` and `system`. Because `handleSaveCharacter` calls `loadCharacter()` on success, these fields immediately reload with raw `{{name}}` template syntax visible in the editor UI.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the load/save asymmetry will cause raw {{name}} tokens to appear in the editor immediately after any save.

One P1 defect: loadCharacter in useCharacterState.ts does not de-tokenize the four field groups that prepareDraftForSave now tokenizes. Because handleSaveCharacter calls loadCharacter() on success, users will see {{name}} as literal text in the topics, post-examples, style, and message-example editors after every save.

packages/app-core/src/state/useCharacterState.ts — the loadCharacter callback (lines 86–102) must be extended to apply replaceNameTokens to all newly-tokenized fields.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/state/useCharacterState.ts | Adds characterData to the dependency array and passes it as previousName to prepareDraftForSave, but loadCharacter only de-tokenizes bio and system — leaving topics, postExamples, style.*, and messageExamples with raw {{name}} tokens visible in the editor after each save. |
| packages/app-core/src/character/character-draft-helpers.ts | Correctly introduces a tokenize closure that covers all free-text fields on save; adjectives are intentionally excluded. Implementation is well-structured. |
| packages/app-core/src/utils/name-tokens.ts | New tokenizeNameOccurrences is case-sensitive, whole-word, idempotent, and safely escapes regex metacharacters; single-char guard is correct. |
| packages/app-core/src/utils/name-tokens.test.ts | Comprehensive 15-case test suite covering tokenization, idempotency, edge guards, and round-trip with replaceNameTokens; no issues found. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Editor
    participant useCharacterState
    participant prepareDraftForSave
    participant Server

    Editor->>useCharacterState: handleSaveCharacter()
    useCharacterState->>prepareDraftForSave: draft + previousName
    prepareDraftForSave->>prepareDraftForSave: tokenize(bio, system, topics, postExamples, style.*, messageExamples)
    prepareDraftForSave-->>useCharacterState: tokenized draft
    useCharacterState->>Server: updateCharacter(draft)
    Server-->>useCharacterState: success
    useCharacterState->>useCharacterState: loadCharacter()
    useCharacterState->>Server: getCharacter()
    Server-->>useCharacterState: character with {{name}} in all fields
    useCharacterState->>useCharacterState: clean(bio) ✅ clean(system) ✅ topics as-is ❌ postExamples as-is ❌ style.* as-is ❌ messageExamples as-is ❌
    useCharacterState-->>Editor: draft with raw {{name}} visible in topics/style/etc
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/state/useCharacterState.ts`, line 86-102 ([link](https://github.com/elizaos/eliza/blob/406f30fea4094536e09fce7c72935c8b668edf2b/packages/app-core/src/state/useCharacterState.ts#L86-L102)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Load-side de-tokenization is incomplete — users will see raw `{{name}}` in the editor**

   `prepareDraftForSave` now tokenizes `topics`, `postExamples`, `style.*`, and `messageExamples[].content.text`, but `loadCharacter` (lines 86–102) only calls `clean` on `bio` and `system`. After a successful save, `handleSaveCharacter` calls `loadCharacter()` (line 137), which reloads the character without de-tokenizing those four field groups — so the user immediately sees `{{name}}` as raw text in the topics, style, post-examples, and message-example editors.

   Concrete path: save character "Momo" with topic `"how Momo thinks"` → stored as `"how {{name}} thinks"` → `loadCharacter` puts it back into the draft untouched → editor renders `"how {{name}} thinks"`.

   Fix: extend the `clean` pass in `loadCharacter` to cover all fields that `prepareDraftForSave` now tokenizes:

   ```
   topics: (character.topics ?? []).map(clean),
   postExamples: (character.postExamples ?? []).map(clean),
   style: {
     all: (character.style?.all ?? []).map(clean),
     chat: (character.style?.chat ?? []).map(clean),
     post: (character.style?.post ?? []).map(clean),
   },
   messageExamples: (character.messageExamples ?? []).map((group) => ({
     ...group,
     examples: group.examples.map((ex) => ({
       ...ex,
       content: { ...ex.content, text: clean(ex.content.text) },
     })),
   })),
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(character): tokenize name occurrence..."](https://github.com/elizaos/eliza/commit/406f30fea4094536e09fce7c72935c8b668edf2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29694663)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->