### PR TITLE
chore(deps): bump @capacitor/* to current minor versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,9 +45,9 @@
       "name": "@elizaos/app-core",
       "version": "2.0.0-alpha.44",
       "dependencies": {
-        "@capacitor/core": "8.0.2",
-        "@capacitor/haptics": "8.0.0",
-        "@capacitor/keyboard": "8.0.0",
+        "@capacitor/core": "8.3.1",
+        "@capacitor/haptics": "8.0.2",
+        "@capacitor/keyboard": "8.0.3",
         "@capacitor/preferences": "^8.0.1",
         "@elizaos/autonomous": "workspace:*",
         "@elizaos/ui": "workspace:*",
@@ -243,11 +243,11 @@
       "name": "@elizaos/home",
       "version": "2.0.0-alpha.25",
       "dependencies": {
-        "@capacitor/app": "^8.0.1",
-        "@capacitor/core": "8.0.2",
-        "@capacitor/keyboard": "8.0.0",
+        "@capacitor/app": "^8.1.0",
+        "@capacitor/core": "8.3.1",
+        "@capacitor/keyboard": "8.0.3",
         "@capacitor/preferences": "^8.0.1",
-        "@capacitor/status-bar": "^8.0.1",
+        "@capacitor/status-bar": "^8.0.2",
         "@elizaos/app-core": "workspace:*",
         "@elizaos/ui": "workspace:*",
         "react": "^19.0.0",
@@ -705,17 +705,17 @@
 
     "@cacheable/utils": ["@cacheable/utils@2.4.0", "", { "dependencies": { "hashery": "^1.5.0", "keyv": "^5.6.0" } }, "sha512-PeMMsqjVq+bF0WBsxFBxr/WozBJiZKY0rUojuaCoIaKnEl3Ju1wfEwS+SV1DU/cSe8fqHIPiYJFif8T3MVt4cQ=="],
 
-    "@capacitor/app": ["@capacitor/app@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-yeG3yyA0ETKqvgqexwHMBlmVOF13A1hRXzv/km0Ptv5TrNIZvZJK4MTI3uiqvnbHrzoJGP5DwWAjEXEfi90v3Q=="],
+    "@capacitor/app": ["@capacitor/app@8.1.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg=="],
 
-    "@capacitor/core": ["@capacitor/core@8.0.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-EXZfxkL6GFJS2cb7TIBR7RiHA5iz6ufDcl1VmUpI2pga3lJ5Ck2+iqbx7N+osL3XYem9ad4XCidJEMm64DX6UQ=="],
+    "@capacitor/core": ["@capacitor/core@8.3.1", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-UF8ItlHguU1Z6GXfPTeT2gakf+ctNI8pAS1kwSBQlsJMlfD4OPoto/SmKnOxKCQvnF4WRcdWeg6C0zREUNaAQg=="],
 
-    "@capacitor/haptics": ["@capacitor/haptics@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-DY1IUOjke1T4ITl7mFHQIKCaJJyHYAYRYHG9bVApU7PDOZiMVGMp48Yjzdqjya+wv/AHS5mDabSTUmhJ5uDvBA=="],
+    "@capacitor/haptics": ["@capacitor/haptics@8.0.2", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ=="],
 
-    "@capacitor/keyboard": ["@capacitor/keyboard@8.0.0", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-ycPW6iQyFwzDK95jihesj5EGiyyGSfbBqNek11iNp9tBOB7zDeYkUA2S/vPpOETt3dhP6pWr7a9gNVGuEfj11g=="],
+    "@capacitor/keyboard": ["@capacitor/keyboard@8.0.3", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ=="],
 
     "@capacitor/preferences": ["@capacitor/preferences@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ=="],
 
-    "@capacitor/status-bar": ["@capacitor/status-bar@8.0.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-OR59dlbwvmrV5dKsC9lvwv48QaGbqcbSTBpk+9/WXWxXYSdXXdzJZU9p8oyNPAkuJhCdnSa3XmU43fZRPBJJ5w=="],
+    "@capacitor/status-bar": ["@capacitor/status-bar@8.0.2", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A=="],
 
     "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -63,9 +63,9 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "@capacitor/core": "8.0.2",
-    "@capacitor/haptics": "8.0.0",
-    "@capacitor/keyboard": "8.0.0",
+    "@capacitor/core": "8.3.1",
+    "@capacitor/haptics": "8.0.2",
+    "@capacitor/keyboard": "8.0.3",
     "@capacitor/preferences": "^8.0.1",
     "@elizaos/autonomous": "workspace:*",
     "@elizaos/ui": "workspace:*",

--- a/packages/home/package.json
+++ b/packages/home/package.json
@@ -15,11 +15,11 @@
     "cap:sync": "capacitor sync"
   },
   "dependencies": {
-    "@capacitor/app": "^8.0.1",
-    "@capacitor/core": "8.0.2",
-    "@capacitor/keyboard": "8.0.0",
+    "@capacitor/app": "^8.1.0",
+    "@capacitor/core": "8.3.1",
+    "@capacitor/keyboard": "8.0.3",
     "@capacitor/preferences": "^8.0.1",
-    "@capacitor/status-bar": "^8.0.1",
+    "@capacitor/status-bar": "^8.0.2",
     "@elizaos/app-core": "workspace:*",
     "@elizaos/ui": "workspace:*",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary
- @capacitor/core 8.0.2 -> 8.3.1
- @capacitor/app ^8.0.1 -> ^8.1.0
- @capacitor/keyboard 8.0.0 -> 8.0.3
- @capacitor/haptics 8.0.0 -> 8.0.2
- @capacitor/status-bar ^8.0.1 -> ^8.0.2
- @capacitor/preferences left at ^8.0.1 (already covers latest)

All bumps stay within the 8.x major. Touches \`packages/app-core\` and \`packages/home\` plus the lockfile. Closes the \`@capacitor/core 8.3.1\` line of #79.

> **Stacked on #7146** (rolodex override is required for \`bun install\` to succeed). Rebase onto \`develop\` once #7146 is merged.

## Test plan
- [ ] CI green on this branch
- [ ] Mobile (iOS/Android) build still works locally if the team validates it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps five `@capacitor/*` packages to their latest minor/patch releases within the 8.x major, updating both `packages/app-core` and `packages/home`. The lockfile is consistent with all new pinned versions, and every plugin's `peerDependencies` requirement (`@capacitor/core >=8.0.0`) is satisfied by the newly resolved `8.3.1`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a dependency version bump with no logic changes and a consistent lockfile.

All version bumps remain within the 8.x major, the lockfile hashes and peer-dependency constraints are coherent, and no application logic was touched. The only risk is a breaking change introduced upstream in one of these minor/patch releases, which is unlikely given the Capacitor project's semver hygiene.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/package.json | Bumps @capacitor/core 8.0.2→8.3.1, @capacitor/haptics 8.0.0→8.0.2, @capacitor/keyboard 8.0.0→8.0.3; all stay within 8.x major. |
| packages/home/package.json | Bumps @capacitor/app ^8.0.1→^8.1.0, @capacitor/core 8.0.2→8.3.1, @capacitor/keyboard 8.0.0→8.0.3, @capacitor/status-bar ^8.0.1→^8.0.2; consistent with app-core changes. |
| bun.lock | Lockfile updated with exact resolved hashes for all bumped @capacitor/* packages; all peer-dependency constraints on @capacitor/core >=8.0.0 are satisfied by 8.3.1. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    core["@capacitor/core 8.3.1"]
    haptics["@capacitor/haptics 8.0.2"]
    keyboard["@capacitor/keyboard 8.0.3"]
    prefs["@capacitor/preferences ^8.0.1"]
    app["@capacitor/app ^8.1.0"]
    statusbar["@capacitor/status-bar ^8.0.2"]
    appcore["@elizaos/app-core"]
    home["@elizaos/home"]

    core --> appcore
    core --> home
    haptics --> appcore
    keyboard --> appcore
    keyboard --> home
    prefs --> appcore
    prefs --> home
    app --> home
    statusbar --> home
```

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump @capacitor/\* to curren..."](https://github.com/elizaos/eliza/commit/5b23ad5343e61d17941f3353cbfd66ef410989ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29945593)</sub>

<!-- /greptile_comment -->