### PR TITLE
fix(chat): bump streaming generation timeout 90s -> 180s

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -310,7 +310,7 @@ const PROVIDER_ISSUE_CHAT_REPLY = "Sorry, I'm having a provider issue";
 const INSUFFICIENT_CREDITS_CHAT_REPLY =
   "Eliza Cloud credits are depleted. Top up the cloud balance and try again.";
 const GENERIC_NO_RESPONSE_CHAT_REPLY = PROVIDER_ISSUE_CHAT_REPLY;
-const DEFAULT_CHAT_GENERATION_TIMEOUT_MS = 90_000;
+const DEFAULT_CHAT_GENERATION_TIMEOUT_MS = 180_000;
 const NON_EXECUTABLE_FALLBACK_ACTIONS = new Set(["REPLY", "NONE", "IGNORE"]);
 
 function isExecutableFallbackAction(action: { name: string }): boolean {


### PR DESCRIPTION
## Summary

Bumps the streaming chat-route generation timeout from 90s to 180s.

90s is too short for many real-world LLM workloads we hit downstream:
- Workflow generation against tool-use / structured-output models routinely takes 60-120s on the first attempt and longer on repair retries.
- Long-context responses (research summaries, large code refactors) can exceed 90s on Anthropic Sonnet / GPT-4-class models.
- Cold-start latency on Eliza Cloud + provider warmup adds 5-15s of head padding.

180s gives realistic headroom without making clients hang indefinitely. The client-side AbortController still cuts off cleanly if the user navigates away, so the cap doesn't tie up server resources for runaway requests.

## Files

- `packages/agent/src/api/chat-routes.ts` — single timeout constant change.

## Test plan

- [x] Verified live downstream: workflow-generation requests that previously hit the 90s timeout now complete cleanly.
- [ ] Reviewer: 1-line change; existing chat-route tests should remain green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps the streaming chat generation timeout constant from 90 s to 180 s in `packages/agent/src/api/chat-routes.ts`. The value can still be overridden at any time via the `ELIZA_CHAT_GENERATION_TIMEOUT_MS` environment variable, so operators who prefer a shorter (or longer) cap are unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — isolated one-line constant change with no logic impact.

The diff is a single numeric constant bump. The env-var override path remains intact so operators retain full control. No edge cases are introduced and existing tests are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/api/chat-routes.ts | Single constant change: DEFAULT_CHAT_GENERATION_TIMEOUT_MS 90_000 → 180_000; no logic altered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ChatRoute as chat-routes.ts
    participant LLM as LLM Provider

    Client->>ChatRoute: POST /chat (message)
    ChatRoute->>ChatRoute: resolveChatGenerationTimeoutMs()<br/>(env override → 180 s default)
    ChatRoute->>LLM: stream generation request
    alt completes within 180 s
        LLM-->>ChatRoute: streamed tokens
        ChatRoute-->>Client: SSE response
    else exceeds 180 s
        ChatRoute-->>Client: timeout error (503)
    else client navigates away
        Client-->>ChatRoute: AbortController signal
        ChatRoute-->>LLM: cancel request
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(chat): bump streaming generation tim..."](https://github.com/elizaos/eliza/commit/4ba196dda65a3e30e189dd9f1e0ed542103f5004) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29765685)</sub>

<!-- /greptile_comment -->