### PR TITLE
chore(deps): bump Node.js to 24.15.0 (LTS Krypton)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/jsdoc-automation.yml
+++ b/.github/workflows/jsdoc-automation.yml
@@ -75,7 +75,7 @@ jobs:
         if: steps.check-autodoc.outputs.exists == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "23"
+          node-version: "24"
 
       - name: Setup Python
         if: steps.check-autodoc.outputs.exists == 'true'

--- a/.github/workflows/publish-next-prerelease.yaml
+++ b/.github/workflows/publish-next-prerelease.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "23.3.0"
+          node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup Bun

--- a/.github/workflows/release-computeruse-npm.yaml
+++ b/.github/workflows/release-computeruse-npm.yaml
@@ -105,14 +105,14 @@ jobs:
         if: matrix.settings.host == 'windows-11-arm'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup node (default)
         if: matrix.settings.host != 'windows-11-arm'
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Linux dependencies
@@ -194,7 +194,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Download all artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "23.3.0"
+          node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup Bun

--- a/.github/workflows/sync-next-dist-tags.yaml
+++ b/.github/workflows/sync-next-dist-tags.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "23.3.0"
+          node-version: "24.15.0"
           registry-url: "https://registry.npmjs.org"
 
       - name: Sync dist-tags

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "module": "index.ts",
   "type": "module",
   "engines": {
-    "node": "23.3.0"
+    "node": "24.15.0"
   },
   "scripts": {
     "fix-deps": "bun scripts/fix-workspace-deps.mjs",


### PR DESCRIPTION
## Summary
- \`engines.node\` 23.3.0 -> 24.15.0 (root)
- Workflow \`node-version\`: 22 / 23 / 23.3.0 -> 24 / 24.15.0
  - \`ci.yaml\` (3 jobs)
  - \`jsdoc-automation.yml\`
  - \`release-computeruse-npm.yaml\` (3 jobs)
  - \`release.yaml\`
  - \`publish-next-prerelease.yaml\`
  - \`sync-next-dist-tags.yaml\`

Node 23 is **non-LTS** and reached EOL in June 2025. Node 24 went LTS in October 2025 (Krypton). Continuing on 23 in CI is a smell that the dashboard caught.

\`packages/tui\` (\`>=20.0.0\`) and \`packages/skills\` (\`>=22.0.0\`) engines fields are left alone — both already accept 24.

> **Stacked on #7146** — same reason as #7147; the lockfile/install path needs the override fix.

Closes the \`update node.js to v24\` row of #79.

## Test plan
- [ ] CI green on this branch (the workflow files I changed will themselves run on this PR)
- [ ] No package fails on Node 24 (any native modules — \`canvas\`, \`onnxruntime-node\`, \`sharp\`, etc. — should already support it)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades Node.js from the EOL v23 to the LTS v24 (Krypton) across `package.json` and all seven affected CI workflow files. The change is straightforward and well-scoped; the only minor concerns are that `engines.node` is pinned to an exact patch version and that `ci.yaml`/`release-computeruse-npm.yaml` use the floating `"24"` alias while the release workflows pin to `"24.15.0"`, creating a small version-drift risk.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only P2 style findings; no logic or security issues.

All findings are P2 (style/consistency). The core change — bumping Node.js to 24 LTS — is correct and well-executed. Two minor inconsistencies (exact engines pin and floating vs pinned workflow versions) are worth addressing but do not block the PR.

package.json (engines.node exact pin) and .github/workflows/ci.yaml / release-computeruse-npm.yaml (floating "24" alias vs pinned "24.15.0" elsewhere).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yaml | Three jobs updated from node-version "23" to "24" — straightforward major-version pin. |
| .github/workflows/jsdoc-automation.yml | Single node-version bump from "23" to "24" in the JSDoc automation job. |
| .github/workflows/publish-next-prerelease.yaml | node-version pinned from "23.3.0" to "24.15.0" for the prerelease publish job. |
| .github/workflows/release-computeruse-npm.yaml | Three jobs bumped from node 22 to 24 — largest version jump in this PR; native-module compatibility should be validated. |
| .github/workflows/release.yaml | node-version pinned from "23.3.0" to "24.15.0" for the release job. |
| .github/workflows/sync-next-dist-tags.yaml | node-version pinned from "23.3.0" to "24.15.0" for the dist-tag sync job. |
| package.json | engines.node updated from "23.3.0" to exact "24.15.0"; an exact pin will warn on any other Node 24 patch. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: bump Node.js to 24.15.0] --> B[package.json\nengines.node: 24.15.0]
    A --> C[CI Workflows]
    C --> D[ci.yaml\nnode-version: 24\n3 jobs]
    C --> E[jsdoc-automation.yml\nnode-version: 24]
    C --> F[release.yaml\nnode-version: 24.15.0]
    C --> G[publish-next-prerelease.yaml\nnode-version: 24.15.0]
    C --> H[sync-next-dist-tags.yaml\nnode-version: 24.15.0]
    C --> I[release-computeruse-npm.yaml\nnode-version: 24\n3 jobs]
    D -.->|floating alias may drift| J[⚠️ Version inconsistency\nci.yaml uses 24 vs others pin 24.15.0]
    I -.->|floating alias may drift| J
```

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump Node.js to 24.15.0 (LT..."](https://github.com/elizaos/eliza/commit/0a6e21522d4d6539e36282fb708597ed7dd59797) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29945761)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->