### PR TITLE
chore(deps): bump TypeScript to ^6.0.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "lerna": "9.0.3",
         "react-test-renderer": "^19.0.0",
         "turbo": "^2.7.4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.17",
       },
     },
@@ -65,7 +65,7 @@
         "@types/react-dom": "^19.0.0",
         "@types/three": "^0.182.0",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -123,10 +123,10 @@
         "@types/node": "^25.0.3",
         "@types/pg": "^8.15.2",
         "@types/ws": "^8.18.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "@elizaos/core": "2.0.0-alpha.22",
+        "@elizaos/core": "workspace:*",
         "@elizaos/signal-native": "*",
       },
       "optionalPeers": [
@@ -160,7 +160,7 @@
       "name": "@elizaos/computeruse",
       "version": "2.0.0-alpha.43",
       "dependencies": {
-        "@mediar-ai/kv": "^0.23.30",
+        "@mediar-ai/kv": "workspace:*",
       },
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -186,7 +186,7 @@
         "@types/node": "^20.11.5",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5",
-        "typescript": "^5.3.3",
+        "typescript": "^6.0.3",
       },
     },
     "packages/computeruse/packages/workflow": {
@@ -202,7 +202,7 @@
         "@types/node": "^20.11.5",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5",
-        "typescript": "^5.3.3",
+        "typescript": "^6.0.3",
       },
       "peerDependencies": {
         "@elizaos/computeruse": "workspace:*",
@@ -214,7 +214,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/node": "^22.10.2",
-        "typescript": "^5.7.3",
+        "typescript": "^6.0.3",
         "vitest": "^2.1.8",
       },
     },
@@ -235,7 +235,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.17",
       },
     },
@@ -260,7 +260,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^5.1.3",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^5.4.21",
         "vitest": "^2.1.9",
       },
@@ -273,7 +273,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
     "packages/prompts": {
@@ -322,7 +322,7 @@
         "@types/bun": "^1.3.5",
         "@types/express": "^4.17.21",
         "@types/node": "^25.0.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.17",
       },
     },
@@ -338,7 +338,7 @@
       "devDependencies": {
         "@types/node": "^24.10.0",
         "bun-types": "^1.3.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
     },
     "packages/tui": {
@@ -392,7 +392,7 @@
         "@vitest/coverage-v8": "^4.0.0",
         "esbuild": "^0.25.0",
         "sharp": "^0.33.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.0.0",
       },
     },
@@ -430,7 +430,7 @@
         "@types/react-dom": "^19.0.0",
         "storybook": "8.6.17",
         "tailwindcss": "^4.1.18",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -3911,7 +3911,7 @@
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -4096,8 +4096,6 @@
     "@elizaos/autonomous/@elizaos/plugin-openai": ["@elizaos/plugin-openai@2.0.0-alpha.16", "", { "dependencies": { "@ai-sdk/openai": "^3.0.9", "ai": "^6.0.30", "js-tiktoken": "^1.0.21", "undici": "^7.16.0" }, "peerDependencies": { "@elizaos/core": "2.0.0-alpha.114", "zod": "^4.3.6" } }, "sha512-l4WaO5/m/Urx+j3/3nUrJ75kFTop7Ct6CbSRqCuhsrMdqE/GE83RrghmOu60IvWpex45P4Gx5mhSsras9+30gg=="],
 
     "@elizaos/autonomous/@elizaos/plugin-sql": ["@elizaos/plugin-sql@2.0.0-alpha.19", "", { "dependencies": { "@electric-sql/pglite": "^0.3.3", "@elizaos/core": "workspace:*", "@neondatabase/serverless": "^1.0.2", "dotenv": "^17.2.3", "drizzle-kit": "^0.31.8", "drizzle-orm": "^0.45.1", "pg": "^8.16.3", "uuid": "^13.0.0" } }, "sha512-LKHzdcD/yMDEZJ2MzJUwIDbYScAlp/oDc3O5x6Byd1Z10VrkWbKIU26+aAPuqTQwlTJMfvddY6u/I9lRxeGyIw=="],
