### PR TITLE
fix(automations): in-flight draft selection survives stale-id check + synthesizes draft item

### DIFF
--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -65,6 +65,7 @@ import type {
   AutomationListResponse,
   AutomationNodeDescriptor,
   AutomationItem as CatalogAutomationItem,
+  AutomationRoomBinding,
   Conversation,
   N8nStatusResponse,
   N8nWorkflow,
@@ -1052,17 +1053,40 @@ function useAutomationsViewController() {
       // BEFORE refreshAutomations surfaced the real workflow). Synthesize
       // a minimal draft item so AutomationDraftPane renders with the
       // WorkflowGenerationProgress card during the LLM call.
+      //
+      // Fill in every required field on AutomationItem with sensible
+      // defaults instead of casting through `unknown`. In particular,
+      // `room` MUST be set when an active workflow conversation exists —
+      // otherwise handleDeleteDraft sees `item.room?.conversationId` as
+      // undefined and shows a misleading "missing automation room" error
+      // when the user clicks "Delete draft" during the generation window.
       if (selectedItemId.startsWith("workflow-draft:")) {
         const draftId = selectedItemId.slice("workflow-draft:".length);
-        return {
+        const draftRoom: AutomationRoomBinding | null =
+          activeWorkflowConversation
+            ? {
+                conversationId: activeWorkflowConversation.id,
+                roomId: activeWorkflowConversation.roomId,
+                scope: "automation-workflow-draft",
+              }
+            : null;
+        const synthesized: AutomationItem = {
           id: selectedItemId,
           type: "automation_draft",
-          isDraft: true,
+          source: "workflow_draft",
           title: "New workflow",
-          updatedAt: Date.now(),
+          description: "",
+          status: "draft",
+          enabled: false,
           system: false,
+          isDraft: true,
+          hasBackingWorkflow: false,
+          updatedAt: null,
           draftId,
-        } as unknown as AutomationItem;
+          schedules: [],
+          room: draftRoom,
+        };
+        return synthesized;
       }
       return null;
     }

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -65,7 +65,6 @@ import type {
   AutomationListResponse,
   AutomationNodeDescriptor,
   AutomationItem as CatalogAutomationItem,
-  AutomationRoomBinding,
   Conversation,
   N8nStatusResponse,
   N8nWorkflow,
@@ -1054,22 +1053,15 @@ function useAutomationsViewController() {
       // a minimal draft item so AutomationDraftPane renders with the
       // WorkflowGenerationProgress card during the LLM call.
       //
-      // Fill in every required field on AutomationItem with sensible
-      // defaults instead of casting through `unknown`. In particular,
-      // `room` MUST be set when an active workflow conversation exists —
-      // otherwise handleDeleteDraft sees `item.room?.conversationId` as
-      // undefined and shows a misleading "missing automation room" error
-      // when the user clicks "Delete draft" during the generation window.
+      // The `room` field is left null here. `activeWorkflowConversation`
+      // — the live conversation tied to this draft — lives in
+      // AutomationsLayout (a different scope from this controller hook),
+      // so we cannot read it from here without a larger refactor.
+      // Instead, handleDeleteDraft reads activeWorkflowConversation
+      // directly and falls back to it when item.room is missing on a
+      // synthesized draft (see the handler below).
       if (selectedItemId.startsWith("workflow-draft:")) {
         const draftId = selectedItemId.slice("workflow-draft:".length);
-        const draftRoom: AutomationRoomBinding | null =
-          activeWorkflowConversation
-            ? {
-                conversationId: activeWorkflowConversation.id,
-                roomId: activeWorkflowConversation.roomId,
-                scope: "automation-workflow-draft",
-              }
-            : null;
         const synthesized: AutomationItem = {
           id: selectedItemId,
           type: "automation_draft",
@@ -1084,7 +1076,7 @@ function useAutomationsViewController() {
           updatedAt: null,
           draftId,
           schedules: [],
-          room: draftRoom,
+          room: null,
         };
         return synthesized;
       }
@@ -4921,7 +4913,14 @@ function AutomationsLayout() {
 
   const handleDeleteDraft = useCallback(
     async (item: AutomationItem) => {
-      const conversationId = item.room?.conversationId;
+      // Synthesized in-flight drafts (workflow-draft:* ids surfaced
+      // before refreshAutomations completes) have no `room` because the
+      // controller's resolvedSelectedItem useMemo can't reach
+      // activeWorkflowConversation from its scope. Fall back to the
+      // live activeWorkflowConversation when item.room is missing —
+      // that's the same conversation the synthesized item represents.
+      const conversationId =
+        item.room?.conversationId ?? activeWorkflowConversation?.id ?? null;
       if (!conversationId) {
         setPageNotice("This draft is missing its automation room.");
         return;

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -771,6 +771,14 @@ function useAutomationsViewController() {
 
   useEffect(() => {
     if (!selectedItemId) return;
+    // Exempt in-flight workflow drafts — they're not in allItems until
+    // generateWorkflowFromPrompt finishes and refreshAutomations
+    // surfaces the real workflow. Without this exemption the draft
+    // selection gets cleared mid-generation, the auto-select effect
+    // below picks lastSelectedIdRef (typically a task like Heartbeat),
+    // and the user lands somewhere unexpected — defeating the
+    // WorkflowGenerationProgress UI we just added on the draft pane.
+    if (selectedItemId.startsWith("workflow-draft:")) return;
     if (!allItems.some((item) => item.id === selectedItemId)) {
       setSelectedItemId(null);
       setSelectedItemKind(null);
@@ -1038,7 +1046,25 @@ function useAutomationsViewController() {
   const resolvedSelectedItem = useMemo(() => {
     if (editorOpen || editingId || editingTaskId) return null;
     if (selectedItemId) {
-      return allItems.find((item) => item.id === selectedItemId) ?? null;
+      const found = allItems.find((item) => item.id === selectedItemId);
+      if (found) return found;
+      // In-flight workflow draft (createWorkflowDraft set selectedItemId
+      // BEFORE refreshAutomations surfaced the real workflow). Synthesize
+      // a minimal draft item so AutomationDraftPane renders with the
+      // WorkflowGenerationProgress card during the LLM call.
+      if (selectedItemId.startsWith("workflow-draft:")) {
+        const draftId = selectedItemId.slice("workflow-draft:".length);
+        return {
+          id: selectedItemId,
+          type: "automation_draft",
+          isDraft: true,
+          title: "New workflow",
+          updatedAt: Date.now(),
+          system: false,
+          draftId,
+        } as unknown as AutomationItem;
+      }
+      return null;
     }
     return allItems[0] ?? null;
   }, [allItems, editingId, editingTaskId, editorOpen, selectedItemId]);


### PR DESCRIPTION
## Summary

Two coupled bugs around in-flight workflow drafts in `AutomationsView`:

1. **Stale-id validation effect cleared the in-flight `workflow-draft:<id>` selection** before generation finished. The `selectedItemId` validation effect cleared the selection because the draft id wasn't in `allItems` until `generateWorkflowFromPrompt` completed and `refreshAutomations` surfaced the real workflow. Once cleared, the auto-select effect would pick `lastSelectedIdRef` (typically a Heartbeat task), so the user landed on the wrong item instead of the still-generating draft.

2. **`resolvedSelectedItem` returned `null` for `workflow-draft:` ids**. Even when the selection survived, `allItems.find` returned nothing for the draft id, so the draft pane never rendered.

## What's new

- **`packages/app-core/src/components/pages/AutomationsView.tsx`** —
  - Exempt `workflow-draft:*` ids from the stale-id validation effect.
  - When `selectedItemId` starts with `workflow-draft:` but isn't in `allItems`, synthesize a minimal `AutomationItem` (`type: "automation_draft"`, `isDraft: true`) so the draft pane renders during the generation window.

## Why this matters

Without these two fixes, the user submits a workflow prompt → page navigates to the draft pane briefly → the validation effect clears the selection → user lands on a stale Heartbeat task → confusing. With them, the draft pane stays visible throughout the ~25s generation, then transitions cleanly to the real workflow detail when generation finishes.

## Stacking

Pairs nicely with [#7127](https://github.com/elizaOS/eliza/pull/7127) (WorkflowGenerationProgress card) — that PR adds the visual feedback that this PR keeps on screen.

## Test plan

- [x] Verified live downstream: hero submit → draft pane stays selected → generation completes → transitions to real workflow detail.
- [ ] Reviewer: existing AutomationsView tests should remain green; the change is additive in the validation/selection effects.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two coupled bugs in `AutomationsView`: the stale-id validation effect was clearing `workflow-draft:*` selections mid-generation, and `resolvedSelectedItem` was returning `null` for draft ids. The fixes — exempting draft ids from the stale-id effect, synthesizing a minimal `AutomationItem`, and falling back to `activeWorkflowConversation` in `handleDeleteDraft` — are well-scoped and the previous-thread concerns (type mismatch, delete failure, scope issue) are all addressed in this revision.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the happy path works correctly and all previous-thread blockers are addressed — one P2 edge case in the error path remains.

Only P2 finding: the stale-id exemption has no fallback when `resolveAutomationConversation` fails, leaving the user on an unescapable synthesized draft pane in that error scenario. This is a narrow, non-crash degradation in an error path.

packages/app-core/src/components/pages/AutomationsView.tsx — specifically the `createWorkflowDraft` catch block and the stale-id exemption guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/AutomationsView.tsx | Two focused fixes: exempts `workflow-draft:*` ids from the stale-id validation effect, and synthesizes a minimal `AutomationItem` so `AutomationDraftPane` renders during the LLM generation window. The `handleDeleteDraft` fallback to `activeWorkflowConversation?.id` correctly handles the synthesized item's null `room`. One P2 concern: the stale-id exemption has no escape hatch for conversation-creation failures, leaving the user stuck on the synthesized pane in that error path. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant CD as createWorkflowDraft
    participant SI as selectedItemId state
    participant RS as resolvedSelectedItem (memo)
    participant GW as generateWorkflowFromPrompt
    participant RA as refreshAutomations

    U->>CD: click "New workflow" (with initialPrompt)
    CD->>SI: setSelectedItemId("workflow-draft:abc")
    Note over SI: stale-id effect EXEMPT for workflow-draft:*
    CD->>CD: resolveAutomationConversation (async)
    CD->>SI: setActiveWorkflowConversation(conversation)
    RS-->>U: synthesized AutomationItem {type:"automation_draft", isDraft:true}
    Note over U: AutomationDraftPane visible
    CD->>GW: generateWorkflowFromPrompt(prompt, conversation)
    GW->>GW: LLM call (~25s)
    GW->>RA: refreshAutomations()
    RA-->>GW: allItems updated with real workflow
    GW->>SI: selectWorkflowById(workflow.id)
    RS-->>U: real AutomationItem found in allItems
    Note over U: WorkflowAutomationDetailPane visible
```

<sub>Reviews (4): Last reviewed commit: ["fix(automations): drop broken room synth..."](https://github.com/elizaos/eliza/commit/17af61c3cb91c506ec10300aed81e713d4a1bdc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29768026)</sub>

<!-- /greptile_comment -->