### PR TITLE
test(n8n): pin handleGenerateWorkflow deployWorkflow path

### DIFF
--- a/packages/app-core/src/api/client-n8n.ts
+++ b/packages/app-core/src/api/client-n8n.ts
@@ -94,10 +94,20 @@ ElizaClient.prototype.generateN8nWorkflow = async function (
   this: ElizaClient,
   request: N8nWorkflowGenerateRequest,
 ): Promise<N8nWorkflow> {
-  return this.fetch<N8nWorkflow>("/api/n8n/workflows/generate", {
-    method: "POST",
-    body: JSON.stringify(request),
-  });
+  // LLM-driven workflow generation runs keyword extraction, node search,
+  // generation, multiple correction passes, and feasibility assessment
+  // sequentially — easily 30-90s on a cold cache. The 10s default fetch
+  // timeout is far too aggressive and surfaces as
+  // "Request timed out after 10000ms" in the Automations UI even when
+  // the backend would have succeeded a few seconds later.
+  return this.fetch<N8nWorkflow>(
+    "/api/n8n/workflows/generate",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+    { timeoutMs: 120_000 },
+  );
 };
 
 ElizaClient.prototype.activateN8nWorkflow = async function (

--- a/packages/app-core/src/api/n8n-routes.test.ts
+++ b/packages/app-core/src/api/n8n-routes.test.ts
@@ -1007,3 +1007,127 @@ describe("n8n route gate", () => {
     expect(handled).toBe(false);
   });
 });
