### PR TITLE
fix(message): respect explicit REPLY action in metadata-rescue gate

### DIFF
--- a/packages/typescript/src/services/message.test.ts
+++ b/packages/typescript/src/services/message.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, State } from "../types";
 import { stringToUuid } from "../utils";
-import { DefaultMessageService, extractPlannerActionNames } from "./message.ts";
+import {
+	DefaultMessageService,
+	extractPlannerActionNames,
+	shouldRunMetadataActionRescue,
+} from "./message.ts";
 
 // Tests for DISABLE_MEMORY_CREATION and ALLOW_MEMORY_SOURCE_IDS logic
 describe("MessageService memory persistence logic", () => {
@@ -187,5 +191,56 @@ describe("DefaultMessageService action-result cache lifecycle", () => {
 
 		expect(result.didRespond).toBe(false);
 		expect(stateCache.has(`${messageId}_action_results`)).toBe(false);
+	});
+});
+
+describe("shouldRunMetadataActionRescue", () => {
+	it("returns true when no actions are present", () => {
+		expect(shouldRunMetadataActionRescue({ actions: [] })).toBe(true);
+		expect(shouldRunMetadataActionRescue(null)).toBe(true);
+		expect(shouldRunMetadataActionRescue(undefined)).toBe(true);
+	});
+
+	it("returns true when actions are only IGNORE / NONE", () => {
+		expect(shouldRunMetadataActionRescue({ actions: ["IGNORE"] })).toBe(true);
+		expect(shouldRunMetadataActionRescue({ actions: ["NONE"] })).toBe(true);
+		expect(
+			shouldRunMetadataActionRescue({ actions: ["IGNORE", "NONE"] }),
+		).toBe(true);
+	});
+
+	it("returns false when REPLY is present (do not override deliberate conversation)", () => {
+		expect(shouldRunMetadataActionRescue({ actions: ["REPLY"] })).toBe(false);
+		expect(shouldRunMetadataActionRescue({ actions: ["RESPOND"] })).toBe(false);
+		expect(
+			shouldRunMetadataActionRescue({ actions: ["reply"] /* lowercase */ }),
+		).toBe(false);
+	});
+
+	it("returns false when a non-passive action is present (already routed)", () => {
+		expect(shouldRunMetadataActionRescue({ actions: ["CREATE_TASK"] })).toBe(
+			false,
+		);
+		expect(shouldRunMetadataActionRescue({ actions: ["SPAWN_AGENT"] })).toBe(
+			false,
+		);
+		expect(
+			shouldRunMetadataActionRescue({ actions: ["REPLY", "CREATE_TASK"] }),
+		).toBe(false);
+	});
+
+	it("ignores non-string entries in the actions array", () => {
+		// The runtime occasionally feeds in malformed planner output; the gate
+		// must not crash on numbers / objects / nulls and must still answer
+		// false when REPLY appears alongside garbage.
+		expect(
+			shouldRunMetadataActionRescue({
+				actions: [
+					42 as unknown as string,
+					null as unknown as string,
+					"REPLY",
+				],
+			}),
+		).toBe(false);
 	});
 });

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -1944,6 +1944,48 @@ function hasNonPassiveAction(
 	);
 }
 
+/**
+ * Returns true when the planner deliberately chose to converse — i.e. the
+ * response actions list contains REPLY (or its alias RESPOND).
+ *
+ * REPLY is a deliberate signal that the LLM judged the message as
+ * conversation, not a delegated task. The metadata-overlap rescue path
+ * must respect this and not promote REPLY to a privileged action like
+ * OWNER_INBOX or MANAGE_ISSUES based on incidental keyword overlap with
+ * those actions' example text. Without this gate, a chitchat message
+ * containing common scheduling/workflow words ("workflow", "policy",
+ * "follow up", "friday", "2026") gets force-routed into a role-gated
+ * action and the user sees "Permission denied: only the owner or admin
+ * may use inbox actions" in response to plain conversation.
+ */
+function hasExplicitReplyIntent(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+): boolean {
+	const replyId = normalizeActionIdentifier("REPLY");
+	const respondId = normalizeActionIdentifier("RESPOND");
+	return (
+		responseContent?.actions?.some((actionName) => {
+			if (typeof actionName !== "string") return false;
+			const id = normalizeActionIdentifier(actionName);
+			return id === replyId || id === respondId;
+		}) ?? false
+	);
+}
+
+/**
+ * Gate for the metadata-rescue path that promotes a passive (REPLY/NONE)
+ * response to a privileged action based on keyword overlap. Run only when
+ * the planner produced no real action AND no explicit REPLY — i.e. when
+ * we genuinely have nothing to say.
+ */
+export function shouldRunMetadataActionRescue(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+): boolean {
+	if (hasNonPassiveAction(responseContent)) return false;
+	if (hasExplicitReplyIntent(responseContent)) return false;
+	return true;
+}
+
 function shouldAttemptActionRescue(
 	runtime: Pick<IAgentRuntime, "actions">,
 	message: Memory,
@@ -5984,7 +6026,7 @@ Output ONLY the continuation, starting immediately after the last character abov
 			}
 		}
 
