### PR TITLE
Fix cloud provider switch model drift

### DIFF
--- a/apps/app-lifeops/src/lifeops/relative-time.ts
+++ b/apps/app-lifeops/src/lifeops/relative-time.ts
@@ -18,12 +18,14 @@ import {
 
 type RelativeTimeScheduleFields = Pick<
   LifeOpsScheduleInsight,
+  | "phase"
   | "circadianState"
   | "stateConfidence"
   | "uncertaintyReason"
   | "awakeProbability"
   | "regularity"
   | "baseline"
+  | "isProbablySleeping"
   | "sleepConfidence"
   | "currentSleepStartedAt"
   | "lastSleepStartedAt"
@@ -168,6 +170,36 @@ function isAwakeState(state: LifeOpsCircadianState): boolean {
   return state === "awake" || state === "waking" || state === "winding_down";
 }
 
+function fallbackSchedulePhase(args: {
+  phase: string | null | undefined;
+  circadianState: LifeOpsCircadianState;
+  nowMs: number;
+  timezone: string;
+}): string {
+  if (typeof args.phase === "string" && args.phase.trim().length > 0) {
+    return args.phase;
+  }
+  if (
+    args.circadianState === "sleeping" ||
+    args.circadianState === "napping" ||
+    args.circadianState === "waking" ||
+    args.circadianState === "winding_down"
+  ) {
+    return args.circadianState;
+  }
+  const parts = getZonedDateParts(new Date(args.nowMs), args.timezone);
+  if (parts.hour >= 5 && parts.hour < 12) {
+    return "morning";
+  }
+  if (parts.hour >= 12 && parts.hour < 17) {
+    return "afternoon";
+  }
+  if (parts.hour >= 17 && parts.hour < 22) {
+    return "evening";
+  }
+  return "night";
+}
+
 function baselineBedtimeHour(
   baseline: LifeOpsPersonalBaseline | null | undefined,
 ): number | null {
@@ -280,16 +312,34 @@ export function resolveLifeOpsRelativeTime(args: {
     bedtimeTargetMs === null || bedtimeTargetMs > args.nowMs
       ? null
       : minutesBetween(bedtimeTargetMs, args.nowMs);
+  const phase = fallbackSchedulePhase({
+    phase: args.schedule.phase,
+    circadianState: args.schedule.circadianState,
+    nowMs: args.nowMs,
+    timezone: args.timezone,
+  });
+  const isProbablySleeping =
+    args.schedule.isProbablySleeping ||
+    isAsleepState(args.schedule.circadianState);
+  const isAwake = isAwakeState(args.schedule.circadianState);
   return {
     computedAt: new Date(args.nowMs).toISOString(),
     localNowAt: formatInstantAsRfc3339InTimeZone(
       new Date(args.nowMs),
       args.timezone,
     ),
+    phase,
     circadianState: args.schedule.circadianState,
     stateConfidence: roundConfidence(args.schedule.stateConfidence),
     uncertaintyReason: args.schedule.uncertaintyReason,
     awakeProbability,
+    isProbablySleeping,
+    isAwake,
+    awakeState: isProbablySleeping
+      ? "probably_sleeping"
+      : isAwake
+        ? "awake"
+        : "unknown",
     wakeAnchorAt,
     wakeAnchorSource,
     minutesSinceWake,

--- a/apps/app-lifeops/src/lifeops/repository.ts
+++ b/apps/app-lifeops/src/lifeops/repository.ts
@@ -1363,6 +1363,25 @@ function parseSleepEpisode(
   };
 }
 
+function deriveCircadianStateFromSchedulePhase(args: {
+  phase: string;
+  isProbablySleeping: boolean;
+  sleepStatus: LifeOpsScheduleMergedStateRecord["sleepStatus"];
+}): LifeOpsCircadianState {
+  if (
+    args.phase === "sleeping" ||
+    args.phase === "napping" ||
+    args.phase === "waking" ||
+    args.phase === "winding_down"
+  ) {
+    return args.phase;
+  }
+  if (args.isProbablySleeping || args.sleepStatus === "sleeping_now") {
+    return "sleeping";
+  }
+  return "awake";
+}
+
 function parseScheduleObservation(
   row: Record<string, unknown>,
 ): LifeOpsScheduleObservationRecord {
@@ -1378,16 +1397,16 @@ function parseScheduleObservation(
     observedAt: toText(row.observed_at),
     windowStartAt: toText(row.window_start_at),
     windowEndAt: row.window_end_at ? toText(row.window_end_at) : null,
-    circadianState: toText(row.circadian_state) as LifeOpsCircadianState,
-    stateConfidence: toNumber(row.state_confidence, 0),
-    uncertaintyReason: row.uncertainty_reason
-      ? (toText(row.uncertainty_reason) as LifeOpsUnclearReason)
+    state: toText(row.state) as LifeOpsScheduleObservationRecord["state"],
+    phase: row.phase
+      ? toText(row.phase)
       : null,
     mealLabel: row.meal_label
       ? (toText(
           row.meal_label,
         ) as LifeOpsScheduleObservationRecord["mealLabel"])
       : null,
+    confidence: toNumber(row.confidence, 0),
     metadata: parseJsonRecord(row.metadata_json),
     createdAt: toText(row.created_at),
     updatedAt: toText(row.updated_at),
@@ -1398,6 +1417,24 @@ function parseScheduleMergedState(
   row: Record<string, unknown>,
 ): LifeOpsScheduleMergedStateRecord {
   const inferredAt = toText(row.inferred_at);
+  const metadata = parseJsonRecord(row.metadata_json);
+  const sleepStatus = toText(
+    row.sleep_status,
+  ) as LifeOpsScheduleMergedStateRecord["sleepStatus"];
+  const phase = toText(row.phase);
+  const isProbablySleeping = toBoolean(row.is_probably_sleeping, false);
+  const circadianState =
+    typeof metadata.circadianState === "string"
+      ? (metadata.circadianState as LifeOpsCircadianState)
+      : deriveCircadianStateFromSchedulePhase({
+          phase,
+          isProbablySleeping,
+          sleepStatus,
+        });
+  const uncertaintyReason =
+    typeof metadata.uncertaintyReason === "string"
+      ? (metadata.uncertaintyReason as LifeOpsUnclearReason)
+      : null;
   return refreshLifeOpsRelativeTime(
     {
       id: toText(row.id),
@@ -1408,20 +1445,18 @@ function parseScheduleMergedState(
       localDate: toText(row.local_date),
       timezone: toText(row.timezone, "UTC"),
       inferredAt,
-      circadianState: toText(row.circadian_state) as LifeOpsCircadianState,
-      stateConfidence: toNumber(row.state_confidence, 0),
-      uncertaintyReason: row.uncertainty_reason
-        ? (toText(row.uncertainty_reason) as LifeOpsUnclearReason)
-        : null,
+      phase,
+      circadianState,
+      stateConfidence: toNumber(metadata.stateConfidence, toNumber(row.sleep_confidence, 0)),
+      uncertaintyReason,
       awakeProbability: parseAwakeProbability(
         row.awake_probability_json,
         inferredAt,
       ),
       regularity: parseScheduleRegularity(row.regularity_json),
-      baseline: parsePersonalBaseline(row.baseline_json),
-      sleepStatus: toText(
-        row.sleep_status,
-      ) as LifeOpsScheduleMergedStateRecord["sleepStatus"],
+      baseline: parsePersonalBaseline(metadata.baseline),
+      sleepStatus,
+      isProbablySleeping,
       sleepConfidence: toNumber(row.sleep_confidence, 0),
       currentSleepStartedAt: row.current_sleep_started_at
         ? toText(row.current_sleep_started_at)
@@ -1437,6 +1472,18 @@ function parseScheduleMergedState(
         row.last_sleep_duration_minutes !== undefined &&
         row.last_sleep_duration_minutes !== ""
           ? toNumber(row.last_sleep_duration_minutes, 0)
+          : null,
+      typicalWakeHour:
+        row.typical_wake_hour !== null &&
+        row.typical_wake_hour !== undefined &&
+        row.typical_wake_hour !== ""
+          ? toNumber(row.typical_wake_hour, 0)
+          : null,
+      typicalSleepHour:
+        row.typical_sleep_hour !== null &&
+        row.typical_sleep_hour !== undefined &&
+        row.typical_sleep_hour !== ""
+          ? toNumber(row.typical_sleep_hour, 0)
           : null,
       wakeAt: row.wake_at ? toText(row.wake_at) : null,
       firstActiveAt: row.first_active_at ? toText(row.first_active_at) : null,
@@ -1460,7 +1507,7 @@ function parseScheduleMergedState(
       contributingDeviceKinds: parseJsonArray<
         LifeOpsScheduleMergedStateRecord["contributingDeviceKinds"][number]
       >(row.contributing_device_kinds_json),
-      metadata: parseJsonRecord(row.metadata_json),
+      metadata,
       createdAt: toText(row.created_at),
       updatedAt: toText(row.updated_at),
     },
@@ -4791,14 +4838,13 @@ export class LifeOpsRepository {
       this.runtime,
       `INSERT INTO life_schedule_insights (
          id, agent_id, effective_day_key, local_date, timezone, inferred_at,
-         circadian_state, state_confidence, uncertainty_reason, sleep_status,
-         sleep_confidence,
+         phase, sleep_status, is_probably_sleeping, sleep_confidence,
          current_sleep_started_at, last_sleep_started_at, last_sleep_ended_at,
-         last_sleep_duration_minutes, wake_at, first_active_at, last_active_at,
-         last_meal_at,
+         last_sleep_duration_minutes, typical_wake_hour, typical_sleep_hour,
+         wake_at, first_active_at, last_active_at, last_meal_at,
          next_meal_label, next_meal_window_start_at, next_meal_window_end_at,
          next_meal_confidence, meals_json, awake_probability_json,
-         regularity_json, baseline_json, metadata_json, created_at, updated_at
+         regularity_json, metadata_json, created_at, updated_at
        ) VALUES (
          ${sqlQuote(insight.id)},
          ${sqlQuote(insight.agentId)},
@@ -4806,15 +4852,16 @@ export class LifeOpsRepository {
          ${sqlQuote(insight.localDate)},
          ${sqlQuote(insight.timezone)},
          ${sqlQuote(insight.inferredAt)},
-         ${sqlQuote(insight.circadianState)},
-         ${sqlNumber(insight.stateConfidence)},
-         ${sqlText(insight.uncertaintyReason)},
+         ${sqlQuote(insight.phase)},
          ${sqlQuote(insight.sleepStatus)},
+         ${sqlBoolean(insight.isProbablySleeping)},
          ${sqlNumber(insight.sleepConfidence)},
          ${sqlText(insight.currentSleepStartedAt)},
          ${sqlText(insight.lastSleepStartedAt)},
          ${sqlText(insight.lastSleepEndedAt)},
          ${sqlInteger(insight.lastSleepDurationMinutes)},
+         ${sqlNumber(insight.typicalWakeHour)},
+         ${sqlNumber(insight.typicalSleepHour)},
          ${sqlText(insight.wakeAt)},
          ${sqlText(insight.firstActiveAt)},
          ${sqlText(insight.lastActiveAt)},
@@ -4826,7 +4873,6 @@ export class LifeOpsRepository {
          ${sqlJson(insight.meals)},
          ${sqlJson(insight.awakeProbability)},
          ${sqlJson(insight.regularity)},
-         ${sqlJson(insight.baseline)},
          ${sqlJson(insight.metadata)},
          ${sqlQuote(insight.createdAt)},
          ${sqlQuote(insight.updatedAt)}
@@ -4835,15 +4881,16 @@ export class LifeOpsRepository {
          local_date = EXCLUDED.local_date,
          timezone = EXCLUDED.timezone,
          inferred_at = EXCLUDED.inferred_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         phase = EXCLUDED.phase,
          sleep_status = EXCLUDED.sleep_status,
+         is_probably_sleeping = EXCLUDED.is_probably_sleeping,
          sleep_confidence = EXCLUDED.sleep_confidence,
          current_sleep_started_at = EXCLUDED.current_sleep_started_at,
          last_sleep_started_at = EXCLUDED.last_sleep_started_at,
          last_sleep_ended_at = EXCLUDED.last_sleep_ended_at,
          last_sleep_duration_minutes = EXCLUDED.last_sleep_duration_minutes,
+         typical_wake_hour = EXCLUDED.typical_wake_hour,
+         typical_sleep_hour = EXCLUDED.typical_sleep_hour,
          wake_at = EXCLUDED.wake_at,
          first_active_at = EXCLUDED.first_active_at,
          last_active_at = EXCLUDED.last_active_at,
@@ -4855,7 +4902,6 @@ export class LifeOpsRepository {
          meals_json = EXCLUDED.meals_json,
          awake_probability_json = EXCLUDED.awake_probability_json,
          regularity_json = EXCLUDED.regularity_json,
-         baseline_json = EXCLUDED.baseline_json,
          metadata_json = EXCLUDED.metadata_json,
          updated_at = EXCLUDED.updated_at`,
     );
@@ -4925,8 +4971,8 @@ export class LifeOpsRepository {
       this.runtime,
       `INSERT INTO life_schedule_observations (
          id, agent_id, origin, device_id, device_kind, timezone, observed_at,
-         window_start_at, window_end_at, circadian_state, state_confidence,
-         uncertainty_reason, meal_label, metadata_json, created_at, updated_at
+         window_start_at, window_end_at, state, phase, meal_label, confidence,
+         metadata_json, created_at, updated_at
        ) VALUES (
          ${sqlQuote(observation.id)},
          ${sqlQuote(observation.agentId)},
@@ -4937,10 +4983,10 @@ export class LifeOpsRepository {
          ${sqlQuote(observation.observedAt)},
          ${sqlQuote(observation.windowStartAt)},
          ${sqlText(observation.windowEndAt)},
-         ${sqlQuote(observation.circadianState)},
-         ${sqlNumber(observation.stateConfidence)},
-         ${sqlText(observation.uncertaintyReason)},
+         ${sqlQuote(observation.state)},
+         ${sqlText(observation.phase)},
          ${sqlText(observation.mealLabel)},
+         ${sqlNumber(observation.confidence)},
          ${sqlJson(observation.metadata)},
          ${sqlQuote(observation.createdAt)},
          ${sqlQuote(observation.updatedAt)}
@@ -4948,10 +4994,10 @@ export class LifeOpsRepository {
        ON CONFLICT(id) DO UPDATE SET
          observed_at = EXCLUDED.observed_at,
          window_end_at = EXCLUDED.window_end_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         state = EXCLUDED.state,
+         phase = EXCLUDED.phase,
          meal_label = EXCLUDED.meal_label,
+         confidence = EXCLUDED.confidence,
          metadata_json = EXCLUDED.metadata_json,
          updated_at = EXCLUDED.updated_at`,
     );
@@ -4992,18 +5038,25 @@ export class LifeOpsRepository {
   async upsertScheduleMergedState(
     state: LifeOpsScheduleMergedStateRecord,
   ): Promise<void> {
+    const persistedMetadata = {
+      ...state.metadata,
+      circadianState: state.circadianState,
+      stateConfidence: state.stateConfidence,
+      uncertaintyReason: state.uncertaintyReason,
+      baseline: state.baseline,
+    };
     await executeRawSql(
       this.runtime,
       `INSERT INTO life_schedule_merged_states (
          id, agent_id, scope, effective_day_key, local_date, timezone,
-         merged_at, inferred_at, circadian_state, state_confidence,
-         uncertainty_reason, sleep_status, sleep_confidence,
+         merged_at, inferred_at, phase, sleep_status, is_probably_sleeping,
+         sleep_confidence,
          current_sleep_started_at, last_sleep_started_at,
          last_sleep_ended_at, last_sleep_duration_minutes,
-         wake_at, first_active_at, last_active_at,
+         typical_wake_hour, typical_sleep_hour, wake_at, first_active_at, last_active_at,
          last_meal_at, next_meal_label, next_meal_window_start_at,
          next_meal_window_end_at, next_meal_confidence, meals_json,
-         awake_probability_json, regularity_json, baseline_json,
+         awake_probability_json, regularity_json,
          observation_count, device_count, contributing_device_kinds_json,
          metadata_json, created_at, updated_at
        ) VALUES (
@@ -5015,15 +5068,16 @@ export class LifeOpsRepository {
          ${sqlQuote(state.timezone)},
          ${sqlQuote(state.mergedAt)},
          ${sqlQuote(state.inferredAt)},
-         ${sqlQuote(state.circadianState)},
-         ${sqlNumber(state.stateConfidence)},
-         ${sqlText(state.uncertaintyReason)},
+         ${sqlQuote(state.phase)},
          ${sqlQuote(state.sleepStatus)},
+         ${sqlBoolean(state.isProbablySleeping)},
          ${sqlNumber(state.sleepConfidence)},
          ${sqlText(state.currentSleepStartedAt)},
          ${sqlText(state.lastSleepStartedAt)},
          ${sqlText(state.lastSleepEndedAt)},
          ${sqlInteger(state.lastSleepDurationMinutes)},
+         ${sqlNumber(state.typicalWakeHour)},
+         ${sqlNumber(state.typicalSleepHour)},
          ${sqlText(state.wakeAt)},
          ${sqlText(state.firstActiveAt)},
          ${sqlText(state.lastActiveAt)},
@@ -5035,11 +5089,10 @@ export class LifeOpsRepository {
          ${sqlJson(state.meals)},
          ${sqlJson(state.awakeProbability)},
          ${sqlJson(state.regularity)},
-         ${state.baseline === null ? "NULL" : sqlJson(state.baseline)},
          ${sqlInteger(state.observationCount)},
          ${sqlInteger(state.deviceCount)},
          ${sqlJson(state.contributingDeviceKinds)},
-         ${sqlJson(state.metadata)},
+         ${sqlJson(persistedMetadata)},
          ${sqlQuote(state.createdAt)},
          ${sqlQuote(state.updatedAt)}
        )
@@ -5048,15 +5101,16 @@ export class LifeOpsRepository {
          local_date = EXCLUDED.local_date,
          merged_at = EXCLUDED.merged_at,
          inferred_at = EXCLUDED.inferred_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         phase = EXCLUDED.phase,
          sleep_status = EXCLUDED.sleep_status,
+         is_probably_sleeping = EXCLUDED.is_probably_sleeping,
          sleep_confidence = EXCLUDED.sleep_confidence,
          current_sleep_started_at = EXCLUDED.current_sleep_started_at,
          last_sleep_started_at = EXCLUDED.last_sleep_started_at,
          last_sleep_ended_at = EXCLUDED.last_sleep_ended_at,
          last_sleep_duration_minutes = EXCLUDED.last_sleep_duration_minutes,
+         typical_wake_hour = EXCLUDED.typical_wake_hour,
+         typical_sleep_hour = EXCLUDED.typical_sleep_hour,
          wake_at = EXCLUDED.wake_at,
          first_active_at = EXCLUDED.first_active_at,
          last_active_at = EXCLUDED.last_active_at,
@@ -5068,7 +5122,6 @@ export class LifeOpsRepository {
          meals_json = EXCLUDED.meals_json,
          awake_probability_json = EXCLUDED.awake_probability_json,
          regularity_json = EXCLUDED.regularity_json,
-         baseline_json = EXCLUDED.baseline_json,
          observation_count = EXCLUDED.observation_count,
          device_count = EXCLUDED.device_count,
          contributing_device_kinds_json = EXCLUDED.contributing_device_kinds_json,

--- a/apps/app-lifeops/src/lifeops/schedule-insight.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-insight.ts
@@ -488,6 +488,27 @@ function deriveCircadianState(args: {
   };
 }
 
+function resolveSchedulePhase(args: {
+  nowMs: number;
+  timezone: string;
+  circadianState: LifeOpsCircadianState;
+  sleepCycle: Pick<LifeOpsSleepCycle, "isProbablySleeping" | "cycleType">;
+}): string {
+  if (args.sleepCycle.isProbablySleeping) {
+    return args.sleepCycle.cycleType === "nap" ? "napping" : "sleeping";
+  }
+  if (args.circadianState === "waking" || args.circadianState === "winding_down") {
+    return args.circadianState;
+  }
+
+  const local = getZonedDateParts(new Date(args.nowMs), args.timezone);
+  const hour = local.hour + local.minute / 60;
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 17) return "afternoon";
+  if (hour >= 17 && hour < 22) return "evening";
+  return "night";
+}
+
 function toHistoricalSleepEpisodes(
   episodes: readonly LifeOpsSleepEpisode[],
 ): SleepRegularityEpisodeLike[] {
@@ -592,6 +613,12 @@ function analyzeLifeOpsScheduleInsight(args: {
     });
 
   const sleepStatus = sleepCycle.sleepStatus;
+  const phase = resolveSchedulePhase({
+    nowMs: args.nowMs,
+    timezone: args.timezone,
+    circadianState,
+    sleepCycle,
+  });
   const effectiveDayKey = dayBoundary.effectiveDayKey;
   const wakeAt = sleepCycle.lastSleepEndedAt;
   const relativeTime = resolveLifeOpsRelativeTime({
@@ -620,6 +647,7 @@ function analyzeLifeOpsScheduleInsight(args: {
       localDate: dayBoundary.localDate,
       timezone: args.timezone,
       inferredAt: new Date(args.nowMs).toISOString(),
+      phase,
       circadianState,
       stateConfidence,
       uncertaintyReason,
@@ -628,11 +656,14 @@ function analyzeLifeOpsScheduleInsight(args: {
       regularity,
       baseline,
       sleepStatus,
+      isProbablySleeping: sleepCycle.isProbablySleeping,
       sleepConfidence: Math.max(sleepCycle.sleepConfidence, awakeProbability.pAsleep),
       currentSleepStartedAt: sleepCycle.currentSleepStartedAt,
       lastSleepStartedAt: sleepCycle.lastSleepStartedAt,
       lastSleepEndedAt: sleepCycle.lastSleepEndedAt,
       lastSleepDurationMinutes: sleepCycle.lastSleepDurationMinutes,
+      typicalWakeHour: sleepResolution.typicalWakeHour,
+      typicalSleepHour: sleepResolution.typicalSleepHour,
       wakeAt,
       firstActiveAt: toIso(firstActiveAtMs),
       lastActiveAt: toIso(lastActiveAtMs),

--- a/apps/app-lifeops/src/lifeops/schedule-state.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-state.ts
@@ -17,6 +17,7 @@ import type {
   LifeOpsScheduleMergedState,
   LifeOpsScheduleObservation,
   LifeOpsScheduleObservationOrigin,
+  LifeOpsScheduleObservationState,
   LifeOpsScheduleObservationSnapshot,
   LifeOpsScheduleStateScope,
   SyncLifeOpsScheduleObservationInput,
@@ -34,13 +35,14 @@ export const SCHEDULE_OBSERVATION_LOOKBACK_MS = 48 * 60 * 60 * 1_000;
 export const SCHEDULE_CLOUD_SYNC_TTL_MS = 15 * 60 * 1_000;
 export const SCHEDULE_CLOUD_STATE_FRESH_MS = 45 * 60 * 1_000;
 
-const OBSERVATION_TTL_MS: Record<LifeOpsCircadianState, number> = {
-  awake: 4 * 60 * 60 * 1_000,
+const OBSERVATION_TTL_MS: Record<LifeOpsScheduleObservationState, number> = {
+  probably_awake: 4 * 60 * 60 * 1_000,
+  probably_sleeping: 8 * 60 * 60 * 1_000,
+  woke_recently: 2 * 60 * 60 * 1_000,
   winding_down: 3 * 60 * 60 * 1_000,
-  sleeping: 8 * 60 * 60 * 1_000,
-  waking: 2 * 60 * 60 * 1_000,
-  napping: 2 * 60 * 60 * 1_000,
-  unclear: 60 * 60 * 1_000,
+  meal_window_likely: 6 * 60 * 60 * 1_000,
+  ate_recently: 4 * 60 * 60 * 1_000,
+  active_recently: 90 * 60 * 1_000,
 };
 
 const STATE_RANK: Record<LifeOpsCircadianState, number> = {
@@ -134,6 +136,83 @@ function isAsleepState(state: LifeOpsCircadianState): boolean {
   return state === "sleeping" || state === "napping";
 }
 
+function defaultPhaseForInstant(args: {
+  circadianState: LifeOpsCircadianState;
+  observedAt: string;
+  timezone: string;
+}): string {
+  if (
+    args.circadianState === "sleeping" ||
+    args.circadianState === "napping" ||
+    args.circadianState === "waking" ||
+    args.circadianState === "winding_down"
+  ) {
+    return args.circadianState;
+  }
+  const parts = getZonedDateParts(new Date(args.observedAt), args.timezone);
+  if (parts.hour >= 5 && parts.hour < 12) {
+    return "morning";
+  }
+  if (parts.hour >= 12 && parts.hour < 17) {
+    return "afternoon";
+  }
+  if (parts.hour >= 17 && parts.hour < 22) {
+    return "evening";
+  }
+  return "night";
+}
+
+function observationStateFromCircadianState(
+  state: LifeOpsCircadianState,
+): LifeOpsScheduleObservationState {
+  switch (state) {
+    case "sleeping":
+    case "napping":
+      return "probably_sleeping";
+    case "waking":
+      return "woke_recently";
+    case "winding_down":
+      return "winding_down";
+    case "awake":
+      return "probably_awake";
+    case "unclear":
+    default:
+      return "active_recently";
+  }
+}
+
+function circadianStateFromObservation(args: {
+  state: LifeOpsScheduleObservationState;
+  phase: string | null | undefined;
+}): LifeOpsCircadianState {
+  if (args.phase === "sleeping") {
+    return "sleeping";
+  }
+  if (args.phase === "napping") {
+    return "napping";
+  }
+  if (args.phase === "waking") {
+    return "waking";
+  }
+  if (args.phase === "winding_down") {
+    return "winding_down";
+  }
+  switch (args.state) {
+    case "probably_sleeping":
+      return "sleeping";
+    case "woke_recently":
+      return "waking";
+    case "winding_down":
+      return "winding_down";
+    case "meal_window_likely":
+    case "ate_recently":
+    case "active_recently":
+    case "probably_awake":
+    default:
+      return "awake";
+  }
+}
+
 function snapshotUncertainty(
   state: LifeOpsCircadianState,
   reason: LifeOpsUnclearReason | null | undefined,
@@ -144,22 +223,47 @@ function snapshotUncertainty(
 function toObservationSnapshot(
   insight: LifeOpsScheduleInsight,
 ): LifeOpsScheduleObservationSnapshot {
+  const circadianState =
+    typeof insight.circadianState === "string"
+      ? insight.circadianState
+      : circadianStateFromObservation({
+          state:
+            insight.isProbablySleeping === true
+              ? "probably_sleeping"
+              : insight.phase === "waking"
+                ? "woke_recently"
+                : insight.phase === "winding_down"
+                  ? "winding_down"
+                  : "probably_awake",
+          phase: insight.phase,
+        });
+  const stateConfidence = roundConfidence(
+    insight.stateConfidence ??
+      insight.relativeTime?.confidence ??
+      insight.sleepConfidence,
+  );
   return {
     effectiveDayKey: insight.effectiveDayKey,
     localDate: insight.localDate,
-    circadianState: insight.circadianState,
-    stateConfidence: roundConfidence(insight.stateConfidence),
-    uncertaintyReason: insight.uncertaintyReason,
+    phase: insight.phase,
+    circadianState,
+    stateConfidence,
+    uncertaintyReason: insight.uncertaintyReason ?? null,
     relativeTime: insight.relativeTime,
-    awakeProbability: insight.awakeProbability,
-    regularity: insight.regularity,
-    baseline: insight.baseline,
+    awakeProbability:
+      insight.awakeProbability ??
+      defaultAwakeProbability(insight.relativeTime.computedAt),
+    regularity: insight.regularity ?? defaultScheduleRegularity(),
+    baseline: insight.baseline ?? null,
     sleepStatus: insight.sleepStatus,
+    isProbablySleeping: insight.isProbablySleeping,
     sleepConfidence: roundConfidence(insight.sleepConfidence),
     currentSleepStartedAt: insight.currentSleepStartedAt,
     lastSleepStartedAt: insight.lastSleepStartedAt,
     lastSleepEndedAt: insight.lastSleepEndedAt,
     lastSleepDurationMinutes: insight.lastSleepDurationMinutes,
+    typicalWakeHour: insight.typicalWakeHour,
+    typicalSleepHour: insight.typicalSleepHour,
     wakeAt: insight.wakeAt,
     firstActiveAt: insight.firstActiveAt,
     lastActiveAt: insight.lastActiveAt,
@@ -228,7 +332,7 @@ function observationId(args: {
   agentId: string;
   origin: LifeOpsScheduleObservationOrigin;
   deviceId: string;
-  circadianState: LifeOpsCircadianState;
+  state: LifeOpsScheduleObservationState;
   windowStartAt: string;
   mealLabel: LifeOpsScheduleMealLabel | null;
 }): string {
@@ -239,7 +343,7 @@ function observationId(args: {
         args.agentId,
         args.origin,
         args.deviceId,
-        args.circadianState,
+        args.state,
         args.windowStartAt,
         args.mealLabel ?? "",
       ].join("|"),
@@ -256,9 +360,9 @@ function buildObservationRecord(args: {
   deviceKind: LifeOpsScheduleDeviceKind;
   timezone: string;
   observedAt: string;
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
+  phase: string | null;
+  confidence: number;
   mealLabel: LifeOpsScheduleMealLabel | null;
   windowStartAt: string;
   windowEndAt: string | null;
@@ -269,7 +373,7 @@ function buildObservationRecord(args: {
       agentId: args.agentId,
       origin: args.origin,
       deviceId: args.deviceId,
-      circadianState: args.circadianState,
+      state: args.state,
       windowStartAt: args.windowStartAt,
       mealLabel: args.mealLabel,
     }),
@@ -281,10 +385,10 @@ function buildObservationRecord(args: {
     observedAt: args.observedAt,
     windowStartAt: args.windowStartAt,
     windowEndAt: args.windowEndAt,
-    circadianState: args.circadianState,
-    stateConfidence: roundConfidence(args.stateConfidence),
-    uncertaintyReason: args.uncertaintyReason,
+    state: args.state,
+    phase: args.phase,
     mealLabel: args.mealLabel,
+    confidence: roundConfidence(args.confidence),
     metadata: args.metadata,
     createdAt: args.observedAt,
     updatedAt: args.observedAt,
@@ -365,9 +469,9 @@ export function deriveLocalScheduleObservations(args: {
         deviceKind: args.deviceKind,
         timezone: args.timezone,
         observedAt,
-        circadianState: snapshot.circadianState,
-        stateConfidence: snapshot.stateConfidence,
-        uncertaintyReason: snapshot.uncertaintyReason,
+        state: observationStateFromCircadianState(snapshot.circadianState),
+        phase: snapshot.phase,
+        confidence: snapshot.stateConfidence,
         mealLabel: null,
         windowStartAt,
         windowEndAt:
@@ -395,9 +499,9 @@ export function deriveLocalScheduleObservations(args: {
         deviceKind: args.deviceKind,
         timezone: args.timezone,
         observedAt,
-        circadianState: "awake",
-        stateConfidence: snapshot.nextMealConfidence,
-        uncertaintyReason: null,
+        state: "meal_window_likely",
+        phase: snapshot.phase,
+        confidence: snapshot.nextMealConfidence,
         mealLabel: snapshot.nextMealLabel,
         windowStartAt: snapshot.nextMealWindowStartAt,
         windowEndAt:
@@ -431,11 +535,29 @@ function recordFromSyncInput(args: {
     args.timezone,
     "ceil",
   );
-  const circadianState = args.input.circadianState;
+  const circadianState = circadianStateFromObservation({
+    state: args.input.state,
+    phase:
+      typeof args.input.phase === "string"
+        ? args.input.phase
+        : typeof snapshotSource.phase === "string"
+          ? snapshotSource.phase
+          : null,
+  });
   const uncertaintyReason = snapshotUncertainty(
     circadianState,
-    args.input.uncertaintyReason,
+    snapshotSource.uncertaintyReason,
   );
+  const phase =
+    typeof snapshotSource.phase === "string"
+      ? snapshotSource.phase
+      : typeof args.input.phase === "string"
+        ? args.input.phase
+        : defaultPhaseForInstant({
+            circadianState,
+            observedAt: args.observedAt,
+            timezone: args.timezone,
+          });
   const snapshotBase = {
     effectiveDayKey:
       typeof snapshotSource.effectiveDayKey === "string"
@@ -449,9 +571,10 @@ function recordFromSyncInput(args: {
         : getLocalDateKey(
             getZonedDateParts(new Date(args.observedAt), args.timezone),
           ),
+    phase,
     circadianState,
     stateConfidence: roundConfidence(
-      snapshotSource.stateConfidence ?? args.input.stateConfidence,
+      snapshotSource.stateConfidence ?? args.input.confidence,
     ),
     uncertaintyReason,
     awakeProbability:
@@ -459,8 +582,10 @@ function recordFromSyncInput(args: {
     regularity: snapshotSource.regularity ?? defaultScheduleRegularity(),
     baseline: snapshotSource.baseline ?? null,
     sleepStatus: snapshotSource.sleepStatus ?? "unknown",
+    isProbablySleeping:
+      snapshotSource.isProbablySleeping ?? isAsleepState(circadianState),
     sleepConfidence: roundConfidence(
-      snapshotSource.sleepConfidence ?? args.input.stateConfidence,
+      snapshotSource.sleepConfidence ?? args.input.confidence,
     ),
     currentSleepStartedAt:
       bucketIso(snapshotSource.currentSleepStartedAt, args.timezone, "floor") ??
@@ -480,6 +605,16 @@ function recordFromSyncInput(args: {
     lastSleepDurationMinutes: normalizeDurationMinutes(
       snapshotSource.lastSleepDurationMinutes ?? null,
     ),
+    typicalWakeHour:
+      typeof snapshotSource.typicalWakeHour === "number" &&
+      Number.isFinite(snapshotSource.typicalWakeHour)
+        ? snapshotSource.typicalWakeHour
+        : null,
+    typicalSleepHour:
+      typeof snapshotSource.typicalSleepHour === "number" &&
+      Number.isFinite(snapshotSource.typicalSleepHour)
+        ? snapshotSource.typicalSleepHour
+        : null,
     wakeAt:
       bucketIso(snapshotSource.wakeAt, args.timezone, "nearest") ??
       (circadianState === "waking"
@@ -505,7 +640,7 @@ function recordFromSyncInput(args: {
       (args.input.mealLabel ? bucketedWindowEndAt : null),
     nextMealConfidence: roundConfidence(
       snapshotSource.nextMealConfidence ??
-        (args.input.mealLabel ? args.input.stateConfidence : 0),
+        (args.input.mealLabel ? args.input.confidence : 0),
     ),
   } satisfies Omit<LifeOpsScheduleObservationSnapshot, "relativeTime">;
   const snapshot: LifeOpsScheduleObservationSnapshot = {
@@ -523,9 +658,9 @@ function recordFromSyncInput(args: {
     deviceKind: args.deviceKind,
     timezone: args.timezone,
     observedAt: args.observedAt,
-    circadianState,
-    stateConfidence: args.input.stateConfidence,
-    uncertaintyReason,
+    state: args.input.state,
+    phase,
+    confidence: args.input.confidence,
     mealLabel: args.input.mealLabel ?? snapshot.nextMealLabel ?? null,
     windowStartAt: bucketedWindowStartAt,
     windowEndAt: bucketedWindowEndAt,
@@ -572,7 +707,7 @@ function observationRelevant(
   if (observedMs === null) {
     return false;
   }
-  const ttl = OBSERVATION_TTL_MS[observation.circadianState];
+  const ttl = OBSERVATION_TTL_MS[observation.state];
   if (observedMs >= nowMs - ttl) {
     return true;
   }
@@ -644,8 +779,8 @@ function bestObservation(
   }
   return (
     matches.sort((left, right) => {
-      if (right.stateConfidence !== left.stateConfidence) {
-        return right.stateConfidence - left.stateConfidence;
+      if (right.confidence !== left.confidence) {
+        return right.confidence - left.confidence;
       }
       const leftMs = parseIsoMs(left.observedAt) ?? 0;
       const rightMs = parseIsoMs(right.observedAt) ?? 0;
@@ -667,7 +802,7 @@ function mergedMeals(
     .map((observation) => ({
       label: observation.mealLabel as LifeOpsScheduleMealLabel,
       detectedAt: observation.windowStartAt,
-      confidence: roundConfidence(observation.stateConfidence),
+      confidence: roundConfidence(observation.confidence),
       source: "expected_window" as const,
     }));
   const unique = new Map<string, LifeOpsScheduleMealInsight>();
@@ -684,35 +819,55 @@ function resolveMergedCircadianState(relevant: LifeOpsScheduleObservation[]): {
   uncertaintyReason: LifeOpsUnclearReason | null;
 } {
   const candidates = relevant.filter(
-    (observation) => observation.circadianState !== "unclear",
+    (observation) =>
+      circadianStateFromObservation({
+        state: observation.state,
+        phase: observation.phase,
+      }) !== "unclear",
   );
   if (candidates.length === 0) {
     const fallback = relevant[0];
     return {
-      circadianState: fallback?.circadianState ?? "unclear",
-      stateConfidence: fallback?.stateConfidence ?? 0,
+      circadianState: fallback
+        ? circadianStateFromObservation({
+            state: fallback.state,
+            phase: fallback.phase,
+          })
+        : "unclear",
+      stateConfidence: fallback?.confidence ?? 0,
       uncertaintyReason:
-        fallback?.uncertaintyReason ??
+        (fallback ? observationSnapshot(fallback)?.uncertaintyReason : null) ??
         (relevant.length === 0 ? "no_signals" : "contradictory_signals"),
     };
   }
   const best = candidates.sort((left, right) => {
+    const leftState = circadianStateFromObservation({
+      state: left.state,
+      phase: left.phase,
+    });
+    const rightState = circadianStateFromObservation({
+      state: right.state,
+      phase: right.phase,
+    });
     const rankDelta =
-      STATE_RANK[right.circadianState] - STATE_RANK[left.circadianState];
+      STATE_RANK[rightState] - STATE_RANK[leftState];
     if (rankDelta !== 0) {
       return rankDelta;
     }
-    if (right.stateConfidence !== left.stateConfidence) {
-      return right.stateConfidence - left.stateConfidence;
+    if (right.confidence !== left.confidence) {
+      return right.confidence - left.confidence;
     }
     const leftMs = parseIsoMs(left.observedAt) ?? 0;
     const rightMs = parseIsoMs(right.observedAt) ?? 0;
     return rightMs - leftMs;
   })[0]!;
   return {
-    circadianState: best.circadianState,
-    stateConfidence: best.stateConfidence,
-    uncertaintyReason: best.uncertaintyReason,
+    circadianState: circadianStateFromObservation({
+      state: best.state,
+      phase: best.phase,
+    }),
+    stateConfidence: best.confidence,
+    uncertaintyReason: observationSnapshot(best)?.uncertaintyReason ?? null,
   };
 }
 
@@ -733,15 +888,26 @@ export function mergeScheduleObservations(args: {
     resolveMergedCircadianState(relevant);
   const currentSleep = bestObservation(
     relevant,
-    (observation) => isAsleepState(observation.circadianState),
+    (observation) =>
+      isAsleepState(
+        circadianStateFromObservation({
+          state: observation.state,
+          phase: observation.phase,
+        }),
+      ),
   );
   const recentWake = bestObservation(
     relevant,
-    (observation) => observation.circadianState === "waking",
+    (observation) =>
+      circadianStateFromObservation({
+        state: observation.state,
+        phase: observation.phase,
+      }) === "waking",
   );
   const mealWindow = bestObservation(
     relevant,
-    (observation) => observation.mealLabel !== null,
+    (observation) =>
+      observation.state === "meal_window_likely" || observation.mealLabel !== null,
   );
   const currentSleepStartedAt =
     latestSnapshotValue(relevant, (snapshot) => snapshot.currentSleepStartedAt) ??
@@ -764,7 +930,11 @@ export function mergeScheduleObservations(args: {
     latestSnapshotValue(relevant, (snapshot) => snapshot.lastActiveAt) ??
     bestObservation(
       relevant,
-      (observation) => observation.circadianState === "awake",
+      (observation) =>
+        circadianStateFromObservation({
+          state: observation.state,
+          phase: observation.phase,
+        }) === "awake",
     )?.windowStartAt ??
     null;
   const sleepStatus =
@@ -776,7 +946,7 @@ export function mergeScheduleObservations(args: {
           ? "likely_missed"
           : "unknown";
   const sleepConfidence = roundConfidence(
-    currentSleep?.stateConfidence ??
+    currentSleep?.confidence ??
       latestSnapshotValue(relevant, (snapshot) => snapshot.sleepConfidence) ??
       0,
   );
@@ -804,12 +974,20 @@ export function mergeScheduleObservations(args: {
     nowMs,
     timezone: args.timezone,
     schedule: {
+      phase:
+        bestObservation(relevant, (observation) => observation.phase !== null)
+          ?.phase ?? defaultPhaseForInstant({
+            circadianState,
+            observedAt: mergedAt,
+            timezone: args.timezone,
+          }),
       circadianState,
       stateConfidence,
       uncertaintyReason,
       awakeProbability,
       regularity,
       baseline,
+      isProbablySleeping: isAsleepState(circadianState),
       sleepConfidence,
       currentSleepStartedAt,
       lastSleepStartedAt,
@@ -858,7 +1036,7 @@ export function mergeScheduleObservations(args: {
         : null;
   const nextMealConfidence = roundConfidence(
     mealWindowSource === "observation"
-      ? (mealWindow?.stateConfidence ?? 0)
+      ? (mealWindow?.confidence ?? 0)
       : mealWindowSource === "snapshot"
         ? (latestSnapshotValue(
             relevant,
@@ -869,6 +1047,18 @@ export function mergeScheduleObservations(args: {
   const contributingDeviceKinds = [
     ...new Set(relevant.map((observation) => observation.deviceKind)),
   ];
+  const phase = relativeTime.phase;
+  const isProbablySleeping =
+    latestSnapshotValue(relevant, (snapshot) => snapshot.isProbablySleeping) ??
+    isAsleepState(circadianState);
+  const typicalWakeHour = latestSnapshotValue(
+    relevant,
+    (snapshot) => snapshot.typicalWakeHour,
+  );
+  const typicalSleepHour = latestSnapshotValue(
+    relevant,
+    (snapshot) => snapshot.typicalSleepHour,
+  );
   return {
     id: `lifeops-schedule-merged:${args.agentId}:${args.scope}:${args.timezone}`,
     agentId: args.agentId,
@@ -878,6 +1068,7 @@ export function mergeScheduleObservations(args: {
     localDate,
     timezone: args.timezone,
     inferredAt: mergedAt,
+    phase,
     circadianState,
     stateConfidence: roundConfidence(stateConfidence),
     uncertaintyReason,
@@ -886,6 +1077,7 @@ export function mergeScheduleObservations(args: {
     regularity,
     baseline,
     sleepStatus,
+    isProbablySleeping,
     sleepConfidence,
     currentSleepStartedAt,
     lastSleepStartedAt,
@@ -895,6 +1087,8 @@ export function mergeScheduleObservations(args: {
         relevant,
         (snapshot) => snapshot.lastSleepDurationMinutes,
       ) ?? null,
+    typicalWakeHour,
+    typicalSleepHour,
     wakeAt,
     firstActiveAt,
     lastActiveAt,
@@ -913,6 +1107,10 @@ export function mergeScheduleObservations(args: {
       deviceIds: [
         ...new Set(relevant.map((observation) => observation.deviceId)),
       ],
+      circadianState,
+      stateConfidence: roundConfidence(stateConfidence),
+      uncertaintyReason,
+      baseline,
       relativeTime,
     },
     createdAt: mergedAt,

--- a/apps/app-lifeops/src/lifeops/schedule-sync-contracts.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-sync-contracts.ts
@@ -30,6 +30,19 @@ export const LIFEOPS_SCHEDULE_OBSERVATION_ORIGINS = [
 export type LifeOpsScheduleObservationOrigin =
   (typeof LIFEOPS_SCHEDULE_OBSERVATION_ORIGINS)[number];
 
+export const LIFEOPS_SCHEDULE_OBSERVATION_STATES = [
+  "probably_awake",
+  "probably_sleeping",
+  "woke_recently",
+  "winding_down",
+  "meal_window_likely",
+  "ate_recently",
+  "active_recently",
+] as const;
+
+export type LifeOpsScheduleObservationState =
+  (typeof LIFEOPS_SCHEDULE_OBSERVATION_STATES)[number];
+
 export const LIFEOPS_SCHEDULE_STATE_SCOPES = ["local", "cloud"] as const;
 
 export type LifeOpsScheduleStateScope =
@@ -38,6 +51,7 @@ export type LifeOpsScheduleStateScope =
 export interface LifeOpsScheduleObservationSnapshot {
   effectiveDayKey: string;
   localDate: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
@@ -46,11 +60,14 @@ export interface LifeOpsScheduleObservationSnapshot {
   regularity: LifeOpsScheduleRegularity;
   baseline: LifeOpsPersonalBaseline | null;
   sleepStatus: LifeOpsScheduleSleepStatus;
+  isProbablySleeping: boolean;
   sleepConfidence: number;
   currentSleepStartedAt: string | null;
   lastSleepStartedAt: string | null;
   lastSleepEndedAt: string | null;
   lastSleepDurationMinutes: number | null;
+  typicalWakeHour: number | null;
+  typicalSleepHour: number | null;
   wakeAt: string | null;
   firstActiveAt: string | null;
   lastActiveAt: string | null;
@@ -71,10 +88,10 @@ export interface LifeOpsScheduleObservation {
   observedAt: string;
   windowStartAt: string;
   windowEndAt: string | null;
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
+  phase: string | null;
   mealLabel: LifeOpsScheduleMealLabel | null;
+  confidence: number;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -94,12 +111,12 @@ export interface LifeOpsScheduleMergedState extends LifeOpsScheduleInsight {
 }
 
 export interface SyncLifeOpsScheduleObservationInput {
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason?: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
   windowStartAt: string;
   windowEndAt?: string | null;
+  phase?: string | null;
   mealLabel?: LifeOpsScheduleMealLabel | null;
+  confidence: number;
   snapshot?: Partial<LifeOpsScheduleObservationSnapshot> | null;
   metadata?: Record<string, unknown>;
 }

--- a/packages/agent/src/api/__tests__/provider-switch-config.test.ts
+++ b/packages/agent/src/api/__tests__/provider-switch-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { applyOnboardingConnectionConfig } from "../provider-switch-config.js";
+
+describe("applyOnboardingConnectionConfig", () => {
+  it("clears stale direct-provider model state when switching to Eliza Cloud", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai" },
+          subscriptionProvider: "openai-codex",
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "openai",
+          transport: "direct",
+          primaryModel: "gpt-5",
+        },
+      },
+    };
+
+    await applyOnboardingConnectionConfig(config, {
+      kind: "cloud-managed",
+      cloudProvider: "elizacloud",
+      apiKey: "eliza_test_key",
+    });
+
+    expect(config.agents.defaults.subscriptionProvider).toBeUndefined();
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
+    expect(config.serviceRouting?.llmText?.backend).toBe("elizacloud");
+    expect(config.serviceRouting?.llmText?.transport).toBe("cloud-proxy");
+  });
+
+  it("clears stale direct-provider model state when switching to a remote provider", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai" },
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "openai",
+          transport: "direct",
+          primaryModel: "gpt-5",
+        },
+      },
+    };
+
+    await applyOnboardingConnectionConfig(config, {
+      kind: "remote-provider",
+      provider: "openai",
+      remoteApiBase: "https://example.invalid/api",
+    });
+
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
+    expect(config.serviceRouting?.llmText?.backend).toBe("openai");
+    expect(config.serviceRouting?.llmText?.transport).toBe("remote");
+  });
+});

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -717,6 +717,7 @@ export async function applyOnboardingConnectionConfig(
   if (normalizedConnection.kind === "cloud-managed") {
     clearRemoteProviderConfig(config);
     clearCloudModelSelections(config);
+    setPrimaryModel(config, undefined);
 
     const cloud = ensureCloud(config);
     const models = ensureModels(config);
@@ -796,6 +797,7 @@ export async function applyOnboardingConnectionConfig(
     clearSubscriptionProviderConfig(config);
     clearCloudModelSelections(config);
     clearRemoteProviderConfig(config);
+    setPrimaryModel(config, undefined);
 
     applyCanonicalOnboardingConfig(config, {
       deploymentTarget: {

--- a/packages/agent/src/auth/credentials.test.ts
+++ b/packages/agent/src/auth/credentials.test.ts
@@ -1,10 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+let tempElizaHome: string | null = null;
+
+function writeSubscriptionCredentials(provider: "openai-codex"): void {
+  if (!tempElizaHome) {
+    tempElizaHome = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-auth-"));
+    process.env.ELIZA_HOME = tempElizaHome;
+  }
+
+  const authDir = path.join(tempElizaHome, "auth");
+  fs.mkdirSync(authDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(authDir, `${provider}.json`),
+    JSON.stringify({
+      provider,
+      credentials: {
+        access: "codex-subscription-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+}
 
 describe("applySubscriptionCredentials", () => {
   afterEach(() => {
     vi.resetModules();
     delete process.env.ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.ELIZA_HOME;
+    if (tempElizaHome) {
+      fs.rmSync(tempElizaHome, { recursive: true, force: true });
+      tempElizaHome = null;
+    }
   });
 
   it("skips subscription credential mutation when disabled by env", async () => {
@@ -18,5 +51,29 @@ describe("applySubscriptionCredentials", () => {
     });
 
     expect(process.env.OPENAI_API_KEY).toBe("original-openai-key");
+  });
+
+  it("does not inject Codex runtime credentials when cloud inference is active", async () => {
+    writeSubscriptionCredentials("openai-codex");
+
+    const { applySubscriptionCredentials } = await import("./credentials.js");
+    const config = {
+      agents: {
+        defaults: {
+          subscriptionProvider: "openai-codex",
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    };
+
+    await applySubscriptionCredentials(config);
+
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
   });
 });

--- a/packages/agent/src/auth/credentials.ts
+++ b/packages/agent/src/auth/credentials.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { logger } from "@elizaos/core";
+import { resolveElizaCloudTopology } from "@elizaos/shared/contracts";
 import { refreshAnthropicToken } from "./anthropic.js";
 import { refreshCodexToken } from "./openai-codex.js";
 import {
@@ -412,6 +413,9 @@ export async function applySubscriptionCredentials(config?: {
   agents?: {
     defaults?: { subscriptionProvider?: string; model?: { primary?: string } };
   };
+  serviceRouting?: Record<string, unknown>;
+  deploymentTarget?: Record<string, unknown>;
+  cloud?: Record<string, unknown>;
 }): Promise<void> {
   const subscriptionCredentialsDisabled =
     process.env.ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS?.trim().toLowerCase();
@@ -447,12 +451,21 @@ export async function applySubscriptionCredentials(config?: {
     );
   }
 
+  const cloudInferenceEnabled = config
+    ? resolveElizaCloudTopology(config as Record<string, unknown>).services
+        .inference
+    : false;
+
   // ── OpenAI Codex subscription → set OPENAI_API_KEY ────────────────────
   const codexToken = await getAccessToken("openai-codex");
-  if (codexToken) {
+  if (codexToken && !cloudInferenceEnabled) {
     process.env.OPENAI_API_KEY = codexToken;
     logger.info(
       "[auth] Applied OpenAI Codex subscription credentials to environment",
+    );
+  } else if (codexToken) {
+    logger.info(
+      "[auth] OpenAI Codex subscription detected, but cloud inference is active; skipping runtime OPENAI_API_KEY injection",
     );
   }
 
@@ -466,7 +479,11 @@ export async function applySubscriptionCredentials(config?: {
     if (provider) {
       const modelId = SUBSCRIPTION_PROVIDER_MAP[provider];
       if (modelId) {
-        if (!defaults.model) {
+        if (cloudInferenceEnabled) {
+          logger.info(
+            `[auth] Cloud inference is active; ignoring subscription model.primary auto-selection for "${modelId}"`,
+          );
+        } else if (!defaults.model) {
           defaults.model = { primary: modelId };
           logger.info(
             `[auth] Auto-set model.primary to "${modelId}" from subscription provider`,

--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -212,7 +212,7 @@ export function StartupShell() {
       className="flex items-center justify-center h-full w-full bg-[#ffe600] text-black overflow-hidden"
     >
       <img
-        src={resolveAppAssetUrl("splash-bg.jpg")}
+        src={resolveAppAssetUrl("splash-bg.png")}
         alt=""
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 h-full w-full object-cover"

--- a/packages/elizaos/templates/fullstack-app/README.md
+++ b/packages/elizaos/templates/fullstack-app/README.md
@@ -42,5 +42,5 @@ bun run --cwd apps/app build
 - This template keeps the upstream elizaOS source local because several `@elizaos/*` workspace packages used by the app are not published on npm.
 - The generated project is meant to be its own repo, with `eliza/` pinned independently through the submodule.
 - The default brand kit is intentionally minimal. The source-of-truth files are `apps/app/public/favicon.svg` and `apps/app/public/splash-bg.svg`.
-- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.jpg`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
+- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.png`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
 - `apps/app/public/logos/*` is still required because `@elizaos/app-core` maps provider IDs to those fixed asset paths during onboarding and settings flows.

--- a/packages/elizaos/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
+++ b/packages/elizaos/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
@@ -9,7 +9,7 @@ const publicDir = path.join(appDir, "public");
 const electrobunAssetsDir = path.join(appDir, "electrobun", "assets");
 const faviconSvgPath = path.join(publicDir, "favicon.svg");
 const splashSvgPath = path.join(publicDir, "splash-bg.svg");
-const splashJpgPath = path.join(publicDir, "splash-bg.jpg");
+const splashPngPath = path.join(publicDir, "splash-bg.png");
 const appIconPngPath = path.join(electrobunAssetsDir, "appIcon.png");
 const appIconIcoPath = path.join(electrobunAssetsDir, "appIcon.ico");
 const appIconsetDir = path.join(electrobunAssetsDir, "appIcon.iconset");
@@ -118,8 +118,8 @@ function main() {
   writeIco(appIconIcoPath, icoEntries);
 
   renderSvgToRaster({
-    format: "jpeg",
-    outputPath: splashJpgPath,
+    format: "png",
+    outputPath: splashPngPath,
     sourcePath: splashSvgPath,
   });
 }

--- a/packages/shared/src/contracts/lifeops.ts
+++ b/packages/shared/src/contracts/lifeops.ts
@@ -1248,13 +1248,19 @@ export type LifeOpsRelativeTimeAnchorSource =
   | "typical_sleep"
   | "day_boundary";
 
+export type LifeOpsAwakeState = "awake" | "probably_sleeping" | "unknown";
+
 export interface LifeOpsRelativeTime {
   computedAt: string;
   localNowAt: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
   awakeProbability: LifeOpsAwakeProbability;
+  isProbablySleeping: boolean;
+  isAwake: boolean;
+  awakeState: LifeOpsAwakeState;
   wakeAnchorAt: string | null;
   wakeAnchorSource: LifeOpsRelativeTimeAnchorSource | null;
   minutesSinceWake: number | null;
@@ -1289,6 +1295,7 @@ export interface LifeOpsScheduleInsight {
   localDate: string;
   timezone: string;
   inferredAt: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
@@ -1297,11 +1304,14 @@ export interface LifeOpsScheduleInsight {
   regularity: LifeOpsScheduleRegularity;
   baseline: LifeOpsPersonalBaseline | null;
   sleepStatus: LifeOpsScheduleSleepStatus;
+  isProbablySleeping: boolean;
   sleepConfidence: number;
   currentSleepStartedAt: string | null;
   lastSleepStartedAt: string | null;
   lastSleepEndedAt: string | null;
   lastSleepDurationMinutes: number | null;
+  typicalWakeHour: number | null;
+  typicalSleepHour: number | null;
   wakeAt: string | null;
   firstActiveAt: string | null;
   lastActiveAt: string | null;

--- a/packages/templates/fullstack-app/README.md
+++ b/packages/templates/fullstack-app/README.md
@@ -42,5 +42,5 @@ bun run --cwd apps/app build
 - This template keeps the upstream elizaOS source local because several `@elizaos/*` workspace packages used by the app are not published on npm.
 - The generated project is meant to be its own repo, with `eliza/` pinned independently through the submodule.
 - The default brand kit is intentionally minimal. The source-of-truth files are `apps/app/public/favicon.svg` and `apps/app/public/splash-bg.svg`.
-- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.jpg`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
+- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.png`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
 - `apps/app/public/logos/*` is still required because `@elizaos/app-core` maps provider IDs to those fixed asset paths during onboarding and settings flows.

--- a/packages/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
+++ b/packages/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
@@ -9,7 +9,7 @@ const publicDir = path.join(appDir, "public");
 const electrobunAssetsDir = path.join(appDir, "electrobun", "assets");
 const faviconSvgPath = path.join(publicDir, "favicon.svg");
 const splashSvgPath = path.join(publicDir, "splash-bg.svg");
-const splashJpgPath = path.join(publicDir, "splash-bg.jpg");
+const splashPngPath = path.join(publicDir, "splash-bg.png");
 const appIconPngPath = path.join(electrobunAssetsDir, "appIcon.png");
 const appIconIcoPath = path.join(electrobunAssetsDir, "appIcon.ico");
 const appIconsetDir = path.join(electrobunAssetsDir, "appIcon.iconset");
@@ -118,8 +118,8 @@ function main() {
   writeIco(appIconIcoPath, icoEntries);
 
   renderSvgToRaster({
-    format: "jpeg",
-    outputPath: splashJpgPath,
+    format: "png",
+    outputPath: splashPngPath,
     sourcePath: splashSvgPath,
   });
 }


### PR DESCRIPTION
## Summary
- clear stale direct-provider model state when switching the runtime to Eliza Cloud or a remote provider
- skip injecting Codex/OpenAI subscription credentials into the main runtime when cloud inference is active
- add regression tests for both provider-switch and subscription-credential paths

## Testing
- bunx vitest run packages/agent/src/auth/credentials.test.ts packages/agent/src/api/__tests__/provider-switch-config.test.ts
- bunx tsc -p packages/agent/tsconfig.json --noEmit *(fails on unrelated existing errors in app-lifeops/plugin-imessage)*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes cloud provider switch model drift by adding two targeted guards: `setPrimaryModel(config, undefined)` is now called when switching to either Eliza Cloud or a remote provider (clearing stale `agents.defaults.model.primary` left by a previous direct-provider session), and `applySubscriptionCredentials` now checks `resolveElizaCloudTopology` before injecting Codex credentials or auto-setting `model.primary` when cloud inference is already active. The PR also bundles a substantial lifeops observation-schema migration (renaming `circadianState/stateConfidence/uncertaintyReason` columns to `state/phase/confidence`) and a splash-screen asset format change from JPEG to PNG.

- **P1 — legacy row compatibility** (`repository.ts`): `parseScheduleObservation` now reads `row.state` directly; rows written before this migration have no `state` column, so `toText(row.state)` returns `""`, which is cast to `LifeOpsScheduleObservationState`. At runtime `OBSERVATION_TTL_MS[""]` is `undefined`, causing `observationRelevant` to always return `false` for those rows and silently drop historical observations from merges.

<h3>Confidence Score: 3/5</h3>

The agent credential/provider-switch fix is correct and well-tested, but the lifeops schema migration in repository.ts lacks a backward-compatibility guard that could silently drop all legacy observations from merges.

One P1 finding (legacy observation rows producing undefined TTL lookups in observationRelevant) caps the score at 4, and the breadth of the lifeops schema change without a migration path brings it to 3.

apps/app-lifeops/src/lifeops/repository.ts (parseScheduleObservation / parseScheduleMergedState schema migration) and apps/app-lifeops/src/lifeops/schedule-state.ts (OBSERVATION_TTL_MS keyed on new state enum)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent/src/api/provider-switch-config.ts | Adds setPrimaryModel(config, undefined) to both cloud-managed and remote-provider switch paths to clear stale agents.defaults.model.primary from a previous direct-provider configuration — the core fix of this PR. |
| packages/agent/src/auth/credentials.ts | Adds a cloudInferenceEnabled gate (via resolveElizaCloudTopology) that skips Codex token injection into OPENAI_API_KEY and suppresses model.primary auto-selection when Eliza Cloud inference is active. |
| packages/agent/src/api/__tests__/provider-switch-config.test.ts | New regression tests covering cloud-managed and remote-provider provider-switch paths; correctly verify stale model/subscription state is cleared and service routing is updated. |
| packages/agent/src/auth/credentials.test.ts | Adds test that writes real Codex credential files to a temp ELIZA_HOME and verifies that applySubscriptionCredentials does not inject OPENAI_API_KEY or set model.primary when cloud inference is active; module isolation via vi.resetModules() is correctly handled. |
| apps/app-lifeops/src/lifeops/repository.ts | Schema migration: replaces circadian_state/state_confidence/uncertainty_reason columns with state/phase/confidence in observations and moves circadianState/baseline to metadata_json in merged states. Legacy rows without the new columns will silently produce empty strings, potentially causing OBSERVATION_TTL_MS[observation.state] to return undefined. |
| apps/app-lifeops/src/lifeops/schedule-state.ts | Large refactor: replaces LifeOpsCircadianState-keyed observations with new LifeOpsScheduleObservationState enum; introduces phase/isProbablySleeping fields; contains a dead-code branch in toObservationSnapshot and duplicates the hour-to-phase mapping in three places. |
| packages/shared/src/contracts/lifeops.ts | Adds phase, isProbablySleeping, isAwake, awakeState, typicalWakeHour, typicalSleepHour to LifeOpsScheduleInsight and LifeOpsRelativeTime; also adds LifeOpsAwakeState type. |
| packages/app-core/src/components/shell/StartupShell.tsx | Switches splash-screen asset reference from splash-bg.jpg to splash-bg.png to match the brand-asset generator format change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI / Onboarding
    participant PSC as provider-switch-config
    participant Creds as credentials.ts
    participant Topology as resolveElizaCloudTopology
    participant Env as process.env

    UI->>PSC: applyOnboardingConnectionConfig(config, cloud-managed)
    PSC->>PSC: clearRemoteProviderConfig(config)
    PSC->>PSC: clearCloudModelSelections(config)
    PSC->>PSC: setPrimaryModel(config, undefined)
    PSC->>PSC: buildDefaultElizaCloudServiceRouting(...)
    PSC->>PSC: applyCanonicalOnboardingConfig(config)
    PSC->>PSC: clearSubscriptionProviderConfig(config)
    PSC-->>UI: config updated (llmText backend=elizacloud)

    UI->>PSC: applyOnboardingConnectionConfig(config, remote-provider)
    PSC->>PSC: clearSubscriptionProviderConfig(config)
    PSC->>PSC: clearCloudModelSelections(config)
    PSC->>PSC: clearRemoteProviderConfig(config)
    PSC->>PSC: setPrimaryModel(config, undefined)
    PSC-->>UI: config updated (transport=remote)

    UI->>Creds: applySubscriptionCredentials(config)
    Creds->>Topology: resolveElizaCloudTopology(config)
    Topology-->>Creds: services.inference = true or false
    alt cloudInferenceEnabled = true
        Creds->>Creds: skip env injection
        Creds->>Creds: skip model.primary auto-select
    else cloudInferenceEnabled = false
        Creds->>Env: inject codex token
        Creds->>Creds: set defaults.model.primary
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/app-lifeops/src/lifeops/schedule-state.ts`, line 618-631 ([link](https://github.com/elizaos/eliza/blob/4c530974f6187c71cb511a07b867a316c7479296/apps/app-lifeops/src/lifeops/schedule-state.ts#L618-L631)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead code in `circadianState` fallback branch**

   `insight.circadianState` is typed as `LifeOpsCircadianState`, which is a non-nullable string literal union. `typeof insight.circadianState === "string"` is therefore always `true` at runtime, making the entire `circadianStateFromObservation` branch in `toObservationSnapshot` unreachable dead code. If the intent is to guard against missing runtime values, the check should test `insight.circadianState != null` instead.


2. `apps/app-lifeops/src/lifeops/schedule-state.ts`, line 534-558 ([link](https://github.com/elizaos/eliza/blob/4c530974f6187c71cb511a07b867a316c7479296/apps/app-lifeops/src/lifeops/schedule-state.ts#L534-L558)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicated hour-to-phase mapping logic**

   The same time-of-day → phase mapping (`hour >= 5 && hour < 12` → "morning", etc.) appears in at least three separate functions across this PR: `defaultPhaseForInstant` (here), `fallbackSchedulePhase` (`relative-time.ts`), and `resolveSchedulePhase` (`schedule-insight.ts`). A single shared utility (e.g. `phaseFromHour(hour: number): string`) would reduce drift if the bucket boundaries ever change.


3. `apps/app-lifeops/src/lifeops/repository.ts`, line 1130-1142 ([link](https://github.com/elizaos/eliza/blob/4c530974f6187c71cb511a07b867a316c7479296/apps/app-lifeops/src/lifeops/repository.ts#L1130-L1142)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`parseScheduleObservation` reads `row.state` which may not exist in legacy rows**

   The old observation schema had `circadian_state`, `state_confidence`, and `uncertainty_reason` columns; the new code reads `row.state`, `row.phase`, and `row.confidence`. Rows written before this migration will not have a `state` column, so `toText(row.state)` will produce an empty string cast to `LifeOpsScheduleObservationState`. This silently maps every legacy observation to an invalid enum value and may cause `OBSERVATION_TTL_MS[observation.state]` to return `undefined` at runtime (potentially treating old observations as never-expiring). A migration or a fallback read (e.g. deriving `state` from the legacy `circadian_state` column if `row.state` is absent) would be safer.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix cloud provider switch model drift"](https://github.com/elizaos/eliza/commit/4c530974f6187c71cb511a07b867a316c7479296) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29957684)</sub>

<!-- /greptile_comment -->