### PR TITLE
Codex signal cli auto install

### DIFF
--- a/packages/agent/src/services/signal-pairing.test.ts
+++ b/packages/agent/src/services/signal-pairing.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveSignalCliExecutable } from "./signal-pairing";
+import {
+  missingSignalCliMessage,
+  resolveSignalCliExecutable,
+  signalCliInstallInstructions,
+} from "./signal-pairing";
 
 describe("resolveSignalCliExecutable", () => {
   it("uses an existing signal-cli from PATH", async () => {
@@ -54,6 +58,78 @@ describe("resolveSignalCliExecutable", () => {
     ]);
   });
 
+  it("auto-installs default signal-cli with Homebrew on Linux", async () => {
+    const execFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("signal-cli missing"))
+      .mockResolvedValueOnce({
+        stdout: "/home/linuxbrew/.linuxbrew/bin/brew\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: "/home/linuxbrew/.linuxbrew/bin/signal-cli\n",
+        stderr: "",
+      });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "linux",
+      }),
+    ).resolves.toBe("/home/linuxbrew/.linuxbrew/bin/signal-cli");
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", [
+      "signal-cli",
+    ]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+    expect(execFile).toHaveBeenNthCalledWith(
+      3,
+      "/home/linuxbrew/.linuxbrew/bin/brew",
+      ["install", "signal-cli"],
+      { env: {} },
+    );
+    expect(execFile).toHaveBeenNthCalledWith(4, "/usr/bin/which", [
+      "signal-cli",
+    ]);
+  });
+
+  it("returns null on Linux when Homebrew is unavailable", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "linux",
+      }),
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", [
+      "signal-cli",
+    ]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+  });
+
+  it("does not auto-install on Windows", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "win32",
+      }),
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
   it("does not auto-install when a custom signal-cli path is configured", async () => {
     const execFile = vi.fn(async () => {
       throw new Error("missing");
@@ -89,5 +165,17 @@ describe("resolveSignalCliExecutable", () => {
       }),
     ).resolves.toBeNull();
     expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns platform-specific fallback instructions", () => {
+    expect(signalCliInstallInstructions("darwin")).toContain("macOS");
+    expect(signalCliInstallInstructions("darwin")).toContain("Homebrew");
+    expect(signalCliInstallInstructions("linux")).toContain("Linux");
+    expect(signalCliInstallInstructions("linux")).toContain("Java Runtime 25+");
+    expect(signalCliInstallInstructions("win32")).toContain("Windows");
+    expect(signalCliInstallInstructions("win32")).toContain("signal-cli.bat");
+    expect(missingSignalCliMessage(undefined, {}, "win32")).toContain(
+      "SIGNAL_CLI_PATH",
+    );
   });
 });

--- a/packages/agent/src/services/signal-pairing.test.ts
+++ b/packages/agent/src/services/signal-pairing.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSignalCliExecutable } from "./signal-pairing";
+
+describe("resolveSignalCliExecutable", () => {
+  it("uses an existing signal-cli from PATH", async () => {
+    const execFile = vi.fn(async (file: string, args?: readonly string[]) => {
+      expect(file).toBe("/usr/bin/which");
+      expect(args).toEqual(["signal-cli"]);
+      return { stdout: "/opt/homebrew/bin/signal-cli\n", stderr: "" };
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      }),
+    ).resolves.toBe("/opt/homebrew/bin/signal-cli");
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-installs default signal-cli with Homebrew on macOS", async () => {
+    const execFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("signal-cli missing"))
+      .mockResolvedValueOnce({ stdout: "/opt/homebrew/bin/brew\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: "/opt/homebrew/bin/signal-cli\n",
+        stderr: "",
+      });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      }),
+    ).resolves.toBe("/opt/homebrew/bin/signal-cli");
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", [
+      "signal-cli",
+    ]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+    expect(execFile).toHaveBeenNthCalledWith(
+      3,
+      "/opt/homebrew/bin/brew",
+      ["install", "signal-cli"],
+      { env: {} },
+    );
+    expect(execFile).toHaveBeenNthCalledWith(4, "/usr/bin/which", [
+      "signal-cli",
+    ]);
+  });
+
+  it("does not auto-install when a custom signal-cli path is configured", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        cliPath: "/custom/bin/signal-cli",
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      }),
+    ).resolves.toBeNull();
+    expect(execFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("brew"),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("respects the auto-install opt-out", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: { MILADY_SIGNAL_CLI_AUTO_INSTALL: "0" },
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      }),
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent/src/services/signal-pairing.ts
+++ b/packages/agent/src/services/signal-pairing.ts
@@ -23,8 +23,13 @@ const BREW_OPENJDK_HOME = "/opt/homebrew/opt/openjdk";
 const COMMON_SIGNAL_CLI_PATHS = [
   "/opt/homebrew/bin/signal-cli",
   "/usr/local/bin/signal-cli",
+  "/home/linuxbrew/.linuxbrew/bin/signal-cli",
 ];
-const COMMON_HOMEBREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
+const COMMON_HOMEBREW_PATHS = [
+  "/opt/homebrew/bin/brew",
+  "/usr/local/bin/brew",
+  "/home/linuxbrew/.linuxbrew/bin/brew",
+];
 const SIGNAL_CLI_AUTO_INSTALL_ENV = "SIGNAL_CLI_AUTO_INSTALL";
 const MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV = "MILADY_SIGNAL_CLI_AUTO_INSTALL";
 
@@ -196,6 +201,10 @@ function autoInstallSignalCliEnabled(env: NodeJS.ProcessEnv): boolean {
   return !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
 }
 
