### PR TITLE
fix(message): add CREATE_TASK to EXPLICIT_INTENT_ACTIONS

### DIFF
--- a/packages/typescript/src/services/message.test.ts
+++ b/packages/typescript/src/services/message.test.ts
@@ -4,6 +4,7 @@ import { stringToUuid } from "../utils";
 import {
 	DefaultMessageService,
 	extractPlannerActionNames,
+	findOwnedActionCorrectionFromMetadata,
 	shouldRunMetadataActionRescue,
 } from "./message.ts";
 
@@ -238,5 +239,58 @@ describe("shouldRunMetadataActionRescue", () => {
 				actions: [42 as unknown as string, null as unknown as string, "REPLY"],
 			}),
 		).toBe(false);
+	});
+});
+
+describe("findOwnedActionCorrectionFromMetadata — explicit-intent guard", () => {
+	// Production observation (2026-04-28): a user asked the bot to "Build
+	// 'Council' at agent-home /apps/council/ ... Each persona turn is a
+	// cloud-SDK call ... debits user balance ...". The planner correctly
+	// chose CREATE_TASK (delegate to a coding sub-agent). The metadata
+	// corrector then overrode CREATE_TASK with OWNER_CALENDAR because today's
+	// date and incidental dev words ("multi turn", "api carries", "workflow",
+	// "call", "user") overlap-scored OWNER_CALENDAR's example text higher
+	// than CREATE_TASK's. The user saw "Google Calendar is not connected.
+	// Connect Google in LifeOps settings." in response to a code request.
+	//
+	// CREATE_TASK is added to EXPLICIT_INTENT_ACTIONS so the corrector
+	// returns null when the planner picked CREATE_TASK, regardless of how
+	// the keyword-overlap scorer feels about it. Same precedent as
+	// SPAWN_AGENT, the sibling delegation action.
+	const runtime = { actions: [] } as unknown as Pick<IAgentRuntime, "actions">;
+
+	it("returns null for CREATE_TASK regardless of overlap candidates", () => {
+		const message = {
+			content: {
+				text: "Build Council at agent-home /apps/council/. Multi-agent debate room — each persona turn is a cloud-SDK call, carries the affiliate header, debits user balance.",
+			},
+		} as unknown as Pick<Memory, "content">;
+		expect(
+			findOwnedActionCorrectionFromMetadata(runtime, message, {
+				actions: ["CREATE_TASK"],
+			}),
+		).toBeNull();
+	});
+
+	it("returns null for SPAWN_AGENT (sibling delegation action)", () => {
+		const message = {
+			content: { text: "spawn an agent to triage open issues by friday" },
+		} as unknown as Pick<Memory, "content">;
+		expect(
+			findOwnedActionCorrectionFromMetadata(runtime, message, {
+				actions: ["SPAWN_AGENT"],
+			}),
+		).toBeNull();
+	});
+
+	it("returns null for REPLY (filtered out by the passive-action check)", () => {
+		const message = {
+			content: { text: "what's on my calendar tuesday" },
+		} as unknown as Pick<Memory, "content">;
+		expect(
+			findOwnedActionCorrectionFromMetadata(runtime, message, {
+				actions: ["REPLY"],
+			}),
+		).toBeNull();
 	});
 });

