### PR TITLE
fix(actions): skip non-string entries in formatActionSimiles/Tags

### DIFF
--- a/packages/typescript/src/__tests__/actions.test.ts
+++ b/packages/typescript/src/__tests__/actions.test.ts
@@ -298,6 +298,70 @@ describe("Actions", () => {
 			const formatted = formatActions([]);
 			expect(formatted).toBe("");
 		});
+
+		// Production observation (2026-04-28): a plugin's action shipped with
+		// `tags: [undefined, "foo"]` (a malformed entry from elsewhere in the
+		// runtime). When the planner-prompt builder formatted that action, the
+		// `(action.tags ?? []).map((tag) => tag.trim())` chain crashed with
+		// "undefined is not an object (evaluating 'tag.trim')". plugin-discord
+		// caught that exception as "Error handling message" and the bot
+		// silently dropped the user's message — no reply, no log line about
+		// the cause beyond the bare error message.
+		//
+		// formatActions must be defensive against non-string entries in
+		// action.tags / action.similes since Action consumers don't always
+		// validate their own arrays.
+		it("skips non-string entries in action.tags without throwing", () => {
+			const formatted = formatActions([
+				{
+					name: "WIDGET",
+					description: "Do widget things.",
+					examples: [],
+					similes: [],
+					tags: [
+						undefined as unknown as string,
+						null as unknown as string,
+						"  alpha  ",
+						42 as unknown as string,
+						"beta",
+					],
+					handler: async () => {
+						throw new Error("Not implemented");
+					},
+					validate: async () => {
+						throw new Error("Not implemented");
+					},
+				},
+			]);
+
+			expect(formatted).toContain("- WIDGET:");
+			expect(formatted).toContain("tags[2]: alpha, beta");
+		});
+
+		it("skips non-string entries in action.similes without throwing", () => {
+			const formatted = formatActions([
+				{
+					name: "GREET",
+					description: "Say hi.",
+					examples: [],
+					similes: [
+						undefined as unknown as string,
+						null as unknown as string,
+						"  hi  ",
+						"hello",
+					],
+					handler: async () => {
+						throw new Error("Not implemented");
+					},
+					validate: async () => {
+						throw new Error("Not implemented");
+					},
+				},
+			]);
+
+			expect(formatted).toContain("- GREET:");
+			expect(formatted).toContain("aliases[2]: hi, hello");
+		});
 	});
 
 	describe("Action benchmark cases", () => {

--- a/packages/typescript/src/actions.ts
+++ b/packages/typescript/src/actions.ts
@@ -212,7 +212,11 @@ function shuffleActions<T>(items: T[], seed = "actions"): T[] {
 
 function formatActionSimiles(action: Action): string | null {
 	const similes = [
-		...new Set((action.similes ?? []).map((simile) => simile.trim())),
+		...new Set(
+			(action.similes ?? [])
+				.filter((simile): simile is string => typeof simile === "string")
+				.map((simile) => simile.trim()),
+		),
 	].filter((simile) => simile.length > 0);
 
 	if (similes.length === 0) {
@@ -224,7 +228,11 @@ function formatActionSimiles(action: Action): string | null {
 
 function formatActionTags(action: Action): string | null {
 	const tags = [
-		...new Set((action.tags ?? []).map((tag) => tag.trim())),
+		...new Set(
+			(action.tags ?? [])
+				.filter((tag): tag is string => typeof tag === "string")
+				.map((tag) => tag.trim()),
+		),
 	].filter((tag) => tag.length > 0 && tag !== "always-include");
 
 	if (tags.length === 0) {


### PR DESCRIPTION
## Summary

`formatActionSimiles` and `formatActionTags` call `.trim()` on every entry of `action.similes` / `action.tags` without filtering out non-string entries. If any registered action ships with a malformed tags/similes array (containing `undefined`, `null`, or non-string values), formatting crashes with `TypeError: undefined is not an object (evaluating 'tag.trim')`. plugin-discord catches the throw as a generic `Error handling message` and **silently drops the entire message** — no reply, no actionable diagnostic.

## Production trace from a milady deployment (2026-04-28)

A user `@`-pinged the bot in a discord channel. The bot received the event, ran the role/settings providers, then bailed:

```
[SERVICE:MESSAGE] Message received (entityId=…, roomId=82bdd9bb-…)
[PLUGIN:ADVANCED-CAPABILITIES:PROVIDER:ROLES] Found roles (roleCount=2)
[PLUGIN:ADVANCED-CAPABILITIES:PROVIDER:SETTINGS] No settings state found for server (…)
Error #agent:remilio nubilio  [PLUGIN:DISCORD] Error handling message
  (error=undefined is not an object (evaluating 'tag.trim'))
```

That `tag.trim` is the closure variable inside `formatActionTags`'s `.map((tag) => tag.trim())`. The throw aborts the planner-prompt build, which aborts message handling, which makes plugin-discord catch it as the generic "Error handling message" with no specific identification of which action's tags caused it.

The bot then receives every subsequent user message in that room with no reply. Restarting the bot only helps until the same malformed action is registered again on the next boot.

## Fix

Filter out non-string entries before `.trim()` in both helpers:

```diff
 function formatActionTags(action: Action): string | null {
   const tags = [
-    ...new Set((action.tags ?? []).map((tag) => tag.trim())),
+    ...new Set(
+      (action.tags ?? [])
+        .filter((tag): tag is string => typeof tag === "string")
+        .map((tag) => tag.trim()),
+    ),
   ].filter((tag) => tag.length > 0 && tag !== "always-include");
```

Same shape for `formatActionSimiles`. String entries still trim/dedupe/empty-filter exactly the same way; only non-string entries are dropped before the `.trim()` call site.

## Why filter at the formatter rather than the type system

`action.tags` and `action.similes` are typed as `string[]` per the `Action` type. In a strictly-typed world this fix would not be needed. In practice, plugins from third-party authors and runtime-merged action lists occasionally produce non-string entries that slip through. The cost of a `typeof === "string"` filter at the format site is negligible (the array is being iterated for `.map` anyway); the failure mode it prevents — every user message in the room silently dropped with no actionable log line — is severe enough to warrant defensive code at the system boundary where the data crosses from "may be malformed" to "must be string".

This is the same defensive style already used in `formatPlannerActionNames` and elsewhere in this file.

## Scope

Two files, additive only:

- `packages/typescript/src/actions.ts` — add `.filter((x): x is string => typeof x === "string")` to both helpers
- `packages/typescript/src/__tests__/actions.test.ts` — two regression tests with mixed `[undefined, null, "  alpha  ", 42, "beta"]` arrays for tags and similes

No new exports, no new types, no behavior change for well-formed arrays.

## Verification

- `bunx vitest run packages/typescript/src/__tests__/actions.test.ts` → **28/28 pass** (2 new + 26 existing)
- The two new tests both fail without this fix (verified by reverting the actions.ts change locally — `TypeError: undefined is not an object (evaluating 'tag.trim')`)
- Production trace above is the exact symptom this fixes

## 5-rule check

1. **No meaningless wrappers** — the `.filter` is one chained call at the existing `.map` site, not a new function.
2. **Reuse existing functions** — uses native `Array.prototype.filter` with a type predicate.
3. **No unused/inline-able type variables** — the `tag is string` predicate is defined inline.
4. **No non-essential parameters** — none added.
5. **Clean separation** — defensive filtering happens at the format-site (where it matters), not pushed up into a shared schema validator that other call sites would have to remember to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a defensive `typeof === "string"` filter in `formatActionSimiles` and `formatActionTags` to prevent a `TypeError` crash when third-party plugins supply non-string entries (`undefined`, `null`, numbers) in `action.tags` / `action.similes`. The fix is minimal, all existing behaviour for well-formed arrays is unchanged, and two regression tests confirm the fix and would fail on revert.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive defensive fix with no breaking changes and solid regression coverage.

No P0/P1/P2 issues found. The fix is strictly narrower than the existing code: it only adds a filter before the map, leaving all downstream logic and well-formed inputs untouched. Tests are arithmetically correct and cover the production failure mode.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/typescript/src/actions.ts | Adds `.filter((x): x is string => typeof x === "string")` before each `.map(...trim())` call in `formatActionSimiles` and `formatActionTags` — minimal, correct defensive fix with no behavior change for well-formed arrays. |
| packages/typescript/src/__tests__/actions.test.ts | Two regression tests added for the new defensive filtering; test inputs and expected counts are arithmetically correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["action.tags / action.similes\n(may contain undefined, null, number, string)"]
    B["?? [] — null-coalesce to empty array"]
    C[".filter(x => typeof x === 'string')\nnew in this PR — drops non-string entries"]
    D[".map(x => x.trim())\nnever called on non-strings now"]
    E["new Set(...) — deduplicate"]
    F[".filter(x => x.length > 0)\n(tags also drops 'always-include')"]
    G{"length === 0?"}
    H["return null — omit from prompt"]
    I["return formatted string\n  tags[N]: a, b, c"]

    A --> B --> C --> D --> E --> F --> G
    G -- yes --> H
    G -- no --> I
```

<sub>Reviews (1): Last reviewed commit: ["fix(actions): skip non-string entries in..."](https://github.com/elizaos/eliza/commit/bbeb3785894ced0140a502f50af2cf7bc19d2d1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29990411)</sub>

<!-- /greptile_comment -->