### PR TITLE
fix(windows): test portability for path separators and mode bits

### DIFF
--- a/packages/agent/src/auth/__tests__/account-storage.test.ts
+++ b/packages/agent/src/auth/__tests__/account-storage.test.ts
@@ -140,7 +140,9 @@ describe("account-storage", () => {
     const newFile = path.join(authDir, provider, "default.json");
     expect(fs.existsSync(newFile)).toBe(true);
     const stat = fs.statSync(newFile);
-    expect(stat.mode & 0o777).toBe(0o600);
+    if (process.platform !== "win32") {
+      expect(stat.mode & 0o777).toBe(0o600);
+    }
 
     // Second migrate call should be a no-op
     const second = migrateLegacySingleAccount();

--- a/packages/app-core/src/services/local-inference/paths.test.ts
+++ b/packages/app-core/src/services/local-inference/paths.test.ts
@@ -26,12 +26,18 @@ describe("paths", () => {
 
   it("uses ELIZA_STATE_DIR when set", () => {
     process.env.ELIZA_STATE_DIR = "/custom/state";
-    expect(localInferenceRoot()).toBe("/custom/state/local-inference");
-    expect(miladyModelsDir()).toBe("/custom/state/local-inference/models");
-    expect(downloadsStagingDir()).toBe(
-      "/custom/state/local-inference/downloads",
+    expect(localInferenceRoot()).toBe(
+      path.join("/custom/state", "local-inference"),
     );
-    expect(registryPath()).toBe("/custom/state/local-inference/registry.json");
+    expect(miladyModelsDir()).toBe(
+      path.join("/custom/state", "local-inference", "models"),
+    );
+    expect(downloadsStagingDir()).toBe(
+      path.join("/custom/state", "local-inference", "downloads"),
+    );
+    expect(registryPath()).toBe(
+      path.join("/custom/state", "local-inference", "registry.json"),
+    );
   });
 
   it("falls back to ~/.eliza/local-inference when unset", () => {
@@ -43,11 +49,12 @@ describe("paths", () => {
 
   it("isWithinMiladyRoot rejects the root itself and external paths", () => {
     process.env.ELIZA_STATE_DIR = "/state";
-    expect(isWithinMiladyRoot("/state/local-inference")).toBe(false);
-    expect(isWithinMiladyRoot("/state/local-inference/models/x.gguf")).toBe(
-      true,
-    );
+    const root = path.join("/state", "local-inference");
+    expect(isWithinMiladyRoot(root)).toBe(false);
+    expect(
+      isWithinMiladyRoot(path.join(root, "models", "x.gguf")),
+    ).toBe(true);
     expect(isWithinMiladyRoot("/etc/passwd")).toBe(false);
-    expect(isWithinMiladyRoot("/state/local-inference-evil")).toBe(false);
+    expect(isWithinMiladyRoot(`${root}-evil`)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- **paths.test.ts**: replace hardcoded forward-slash expected values with `path.join()` so tests pass on windows where `path.join` produces backslashes
- **account-storage.test.ts**: gate the `0o600` POSIX mode-bit assertion behind `process.platform !== "win32"` since windows ACLs don't map to unix rwx bits

## Context
ran full windows build test on win11 pro (bun 1.3.3, node 22.22.2). build passes, 1975/2074 tests pass. these 2 failures are the confirmed windows-specific test regressions.

## Test plan
- [x] `account-storage.test.ts` — 6/6 pass on windows after fix
- [x] `paths.test.ts` — uses `path.join()` which produces correct OS-native paths on both platforms
- [x] `bun run build` — passes on windows (30.49s, 4366 modules)
- [ ] verify tests still pass on linux/macos CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two Windows-specific test failures by (1) skipping the `0o600` POSIX mode-bit assertion on `win32` in `account-storage.test.ts`, and (2) replacing hardcoded forward-slash path strings with `path.join()` in `paths.test.ts` so assertions match the OS-native separator. Both fixes are minimal, targeted, and consistent with the implementation code which already uses `path.join` and `path.sep` throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to test files and fix real cross-platform failures without weakening any assertions on Linux/macOS CI

Both changes are correct and minimal: the mode-bit guard is the standard pattern for skipping POSIX-only assertions on Windows, and path.join() consistently mirrors what the implementation already does. No production code is touched and Linux/macOS test coverage is unchanged.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/auth/__tests__/account-storage.test.ts | Gates the 0o600 POSIX mode-bit assertion behind process.platform !== "win32"; correct approach since Windows doesn't expose rwx bits via fs.statSync |
| packages/app-core/src/services/local-inference/paths.test.ts | Replaces hardcoded forward-slash path literals with path.join() calls so assertions match the OS-native separator; aligns with the implementation which already uses path.join throughout |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Test Run] --> B{process.platform}
    B -- "win32" --> C[Skip 0o600 mode check\naccount-storage.test.ts]
    B -- "linux/macOS" --> D[Assert stat.mode & 0o777 === 0o600]
    C --> E[Test Passes on Windows]
    D --> E

    F[paths.test.ts assertions] --> G["path.join('/custom/state', 'local-inference')"]
    G -- "linux/macOS" --> H["/custom/state/local-inference"]
    G -- "Windows" --> I["\\custom\\state\\local-inference"]
    H --> J[Matches implementation output]
    I --> J
```

<sub>Reviews (1): Last reviewed commit: ["fix(windows): use path.join in test asse..."](https://github.com/elizaos/eliza/commit/944140b6eb7f1d6e31a4d6e1b2a2157156504776) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29937811)</sub>

<!-- /greptile_comment -->