-
-    "@elizaos/computeruse/@mediar-ai/kv": ["@mediar-ai/kv@0.23.51", "", { "dependencies": { "ioredis": "^5.3.2" } }, "sha512-7tDiy/s4Y8QPa+JtIbkuSh/GXtDEHIYNBQDdaMRaJBNNHXHEg2PRfkd/JzYgFxokd6FMrjXTbEBRcBrCcVQMPg=="],
 
     "@elizaos/computeruse-nodejs/@elizaos/computeruse-darwin-arm64": ["@elizaos/computeruse-darwin-arm64@0.24.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0O8RogosGSjZgD+ybioSJtl2yUnbKbUy6A4DvFC3iY7j9oqVIZlN9P0Aut7NUDzuSgDP2nqxdZd3Z0gYpyqzAg=="],
 
@@ -4568,6 +4566,8 @@
     "lerna/chalk": ["chalk@4.1.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A=="],
 
     "lerna/dedent": ["dedent@1.5.3", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ=="],
+
+    "lerna/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "lerna/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "bun": "^1.3.5",
     "lerna": "9.0.3",
     "turbo": "^2.7.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.17"
   },
   "resolutions": {

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -86,7 +86,7 @@
     "@types/react-dom": "^19.0.0",
     "@types/three": "^0.182.0",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2"
 }

--- a/packages/autonomous/package.json
+++ b/packages/autonomous/package.json
@@ -272,7 +272,7 @@
     "@types/node": "^25.0.3",
     "@types/pg": "^8.15.2",
     "@types/ws": "^8.18.1",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2"
 }

--- a/packages/autonomous/tsconfig.json
+++ b/packages/autonomous/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",

--- a/packages/computeruse/examples/mcp-client-elicitation/package.json
+++ b/packages/computeruse/examples/mcp-client-elicitation/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/computeruse/examples/recaptcha-resolver/package.json
+++ b/packages/computeruse/examples/recaptcha-resolver/package.json
@@ -7,7 +7,7 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^5"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@google/genai": "^1.22.0",

--- a/packages/computeruse/packages/kv/package.json
+++ b/packages/computeruse/packages/kv/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^20.11.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.5",
-    "typescript": "^5.3.3"
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist",

--- a/packages/computeruse/packages/kv/tsconfig.json
+++ b/packages/computeruse/packages/kv/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],

--- a/packages/computeruse/packages/workflow/package.json
+++ b/packages/computeruse/packages/workflow/package.json
@@ -12,7 +12,7 @@
     "@types/node": "^20.11.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.5",
-    "typescript": "^5.3.3"
+    "typescript": "^6.0.3"
   },
   "files": [
     "dist",

--- a/packages/computeruse/packages/workflow/tsconfig.json
+++ b/packages/computeruse/packages/workflow/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.10.2",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "vitest": "^2.1.8"
   },
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2"

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.17"
   },
   "keywords": [

--- a/packages/home/package.json
+++ b/packages/home/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.1.3",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^5.4.21",
     "vitest": "^2.1.9"
   }

--- a/packages/home/tsconfig.json
+++ b/packages/home/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "author": "elizaOS",
   "license": "MIT",

--- a/packages/sweagent/package.json
+++ b/packages/sweagent/package.json
@@ -74,7 +74,7 @@
     "@types/bun": "^1.3.5",
     "@types/express": "^4.17.21",
     "@types/node": "^25.0.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.17"
   },
   "publishConfig": {

--- a/packages/sweagent/typescript/package.json
+++ b/packages/sweagent/typescript/package.json
@@ -94,7 +94,7 @@
     "@types/ws": "^8.18.1",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.17"
   },
   "repository": {

--- a/packages/sweagent/typescript/src/run/package.json
+++ b/packages/sweagent/typescript/src/run/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^20.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/sweagent/typescript/src/run/tsconfig.json
+++ b/packages/sweagent/typescript/src/run/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],