-		if (!hasNonPassiveAction(responseContent)) {
+		if (shouldRunMetadataActionRescue(responseContent)) {
 			const metadataSuggestion = suggestOwnedActionFromMetadata(
 				runtime,
 				message,


### PR DESCRIPTION
## what

When the planner returns `['REPLY']`, the metadata-overlap rescue at the end of the action-routing pipeline (`message.ts:5987`, the "Recovered primary action from action metadata after passive reply draft" log line) considers REPLY "passive" and runs `suggestOwnedActionFromMetadata` anyway. If any user message contains common scheduling / workflow vocabulary (`workflow`, `policy`, `follow up`, `friday`, `2026`), the keyword-overlap scorer promotes the chitchat to a privileged action like `OWNER_INBOX` or `MANAGE_ISSUES`. The action's role gate then denies the non-owner user with messages like:

```
Permission denied: only the owner or admin may use inbox actions.
```

…in response to plain conversation.

## concrete repro

From a milady deployment, captured today:

1. In a Discord channel, `botdick` (a guest user, not the bot owner) `@`-pinged `remilio nubilio` with a multi-line monitoring proposal:
   > "Plan, short and actionable: Short term: ship Grafana (metrics), Loki (logs), Sentry (errors). Dashboards: request latency, error rate, 5xx spike, deploy failures. Alerts -> this Discord channel + Pager when critical. Instrumentation: …"

2. The planner correctly chose `REPLY` — this is a chitchat / consult message, no delegation, no inbox action requested.

3. The metadata-rescue overrode it. Bot log:
   ```
   [SERVICE:MESSAGE] Recovered primary action from action metadata after passive reply draft
     (originalActions=["REPLY"], suggestedAction=OWNER_INBOX,
      score=15.57, secondBestScore=10.75,
      reasons=["overlap:2026,friday","workflow"])
   ```

4. The owner-inbox role gate then bailed:
   ```
   Permission denied: only the owner or admin may use inbox actions.
   ```

5. Same path also fires `REPLY → MANAGE_ISSUES` on messages mentioning "issue" / "ll" (saw it on a different message in the same channel: `reasons=["overlap:issue,ll","overlap:issue,ll","example"]`).

## fix

Extract the rescue-eligibility check into a tiny exported predicate and add an explicit guard for REPLY:

```ts
export function shouldRunMetadataActionRescue(
  responseContent: Pick<Content, "actions"> | null | undefined,
): boolean {
  if (hasNonPassiveAction(responseContent)) return false;
  if (hasExplicitReplyIntent(responseContent)) return false;
  return true;
}
```

`hasExplicitReplyIntent` is true when `actions` contains REPLY or RESPOND. The rescue path now runs only when:
- the planner returned no actions at all, OR
- the only actions are IGNORE / NONE (genuine "nothing to do")

If REPLY is in there, the planner deliberately chose to converse and we respect that. The keyword-overlap scorer is a fallback for the "we have no idea what to do" case, not a second-guesser of an explicit conversational signal.

## scope

Single source file + new tests:

- `packages/typescript/src/services/message.ts`: adds `hasExplicitReplyIntent` (private) + `shouldRunMetadataActionRescue` (exported, used by the gate at the call site that previously inlined `!hasNonPassiveAction(...)`).
- `packages/typescript/src/services/message.test.ts`: 5 new test cases in a dedicated `describe("shouldRunMetadataActionRescue")` block covering empty / null / IGNORE-only / REPLY / RESPOND / non-passive / mixed-types-with-REPLY.

No public API change beyond exporting one tested helper. No behavior change for cases where the planner had nothing to say — those still get the metadata-rescue rescue. The change is purely "stop overriding REPLY."

## verification

- `bunx vitest run src/services/message.test.ts` → **19/19 pass** (5 new + 14 existing).
- `bunx tsc --noEmit` → no new errors.
- The earlier production trace (`Recovered primary action from action metadata after passive reply draft (originalActions=["REPLY"], suggestedAction=OWNER_INBOX...)`) cannot fire after this change — verified by the `actions: ["REPLY"]` test case returning `false` from `shouldRunMetadataActionRescue`.

## what I deliberately didn't ship

| Item | Why |
|---|---|
| **Tightening `ACTION_OWNERSHIP_TRIGGER_PATTERNS`** (the regex list at `message.ts:1600`) — words like `workflow`, `policy`, `follow up`, `if`, `when` are too loose | Even with the loose triggers, the gate fix is correct: if the planner picked REPLY, don't override regardless of how loose the triggers are. Tightening triggers is a separate prompt-engineering exercise that needs careful regression testing on the cases where the rescue legitimately helps. |
| **A more polished failure message** in `app-lifeops/src/actions/inbox.ts:358` instead of "Permission denied: only the owner or admin may use inbox actions." | Out of scope. Once this PR lands, that text shouldn't appear in response to chitchat anymore. For legitimate "guest tries to use inbox" cases, improving the wording can be a small follow-up. |
| **Pre-filtering by author role** so guest users never get owner-only actions suggested | A defense-in-depth change. The current fix already prevents the false-suggestion from reaching the role gate; layering role-aware suggestion would be cleaner architecturally but is a bigger change touching more code paths. |

## 5-rule check

1. **No meaningless wrappers** — `hasExplicitReplyIntent` is a one-job predicate (REPLY/RESPOND test). `shouldRunMetadataActionRescue` is the gate, used at one call site, exported only for tests.
2. **Reuse existing functions** — uses `hasNonPassiveAction` and `normalizeActionIdentifier` already in the file.
3. **No unused/inline-able type variables** — none added.
4. **No non-essential parameters** — both helpers take only `responseContent`.
5. **Clean separation** — gate is a pure predicate over `Content.actions`. The call site reads as English ("if we should run the rescue, run it").

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `shouldRunMetadataActionRescue` predicate that prevents the metadata-overlap rescue from overriding an explicit `REPLY` (or `RESPOND`) action chosen by the planner. Previously, `!hasNonPassiveAction(["REPLY"])` evaluated to `true` because REPLY is in `PROVIDER_FOLLOWUP_PASSIVE_ACTIONS`, so the rescue ran and could promote a chitchat message to a role-gated action like `OWNER_INBOX`, producing a spurious "Permission denied" response to plain conversation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with correct logic and comprehensive tests covering all edge cases.

The change is a two-function addition with a one-line call-site swap. The logic correctly handles the documented bug (REPLY bypassing the rescue gate), all reachable branches are tested, `normalizeActionIdentifier` already handles case-folding so the lowercase 'reply' case works, and no existing behavior is altered for the 'nothing to do' path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds `hasExplicitReplyIntent` (private) and `shouldRunMetadataActionRescue` (exported); replaces inline `!hasNonPassiveAction` guard at the metadata-rescue call site — logic is correct and well-scoped. |
| packages/typescript/src/services/message.test.ts | Adds 5 new test cases for `shouldRunMetadataActionRescue` covering empty/null, IGNORE-only, REPLY, RESPOND, non-passive, and mixed-type-with-REPLY inputs; all cases are correct and match the implementation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[planner returns responseContent] --> B{hasNonPassiveAction?}
    B -- yes --> C[rescue skipped — action already routed]
    B -- no --> D{hasExplicitReplyIntent?\nREPLY or RESPOND in actions?}
    D -- yes --> E[rescue skipped — deliberate conversation]
    D -- no --> F[run suggestOwnedActionFromMetadata]
    F --> G{metadataSuggestion found?}
    G -- yes --> H[override responseContent.actions\nlog: Recovered primary action from metadata]
    G -- no --> I[no change]
```

<sub>Reviews (1): Last reviewed commit: ["fix(message): respect explicit REPLY act..."](https://github.com/elizaos/eliza/commit/9517941bb4100a9f39d6318222e3a96c8b7207cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29844753)</sub>

<!-- /greptile_comment -->