### PR TITLE
fix(lifeops): scope-reject LIFE on foreign page-* scopes

### DIFF
--- a/apps/app-lifeops/src/actions/life.test.ts
+++ b/apps/app-lifeops/src/actions/life.test.ts
@@ -63,17 +63,20 @@ describe("lifeAction.validate — scope gating", () => {
     expect(result).toBe(false);
   });
 
-  // `page-settings` is omitted deliberately — it is absent from the server-side
-  // `VALID_SCOPES` allowlist in `@elizaos/agent/api/conversation-metadata`, so
-  // the server sanitizes the scope out of room metadata before it reaches any
-  // action `validate()`. LIFE cannot reject a scope the server has already
-  // dropped; that inconsistency is a separate cleanup (parking-lot item in the
-  // workflows-automations plan).
+  // Cover every page-* scope in the server-side `VALID_SCOPES` allowlist
+  // (`@elizaos/agent/api/conversation-metadata`) other than `page-lifeops`
+  // itself. `isForeignPageScope` must reject all of these so the planner
+  // sees a clean candidate set on each non-LifeOps surface.
+  // (`page-automations` has its own explicit test above with the same
+  // assertion shape; not duplicated here.)
   it.each([
-    "page-browser",
     "page-apps",
+    "page-browser",
     "page-character",
+    "page-connectors",
     "page-phone",
+    "page-plugins",
+    "page-settings",
     "page-wallet",
   ])("rejects on foreign page scope %s", async (scope) => {
     const { runtime } = buildRuntime(scope);

--- a/apps/app-lifeops/src/actions/life.test.ts
+++ b/apps/app-lifeops/src/actions/life.test.ts
@@ -1,0 +1,113 @@
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./lifeops/service.js", () => ({
+  LifeOpsService: class LifeOpsService {},
+  LifeOpsServiceError: class LifeOpsServiceError extends Error {
+    status: number;
+    constructor(message: string, status = 500) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const ROOM_ID = "00000000-0000-4000-8000-000000000001" as UUID;
+
+function buildRuntime(scope: string | undefined): {
+  runtime: IAgentRuntime;
+  getRoom: ReturnType<typeof vi.fn>;
+} {
+  // Room metadata is extracted via `extractConversationMetadataFromRoom`,
+  // which reads the ConversationMetadata out of `room.metadata.webConversation`.
+  // A missing webConversation block models "no scope set" (home chat).
+  const metadata =
+    scope === undefined ? undefined : { webConversation: { scope } };
+  const getRoom = vi.fn(async (roomId: string) => ({
+    id: roomId,
+    metadata,
+  }));
+  const runtime = { getRoom } as unknown as IAgentRuntime;
+  return { runtime, getRoom };
+}
+
+function buildMessage(text: string): Memory {
+  return {
+    id: "11111111-1111-4000-8000-000000000001" as UUID,
+    roomId: ROOM_ID,
+    entityId: "22222222-2222-4000-8000-000000000001" as UUID,
+    agentId: "33333333-3333-4000-8000-000000000001" as UUID,
+    content: { text, source: "test" },
+  } as Memory;
+}
+
+async function runValidate(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<boolean> {
+  const { lifeAction } = await import("./life.js");
+  const { validate } = lifeAction;
+  if (!validate) {
+    throw new Error("lifeAction.validate is required for this suite");
+  }
+  return validate(runtime, message);
+}
+
+describe("lifeAction.validate — scope gating", () => {
+  const reminderPrompt = "set an alarm for 7am";
+
+  it("rejects on page-automations scope (Session 8/10 reproduction)", async () => {
+    const { runtime } = buildRuntime("page-automations");
+    const message = buildMessage(reminderPrompt);
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(false);
+  });
+
+  // `page-settings` is omitted deliberately — it is absent from the server-side
+  // `VALID_SCOPES` allowlist in `@elizaos/agent/api/conversation-metadata`, so
+  // the server sanitizes the scope out of room metadata before it reaches any
+  // action `validate()`. LIFE cannot reject a scope the server has already
+  // dropped; that inconsistency is a separate cleanup (parking-lot item in the
+  // workflows-automations plan).
+  it.each([
+    "page-browser",
+    "page-apps",
+    "page-character",
+    "page-phone",
+    "page-wallet",
+  ])("rejects on foreign page scope %s", async (scope) => {
+    const { runtime } = buildRuntime(scope);
+    const message = buildMessage(reminderPrompt);
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(false);
+  });
+
+  it("accepts on page-lifeops scope (LifeOps surface)", async () => {
+    const { runtime } = buildRuntime("page-lifeops");
+    const message = buildMessage(reminderPrompt);
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(true);
+  });
+
+  it("accepts when no scope metadata is set (home chat / direct app-lifeops room)", async () => {
+    const { runtime } = buildRuntime(undefined);
+    const message = buildMessage(reminderPrompt);
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(true);
+  });
+
+  it("accepts on non-page scope (e.g. automation-draft)", async () => {
+    const { runtime } = buildRuntime("automation-draft");
+    const message = buildMessage(reminderPrompt);
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(true);
+  });
+
+  it("rejects coding-task text even on page-lifeops scope (text filter short-circuits before scope check)", async () => {
+    const { runtime, getRoom } = buildRuntime("page-lifeops");
+    const message = buildMessage("build a dashboard component");
+    const result = await runValidate(runtime, message);
+    expect(result).toBe(false);
+    expect(getRoom).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app-lifeops/src/actions/life.ts
+++ b/apps/app-lifeops/src/actions/life.ts
@@ -40,6 +40,10 @@ import {
 } from "../lifeops/time.js";
 import { gmailAction } from "./gmail.js";
 import {
+  extractConversationMetadataFromRoom,
+  isPageScopedConversationMetadata,
+} from "@elizaos/agent/api/conversation-metadata";
+import {
   type ExtractedLifeMissingField,
   type ExtractedLifeOperation,
   extractLifeOperationWithLlm,
@@ -2261,6 +2265,25 @@ function formatWeeklyGoalReview(args: {
 
 // ── Main action ───────────────────────────────────────
 
+// LIFE belongs to the LifeOps surface (home chat / page-lifeops /
+// app-lifeops direct rooms). On foreign page-* scopes the action set is
+// scoped to that surface (page-automations → CREATE_TRIGGER_TASK,
+// page-browser → browser actions, etc.). When LIFE stays eligible on those
+// scopes its long description contaminates the ACTION_PLANNER candidate
+// list, driving the LLM to mimic the life-param-extractor JSON schema and
+// producing envelopes the planner's XML parse cannot read.
+async function isForeignPageScope(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<boolean> {
+  const room = await runtime.getRoom(message.roomId);
+  const metadata = extractConversationMetadataFromRoom(room);
+  if (!isPageScopedConversationMetadata(metadata)) {
+    return false;
+  }
+  return metadata?.scope !== "page-lifeops";
+}
+
 export const lifeAction: Action & {
   suppressPostActionContinuation?: boolean;
 } = {
@@ -2317,6 +2340,9 @@ export const lifeAction: Action & {
     // the action selector can still pick LIFE. Decline here to let
     // plugin-agent-orchestrator's CREATE_TASK take the route.
     if (looksLikeCodingTaskRequest(messageText(message))) {
+      return false;
+    }
+    if (await isForeignPageScope(runtime, message)) {
       return false;
     }
     return hasLifeOpsAccess(runtime, message);


### PR DESCRIPTION
## Summary

Adjusts the `LIFE` action handler in app-lifeops to scope-reject when invoked on a foreign `page-*` scope (e.g. `page-automations`, `page-chat`). Previously, `LIFE` would accept the action even from these foreign scopes, which gave the action-planner two equally-valid candidates and frequently caused it to pick `LIFE` when the user clearly meant something page-scoped.

### Why

`LIFE` is the catch-all generic-life-event action — it's intentionally broad. When the user is on the Automations page and types "remind me to drink water at 10am", they want a trigger created in the page-automations scope, not a generic life-event row. By having `LIFE` scope-reject on foreign page scopes, the planner sees a clean candidate set on those pages and picks the right action.

### Files

- `apps/app-lifeops/src/actions/life.ts` — adds `isForeignPageScope` check at the top of the handler validator.
- `apps/app-lifeops/src/actions/life.test.ts` — new tests pin the scope-reject behavior.

## Test plan

- [x] Verified live downstream: prompts on `page-automations` no longer route to `LIFE`; the planner picks the correct page-scoped action.
- [x] New unit tests cover both accept (default scope) and reject (foreign page-* scope) paths.
- [ ] Reviewer: existing life.test.ts should remain green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `isForeignPageScope` to `lifeAction.validate` so that `LIFE` scope-rejects on any `page-*` scope other than `page-lifeops`, preventing the action planner from picking the catch-all life-event handler when the user is on a page-scoped surface. The implementation correctly uses the existing `extractConversationMetadataFromRoom` / `isPageScopedConversationMetadata` utilities and is consistent with how other guards are structured in this file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — core logic is correct and all VALID_SCOPES page-* entries are covered.

Only P2 findings present (test fragility regarding implicit hasPrivateAccess fallback). No logic or security issues identified.

No files require special attention beyond the optional test improvement noted in the inline comment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/app-lifeops/src/actions/life.ts | Adds `isForeignPageScope` helper and wires it into `validate`; logic is correct — `isPageScopedConversationMetadata` guard plus `!== "page-lifeops"` check covers all VALID_SCOPES page-* entries cleanly. |
| apps/app-lifeops/src/actions/life.test.ts | New test file covering scope-gating; rejection paths are solid, but the three "accepts" cases implicitly rely on `hasPrivateAccess`'s lenient no-context fallback rather than an explicit mock of `hasLifeOpsAccess` as done in sibling test files. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Planner as Action Planner
    participant Validate as lifeAction.validate
    participant TextFilter as looksLikeCodingTaskRequest
    participant ScopeCheck as isForeignPageScope
    participant DB as runtime.getRoom
    participant Access as hasLifeOpsAccess

    Planner->>Validate: validate(runtime, message)
    Validate->>TextFilter: looksLikeCodingTaskRequest(text)
    alt coding task
        TextFilter-->>Validate: true
        Validate-->>Planner: false (reject)
    else not coding task
        TextFilter-->>Validate: false
        Validate->>ScopeCheck: isForeignPageScope(runtime, message)
        ScopeCheck->>DB: getRoom(message.roomId)
        DB-->>ScopeCheck: room
        ScopeCheck->>ScopeCheck: extractConversationMetadataFromRoom(room)
        ScopeCheck->>ScopeCheck: isPageScopedConversationMetadata(metadata)
        alt foreign page-* scope (e.g. page-automations)
            ScopeCheck-->>Validate: true
            Validate-->>Planner: false (reject)
        else home / page-lifeops / non-page scope
            ScopeCheck-->>Validate: false
            Validate->>Access: hasLifeOpsAccess(runtime, message)
            Access-->>Validate: bool
            Validate-->>Planner: bool
        end
    end
```

<sub>Reviews (4): Last reviewed commit: ["fix(lifeops): correct misleading test co..."](https://github.com/elizaos/eliza/commit/7af5d674e7bb55b3088844611d694e369194126b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29765841)</sub>

<!-- /greptile_comment -->