--- a/packages/sweagent/typescript/tools/package.json
+++ b/packages/sweagent/typescript/tools/package.json
@@ -43,7 +43,7 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.0",
-    "typescript": "^5.3.0"
+    "typescript": "^6.0.3"
   },
   "bin": {
     "registry": "./dist/registry/index.js",

--- a/packages/sweagent/typescript/tools/tsconfig.json
+++ b/packages/sweagent/typescript/tools/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "commonjs",
     "lib": ["ES2022"],

--- a/packages/training/package.json
+++ b/packages/training/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@types/node": "^24.10.0",
     "bun-types": "^1.3.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "gitHead": "cb192f7b21c441e9463d1af2f890c145814baad2"
 }

--- a/packages/training/tsconfig.json
+++ b/packages/training/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -75,7 +75,7 @@
     "@vitest/coverage-v8": "^4.0.0",
     "esbuild": "^0.25.0",
     "sharp": "^0.33.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.0.0"
   },
   "dependencies": {

--- a/packages/typescript/tsconfig.declarations.json
+++ b/packages/typescript/tsconfig.declarations.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
+    "ignoreDeprecations": "6.0",
 		"outDir": "./dist",
 		"rootDir": "./src",
 		"baseUrl": "./src",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -84,7 +84,7 @@
     "@types/react-dom": "^19.0.0",
     "storybook": "8.6.17",
     "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "author": "elizaOS Team",
   "engines": {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],

--- a/tsconfig.build.template.json
+++ b/tsconfig.build.template.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2021",
     "module": "ESNext",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ES2022",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary
- Bumps the \`typescript\` devDependency to \`^6.0.3\` across all 18 packages that previously pinned a 5.x version.
- Adds \`\"ignoreDeprecations\": \"6.0\"\` to the tsconfigs that still use TS 6-deprecated options (\`moduleResolution=node10\`, \`baseUrl\`, \`esModuleInterop=false\`). These will hard-error in TS 7 and should be migrated before then; for now we silence the warnings.

Inheriting tsconfigs (those with \`\"extends\": \"../../tsconfig.json\"\`) pick the option up from root automatically and don't need explicit overrides.

## Verification
\`\`\`
$ bun run typecheck
…all packages pass except @elizaos/autonomous (see below)
\`\`\`

The two errors that remain in \`@elizaos/autonomous\` are about a missing \`@elizaos/plugin-agent-orchestrator\` import in \`src/api/server.ts\` and \`src/runtime/eliza.ts\`. Those are **pre-existing on TS 5.9** — confirmed by reverting only the typescript pin (keeping \`ignoreDeprecations\` off), the exact same TS2307 errors reproduce. Out of scope for this PR.

## Why TS 6 is safe for this codebase
- No real type errors surfaced from the bump beyond the pre-existing \`autonomous\` import issue.
- All TS 6 deprecation warnings are silenced via \`ignoreDeprecations: \"6.0\"\`, the official escape hatch from the TS team.
- TS 6 changelogs flag mostly typing-strictness improvements that this codebase already passes.

> **Stacked on #7146** — the rolodex override is required for \`bun install\` to succeed at all on this branch.

## Follow-ups (separate PRs)
- Add \`@elizaos/plugin-agent-orchestrator\` to \`packages/autonomous\` deps (or remove the imports) so its typecheck passes.
- Migrate tsconfigs off the deprecated options before TS 7 lands.
- Fix the \`generate:types\` script — \`cd packages/@schemas\` should be \`cd packages/schemas\`.

Closes the \`typescript -> v6\` row of #79.

## Test plan
- [ ] CI green
- [ ] No build regressions in any of the 18 packages whose typescript pin changed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `typescript` devDependency from various 5.x pins to `^6.0.3` across 18 packages and adds `"ignoreDeprecations": "6.0"` to the tsconfigs that use options deprecated in TS 6 (`moduleResolution: node`, `baseUrl`, `esModuleInterop: false`). The approach is correct — packages whose tsconfigs extend the root pick up `ignoreDeprecations` automatically, while standalone configs receive explicit additions.

Two minor issues to note:
- `packages/typescript/tsconfig.declarations.json` adds `ignoreDeprecations` redundantly (it already inherits from root via `extends`) and with inconsistent tab/space indentation.
- `packages/computeruse/examples/recaptcha-resolver/package.json` bumps TypeScript in `peerDependencies` (not `devDependencies`), making TS 5 consumers incompatible — low risk since the package is private.

<h3>Confidence Score: 4/5</h3>

Safe to merge — only P2 style/redundancy findings, no functional regressions introduced.

All findings are P2: a redundant and mis-indented ignoreDeprecations entry in one tsconfig, and a peer-dependency version bump in a private example package. No logic errors, no type-safety regressions, and the deprecated-option escape hatch is the officially recommended approach from the TypeScript team.

packages/typescript/tsconfig.declarations.json (redundant + mis-indented option) and packages/computeruse/examples/recaptcha-resolver/package.json (peerDependency bump).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Root devDependency bumped from `^5.9.3` to `^6.0.3`; straightforward change. |
| tsconfig.json | Added `ignoreDeprecations: "6.0"` to silence errors for `moduleResolution: node` and `baseUrl` deprecated in TS 6; correct approach. |
| tsconfig.build.template.json | Added `ignoreDeprecations: "6.0"` for `moduleResolution: node` deprecation; no issues. |
| packages/typescript/tsconfig.declarations.json | Added `ignoreDeprecations: "6.0"` with wrong indentation (spaces vs tabs) and redundantly — this tsconfig already inherits the option from the root via `extends`. |
| packages/computeruse/examples/recaptcha-resolver/package.json | Bumps `typescript` in `peerDependencies` (not devDependencies) from `^5` to `^6.0.3`; breaking peer-dep change with low practical risk as package is private. |
| packages/autonomous/tsconfig.json | Added `ignoreDeprecations: "6.0"` for standalone `baseUrl` deprecation; appropriate. |
| packages/ui/tsconfig.json | Added `ignoreDeprecations: "6.0"` for `esModuleInterop: false` and `baseUrl` deprecations; correct. |
| packages/home/tsconfig.json | Added `ignoreDeprecations: "6.0"` for `baseUrl` deprecation; no issues. |
| packages/computeruse/packages/kv/tsconfig.json | Added `ignoreDeprecations: "6.0"` for `moduleResolution: node` deprecation; correct. |
| packages/computeruse/packages/workflow/tsconfig.json | Added `ignoreDeprecations: "6.0"` for `moduleResolution: node` deprecation; correct. |
| packages/training/tsconfig.json | Added `ignoreDeprecations: "6.0"` for `baseUrl` deprecation handling; no issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TypeScript bumped to ^6.0.3\nacross 18 packages] --> B{tsconfig has\ndeprecated options?}
    B -->|No deprecated options\nbundler moduleResolution, no baseUrl| C[No change needed\ne.g. app-core, elizaos, sweagent/typescript]
    B -->|Uses deprecated options\nnode/node10, baseUrl, esModuleInterop=false| D{Extends root\ntsconfig.json?}
    D -->|Yes extends root| E[ignoreDeprecations inherited\nautomatically from root\ne.g. interop]
    D -->|No standalone tsconfig| F[Add ignoreDeprecations: 6.0\nexplicitly\ne.g. kv, workflow, ui, home, training]
    E --> G[TS 6 typecheck passes]
    F --> G
    C --> G
    H[Root tsconfig.json] -->|provides ignoreDeprecations: 6.0| E
    H --> G
```

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump TypeScript to ^6.0.3"](https://github.com/elizaos/eliza/commit/4e8c48de5b4ac74502aa461bb917ae949bf9475d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29946776)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->