### PR TITLE
fix(n8n-sidecar): demote binary-missing diagnostics to debug

### DIFF
--- a/packages/app-core/src/services/n8n-sidecar.test.ts
+++ b/packages/app-core/src/services/n8n-sidecar.test.ts
@@ -24,6 +24,7 @@ import {
   disposeN8nSidecar,
   getN8nSidecar,
   getN8nSidecarAsync,
+  isBinaryMissingMessage,
   N8nSidecar,
   type N8nSidecarConfig,
   type N8nSidecarDeps,
@@ -965,6 +966,31 @@ describe("N8nSidecar", () => {
       await disposalPromise;
       const next = await nextPromise;
       expect(next).not.toBe(sidecar);
+    });
+  });
+
+  describe("isBinaryMissingMessage", () => {
+    it("matches the four well-known binary-missing signatures", () => {
+      expect(isBinaryMissingMessage("sh: 1: n8n: not found")).toBe(true);
+      expect(isBinaryMissingMessage("bash: n8n: command not found")).toBe(true);
+      expect(
+        isBinaryMissingMessage(
+          "bunx runtime not found on PATH — required for local n8n. Install from https://bun.sh.",
+        ),
+      ).toBe(true);
+      expect(
+        isBinaryMissingMessage(
+          "n8n child exited with code 127 before readiness probe succeeded",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not match generic n8n runtime errors", () => {
+      expect(isBinaryMissingMessage("workflow not found in cache")).toBe(false);
+      expect(isBinaryMissingMessage("user not found")).toBe(false);
+      expect(isBinaryMissingMessage("exited with code 1")).toBe(false);
+      expect(isBinaryMissingMessage("readiness probe timed out")).toBe(false);
+      expect(isBinaryMissingMessage("")).toBe(false);
     });
   });
 });