--- a/packages/typescript/src/services/message.ts
+++ b/packages/typescript/src/services/message.ts
@@ -1330,9 +1330,21 @@ const ACTION_REPAIR_PASSIVE_ACTIONS = new Set(
 // "Contact not found in relationships" error from the wrong action path.
 // Treat OWNER_RELATIONSHIP as explicit planner intent so the corrector does
 // not second-guess it.
+//
+// CREATE_TASK is the orchestrator's coding-sub-agent delegation. When a user
+// says "build me X" or "implement Y", the planner correctly picks CREATE_TASK,
+// but the user's prose contains zero CREATE_TASK keywords. Without this entry
+// the corrector overrides CREATE_TASK with whatever role-gated action
+// (OWNER_CALENDAR, OWNER_INBOX, MANAGE_ISSUES) happens to overlap with
+// incidental words in the prompt — e.g. a build request that mentions a date
+// keyword-rescores OWNER_CALENDAR over CREATE_TASK and the user gets
+// "Google Calendar is not connected" in response to a code request. Same
+// precedent as SPAWN_AGENT, the sibling delegation action that's already
+// protected here.
 const EXPLICIT_INTENT_ACTIONS = new Set(
 	[
 		"SPAWN_AGENT",
+		"CREATE_TASK",
 		"CREATE_TRIGGER_TASK",
 		"CREATE_TRIGGER",
 		"SCHEDULE_TRIGGER",


### PR DESCRIPTION
## Summary

`findOwnedActionCorrectionFromMetadata` was overriding the planner's correct `CREATE_TASK` pick with role-gated actions like `OWNER_CALENDAR` based on incidental keyword overlap (e.g. a date in the prompt overlapping the calendar action's example text). Result: the bot replied "Google Calendar is not connected" in response to a code-build request.

## Concrete repro from a milady deployment (2026-04-28)

A user `@`-pinged the bot with a council-app build request:

> `Build "Council" at agent-home /apps/council/. Multi-agent debate room: user picks 3–5 personas, poses a question, they debate N rounds. Copy the eDad pattern (see agent-home/data/apps/edad/ + app/apps/edad/api/). Each persona turn is a cloud-SDK call — debits user balance, carries the affiliate header. Transcript encrypted client-side with sarin-wrap (local clone at projects/sarin-wrap, read-only). OAuth only from eliza cloud, no BYOK.`

The planner correctly chose `CREATE_TASK`. The metadata-corrector then ran:

```
[SERVICE:MESSAGE] Corrected routed action from action metadata
  (originalActions=["CREATE_TASK"],
   suggestedAction=OWNER_CALENDAR,
   score=38.54, secondBestScore=36.32,
   reasons=["overlap:multi,turn","overlap:api,carries","overlap:call,no",
            "overlap:user,no","overlap:tue,28","overlap:04,2026",
            "example","workflow"])
```

`tue,28` and `04,2026` are today's date leaking into context; `multi,turn`, `api,carries`, `workflow`, `call`, `user` are generic dev words present in any code-build request that match `OWNER_CALENDAR`'s example text.

The override fired, `OWNER_CALENDAR`'s pre-flight bailed with the LifeOps "connect Google" string, and the user got a calendar error in response to a code request.

## Fix

Add `CREATE_TASK` to `EXPLICIT_INTENT_ACTIONS`.

```diff
 const EXPLICIT_INTENT_ACTIONS = new Set(
 	[
 		"SPAWN_AGENT",
+		"CREATE_TASK",
 		"CREATE_TRIGGER_TASK",
```

`CREATE_TASK` is structurally identical to `SPAWN_AGENT` (already in the set): the planner picks it based on intent, not based on keyword overlap with the user's prose. "Build me X" / "implement Y" never literally contains "create task" or "spawn agent". Same precedent established by [#7075](https://github.com/elizaOS/eliza/pull/7075) (SPAWN_AGENT), [#7141](https://github.com/elizaOS/eliza/pull/7141), `c144bb8` (OWNER_RELATIONSHIP), `b0d032f` (LIFE).

## Scope

Single source file + tests:

- `packages/typescript/src/services/message.ts` — add `"CREATE_TASK"` to the set + extend the comment block to record this category of bug.
- `packages/typescript/src/services/message.test.ts` — three regression tests in a new `findOwnedActionCorrectionFromMetadata — explicit-intent guard` describe block covering `CREATE_TASK` / `SPAWN_AGENT` / `REPLY`. Without these, a future refactor could remove the entry without anything failing.

No new types, no new helpers, no new exports.

## Verification

- `bunx vitest run packages/typescript/src/services/message.test.ts` → **22/22 pass** (3 new + 19 existing)
- `bunx tsc --noEmit` → no errors in changed file
- Live on the running bot: synced this fix into the deployment, restarted, fired the same prompt that previously produced the "Google Calendar is not connected" reply. Bot now correctly delegates to a coding sub-agent that builds the council app.

## 5-rule check

1. **No meaningless wrappers** — single-line addition to an existing `Set`.
2. **Reuse existing functions** — uses the existing `EXPLICIT_INTENT_ACTIONS` set + `findOwnedActionCorrectionFromMetadata` flow.
3. **No unused/inline-able type variables** — none added.
4. **No non-essential parameters** — none added.
5. **Clean separation** — the guard is a single conscious entry in a single-purpose Set; comment block explains why so future readers don't accidentally remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `"CREATE_TASK"` to the `EXPLICIT_INTENT_ACTIONS` set in `message.ts`, preventing `findOwnedActionCorrectionFromMetadata` from overriding the planner's `CREATE_TASK` pick with keyword-overlapping role-gated actions (e.g., `OWNER_CALENDAR`). The fix follows the identical precedent already established for `SPAWN_AGENT`, `OWNER_RELATIONSHIP`, and `LIFE`, and is accompanied by three regression tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-precedented single-line addition with regression coverage.

The change is a one-liner that follows an exact established pattern (SPAWN_AGENT, OWNER_RELATIONSHIP, LIFE already in the set). The logic is correct: EXPLICIT_INTENT_ACTIONS causes findOwnedActionCorrectionFromMetadata to return null immediately, which is exactly the desired behavior. Three regression tests cover CREATE_TASK and the two guard paths. No new exports, no new types, no behavioral changes outside the targeted correction path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/services/message.ts | Adds "CREATE_TASK" to EXPLICIT_INTENT_ACTIONS set and extends the comment block; change is a single-line addition following the exact same pattern as SPAWN_AGENT and OWNER_RELATIONSHIP |
| packages/typescript/src/services/message.test.ts | Exports findOwnedActionCorrectionFromMetadata and adds three regression tests; the REPLY test exercises the passive-action guard (not the explicit-intent guard) which is working-as-intended but the describe block title slightly misrepresents it |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["findOwnedActionCorrectionFromMetadata called"] --> B{"Any action in\nEXPLICIT_INTENT_ACTIONS?\n(SPAWN_AGENT, CREATE_TASK, ...)"}
    B -- "Yes (NEW: CREATE_TASK)" --> C["return null\n(no correction)"]
    B -- "No" --> D{"currentAction is\nnon-passive?"}
    D -- "No (REPLY/RESPOND/NONE)" --> E["return null"]
    D -- "Yes" --> F["suggestOwnedActionFromMetadata()"]
    F --> G{"suggestion score -\ncurrent score >= 4?"}
    G -- "No" --> H["return null"]
    G -- "Yes" --> I["return suggestion\n(override planner's choice)"]
    I --> J["❌ Old behavior: CREATE_TASK\noverridden by OWNER_CALENDAR"]
    C --> K["✅ New behavior: CREATE_TASK\nrespected as-is"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(message): add CREATE\_TASK to EXPLICI..."](https://github.com/elizaos/eliza/commit/8acb610e73673f635698e5d625253d268bb48652) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29954123)</sub>

<!-- /greptile_comment -->