### PR TITLE
fix(telegram): emit MESSAGE_RECEIVED on Telegram messages so event-kind triggers fire

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -735,8 +735,13 @@ async function ensureTelegramBotPolling(runtime: AgentRuntime): Promise<void> {
               `telegram-user:${username}:${chatId}`,
             ) as UUID;
             const memory: Memory = {
+              // Use the same `username` value (with first_name fallback) that
+              // entityId is derived from — using ctx.message.from?.username
+              // here would give an empty string for users with no Telegram
+              // username, making `id` and `entityId` disagree for the same
+              // sender.
               id: stringToUuid(
-                `telegram:${chatId}:${ctx.message.from?.username ?? ""}:${Date.now()}`,
+                `telegram:${chatId}:${username}:${Date.now()}`,
               ) as UUID,
               entityId,
               agentId: runtime.agentId,

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -27,10 +27,13 @@ import {
   type AgentRuntime,
   AutonomyService,
   ChannelType,
+  EventType,
   logger,
+  type Memory,
   ModelType,
   type Plugin,
   stringToUuid,
+  type UUID,
 } from "@elizaos/core";
 
 export {
@@ -716,6 +719,44 @@ async function ensureTelegramBotPolling(runtime: AgentRuntime): Promise<void> {
           logger.info(
             `[eliza] Telegram message from @${username}: ${text.substring(0, 80)}`,
           );
+
+          // Surface the inbound Telegram message on the runtime event bus
+          // so event-kind triggers (Session 2 G1 bridge → executeTriggerTask)
+          // can fire on real Telegram messages. Without this hop the Milady
+          // shim handles the chat reply via useModel directly and bypasses
+          // messageService entirely — DoD-F4 fails (Session 17b finding).
+          // Build a minimal Memory that satisfies the event-bus contract;
+          // the trigger-event-bridge only reads roomId / source / kind.
+          try {
+            const telegramRoomId = stringToUuid(
+              `telegram:${chatId}`,
+            ) as UUID;
+            const entityId = stringToUuid(
+              `telegram-user:${username}:${chatId}`,
+            ) as UUID;
+            const memory: Memory = {
+              id: stringToUuid(
+                `telegram:${chatId}:${ctx.message.from?.username ?? ""}:${Date.now()}`,
+              ) as UUID,
+              entityId,
+              agentId: runtime.agentId,
+              roomId: telegramRoomId,
+              content: {
+                text,
+                source: "telegram",
+              },
+              createdAt: Date.now(),
+            };
+            await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+              runtime,
+              message: memory,
+              source: "telegram",
+            });
+          } catch (emitErr) {
+            logger.warn(
+              `[eliza] Telegram MESSAGE_RECEIVED emit failed: ${emitErr instanceof Error ? emitErr.message : String(emitErr)}`,
+            );
+          }
 
           let history = chatHistories.get(chatId);
           if (!history) {


### PR DESCRIPTION
## Summary

Emits `MESSAGE_RECEIVED` on the runtime event bus when an inbound Telegram message arrives via the in-process Telegram shim path. Without this emission, event-kind triggers bound to Telegram messages register fine but never fire because the bridge ([elizaOS/eliza#7116](https://github.com/elizaOS/eliza/pull/7116)) sees no event to dispatch on.

The Discord shim already emits `MESSAGE_RECEIVED` correctly. This brings Telegram to parity.

### Files

- `packages/app-core/src/runtime/eliza.ts` — adds the emit in the Telegram-shim message handler. Mirrors the existing Discord-side pattern in the same file.

### Pairs with

This PR depends conceptually on **[elizaOS/eliza#7116](https://github.com/elizaOS/eliza/pull/7116)** (`TriggerEventBridge`) — without that, the emit goes nowhere useful. Both should land before Telegram-event triggers are documented.

## Test plan

- [x] Verified live downstream: an event-kind trigger bound to Telegram MESSAGE_RECEIVED fires when a message arrives in the bound chat.
- [ ] Reviewer: confirm the emit signature matches the existing Discord-shim pattern in the same file.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `MESSAGE_RECEIVED` emit to the Telegram in-process shim in `packages/app-core/src/runtime/eliza.ts`, building a minimal `Memory` object and firing it on the runtime event bus before the existing `useModel` + `ctx.reply()` path continues. The payload shape correctly satisfies `MessagePayload` (`{ runtime, message: Memory, source }`) and the emit is wrapped in a try/catch so failures are non-fatal.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of the ephemeral-memory contract and the already-noted duplicate-response risk.

No P0 issues; a P1 ceiling applies because of the un-persisted Memory being emitted on a typed bus where handlers may legitimately attempt DB lookups by ID. All other concerns are P2 style/quality. The fix is small, isolated, and correctly typed against MessagePayload.

packages/app-core/src/runtime/eliza.ts — specifically the ephemeral Memory pattern and the await-blocking interaction between emitEvent and the reply path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/runtime/eliza.ts | Adds `MESSAGE_RECEIVED` emit in the Telegram message handler; payload matches `MessagePayload`; ephemeral (un-persisted) `Memory` object is intentional per stated bridge contract, but the `await` on `emitEvent` blocks the reply path for the duration of all registered handlers. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TG as Telegram (bot.on message)
    participant Shim as eliza.ts Telegram Shim
    participant Bus as runtime.emitEvent
    participant Bridge as TriggerEventBridge (#7116)
    participant Model as useModel + ctx.reply()

    TG->>Shim: incoming text message
    Shim->>Shim: build minimal Memory{id, entityId, roomId, content}
    Shim->>Bus: await emitEvent(MESSAGE_RECEIVED, {runtime, message, source:"telegram"})
    Bus->>Bridge: dispatch to all MESSAGE_RECEIVED handlers
    Bridge-->>Bus: (trigger tasks fire here)
    Bus-->>Shim: resolved
    Shim->>Model: useModel(TEXT_LARGE, prompt)
    Model-->>Shim: responseText
    Shim->>TG: ctx.reply(responseText)
```

<sub>Reviews (3): Last reviewed commit: ["fix(telegram): align memory id with pre-..."](https://github.com/elizaos/eliza/commit/9de890179d2365d375a855bfd9053d7cb92c32bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29765825)</sub>

<!-- /greptile_comment -->