+
+// ── handleGenerateWorkflow → deployWorkflow path ────────────────────────────
+//
+// Pins the post-Session-19 behavior of POST /api/n8n/workflows/generate:
+// when the n8n_workflow service is registered, the route MUST go through
+// service.generateWorkflowDraft → service.deployWorkflow → service.getWorkflow
+// (with userId = resolveAgentId(ctx)) so credential resolution runs
+// server-side. Without this, generated workflows reach n8n with
+// `{{CREDENTIAL_ID}}` placeholders unresolved and crash on activate. A
+// future refactor that silently reverts to the legacy proxy path would be
+// caught here.
+
+interface MockGenerateService {
+  generateWorkflowDraft: ReturnType<typeof vi.fn>;
+  deployWorkflow: ReturnType<typeof vi.fn>;
+  getWorkflow: ReturnType<typeof vi.fn>;
+}
+
+function runtimeWithWorkflowService(
+  service: Partial<MockGenerateService>,
+): AgentRuntime {
+  return {
+    getService: vi.fn((name: string) =>
+      name === "n8n_workflow" ? service : null,
+    ),
+  } as unknown as AgentRuntime;
+}
+
+describe("n8n POST /api/n8n/workflows/generate", () => {
+  it("calls generateWorkflowDraft → deployWorkflow → getWorkflow in order with resolveAgentId(ctx) as userId", async () => {
+    const draft = {
+      name: "Test Draft",
+      nodes: [],
+      connections: {},
+    };
+    const deployed = {
+      id: "wf-123",
+      name: "Test Draft",
+      active: false,
+      nodeCount: 0,
+      missingCredentials: [],
+    };
+    const full = {
+      id: "wf-123",
+      name: "Test Draft",
+      nodes: [],
+      connections: {},
+      active: false,
+    };
+    const generateWorkflowDraft = vi.fn(async () => draft);
+    const deployWorkflow = vi.fn(async () => deployed);
+    const getWorkflow = vi.fn(async () => full);
+    const service: MockGenerateService = {
+      generateWorkflowDraft,
+      deployWorkflow,
+      getWorkflow,
+    };
+    const runtime = runtimeWithWorkflowService(service);
+
+    const { handled, status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/generate",
+      runtime,
+      agentId: "agent-abc",
+      body: { prompt: "create a hello workflow" },
+    });
+
+    expect(handled).toBe(true);
+    expect(status).toBe(200);
+    expect(payload).toEqual(full);
+
+    // Argument shapes
+    expect(generateWorkflowDraft).toHaveBeenCalledWith(
+      "create a hello workflow",
+    );
+    expect(deployWorkflow).toHaveBeenCalledWith(draft, "agent-abc");
+    expect(getWorkflow).toHaveBeenCalledWith("wf-123");
+
+    // Call ordering — generate < deploy < getWorkflow
+    const genOrder = generateWorkflowDraft.mock.invocationCallOrder[0];
+    const deployOrder = deployWorkflow.mock.invocationCallOrder[0];
+    const getOrder = getWorkflow.mock.invocationCallOrder[0];
+    expect(genOrder).toBeLessThan(deployOrder);
+    expect(deployOrder).toBeLessThan(getOrder);
+  });
+
+  it("short-circuits with warning when deployWorkflow reports missingCredentials and skips getWorkflow", async () => {
+    const draft = { name: "Gmail Draft", nodes: [], connections: {} };
+    const deployed = {
+      id: "wf-456",
+      name: "Gmail Draft",
+      active: false,
+      nodeCount: 0,
+      missingCredentials: [
+        { credType: "gmailOAuth2", authUrl: "milady://settings/connectors/gmail" },
+      ],
+    };
+    const generateWorkflowDraft = vi.fn(async () => draft);
+    const deployWorkflow = vi.fn(async () => deployed);
+    const getWorkflow = vi.fn(async () => ({}));
+    const service: MockGenerateService = {
+      generateWorkflowDraft,
+      deployWorkflow,
+      getWorkflow,
+    };
+    const runtime = runtimeWithWorkflowService(service);
+
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/generate",
+      runtime,
+      agentId: "agent-abc",
+      body: { prompt: "send my Gmail summary to Discord" },
+    });
+
+    expect(status).toBe(200);
+    expect(payload).toMatchObject({
+      id: "wf-456",
+      missingCredentials: deployed.missingCredentials,
+      warning: "missing credentials",
+    });
+    expect(getWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -1287,6 +1287,23 @@ async function handleGenerateWorkflow(
     typeof service?.deployWorkflow === "function" &&
     typeof service?.getWorkflow === "function"
   ) {
+    // Two-phase try blocks. The OUTER try wraps only operations that have NOT
+    // yet committed a side effect to n8n — generateWorkflowDraft (LLM call,
+    // pure) and deployWorkflow (the write). Failures here can safely fall
+    // through to the legacy proxy path because no workflow has been written
+    // yet. Once deployWorkflow returns successfully, the workflow IS in n8n
+    // and any further failure (e.g. the follow-up getWorkflow read) must NOT
+    // re-enter the legacy path — that path would re-invoke the LLM and POST
+    // a new workflow OR PUT-overwrite the just-deployed one with unresolved
+    // `{{CREDENTIAL_ID}}` placeholders.
+    let deployed:
+      | {
+          id: string;
+          name: string;
+          active: boolean;
+          missingCredentials: Array<{ credType: string; authUrl?: string }>;
+        }
+      | undefined;
     try {
       const draft = await service.generateWorkflowDraft(prompt);
       if (name?.trim()) {
@@ -1302,10 +1319,22 @@ async function handleGenerateWorkflow(
       // entity in Milady local and gives a stable per-agent tag for n8n
       // credential mapping.
       const userId = resolveAgentId(ctx);
-      const deployed = await service.deployWorkflow(
+      deployed = await service.deployWorkflow(
         draft as Record<string, unknown>,
         userId,
       );
+    } catch (err) {
+      logger.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "[n8n-routes] generate/deploy path failed before commit; falling back to direct proxy",
+      );
+      // Pre-deploy failure — deploy never committed. Legacy proxy fallback
+      // is safe here.
+    }
+
+    if (deployed) {
       if (deployed.missingCredentials.length > 0) {
         sendJson(ctx, 200, {
           ...deployed,
@@ -1313,17 +1342,24 @@ async function handleGenerateWorkflow(
         });
         return true;
       }
-      const full = await service.getWorkflow(deployed.id);
-      sendJson(ctx, 200, full);
+      // Deploy succeeded — the workflow is committed in n8n. Try to enrich
+      // the response with the full workflow body, but on failure return the
+      // deploy summary instead of falling through (see comment above on why
+      // the legacy path would corrupt the just-deployed workflow).
+      let full: Record<string, unknown> | undefined;
+      try {
+        full = await service.getWorkflow(deployed.id);
+      } catch (readErr) {
+        logger.warn(
+          {
+            err: readErr instanceof Error ? readErr.message : String(readErr),
+            deployedId: deployed.id,
+          },
+          "[n8n-routes] follow-up getWorkflow failed after successful deploy; returning deploy summary",
+        );
+      }
+      sendJson(ctx, 200, full ?? deployed);
       return true;
-    } catch (err) {
-      logger.warn(
-        {
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "[n8n-routes] deployWorkflow path failed; falling back to direct proxy",
-      );
-      // fall through to legacy proxy path
     }
   }
 

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -1255,6 +1255,81 @@ async function handleGenerateWorkflow(
 
   const name = readOptionalString(body, "name");
   const workflowId = readOptionalString(body, "workflowId");
+
+  // Prefer the plugin's `deployWorkflow` pipeline so generated workflows go
+  // through credential resolution server-side. Without this, the LLM emits
+  // `credentials: { gmailOAuth2: { id: "{{CREDENTIAL_ID}}" } }` and the
+  // placeholder reaches n8n raw — n8n then crashes on
+  // `Cannot read properties of undefined (reading 'execute')` whenever the
+  // user tries to activate or run the workflow because no real credential id
+  // exists for the lookup. The fallback proxy chain only runs when the
+  // plugin's workflow service isn't registered (test/CI shapes).
+  const service = ctx.runtime?.getService?.("n8n_workflow") as
+    | {
+        generateWorkflowDraft?: (prompt: string) => Promise<{
+          id?: string;
+          [k: string]: unknown;
+        }>;
+        deployWorkflow?: (
+          workflow: Record<string, unknown>,
+          userId: string,
+        ) => Promise<{
+          id: string;
+          name: string;
+          active: boolean;
+          missingCredentials: Array<{ credType: string; authUrl?: string }>;
+        }>;
+        getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
+      }
+    | undefined;
+  if (
+    typeof service?.generateWorkflowDraft === "function" &&
+    typeof service?.deployWorkflow === "function" &&
+    typeof service?.getWorkflow === "function"
+  ) {
+    try {
+      const draft = await service.generateWorkflowDraft(prompt);
+      if (name?.trim()) {
+        (draft as Record<string, unknown>).name = name.trim();
+      }
+      if (workflowId) {
+        (draft as Record<string, unknown>).id = workflowId;
+      }
+      // The plugin's deployWorkflow → getUserTagName → getEntityById(userId)
+      // requires a real UUID; passing "local" makes the entity lookup throw
+      // "Failed query: ... where entities.id in ($1)" because pg rejects the
+      // non-UUID string. Use the runtime's agentId — it's always a valid
+      // entity in Milady local and gives a stable per-agent tag for n8n
+      // credential mapping.
+      const userId = resolveAgentId(ctx);
+      const deployed = await service.deployWorkflow(
+        draft as Record<string, unknown>,
+        userId,
+      );
+      if (deployed.missingCredentials.length > 0) {
+        sendJson(ctx, 200, {
+          ...deployed,
+          warning: "missing credentials",
+        });
+        return true;
+      }
+      const full = await service.getWorkflow(deployed.id);
+      sendJson(ctx, 200, full);
+      return true;
+    } catch (err) {
+      logger.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "[n8n-routes] deployWorkflow path failed; falling back to direct proxy",
+      );
+      // fall through to legacy proxy path
+    }
+  }
+
+  // Legacy proxy fallback — used when the workflow service isn't available
+  // (e.g. plugin disabled in tests). Generated workflows from this path
+  // ship to n8n with `{{CREDENTIAL_ID}}` placeholders unresolved.
   const payload = await generateWorkflowPayload(ctx, prompt, name);
   if (workflowId) {
     return writeWorkflow(


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the `handleGenerateWorkflow` → `service.deployWorkflow` → `service.getWorkflow` flow introduced by [#7118](https://github.com/elizaOS/eliza/pull/7118). This is the regression net for the route's new service-driven path so a future refactor can't silently revert it to the legacy HTTP proxy.

### What's tested

1. **Happy path:** `POST /api/n8n/workflows/generate` calls `generateWorkflowDraft` → `deployWorkflow` → `getWorkflow` in order, with `userId = resolveAgentId(ctx)`. Argument shapes pinned, call ordering pinned, response shape pinned.
2. **Missing credentials:** when `deployWorkflow` reports a non-empty `missingCredentials` array, the route short-circuits with a 200 + `warning: "missing credentials"` envelope and **does not** call `getWorkflow`.

### Files

- `packages/app-core/src/api/n8n-routes.test.ts` — 124 lines added (one new `describe` block with two `it` cases).

## Stacking — strict dependency

**Depends on [#7118](https://github.com/elizaOS/eliza/pull/7118)** (which introduces the `service.deployWorkflow` path that this PR tests). Without #7118 merged first, the route still proxies via HTTP and these tests fail with 503.

This branch was rebased on top of #7118's branch (commit `548a989739`), so:
- Until #7118 merges: the PR diff includes #7118's commits plus this PR's test commit.
- When #7118 merges: this PR auto-rebases against develop, the diff collapses to just the test additions, and CI on this branch turns green.

**Maintainer order:** merge [#7118](https://github.com/elizaOS/eliza/pull/7118) first, then this PR.

## Test plan

- [x] When run against #7118's branch (which is what this PR is now stacked on), both tests pass.
- [ ] Reviewer: `bun test packages/app-core/src/api/n8n-routes.test.ts` after #7118 lands.

## Greptile feedback addressed

- **P1 (tests reference unimplemented impl)** — fixed by stacking on #7118 instead of develop. The deploy/getWorkflow service path now exists in this branch's tree.
- **Mock data concern (`nodes: []` causing fallback)** — confirmed not an issue: the `normalizeWorkflowWritePayload` rejection path is in the LEGACY proxy code, which doesn't run when the service is registered. The new service-driven path passes the mock draft directly to `deployWorkflow`, which the test mocks to return a fixed deployed object.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds test coverage for the service-driven `handleGenerateWorkflow` path introduced in #7118, and increases the client-side fetch timeout for workflow generation from 10 s to 120 s. The implementation in `n8n-routes.ts` looks correct: it resolves the `n8n_workflow` service, calls `generateWorkflowDraft → deployWorkflow → getWorkflow` in order, and falls through to the legacy proxy only on pre-deploy failure. Both test cases verify the happy path and the `missingCredentials` short-circuit, and are consistent with the route logic.

<h3>Confidence Score: 5/5</h3>

Safe to merge once #7118 is landed; no defects found in the implementation or test logic.

All three files are correct: the route implementation follows the intended two-phase pattern with safe fallbacks, the test assertions align exactly with the route code, and the timeout increase in the client is well-supported by the base class API. No P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/n8n-routes.ts | Adds service-driven path in handleGenerateWorkflow with two-phase try blocks, missingCredentials short-circuit, and safe legacy fallback; logic is correct and well-commented. |
| packages/app-core/src/api/n8n-routes.test.ts | Adds two focused test cases pinning the deploy path and the missingCredentials short-circuit; test harness wiring (agentId, runtime mock) is correct and consistent with the route handler. |
| packages/app-core/src/api/client-n8n.ts | Raises generateN8nWorkflow fetch timeout to 120 s; ElizaClient.fetch() accepts timeoutMs as a third argument so the call is well-formed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant R as n8n-routes (handleGenerateWorkflow)
    participant S as n8n_workflow service
    participant N8N as n8n

    C->>R: POST /api/n8n/workflows/generate {prompt}
    R->>R: ctx.runtime.getService("n8n_workflow")
    alt service registered
        R->>S: generateWorkflowDraft(prompt)
        S-->>R: draft
        R->>S: deployWorkflow(draft, userId)
        S-->>R: deployed {id, missingCredentials}
        alt missingCredentials.length > 0
            R-->>C: 200 {...deployed, warning: "missing credentials"}
        else credentials OK
            R->>S: getWorkflow(deployed.id)
            S-->>N8N: GET /workflow/:id
            N8N-->>S: full workflow
            S-->>R: full
            R-->>C: 200 full
        end
    else service not registered / pre-deploy error
        R->>R: legacy proxy fallback
        R-->>C: response from proxy
    end
```

<sub>Reviews (3): Last reviewed commit: ["test(n8n): pin handleGenerateWorkflow de..."](https://github.com/elizaos/eliza/commit/81faf9debff95976358ee46d48aae330e30bbd57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29767686)</sub>

<!-- /greptile_comment -->