+function canAutoInstallSignalCli(platform: NodeJS.Platform): boolean {
+  return platform === "darwin" || platform === "linux";
+}
+
 async function resolveHomebrewPath(
   deps: ExecutableResolutionDeps,
 ): Promise<string | null> {
@@ -217,15 +226,21 @@ async function resolveHomebrewPath(
 
 async function installSignalCliWithHomebrew(
   deps: ExecutableResolutionDeps,
-): Promise<void> {
+): Promise<boolean> {
   const brewPath = await resolveHomebrewPath(deps);
   if (!brewPath) {
-    throw new Error(
-      "Homebrew is not installed. Install Homebrew or run `brew install signal-cli` manually, then retry.",
-    );
+    return false;
   }
 
-  await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+  try {
+    await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+  } catch (error) {
+    throw new Error(
+      `Failed to auto-install signal-cli with Homebrew. ${signalCliInstallInstructions(deps.platform)}`,
+      { cause: error },
+    );
+  }
+  return true;
 }
 
 function isDefaultSignalCliRequest(
@@ -266,26 +281,45 @@ export async function resolveSignalCliExecutable(
   }
 
   if (
-    deps.platform !== "darwin" ||
+    !canAutoInstallSignalCli(deps.platform) ||
     !isDefaultSignalCliRequest(requestedBinary, options, deps.env) ||
     !autoInstallSignalCliEnabled(deps.env)
   ) {
     return null;
   }
 
-  await installSignalCliWithHomebrew(deps);
+  const installed = await installSignalCliWithHomebrew(deps);
+  if (!installed) {
+    return null;
+  }
   return resolveExecutablePath(DEFAULT_SIGNAL_CLI_NAME, deps);
 }
 
-function missingSignalCliMessage(
+export function signalCliInstallInstructions(
+  platform: NodeJS.Platform,
+): string {
+  if (platform === "darwin") {
+    return "Milady can auto-install the default Signal CLI on macOS when Homebrew is available (`brew install signal-cli`). Fallback: install signal-cli from https://github.com/AsamK/signal-cli/releases and set SIGNAL_CLI_PATH to its bin/signal-cli executable.";
+  }
+  if (platform === "linux") {
+    return "Milady can auto-install the default Signal CLI on Linux when Homebrew/Linuxbrew is available (`brew install signal-cli`). Fallback: install the latest signal-cli Linux release from https://github.com/AsamK/signal-cli/releases, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to its bin/signal-cli executable.";
+  }
+  if (platform === "win32") {
+    return "On Windows, install the latest signal-cli release from https://github.com/AsamK/signal-cli/releases, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to signal-cli.bat or signal-cli.exe. Milady does not auto-run a Windows package manager.";
+  }
+  return "Install signal-cli from https://github.com/AsamK/signal-cli/releases for your platform, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to the signal-cli executable.";
+}
+
+export function missingSignalCliMessage(
   cliPath: string | undefined,
   env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = os.platform(),
 ): string {
   const requestedBinary =
     cliPath?.trim() || env.SIGNAL_CLI_PATH?.trim() || DEFAULT_SIGNAL_CLI_NAME;
   const installHint =
     requestedBinary === DEFAULT_SIGNAL_CLI_NAME
-      ? "Milady auto-installs the default Signal CLI on macOS when Homebrew is available; otherwise run `brew install signal-cli` and retry."
+      ? signalCliInstallInstructions(platform)
       : "Install that binary or update SIGNAL_CLI_PATH to point at an existing signal-cli executable.";
   return `Failed to load dependencies: Cannot find ${requestedBinary}. ${installHint}`;
 }

--- a/packages/agent/src/services/signal-pairing.ts
+++ b/packages/agent/src/services/signal-pairing.ts
@@ -8,6 +8,7 @@
 
 import { type ChildProcess, execFile, spawn } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { promisify } from "node:util";
@@ -23,6 +24,22 @@ const COMMON_SIGNAL_CLI_PATHS = [
   "/opt/homebrew/bin/signal-cli",
   "/usr/local/bin/signal-cli",
 ];
+const COMMON_HOMEBREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
+const SIGNAL_CLI_AUTO_INSTALL_ENV = "SIGNAL_CLI_AUTO_INSTALL";
+const MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV = "MILADY_SIGNAL_CLI_AUTO_INSTALL";
+
+type ExecFileAsync = (
+  file: string,
+  args?: readonly string[],
+  options?: { env?: NodeJS.ProcessEnv },
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface ExecutableResolutionDeps {
+  env: NodeJS.ProcessEnv;
+  execFile: ExecFileAsync;
+  existsSync: (path: string) => boolean;
+  platform: NodeJS.Platform;
+}
 
 type SignalNativeModule = {
   linkDevice: (authDir: string, deviceName: string) => Promise<string>;
@@ -127,18 +144,32 @@ export function parseSignalCliAccountsOutput(output: string): string | null {
   return null;
 }
 
-async function resolveExecutablePath(binary: string): Promise<string | null> {
+function createExecutableResolutionDeps(
+  env: NodeJS.ProcessEnv = process.env,
+): ExecutableResolutionDeps {
+  return {
+    env,
+    execFile: execFileAsync as ExecFileAsync,
+    existsSync: fs.existsSync,
+    platform: os.platform(),
+  };
+}
+
+async function resolveExecutablePath(
+  binary: string,
+  deps: ExecutableResolutionDeps = createExecutableResolutionDeps(),
+): Promise<string | null> {
   const trimmed = binary.trim();
   if (!trimmed) {
     return null;
   }
 
   if (trimmed.includes("/") || trimmed.startsWith(".")) {
-    return fs.existsSync(trimmed) ? trimmed : null;
+    return deps.existsSync(trimmed) ? trimmed : null;
   }
 
   try {
-    const { stdout } = await execFileAsync("/usr/bin/which", [trimmed]);
+    const { stdout } = await deps.execFile("/usr/bin/which", [trimmed]);
     const resolved = stdout.trim();
     return resolved.length > 0 ? resolved : null;
   } catch {
@@ -147,13 +178,116 @@ async function resolveExecutablePath(binary: string): Promise<string | null> {
     }
 
     for (const candidate of COMMON_SIGNAL_CLI_PATHS) {
-      if (fs.existsSync(candidate)) {
+      if (deps.existsSync(candidate)) {
         return candidate;
       }
     }
 
     return null;
   }
+}
+
+function autoInstallSignalCliEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw =
+    env[MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV] ?? env[SIGNAL_CLI_AUTO_INSTALL_ENV];
+  if (typeof raw !== "string") {
+    return true;
+  }
+  return !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
+}
+
+async function resolveHomebrewPath(
+  deps: ExecutableResolutionDeps,
+): Promise<string | null> {
+  try {
+    const { stdout } = await deps.execFile("/usr/bin/which", ["brew"]);
+    const resolved = stdout.trim();
+    if (resolved.length > 0) {
+      return resolved;
+    }
+  } catch {
+    for (const candidate of COMMON_HOMEBREW_PATHS) {
+      if (deps.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+async function installSignalCliWithHomebrew(
+  deps: ExecutableResolutionDeps,
+): Promise<void> {
+  const brewPath = await resolveHomebrewPath(deps);
+  if (!brewPath) {
+    throw new Error(
+      "Homebrew is not installed. Install Homebrew or run `brew install signal-cli` manually, then retry.",
+    );
+  }
+
+  await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+}
+
+function isDefaultSignalCliRequest(
+  requestedBinary: string,
+  options: Pick<SignalPairingOptions, "cliPath">,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return (
+    requestedBinary === DEFAULT_SIGNAL_CLI_NAME &&
+    !options.cliPath?.trim() &&
+    !env.SIGNAL_CLI_PATH?.trim()
+  );
+}
+
+export async function resolveSignalCliExecutable(
+  options: {
+    cliPath?: string;
+    env?: NodeJS.ProcessEnv;
+    execFile?: ExecFileAsync;
+    existsSync?: (path: string) => boolean;
+    platform?: NodeJS.Platform;
+  } = {},
+): Promise<string | null> {
+  const deps: ExecutableResolutionDeps = {
+    ...createExecutableResolutionDeps(options.env),
+    ...(options.execFile ? { execFile: options.execFile } : {}),
+    ...(options.existsSync ? { existsSync: options.existsSync } : {}),
+    ...(options.platform ? { platform: options.platform } : {}),
+  };
+  const requestedBinary =
+    options.cliPath?.trim() ||
+    deps.env.SIGNAL_CLI_PATH?.trim() ||
+    DEFAULT_SIGNAL_CLI_NAME;
+
+  const existingPath = await resolveExecutablePath(requestedBinary, deps);
+  if (existingPath) {
+    return existingPath;
+  }
+
+  if (
+    deps.platform !== "darwin" ||
+    !isDefaultSignalCliRequest(requestedBinary, options, deps.env) ||
+    !autoInstallSignalCliEnabled(deps.env)
+  ) {
+    return null;
+  }
+
+  await installSignalCliWithHomebrew(deps);
+  return resolveExecutablePath(DEFAULT_SIGNAL_CLI_NAME, deps);
+}
+
+function missingSignalCliMessage(
+  cliPath: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const requestedBinary =
+    cliPath?.trim() || env.SIGNAL_CLI_PATH?.trim() || DEFAULT_SIGNAL_CLI_NAME;
+  const installHint =
+    requestedBinary === DEFAULT_SIGNAL_CLI_NAME
+      ? "Milady auto-installs the default Signal CLI on macOS when Homebrew is available; otherwise run `brew install signal-cli` and retry."
+      : "Install that binary or update SIGNAL_CLI_PATH to point at an existing signal-cli executable.";
+  return `Failed to load dependencies: Cannot find ${requestedBinary}. ${installHint}`;
 }
 
 function resolveSignalCliJavaHome(): string | null {
@@ -349,16 +483,13 @@ export class SignalPairingSession {
   }
 
   private async startWithSignalCli(qrCode: QrCodeModule): Promise<void> {
-    const cliPath = await resolveExecutablePath(
-      this.options.cliPath?.trim() ||
-        process.env.SIGNAL_CLI_PATH ||
-        DEFAULT_SIGNAL_CLI_NAME,
-    );
+    const cliPath = await resolveSignalCliExecutable({
+      cliPath: this.options.cliPath,
+      env: process.env,
+    });
 
     if (!cliPath) {
-      throw new Error(
-        `Failed to load dependencies: Cannot find ${this.options.cliPath?.trim() || DEFAULT_SIGNAL_CLI_NAME}`,
-      );
+      throw new Error(missingSignalCliMessage(this.options.cliPath));
     }
 
     console.info(`${LOG_PREFIX} Starting device linking with signal-cli...`);

--- a/packages/app-core/src/registry/entries/connectors/signal.json
+++ b/packages/app-core/src/registry/entries/connectors/signal.json
@@ -20,8 +20,16 @@
       "required": false,
       "sensitive": false,
       "label": "Cli Path",
-      "help": "Path to signal-cli executable (alternative to HTTP API)",
+      "help": "Path to signal-cli executable (alternative to HTTP API). Leave blank to resolve signal-cli from PATH and auto-install with Homebrew on macOS/Linux when available; on Windows or without Homebrew, install signal-cli manually and set this path.",
       "advanced": false
+    },
+    "SIGNAL_CLI_AUTO_INSTALL": {
+      "type": "boolean",
+      "required": false,
+      "sensitive": false,
+      "label": "Auto Install Cli",
+      "help": "Set false to disable Homebrew auto-install for the default signal-cli binary on macOS/Linux.",
+      "advanced": true
     },
     "SIGNAL_HTTP_URL": {
       "type": "url",

--- a/plugins/plugin-signal/typescript/package.json
+++ b/plugins/plugin-signal/typescript/package.json
@@ -83,7 +83,13 @@
       },
       "SIGNAL_CLI_PATH": {
         "type": "string",
-        "description": "Path to signal-cli executable (alternative to HTTP API)",
+        "description": "Path to signal-cli executable (alternative to HTTP API). Leave blank to resolve signal-cli from PATH and auto-install with Homebrew on macOS/Linux when available; on Windows or without Homebrew, install signal-cli manually and set this path.",
+        "required": false,
+        "sensitive": false
+      },
+      "SIGNAL_CLI_AUTO_INSTALL": {
+        "type": "boolean",
+        "description": "Set false to disable Homebrew auto-install for the default signal-cli binary on macOS/Linux.",
         "required": false,
         "sensitive": false
       },

--- a/plugins/plugin-signal/typescript/src/config.ts
+++ b/plugins/plugin-signal/typescript/src/config.ts
@@ -53,7 +53,7 @@ export type SignalAccountConfig = {
   httpHost?: string;
   /** HTTP port for signal-cli daemon (default 8080). */
   httpPort?: number;
-  /** signal-cli binary path (default: signal-cli). */
+  /** signal-cli binary path. Leave blank to auto-resolve/install the default binary where supported. */
   cliPath?: string;
   /** Auto-start signal-cli daemon (default: true if httpUrl not set). */
   autoStart?: boolean;

--- a/plugins/plugin-signal/typescript/src/pairing-service.test.ts
+++ b/plugins/plugin-signal/typescript/src/pairing-service.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveSignalCliExecutable } from "./pairing-service";
+import {
+  missingSignalCliMessage,
+  resolveSignalCliExecutable,
+  signalCliInstallInstructions,
+} from "./pairing-service";
 
 describe("resolveSignalCliExecutable", () => {
   it("uses an existing signal-cli from PATH", async () => {
@@ -50,6 +54,72 @@ describe("resolveSignalCliExecutable", () => {
     expect(execFile).toHaveBeenNthCalledWith(4, "/usr/bin/which", ["signal-cli"]);
   });
 
+  it("auto-installs default signal-cli with Homebrew on Linux", async () => {
+    const execFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("signal-cli missing"))
+      .mockResolvedValueOnce({
+        stdout: "/home/linuxbrew/.linuxbrew/bin/brew\n",
+        stderr: "",
+      })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: "/home/linuxbrew/.linuxbrew/bin/signal-cli\n",
+        stderr: "",
+      });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "linux",
+      })
+    ).resolves.toBe("/home/linuxbrew/.linuxbrew/bin/signal-cli");
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", ["signal-cli"]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+    expect(execFile).toHaveBeenNthCalledWith(
+      3,
+      "/home/linuxbrew/.linuxbrew/bin/brew",
+      ["install", "signal-cli"],
+      { env: {} }
+    );
+    expect(execFile).toHaveBeenNthCalledWith(4, "/usr/bin/which", ["signal-cli"]);
+  });
+
+  it("returns null on Linux when Homebrew is unavailable", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "linux",
+      })
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", ["signal-cli"]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+  });
+
+  it("does not auto-install on Windows", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "win32",
+      })
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
   it("does not auto-install when a custom signal-cli path is configured", async () => {
     const execFile = vi.fn(async () => {
       throw new Error("missing");
@@ -85,5 +155,15 @@ describe("resolveSignalCliExecutable", () => {
       })
     ).resolves.toBeNull();
     expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns platform-specific fallback instructions", () => {
+    expect(signalCliInstallInstructions("darwin")).toContain("macOS");
+    expect(signalCliInstallInstructions("darwin")).toContain("Homebrew");
+    expect(signalCliInstallInstructions("linux")).toContain("Linux");
+    expect(signalCliInstallInstructions("linux")).toContain("Java Runtime 25+");
+    expect(signalCliInstallInstructions("win32")).toContain("Windows");
+    expect(signalCliInstallInstructions("win32")).toContain("signal-cli.bat");
+    expect(missingSignalCliMessage(undefined, {}, "win32")).toContain("SIGNAL_CLI_PATH");
   });
 });

--- a/plugins/plugin-signal/typescript/src/pairing-service.test.ts
+++ b/plugins/plugin-signal/typescript/src/pairing-service.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSignalCliExecutable } from "./pairing-service";
+
+describe("resolveSignalCliExecutable", () => {
+  it("uses an existing signal-cli from PATH", async () => {
+    const execFile = vi.fn(async (file: string, args?: readonly string[]) => {
+      expect(file).toBe("/usr/bin/which");
+      expect(args).toEqual(["signal-cli"]);
+      return { stdout: "/opt/homebrew/bin/signal-cli\n", stderr: "" };
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      })
+    ).resolves.toBe("/opt/homebrew/bin/signal-cli");
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-installs default signal-cli with Homebrew on macOS", async () => {
+    const execFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("signal-cli missing"))
+      .mockResolvedValueOnce({ stdout: "/opt/homebrew/bin/brew\n", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" })
+      .mockResolvedValueOnce({
+        stdout: "/opt/homebrew/bin/signal-cli\n",
+        stderr: "",
+      });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      })
+    ).resolves.toBe("/opt/homebrew/bin/signal-cli");
+    expect(execFile).toHaveBeenNthCalledWith(1, "/usr/bin/which", ["signal-cli"]);
+    expect(execFile).toHaveBeenNthCalledWith(2, "/usr/bin/which", ["brew"]);
+    expect(execFile).toHaveBeenNthCalledWith(
+      3,
+      "/opt/homebrew/bin/brew",
+      ["install", "signal-cli"],
+      { env: {} }
+    );
+    expect(execFile).toHaveBeenNthCalledWith(4, "/usr/bin/which", ["signal-cli"]);
+  });
+
+  it("does not auto-install when a custom signal-cli path is configured", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        cliPath: "/custom/bin/signal-cli",
+        env: {},
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      })
+    ).resolves.toBeNull();
+    expect(execFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("brew"),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("respects the auto-install opt-out", async () => {
+    const execFile = vi.fn(async () => {
+      throw new Error("missing");
+    });
+
+    await expect(
+      resolveSignalCliExecutable({
+        env: { MILADY_SIGNAL_CLI_AUTO_INSTALL: "0" },
+        execFile,
+        existsSync: () => false,
+        platform: "darwin",
+      })
+    ).resolves.toBeNull();
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-signal/typescript/src/pairing-service.ts
+++ b/plugins/plugin-signal/typescript/src/pairing-service.ts
@@ -21,6 +21,22 @@ const DEFAULT_SIGNAL_DEVICE_NAME = "Eliza Mac";
 const DEFAULT_SIGNAL_CLI_WAIT_TIMEOUT_MS = 30_000;
 const BREW_OPENJDK_HOME = "/opt/homebrew/opt/openjdk";
 const COMMON_SIGNAL_CLI_PATHS = ["/opt/homebrew/bin/signal-cli", "/usr/local/bin/signal-cli"];
+const COMMON_HOMEBREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
+const SIGNAL_CLI_AUTO_INSTALL_ENV = "SIGNAL_CLI_AUTO_INSTALL";
+const MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV = "MILADY_SIGNAL_CLI_AUTO_INSTALL";
+
+type ExecFileAsync = (
+  file: string,
+  args?: readonly string[],
+  options?: { env?: NodeJS.ProcessEnv }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface ExecutableResolutionDeps {
+  env: NodeJS.ProcessEnv;
+  execFile: ExecFileAsync;
+  existsSync: (path: string) => boolean;
+  platform: NodeJS.Platform;
+}
 
 /** Validate accountId to prevent path traversal. */
 export function sanitizeAccountId(raw: string): string {
@@ -114,18 +130,32 @@ export function parseSignalCliAccountsOutput(output: string): string | null {
   return null;
 }
 
-async function resolveExecutablePath(binary: string): Promise<string | null> {
+function createExecutableResolutionDeps(
+  env: NodeJS.ProcessEnv = process.env
+): ExecutableResolutionDeps {
+  return {
+    env,
+    execFile: execFileAsync as ExecFileAsync,
+    existsSync: fs.existsSync,
+    platform: os.platform(),
+  };
+}
+
+async function resolveExecutablePath(
+  binary: string,
+  deps: ExecutableResolutionDeps = createExecutableResolutionDeps()
+): Promise<string | null> {
   const trimmed = binary.trim();
   if (!trimmed) {
     return null;
   }
 
   if (trimmed.includes("/") || trimmed.startsWith(".")) {
-    return fs.existsSync(trimmed) ? trimmed : null;
+    return deps.existsSync(trimmed) ? trimmed : null;
   }
 
   try {
-    const { stdout } = await execFileAsync("/usr/bin/which", [trimmed]);
+    const { stdout } = await deps.execFile("/usr/bin/which", [trimmed]);
     const resolved = stdout.trim();
     return resolved.length > 0 ? resolved : null;
   } catch {
@@ -134,13 +164,108 @@ async function resolveExecutablePath(binary: string): Promise<string | null> {
     }
 
     for (const candidate of COMMON_SIGNAL_CLI_PATHS) {
-      if (fs.existsSync(candidate)) {
+      if (deps.existsSync(candidate)) {
         return candidate;
       }
     }
 
     return null;
   }
+}
+
+function autoInstallSignalCliEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = env[MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV] ?? env[SIGNAL_CLI_AUTO_INSTALL_ENV];
+  if (typeof raw !== "string") {
+    return true;
+  }
+  return !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
+}
+
+async function resolveHomebrewPath(deps: ExecutableResolutionDeps): Promise<string | null> {
+  try {
+    const { stdout } = await deps.execFile("/usr/bin/which", ["brew"]);
+    const resolved = stdout.trim();
+    if (resolved.length > 0) {
+      return resolved;
+    }
+  } catch {
+    for (const candidate of COMMON_HOMEBREW_PATHS) {
+      if (deps.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+async function installSignalCliWithHomebrew(deps: ExecutableResolutionDeps): Promise<void> {
+  const brewPath = await resolveHomebrewPath(deps);
+  if (!brewPath) {
+    throw new Error(
+      "Homebrew is not installed. Install Homebrew or run `brew install signal-cli` manually, then retry."
+    );
+  }
+
+  await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+}
+
+function isDefaultSignalCliRequest(
+  requestedBinary: string,
+  options: Pick<SignalPairingOptions, "cliPath">,
+  env: NodeJS.ProcessEnv
+): boolean {
+  return (
+    requestedBinary === DEFAULT_SIGNAL_CLI_NAME &&
+    !options.cliPath?.trim() &&
+    !env.SIGNAL_CLI_PATH?.trim()
+  );
+}
+
+export async function resolveSignalCliExecutable(
+  options: {
+    cliPath?: string;
+    env?: NodeJS.ProcessEnv;
+    execFile?: ExecFileAsync;
+    existsSync?: (path: string) => boolean;
+    platform?: NodeJS.Platform;
+  } = {}
+): Promise<string | null> {
+  const deps: ExecutableResolutionDeps = {
+    ...createExecutableResolutionDeps(options.env),
+    ...(options.execFile ? { execFile: options.execFile } : {}),
+    ...(options.existsSync ? { existsSync: options.existsSync } : {}),
+    ...(options.platform ? { platform: options.platform } : {}),
+  };
+  const requestedBinary =
+    options.cliPath?.trim() || deps.env.SIGNAL_CLI_PATH?.trim() || DEFAULT_SIGNAL_CLI_NAME;
+
+  const existingPath = await resolveExecutablePath(requestedBinary, deps);
+  if (existingPath) {
+    return existingPath;
+  }
+
+  if (
+    deps.platform !== "darwin" ||
+    !isDefaultSignalCliRequest(requestedBinary, options, deps.env) ||
+    !autoInstallSignalCliEnabled(deps.env)
+  ) {
+    return null;
+  }
+
+  await installSignalCliWithHomebrew(deps);
+  return resolveExecutablePath(DEFAULT_SIGNAL_CLI_NAME, deps);
+}
+
+function missingSignalCliMessage(
+  cliPath: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const requestedBinary = cliPath?.trim() || env.SIGNAL_CLI_PATH?.trim() || DEFAULT_SIGNAL_CLI_NAME;
+  const installHint =
+    requestedBinary === DEFAULT_SIGNAL_CLI_NAME
+      ? "Milady auto-installs the default Signal CLI on macOS when Homebrew is available; otherwise run `brew install signal-cli` and retry."
+      : "Install that binary or update SIGNAL_CLI_PATH to point at an existing signal-cli executable.";
+  return `Failed to load dependencies: Cannot find ${requestedBinary}. ${installHint}`;
 }
 
 function resolveSignalCliJavaHome(): string | null {
@@ -323,14 +448,13 @@ export class SignalPairingSession {
   }
 
   private async startWithSignalCli(qrCode: QrCodeModule): Promise<void> {
-    const cliPath = await resolveExecutablePath(
-      this.options.cliPath?.trim() || process.env.SIGNAL_CLI_PATH || DEFAULT_SIGNAL_CLI_NAME
-    );
+    const cliPath = await resolveSignalCliExecutable({
+      cliPath: this.options.cliPath,
+      env: process.env,
+    });
 
     if (!cliPath) {
-      throw new Error(
-        `Failed to load dependencies: Cannot find ${this.options.cliPath?.trim() || DEFAULT_SIGNAL_CLI_NAME}`
-      );
+      throw new Error(missingSignalCliMessage(this.options.cliPath));
     }
 
     console.info(`${LOG_PREFIX} Starting device linking with signal-cli...`);

--- a/plugins/plugin-signal/typescript/src/pairing-service.ts
+++ b/plugins/plugin-signal/typescript/src/pairing-service.ts
@@ -20,8 +20,16 @@ const DEFAULT_SIGNAL_CLI_NAME = "signal-cli";
 const DEFAULT_SIGNAL_DEVICE_NAME = "Eliza Mac";
 const DEFAULT_SIGNAL_CLI_WAIT_TIMEOUT_MS = 30_000;
 const BREW_OPENJDK_HOME = "/opt/homebrew/opt/openjdk";
-const COMMON_SIGNAL_CLI_PATHS = ["/opt/homebrew/bin/signal-cli", "/usr/local/bin/signal-cli"];
-const COMMON_HOMEBREW_PATHS = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"];
+const COMMON_SIGNAL_CLI_PATHS = [
+  "/opt/homebrew/bin/signal-cli",
+  "/usr/local/bin/signal-cli",
+  "/home/linuxbrew/.linuxbrew/bin/signal-cli",
+];
+const COMMON_HOMEBREW_PATHS = [
+  "/opt/homebrew/bin/brew",
+  "/usr/local/bin/brew",
+  "/home/linuxbrew/.linuxbrew/bin/brew",
+];
 const SIGNAL_CLI_AUTO_INSTALL_ENV = "SIGNAL_CLI_AUTO_INSTALL";
 const MILADY_SIGNAL_CLI_AUTO_INSTALL_ENV = "MILADY_SIGNAL_CLI_AUTO_INSTALL";
 
@@ -181,6 +189,10 @@ function autoInstallSignalCliEnabled(env: NodeJS.ProcessEnv): boolean {
   return !["0", "false", "no", "off"].includes(raw.trim().toLowerCase());
 }
 
+function canAutoInstallSignalCli(platform: NodeJS.Platform): boolean {
+  return platform === "darwin" || platform === "linux";
+}
+
 async function resolveHomebrewPath(deps: ExecutableResolutionDeps): Promise<string | null> {
   try {
     const { stdout } = await deps.execFile("/usr/bin/which", ["brew"]);
@@ -198,15 +210,21 @@ async function resolveHomebrewPath(deps: ExecutableResolutionDeps): Promise<stri
   return null;
 }
 
-async function installSignalCliWithHomebrew(deps: ExecutableResolutionDeps): Promise<void> {
+async function installSignalCliWithHomebrew(deps: ExecutableResolutionDeps): Promise<boolean> {
   const brewPath = await resolveHomebrewPath(deps);
   if (!brewPath) {
-    throw new Error(
-      "Homebrew is not installed. Install Homebrew or run `brew install signal-cli` manually, then retry."
-    );
+    return false;
   }
 
-  await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+  try {
+    await deps.execFile(brewPath, ["install", "signal-cli"], { env: deps.env });
+  } catch (error) {
+    throw new Error(
+      `Failed to auto-install signal-cli with Homebrew. ${signalCliInstallInstructions(deps.platform)}`,
+      { cause: error }
+    );
+  }
+  return true;
 }
 
 function isDefaultSignalCliRequest(
@@ -245,25 +263,42 @@ export async function resolveSignalCliExecutable(
   }
 
   if (
-    deps.platform !== "darwin" ||
+    !canAutoInstallSignalCli(deps.platform) ||
     !isDefaultSignalCliRequest(requestedBinary, options, deps.env) ||
     !autoInstallSignalCliEnabled(deps.env)
   ) {
     return null;
   }
 
-  await installSignalCliWithHomebrew(deps);
+  const installed = await installSignalCliWithHomebrew(deps);
+  if (!installed) {
+    return null;
+  }
   return resolveExecutablePath(DEFAULT_SIGNAL_CLI_NAME, deps);
 }
 
-function missingSignalCliMessage(
+export function signalCliInstallInstructions(platform: NodeJS.Platform): string {
+  if (platform === "darwin") {
+    return "Milady can auto-install the default Signal CLI on macOS when Homebrew is available (`brew install signal-cli`). Fallback: install signal-cli from https://github.com/AsamK/signal-cli/releases and set SIGNAL_CLI_PATH to its bin/signal-cli executable.";
+  }
+  if (platform === "linux") {
+    return "Milady can auto-install the default Signal CLI on Linux when Homebrew/Linuxbrew is available (`brew install signal-cli`). Fallback: install the latest signal-cli Linux release from https://github.com/AsamK/signal-cli/releases, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to its bin/signal-cli executable.";
+  }
+  if (platform === "win32") {
+    return "On Windows, install the latest signal-cli release from https://github.com/AsamK/signal-cli/releases, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to signal-cli.bat or signal-cli.exe. Milady does not auto-run a Windows package manager.";
+  }
+  return "Install signal-cli from https://github.com/AsamK/signal-cli/releases for your platform, ensure Java Runtime 25+ is installed, and set SIGNAL_CLI_PATH to the signal-cli executable.";
+}
+
+export function missingSignalCliMessage(
   cliPath: string | undefined,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = os.platform()
 ): string {
   const requestedBinary = cliPath?.trim() || env.SIGNAL_CLI_PATH?.trim() || DEFAULT_SIGNAL_CLI_NAME;
   const installHint =
     requestedBinary === DEFAULT_SIGNAL_CLI_NAME
-      ? "Milady auto-installs the default Signal CLI on macOS when Homebrew is available; otherwise run `brew install signal-cli` and retry."
+      ? signalCliInstallInstructions(platform)
       : "Install that binary or update SIGNAL_CLI_PATH to point at an existing signal-cli executable.";
   return `Failed to load dependencies: Cannot find ${requestedBinary}. ${installHint}`;
 }

--- a/plugins/plugin-signal/typescript/src/service.ts
+++ b/plugins/plugin-signal/typescript/src/service.ts
@@ -1,8 +1,7 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { promisify } from "node:util";
 import {
   ChannelType,
   type Character,
@@ -34,6 +33,7 @@ const getMessageService = (runtime: IAgentRuntime): MessageService | null => {
   return null;
 };
 
+import { resolveSignalCliExecutable } from "./pairing-service";
 import {
   getSignalContactDisplayName,
   type ISignalService,
@@ -53,13 +53,11 @@ import {
   type SignalSettings,
 } from "./types";
 
-const execFileAsync = promisify(execFile);
 export const DEFAULT_SIGNAL_HTTP_HOST = "127.0.0.1";
 export const DEFAULT_SIGNAL_HTTP_PORT = 8080;
 const DEFAULT_SIGNAL_DAEMON_STARTUP_TIMEOUT_MS = 30_000;
 export const DEFAULT_SIGNAL_CLI_PATH = "signal-cli";
 const BREW_OPENJDK_HOME = "/opt/homebrew/opt/openjdk";
-const COMMON_SIGNAL_CLI_PATHS = ["/opt/homebrew/bin/signal-cli", "/usr/local/bin/signal-cli"];
 
 /**
  * signal-cli uses `$HOME/.local/share/signal-cli` as its default data
@@ -82,35 +80,6 @@ function sleep(ms: number): Promise<void> {
 
 function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/, "");
-}
-
-async function resolveSignalCliPath(cliPath: string): Promise<string | null> {
-  const trimmed = cliPath.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  if (trimmed.includes("/") || trimmed.startsWith(".")) {
-    return fs.existsSync(trimmed) ? trimmed : null;
-  }
-
-  try {
-    const { stdout } = await execFileAsync("/usr/bin/which", [trimmed]);
-    const resolved = stdout.trim();
-    return resolved.length > 0 ? resolved : null;
-  } catch {
-    if (trimmed !== DEFAULT_SIGNAL_CLI_PATH) {
-      return null;
-    }
-
-    for (const candidate of COMMON_SIGNAL_CLI_PATHS) {
-      if (fs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    return null;
-  }
 }
 
 function buildSignalCliEnv(): NodeJS.ProcessEnv {
@@ -566,7 +535,10 @@ export class SignalService extends Service implements ISignalService {
       return;
     }
 
-    const resolvedCliPath = await resolveSignalCliPath(cliPath);
+    const resolvedCliPath = await resolveSignalCliExecutable({
+      cliPath,
+      env: process.env,
+    });
     if (!resolvedCliPath) {
       throw new Error(`signal-cli executable not found for ${cliPath}`);
     }

--- a/plugins/plugin-signal/typescript/src/service.ts
+++ b/plugins/plugin-signal/typescript/src/service.ts
@@ -33,7 +33,7 @@ const getMessageService = (runtime: IAgentRuntime): MessageService | null => {
   return null;
 };
 
-import { resolveSignalCliExecutable } from "./pairing-service";
+import { missingSignalCliMessage, resolveSignalCliExecutable } from "./pairing-service";
 import {
   getSignalContactDisplayName,
   type ISignalService,
@@ -540,7 +540,7 @@ export class SignalService extends Service implements ISignalService {
       env: process.env,
     });
     if (!resolvedCliPath) {
-      throw new Error(`signal-cli executable not found for ${cliPath}`);
+      throw new Error(missingSignalCliMessage(cliPath));
     }
 
     fs.mkdirSync(authDir, { recursive: true });


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Homebrew-based auto-install of `signal-cli` on macOS/Linux when the binary is not already present, and exposes a `SIGNAL_CLI_AUTO_INSTALL` env var to opt out. The `service.ts` daemon path is cleaned up to share the new resolver from `pairing-service.ts`.

- The user-facing `signalCliInstallInstructions` strings reference **"Milady"** (e.g. _"Milady can auto-install..."_) which appears to be the wrong product name for this project, and is visible whenever signal-cli is missing or fails to install.
- The entire auto-install block is **duplicated verbatim** between `plugins/plugin-signal/typescript/src/pairing-service.ts` and `packages/agent/src/services/signal-pairing.ts`, meaning any future fix must be applied twice.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-up items; no runtime breakage introduced.

All findings are P2 — no logic errors that cause incorrect behavior in the normal flow. The "Milady" branding is cosmetic, the env-var precedence issue only matters in an unusual dual-env-var configuration, and the resolveHomebrewPath empty-stdout edge case is unlikely in practice. The code duplication is the most actionable concern but doesn't affect correctness.

plugins/plugin-signal/typescript/src/pairing-service.ts and packages/agent/src/services/signal-pairing.ts — duplicated auto-install logic and user-facing "Milady" strings.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-signal/typescript/src/pairing-service.ts | Core of the PR — adds auto-install logic for signal-cli via Homebrew; contains "Milady" branding in user-facing strings, a silent env-var precedence issue, and a resolveHomebrewPath fallback gap. |
| packages/agent/src/services/signal-pairing.ts | Duplicate of the plugin's auto-install logic; identical issues apply — "Milady" strings, env-var precedence, and resolveHomebrewPath fallback. |
| plugins/plugin-signal/typescript/src/service.ts | Removes its own resolveSignalCliPath and delegates to resolveSignalCliExecutable/missingSignalCliMessage from pairing-service; clean refactor. |
| packages/app-core/src/registry/entries/connectors/signal.json | Adds SIGNAL_CLI_AUTO_INSTALL boolean config entry and updates SIGNAL_CLI_PATH help text; consistent with code changes. |
| plugins/plugin-signal/typescript/package.json | Adds SIGNAL_CLI_AUTO_INSTALL to published env config schema; mirrors registry JSON change correctly. |
| packages/agent/src/services/signal-pairing.test.ts | New unit tests covering the happy path, platform guards, opt-out env var, and custom path suppression; good coverage of the new branches. |
| plugins/plugin-signal/typescript/src/pairing-service.test.ts | Duplicate of the agent test file for the plugin's pairing-service; same coverage gaps around the resolveHomebrewPath empty-stdout edge case. |
| plugins/plugin-signal/typescript/src/config.ts | JSDoc comment update only — safe change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveSignalCliExecutable called] --> B[resolveExecutablePath: which / existsSync]
    B -->|found| Z[return path]
    B -->|not found| C{canAutoInstall?\ndarwin or linux}
    C -->|no| N[return null]
    C -->|yes| D{isDefaultSignalCliRequest?\nno custom cliPath/SIGNAL_CLI_PATH}
    D -->|no| N
    D -->|yes| E{autoInstallEnabled?\ncheck env vars}
    E -->|disabled| N
    E -->|enabled| F[resolveHomebrewPath:\nwhich brew / COMMON_HOMEBREW_PATHS]
    F -->|not found| N
    F -->|found| G[brew install signal-cli]
    G -->|error| ERR[throw Error with install instructions]
    G -->|ok| H[resolveExecutablePath again]
    H -->|found| Z
    H -->|not found| N
```

<sub>Reviews (1): Last reviewed commit: ["Cover Signal CLI install guidance across..."](https://github.com/elizaos/eliza/commit/3e4d5904be485e59ba65097373415bea44165a6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29744175)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->