### PR TITLE
fix(automations): hide right-rail chat dock on Overview empty state

### DIFF
--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -5313,6 +5313,14 @@ export function AutomationsView() {
 
 export function AutomationsDesktopShell() {
   const controller = useAutomationsViewController();
+  // Session 22 UI cleanup: collapse the right-rail chat dock when no
+  // workflow / draft is selected. The Automations Overview page already
+  // has a centered hero compose ("Describe a task or workflow…") that's
+  // the canonical create surface; the bottom-right dock + hero showed
+  // two inputs at once and confused users. When a workflow or draft IS
+  // selected, restore uncontrolled behavior so the rail (and its
+  // PageScopedChatPane) is available for editing/refining.
+  const hasScopedItem = controller.resolvedSelectedItem != null;
   return (
     <AutomationsViewContext.Provider value={controller}>
       <AppWorkspaceChrome
@@ -5322,6 +5330,9 @@ export function AutomationsDesktopShell() {
             activeItem={controller.resolvedSelectedItem}
           />
         }
+        {...(hasScopedItem
+          ? {}
+          : { chatCollapsed: true, onToggleChat: () => {}, hideCollapseButton: true })}
         main={
           <div className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
             <AutomationsLayout />

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -5318,9 +5318,32 @@ export function AutomationsDesktopShell() {
   // has a centered hero compose ("Describe a task or workflow…") that's
   // the canonical create surface; the bottom-right dock + hero showed
   // two inputs at once and confused users. When a workflow or draft IS
-  // selected, restore uncontrolled behavior so the rail (and its
-  // PageScopedChatPane) is available for editing/refining.
+  // selected, the rail (and its PageScopedChatPane) opens so the user
+  // can edit/refine.
+  //
+  // Stay in CONTROLLED mode at all times. An earlier revision flipped
+  // between controlled (when nothing selected) and uncontrolled (when
+  // something selected); that left AppWorkspaceChrome's internal
+  // `internalCollapsed` stuck at `true` after the controlled phase, so
+  // the rail never opened on the first selection. Always-controlled
+  // avoids that transition entirely.
   const hasScopedItem = controller.resolvedSelectedItem != null;
+  const [userCollapsedWhenSelected, setUserCollapsedWhenSelected] =
+    useState(false);
+  // When the user clears the selection, also reset the toggle so the next
+  // selection starts with the rail open by default.
+  useEffect(() => {
+    if (!hasScopedItem) setUserCollapsedWhenSelected(false);
+  }, [hasScopedItem]);
+  const chatCollapsed = hasScopedItem ? userCollapsedWhenSelected : true;
+  const handleToggleChat = useCallback(
+    (next: boolean) => {
+      // No-op when nothing is selected — the rail is force-closed in that
+      // state and the toggle button is hidden, so this should never fire.
+      if (hasScopedItem) setUserCollapsedWhenSelected(next);
+    },
+    [hasScopedItem],
+  );
   return (
     <AutomationsViewContext.Provider value={controller}>
       <AppWorkspaceChrome
@@ -5330,9 +5353,9 @@ export function AutomationsDesktopShell() {
             activeItem={controller.resolvedSelectedItem}
           />
         }
-        {...(hasScopedItem
-          ? {}
-          : { chatCollapsed: true, onToggleChat: () => {}, hideCollapseButton: true })}
+        chatCollapsed={chatCollapsed}
+        onToggleChat={handleToggleChat}
+        hideCollapseButton={!hasScopedItem}
         main={
           <div className="flex flex-col flex-1 min-h-0 min-w-0 overflow-hidden">
             <AutomationsLayout />

--- a/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
+++ b/packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx
@@ -304,16 +304,29 @@ export function AppWorkspaceChrome({
   const collapsed = isControlled
     ? (chatCollapsedProp ?? false)
     : internalCollapsed;
+  // Controlled mode is the source of truth on every viewport — including
+  // mobile. When the page passes chatCollapsed=true (e.g. forcing a
+  // single canonical compose surface in an empty state), the mobile
+  // pane-switcher must respect that and not flip back to open via local
+  // mobileChatOpen state.
   const effectiveCollapsed = chatDisabled
     ? true
-    : isMobileViewport
-      ? !mobileChatOpen
-      : collapsed;
+    : isControlled
+      ? collapsed
+      : isMobileViewport
+        ? !mobileChatOpen
+        : collapsed;
 
   const handleToggle = useCallback(
     (next: boolean) => {
       if (isMobileViewport) {
         mobileSidebarControl?.setOpen(false);
+        if (isControlled) {
+          // Page is the source of truth on mobile too — defer to it
+          // instead of touching local mobileChatOpen state.
+          onToggleChat?.(next);
+          return;
+        }
         setMobileChatOpen(chatDisabled ? false : !next);
         return;
       }
@@ -495,12 +508,12 @@ export function AppWorkspaceChrome({
               data-testid={`${testId}-chat-sidebar`}
               data-collapsed
             >
-              {isMobileViewport ? null : (
+              {!isMobileViewport && !hideCollapseButton ? (
                 <AppWorkspaceChatDockToggleButton
                   collapsed
                   testId={`${testId}-chat-expand`}
                 />
-              )}
+              ) : null}
             </aside>
           ) : (
             <>


### PR DESCRIPTION
## Summary

When the Automations Overview is in its empty state (no workflows, no triggers selected), the right-rail page-scoped chat dock was visible alongside the hero-input compose surface — two compose surfaces on screen at once with overlapping placeholder copy.

This PR collapses the right-rail when the Overview is showing AND nothing is selected. Selecting a workflow opens the rail (planner-routed conversational editing); clearing selection collapses it again. Single canonical compose surface per page state.

### Files

- `packages/app-core/src/components/pages/AutomationsView.tsx` — pass `chatCollapsed={true}` + `hideCollapseButton={true}` to `AppWorkspaceChrome` when no workflow / draft / trigger is selected.

## Note on a 6-commit chain that this is the first of

Downstream there are 5 follow-up commits that further evolve this UX (rail-state-driven on Automations, in-flight draft selection survival, WorkflowGenerationProgress card during draft generation, etc.). Several of them depend on a refactor of `AppWorkspaceChrome.tsx` that conflicts with upstream's recent mobile-viewport additions to the same file. Rather than ship a half-resolved chain, this PR ships only the first commit (which is self-contained on `AutomationsView.tsx` and applies cleanly).

The follow-up 5 commits will be opened as separate PRs once a maintainer can advise on whether to:
- (a) rebase our `AppWorkspaceChrome.tsx` change on top of the new mobile-viewport structure, or
- (b) drop the `AppWorkspaceChrome.tsx` change entirely and refactor the dependent code to use a different mechanism.

## Test plan

- [x] Verified live downstream: empty Automations Overview shows only the hero compose; selecting a workflow expands the rail; clearing selection collapses it.
- [ ] Reviewer: existing AutomationsView tests should remain green; the change is additive (adds new props on the empty-state branch).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR collapses the `AppWorkspaceChrome` right-rail chat dock on the Automations Overview when no workflow or draft is selected, eliminating the overlapping dual-compose-surface UX issue. It does so by keeping `AppWorkspaceChrome` in always-controlled mode (chatCollapsed always defined) and routing toggle state through a local `userCollapsedWhenSelected` flag, while also patching `AppWorkspaceChrome` to respect controlled mode on mobile viewports and to gate the expand-button behind `hideCollapseButton`.

All four issues raised in previous review threads have been addressed: the stuck-collapsed-on-first-selection bug (always-controlled), the silent no-op handler, the visible-but-unguarded expand button, and the mobile pane-switcher bypass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues found; all four previously identified bugs have been resolved in this revision.

The always-controlled approach cleanly avoids the internalCollapsed-stuck-at-true bug. The effectiveCollapsed priority change ensures mobile respects controlled state. The hideCollapseButton guard now covers the expand button. The handleToggle mobile path correctly delegates to onToggleChat. No new logic errors introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/AutomationsView.tsx | Adds always-controlled chat-rail state (chatCollapsed, onToggleChat, hideCollapseButton) to AutomationsDesktopShell; correctly resets userCollapsedWhenSelected on selection clear; addresses all previously identified issues with the earlier controlled/uncontrolled flip. |
| packages/app-core/src/components/workspace/AppWorkspaceChrome.tsx | Patches effectiveCollapsed to short-circuit to controlled state before mobile-local mobileChatOpen; delegates handleToggle's mobile path to onToggleChat when controlled; gates the expand-button render behind !hideCollapseButton. All changes are logically consistent with the new always-controlled contract. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant ADS as AutomationsDesktopShell
    participant AWC as AppWorkspaceChrome

    Note over ADS: hasScopedItem = false
    ADS->>AWC: chatCollapsed=true, hideCollapseButton=true
    AWC-->>U: Rail collapsed, no expand/collapse buttons shown

    U->>ADS: selects a workflow
    Note over ADS: hasScopedItem = true, userCollapsedWhenSelected = false
    ADS->>AWC: chatCollapsed=false, hideCollapseButton=false
    AWC-->>U: Rail opens, collapse button visible

    U->>AWC: clicks collapse button
    AWC->>ADS: onToggleChat(true)
    ADS->>ADS: setUserCollapsedWhenSelected(true)
    ADS->>AWC: chatCollapsed=true
    AWC-->>U: Rail collapses, expand button visible

    U->>AWC: clicks expand button
    AWC->>ADS: onToggleChat(false)
    ADS->>ADS: setUserCollapsedWhenSelected(false)
    ADS->>AWC: chatCollapsed=false
    AWC-->>U: Rail reopens

    U->>ADS: clears selection
    Note over ADS: hasScopedItem = false
    ADS->>ADS: useEffect resets userCollapsedWhenSelected=false
    ADS->>AWC: chatCollapsed=true, hideCollapseButton=true
    AWC-->>U: Rail collapsed, no buttons shown
```

<sub>Reviews (4): Last reviewed commit: ["fix(workspace): hideCollapseButton + con..."](https://github.com/elizaos/eliza/commit/2da0b8b4198e9f3cf1f14b96bfafbf4354d1e380) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29766020)</sub>

<!-- /greptile_comment -->