--- a/packages/app-core/src/services/n8n-sidecar.ts
+++ b/packages/app-core/src/services/n8n-sidecar.ts
@@ -362,13 +362,17 @@ function fingerprint(secret: string): string {
  * Match diagnostics that mean "n8n binary is not installed/resolvable" rather
  * than a real runtime fault. Users without n8n installed shouldn't see warn-
  * level spam every supervisor retry — those lines belong at debug.
+ *
+ * Patterns are intentionally narrow so generic "X not found" messages from a
+ * running n8n instance keep their warn level.
  */
-const BINARY_MISSING_PATTERNS: RegExp[] = [
-  /\bnot found\b/i, // sh: 1: n8n: not found, command not found, ENOENT "not found"
-  /not found on PATH/i, // preflightBinary error string
-  /exited with code 127\b/i, // npx/sh exit code for "command not found"
+const BINARY_MISSING_PATTERNS = [
+  /^sh:\s*\d+:\s*\S+:\s*not found$/i, // sh: 1: n8n: not found
+  /:\s*command not found$/i, // bash/zsh "command not found"
+  /\bnot found on PATH\b/i, // preflightBinary error string
+  /\bexited with code 127\b/i, // npx/sh exit code for "command not found"
 ];
-function isBinaryMissing(message: string): boolean {
+export function isBinaryMissingMessage(message: string): boolean {
   return BINARY_MISSING_PATTERNS.some((re) => re.test(message));
 }
 
@@ -707,7 +711,7 @@ export class N8nSidecar {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           await this.clearNpmCacheAfterJsonParseFailure();
-          if (isBinaryMissing(msg)) {
+          if (isBinaryMissingMessage(msg)) {
             logger.debug(`[n8n-sidecar] start attempt failed: ${msg}`);
           } else {
             logger.warn(`[n8n-sidecar] start attempt failed: ${msg}`);
@@ -826,7 +830,7 @@ export class N8nSidecar {
         // "binary not found" lines are user-config noise, not runtime faults,
         // so they go to debug.
         if (stream === "stderr") {
-          if (isBinaryMissing(trimmed)) {
+          if (isBinaryMissingMessage(trimmed)) {
             logger.debug(`[n8n-sidecar:stderr] ${trimmed}`);
           } else {
             logger.warn(`[n8n-sidecar:stderr] ${trimmed}`);

--- a/packages/app-core/src/services/n8n-sidecar.ts
+++ b/packages/app-core/src/services/n8n-sidecar.ts
@@ -359,6 +359,20 @@ function fingerprint(secret: string): string {
 }
 
 /**
+ * Match diagnostics that mean "n8n binary is not installed/resolvable" rather
+ * than a real runtime fault. Users without n8n installed shouldn't see warn-
+ * level spam every supervisor retry — those lines belong at debug.
+ */
+const BINARY_MISSING_PATTERNS: RegExp[] = [
+  /\bnot found\b/i, // sh: 1: n8n: not found, command not found, ENOENT "not found"
+  /not found on PATH/i, // preflightBinary error string
+  /exited with code 127\b/i, // npx/sh exit code for "command not found"
+];
+function isBinaryMissing(message: string): boolean {
+  return BINARY_MISSING_PATTERNS.some((re) => re.test(message));
+}
+
+/**
  * Extract the n8n-auth cookie from a `Response` for re-use on subsequent
  * calls. Returns a ready-to-send `Cookie:` header value, or null if the
  * response didn't set one. Tolerates fetch implementations that expose
@@ -693,7 +707,11 @@ export class N8nSidecar {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           await this.clearNpmCacheAfterJsonParseFailure();
-          logger.warn(`[n8n-sidecar] start attempt failed: ${msg}`);
+          if (isBinaryMissing(msg)) {
+            logger.debug(`[n8n-sidecar] start attempt failed: ${msg}`);
+          } else {
+            logger.warn(`[n8n-sidecar] start attempt failed: ${msg}`);
+          }
           this.cancelRetryResetTimer();
           this.setState({
             status: "starting",
@@ -805,8 +823,14 @@ export class N8nSidecar {
         this.recordOutput(`[${stream}] ${trimmed}`);
         // Surface n8n errors at warn so they land in the dev-server log even
         // when debug is off — the sidecar was silent before when n8n died.
+        // "binary not found" lines are user-config noise, not runtime faults,
+        // so they go to debug.
         if (stream === "stderr") {
-          logger.warn(`[n8n-sidecar:stderr] ${trimmed}`);
+          if (isBinaryMissing(trimmed)) {
+            logger.debug(`[n8n-sidecar:stderr] ${trimmed}`);
+          } else {
+            logger.warn(`[n8n-sidecar:stderr] ${trimmed}`);
+          }
         } else {
           logger.debug(`[n8n-sidecar:stdout] ${trimmed}`);
         }


### PR DESCRIPTION
## what

When the local n8n sidecar can't find the n8n binary (user hasn't installed it / npm cache miss), every supervisor retry pumps two warn-level lines into the dev-server log:

```
[n8n-sidecar:stderr] sh: 1: n8n: not found
[n8n-sidecar] start attempt failed: n8n child exited with code 127 before readiness probe succeeded
```

These are user-config diagnostics, not runtime faults. The supervisor already handles binary-missing correctly (preflight + retry cap + error state). The log level was the only thing inconsistent with that intent — bumping these at warn just trains the user to ignore the warn channel.

This PR adds a narrowly-anchored predicate `isBinaryMissingMessage(message)` that matches the four well-known binary-missing signatures and routes those lines to `logger.debug`. All other stderr output and any non-binary-missing start failure still log at `warn` — actual n8n runtime errors continue to surface.

## why

- VPS users without n8n installed (e.g. milady on a fresh box) see one warn-spam pulse every restart. Three retries × two log lines = six warn entries per boot — enough to swamp other warnings worth reading.
- Real n8n crashes (non-zero exit codes other than 127, runtime stack traces, API errors) are unaffected — they don't match any of the four patterns.

## commits

1. **`fix(n8n-sidecar): demote binary-missing diagnostics to debug`** — initial change with three regex patterns and predicate gating both call sites.
2. **`fix(n8n-sidecar): tighten binary-missing patterns + cover with test`** — addresses the only review concern I anticipated: the original `/\bnot found\b/i` was too broad and could false-positive on generic n8n runtime errors. Tightened to four anchored patterns:
   - `/^sh:\s*\d+:\s*\S+:\s*not found$/i` — anchored shell error
   - `/:\s*command not found$/i` — anchored bash/zsh variant
   - `/\bnot found on PATH\b/i` — preflight error string
   - `/\bexited with code 127\b/i` — npx/sh exit code

   Also exports the predicate for direct test coverage rather than indirect spy assertions.

## scope

Single file change + co-located test additions:
- `packages/app-core/src/services/n8n-sidecar.ts` — predicate (export) + log-level routing at two call sites (stderr capture + supervisor catch block).
- `packages/app-core/src/services/n8n-sidecar.test.ts` — 2 new tests in a dedicated `describe("isBinaryMissingMessage")` block: positive matches for the four signatures, negative-control matches for generic "X not found" runtime errors and non-127 exits.

No public API change beyond exporting one tested helper. No behavior change beyond log level for binary-missing diagnostics.

## verification

- `bunx vitest run src/services/n8n-sidecar.test.ts` → **27/27 pass** (25 existing + 2 new predicate tests)
- `bunx tsc --noEmit` → no new errors in n8n-sidecar.ts (pre-existing errors in other unrelated files unchanged)
- live-tested on the milady VPS: with `n8n.localEnabled=true` and no n8n binary installed, dev-server log shows **0 warn-level binary-missing lines** post-fix. The only n8n warn line that still fires is `N8N_HOST not provided — plugin will not be functional` from a separate plugin's config check, which is correct behavior and out of scope here.

## what I deliberately didn't ship

- A bigger preflight that detects n8n binary absence and short-circuits the supervisor before any spawn attempts. That's a cleaner architectural fix but touches the spawn topology and risks regressing setups where npx lazily installs n8n on first run. This PR is the surgical one — log-level only, no state-machine impact. Happy to follow up with the preflight version if a reviewer prefers it.
