### PR TITLE
chore(deps): bump rimraf transitive to 6.1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -471,6 +471,7 @@
     "is-core-module": "2.13.1",
     "libpq": "npm:empty-npm-package@1.0.0",
     "pg-native": "npm:empty-npm-package@1.0.0",
+    "rimraf": "^6.0.1",
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
@@ -3603,7 +3604,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rimraf": ["rimraf@4.4.1", "", { "dependencies": { "glob": "^9.2.0" }, "bin": { "rimraf": "dist/cjs/src/bin.js" } }, "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og=="],
+    "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
 
     "ripemd160": ["ripemd160@2.0.3", "", { "dependencies": { "hash-base": "^3.1.2", "inherits": "^2.0.4" } }, "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA=="],
 
@@ -4701,8 +4702,6 @@
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
-    "rimraf/glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
-
     "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
 
     "roarr/sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
@@ -5321,12 +5320,6 @@
 
     "read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
-    "rimraf/glob/minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
-
-    "rimraf/glob/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
-
-    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
     "ripemd160/hash-base/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
@@ -5548,12 +5541,6 @@
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "read-pkg-up/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
-
-    "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "rimraf/glob/path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ripemd160/hash-base/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "@uniswap/v3-sdk": "3.28.0",
     "@uniswap/v2-sdk": "4.6.0",
     "@uniswap/v4-sdk": "1.14.2",
-    "@elizaos/plugin-rolodex": "2.0.0-alpha.10"
+    "@elizaos/plugin-rolodex": "2.0.0-alpha.10",
+    "rimraf": "^6.0.1"
   },
   "trustedDependencies": [
     "@biomejs/biome",


### PR DESCRIPTION
## Summary
- Adds \`rimraf: ^6.0.1\` to root \`overrides\`, bumping the lockfile from rimraf@4.4.1 to rimraf@6.1.3.

## Why this is safe
- rimraf v5/v6 breaking changes are mostly about dropping Node <18 (we're on Node 24 across the stack).
- Only direct consumer in the lockfile is \`lerna@9.0.3\` / \`@lerna/create@9.0.3\`, which depends on rimraf at \`^4.4.1\`. Lerna uses rimraf only via the top-level callback API which is stable across v4-v6.
- Smoke test passes:
  \`\`\`
  $ bunx lerna --version
  9.0.3
  \`\`\`

> **Stacked on #7146** for the same reason as the other PRs in this stack.

Closes the \`rimraf -> v6\` row of #79.

## Test plan
- [ ] CI green
- [ ] No lerna release commands break (release workflows touch lerna)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `rimraf: "^6.0.1"` to the root `overrides` in `package.json`, upgrading the resolved version in `bun.lock` from rimraf@4.4.1 to rimraf@6.1.3. The bump removes the old rimraf@4 transitive dependency tree (`glob@9`, `minimatch@8`, `minipass@4`, `path-scurry@1`, etc.) and relies on `glob@13` and `package-json-from-dist` which are already present in the lockfile from other packages, so all dependencies are fully satisfied.

<h3>Confidence Score: 5/5</h3>

Safe to merge — clean dependency bump with all transitive deps already satisfied in the lockfile.

Only two files changed: a one-line addition to `overrides` in `package.json` and the corresponding lockfile update. rimraf@6's new transitive dependencies (`glob@13`, `package-json-from-dist`) are already present in `bun.lock` from other packages. The orphaned rimraf@4 sub-tree is cleanly removed. No logic changes, no security concerns.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Adds `rimraf: "^6.0.1"` to the `overrides` section — minimal, correct change to force the transitive rimraf upgrade. |
| bun.lock | Resolves rimraf to 6.1.3, removes orphaned rimraf@4 sub-tree (glob@9, minimatch@8, minipass@4, path-scurry@1, lru-cache@10, brace-expansion@2); rimraf@6's new deps (glob@13, package-json-from-dist) are already present from other packages. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["package.json overrides\nrimraf: ^6.0.1"] --> B["bun.lock resolves\nrimraf@6.1.3"]
    B --> C["glob@13.0.6\n(already in lockfile)"]
    B --> D["package-json-from-dist@1.0.1\n(already in lockfile)"]
    E["rimraf@4.4.1 (removed)"] -. "removed transitive deps" .-> F["glob@9.3.5\nminimatch@8.0.7\nminipass@4.2.8\npath-scurry@1.11.1\nlru-cache@10.4.3\nbrace-expansion@2.0.2"]
    style E fill:#ffcccc,stroke:#cc0000
    style F fill:#ffcccc,stroke:#cc0000
    style B fill:#ccffcc,stroke:#009900
```

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump rimraf transitive to 6..."](https://github.com/elizaos/eliza/commit/9d0812de8a6e498a8dd4a0a21fff3cf3b9f82f32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29946096)</sub>

<!-- /greptile_comment -->