### PR TITLE
feat(n8n): propagate originating-conversation routing into workflow generator

### DIFF
--- a/packages/app-core/src/api/client-types-chat.ts
+++ b/packages/app-core/src/api/client-types-chat.ts
@@ -505,4 +505,12 @@ export interface N8nWorkflowGenerateRequest {
   prompt: string;
   name?: string;
   workflowId?: string;
+  /**
+   * Optional originating conversation id. When present, the server reads
+   * the conversation's tail inbound message metadata and threads platform
+   * routing (Discord channelId/guildId, Telegram chatId, etc.) into the
+   * workflow generator so the LLM can target "this channel" / "back to
+   * here" without the user naming an ID.
+   */
+  bridgeConversationId?: string;
 }

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -610,6 +610,142 @@ function readOptionalNumber(
     : undefined;
 }
 
+/**
+ * Shape of the routing block we hand to the n8n workflow service so the
+ * generator can target "this channel" / "back to here" without the user
+ * naming an ID. Mirrors the upstream `TriggerContext` in
+ * `@elizaos/plugin-n8n-workflow` — duplicated here so this route doesn't
+ * import from the plugin (the host already has its own copy in the
+ * runtime context provider, and the LLM ultimately reads it as a
+ * `## Runtime Facts` line, not via the plugin's prompt builder).
+ */
+interface TriggerContext {
+  source?: string;
+  discord?: { channelId?: string; guildId?: string; threadId?: string };
+  telegram?: { chatId?: string | number; threadId?: string | number };
+  slack?: { channelId?: string; teamId?: string };
+  resolvedNames?: { channel?: string; server?: string };
+}
+
+/**
+ * Read the originating conversation's tail inbound message metadata and
+ * derive a `TriggerContext`. Reads both the canonical
+ * `metadata.discord.{channelId,guildId,messageId}` /
+ * `metadata.telegram.{chatId,threadId}` blocks AND the flat
+ * `discordChannelId` / `discordServerId` / `discordMessageId` fields the
+ * upstream Discord plugin currently writes (pre-existing schema gap —
+ * canonical wins when present, flat is the fallback so nothing today
+ * breaks).
+ *
+ * Returns `undefined` when the conversation has no inbound platform
+ * metadata or the runtime can't read memories.
+ */
+async function buildTriggerContextFromConversation(
+  runtime: AgentRuntime | undefined,
+  roomId: string,
+): Promise<TriggerContext | undefined> {
+  if (!runtime || typeof runtime.getMemories !== "function") return undefined;
+  let memories: Array<{
+    entityId?: string;
+    metadata?: Record<string, unknown>;
+  }>;
+  try {
+    memories = (await runtime.getMemories({
+      roomId: roomId as never,
+      tableName: "messages",
+      count: 12,
+    } as Parameters<typeof runtime.getMemories>[0])) as Array<{
+      entityId?: string;
+      metadata?: Record<string, unknown>;
+    }>;
+  } catch (err) {
+    logger.debug?.(
+      `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return undefined;
+  }
+  if (!Array.isArray(memories) || memories.length === 0) return undefined;
+
+  // Tail inbound = most recent memory whose entityId is NOT the agent.
+  // `runtime.getMemories` typically returns most-recent-first; defensively
+  // handle either order.
+  const inbound = memories.find(
+    (m) => m.entityId && m.entityId !== runtime.agentId,
+  );
+  if (!inbound?.metadata) return undefined;
+
+  const meta = inbound.metadata as Record<string, unknown>;
+  const discord = (meta.discord ?? {}) as Record<string, unknown>;
+  const telegram = (meta.telegram ?? {}) as Record<string, unknown>;
+  const slack = (meta.slack ?? {}) as Record<string, unknown>;
+
+  // Canonical wins; flat fields are the legacy de-facto shape.
+  const discordChannelId =
+    (typeof discord.channelId === "string" ? discord.channelId : undefined) ??
+    (typeof meta.discordChannelId === "string"
+      ? meta.discordChannelId
+      : undefined);
+  const discordGuildId =
+    (typeof discord.guildId === "string" ? discord.guildId : undefined) ??
+    (typeof meta.discordServerId === "string"
+      ? meta.discordServerId
+      : undefined);
+  const discordThreadId =
+    typeof discord.threadId === "string" ? discord.threadId : undefined;
+
+  const telegramChatId =
+    (typeof telegram.chatId === "string" || typeof telegram.chatId === "number"
+      ? telegram.chatId
+      : undefined) ??
+    (typeof meta.fromId === "string" || typeof meta.fromId === "number"
+      ? (meta.fromId as string | number)
+      : undefined);
+  const telegramThreadId =
+    typeof telegram.threadId === "string" ||
+    typeof telegram.threadId === "number"
+      ? (telegram.threadId as string | number)
+      : undefined;
+
+  const slackChannelId =
+    typeof slack.channelId === "string" ? slack.channelId : undefined;
+  const slackTeamId =
+    typeof slack.teamId === "string" ? slack.teamId : undefined;
+
+  if (discordChannelId) {
+    return {
+      source: "discord",
+      discord: {
+        ...(discordChannelId ? { channelId: discordChannelId } : {}),
+        ...(discordGuildId ? { guildId: discordGuildId } : {}),
+        ...(discordThreadId ? { threadId: discordThreadId } : {}),
+      },
+    };
+  }
+  if (telegramChatId !== undefined) {
+    return {
+      source: "telegram",
+      telegram: {
+        chatId: telegramChatId,
+        ...(telegramThreadId !== undefined
+          ? { threadId: telegramThreadId }
+          : {}),
+      },
+    };
+  }
+  if (slackChannelId) {
+    return {
+      source: "slack",
+      slack: {
+        channelId: slackChannelId,
+        ...(slackTeamId ? { teamId: slackTeamId } : {}),
+      },
+    };
+  }
+  return undefined;
+}
+
 function readPosition(value: unknown): [number, number] | null {
   return Array.isArray(value) &&
     value.length >= 2 &&
@@ -1130,10 +1266,14 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
 
   const name = readOptionalString(body, "name");
   const workflowId = readOptionalString(body, "workflowId");
+  const bridgeConversationId = readOptionalString(body, "bridgeConversationId");
 
   const service = ctx.runtime?.getService?.("n8n_workflow") as
     | {
-        generateWorkflowDraft?: (prompt: string) => Promise<{
+        generateWorkflowDraft?: (
+          prompt: string,
+          opts?: { triggerContext?: TriggerContext },
+        ) => Promise<{
           id?: string;
           [k: string]: unknown;
         }>;
@@ -1158,7 +1298,14 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
     return true;
   }
 
-  const draft = await service.generateWorkflowDraft(prompt);
+  const triggerContext = bridgeConversationId
+    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
+    : undefined;
+
+  const draft = await service.generateWorkflowDraft(
+    prompt,
+    triggerContext ? { triggerContext } : undefined,
+  );
   if (name?.trim()) {
     (draft as Record<string, unknown>).name = name.trim();
   }

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -695,13 +695,17 @@ async function buildTriggerContextFromConversation(
   const discordThreadId =
     typeof discord.threadId === "string" ? discord.threadId : undefined;
 
+  // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
+  // id, which equals the chat id only in private 1:1 DMs. In group chats /
+  // channels the chat id is a distinct (typically negative) integer, so
+  // falling back to fromId would silently route the workflow to the wrong
+  // entity. Only use the canonical `metadata.telegram.chatId`. If the
+  // upstream Telegram plugin hasn't populated it yet, we skip Telegram
+  // routing rather than guess.
   const telegramChatId =
-    (typeof telegram.chatId === "string" || typeof telegram.chatId === "number"
+    typeof telegram.chatId === "string" || typeof telegram.chatId === "number"
       ? telegram.chatId
-      : undefined) ??
-    (typeof meta.fromId === "string" || typeof meta.fromId === "number"
-      ? (meta.fromId as string | number)
-      : undefined);
+      : undefined;
   const telegramThreadId =
     typeof telegram.threadId === "string" ||
     typeof telegram.threadId === "number"

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -4596,6 +4596,7 @@ function AutomationsLayout() {
           prompt,
           ...(title?.trim() ? { name: title.trim() } : {}),
           ...(workflowId ? { workflowId } : {}),
+          ...(bridgeConversationId ? { bridgeConversationId } : {}),
         });
         if (isMissingCredentialsResponse(result)) {
           setMissingCredentials(result.missingCredentials);

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -513,6 +513,14 @@ async function repairRuntimeAfterBoot(
   // triggers can dispatch immediately on first emit.
   await ensureTriggerEventBridge(runtime);
 
+  // Register the n8n runtime-context provider so the patched
+  // `@elizaos/plugin-n8n-workflow` can pull real Discord guild/channel IDs
+  // and the user's Gmail email into the workflow-generation prompt — closing
+  // the placeholder + missing-credentials-block gaps. The plugin treats this
+  // service as advisory; if it isn't registered the prompt simply omits the
+  // facts/credentials sections.
+  await ensureN8nRuntimeContextProvider(runtime);
+
   return runtime;
 }
 
@@ -538,6 +546,11 @@ let _n8nDispatch: { execute: (workflowId: string) => Promise<unknown> } | null =
 // hot-reloads so we never leave two handler sets racing the runtime's
 // event bus.
 let _triggerEventBridge: { stop: () => void } | null = null;
+
+// Module-level handle for the n8n runtime-context provider. Reset across
+// hot-reloads so the previous closure (capturing an outdated config getter)
+// does not survive into the fresh runtime's services map.
+let _n8nRuntimeContextProvider: { stop: () => void } | null = null;
 
 async function ensureN8nAuthBridge(runtime: AgentRuntime): Promise<void> {
   if (_n8nAuthBridge) {
@@ -654,6 +667,56 @@ async function ensureTriggerEventBridge(runtime: AgentRuntime): Promise<void> {
   } catch (err) {
     logger.warn(
       `[eliza] Failed to start trigger event bridge: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+async function ensureN8nRuntimeContextProvider(
+  runtime: AgentRuntime,
+): Promise<void> {
+  if (_n8nRuntimeContextProvider) {
+    try {
+      _n8nRuntimeContextProvider.stop();
+    } catch {
+      /* ignore */
+    }
+    _n8nRuntimeContextProvider = null;
+  }
+  try {
+    const { startMiladyN8nRuntimeContextProvider } = await import(
+      "../services/n8n-runtime-context-provider.js"
+    );
+    // If a sibling `n8n_credential_provider` is registered (Milady ships one
+    // separately), reach into the runtime services map for its `resolve` so
+    // the context provider can filter `supportedCredentials` to types that
+    // actually have data right now. Optional — without it the context
+    // provider falls back to "config has connector token" heuristics.
+    const credEntries =
+      runtime.services.get("n8n_credential_provider" as never) ?? [];
+    const credProviderInstance = credEntries[0] as
+      | {
+          resolve?: (
+            userId: string,
+            credType: string,
+          ) => Promise<unknown>;
+        }
+      | undefined;
+    const credProvider =
+      credProviderInstance && typeof credProviderInstance.resolve === "function"
+        ? (credProviderInstance as Parameters<
+            typeof startMiladyN8nRuntimeContextProvider
+          >[1]["credProvider"])
+        : undefined;
+    _n8nRuntimeContextProvider = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => loadElizaConfig(),
+      credProvider,
+    });
+    logger.info("[eliza] n8n runtime-context provider registered");
+  } catch (err) {
+    logger.warn(
+      `[eliza] Failed to register n8n runtime-context provider: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/packages/app-core/src/services/n8n-runtime-context-provider.test.ts
+++ b/packages/app-core/src/services/n8n-runtime-context-provider.test.ts
@@ -1,0 +1,268 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type ConnectorConfigLike,
+  N8N_RUNTIME_CONTEXT_PROVIDER_SERVICE_TYPE,
+  startMiladyN8nRuntimeContextProvider,
+} from "./n8n-runtime-context-provider";
+
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+function makeRuntime(): AgentRuntime {
+  const services = new Map<string, unknown[]>();
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  return {
+    services,
+    logger,
+  } as unknown as AgentRuntime;
+}
+
+function makeConfig(overrides: ConnectorConfigLike = {}): ConnectorConfigLike {
+  return {
+    connectors: {
+      ...(overrides.connectors ?? {}),
+    },
+  };
+}
+
+/**
+ * Plugin's `NodeDefinition.credentials` shape, minimally typed for tests.
+ */
+const DISCORD_NODE = {
+  name: "n8n-nodes-base.discord",
+  displayName: "Discord",
+  credentials: [{ name: "discordApi", required: true }],
+} as const;
+
+const GMAIL_NODE = {
+  name: "n8n-nodes-base.gmail",
+  displayName: "Gmail",
+  credentials: [{ name: "gmailOAuth2", required: true }],
+} as const;
+
+describe("startMiladyN8nRuntimeContextProvider", () => {
+  let runtime: AgentRuntime;
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers itself under n8n_runtime_context_provider on construction", () => {
+    startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => makeConfig(),
+    });
+    const instances = runtime.services.get(
+      N8N_RUNTIME_CONTEXT_PROVIDER_SERVICE_TYPE as never,
+    );
+    expect(instances).toBeDefined();
+    expect(instances?.length).toBe(1);
+    expect(
+      typeof (instances?.[0] as { getRuntimeContext: unknown })
+        .getRuntimeContext,
+    ).toBe("function");
+  });
+
+  it("emits empty facts when no connector config and no credProvider injected — but still lists architecturally supported cred types", async () => {
+    // Without a credProvider, the context provider can't filter by what's
+    // actually resolvable, so it falls back to MILADY_SUPPORTED_CRED_TYPES.
+    // That's the right call: the LLM should still attach the credentials
+    // block — failure to resolve at deploy time surfaces a clear `needs_auth`
+    // error, while omitting the block silently is what we're trying to fix.
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => makeConfig(),
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE],
+      relevantCredTypes: ["discordApi"],
+    });
+    expect(ctx.facts).toEqual([]);
+    expect(ctx.supportedCredentials.map((c) => c.credType)).toEqual([
+      "discordApi",
+    ]);
+  });
+
+  it("emits one fact per Discord guild with channels enumerated", async () => {
+    const config = makeConfig({
+      connectors: { discord: { token: "discord-bot-token" } },
+    });
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (typeof url === "string" && url.endsWith("/users/@me/guilds")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { id: "guild1", name: "2PM" },
+            { id: "guild2", name: "TestServer" },
+          ],
+        } as unknown as Response;
+      }
+      if (typeof url === "string" && url.includes("/guilds/guild1/channels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { id: "chan-general", name: "general", type: 0 },
+            { id: "chan-voice", name: "voice", type: 2 },
+          ],
+        } as unknown as Response;
+      }
+      if (typeof url === "string" && url.includes("/guilds/guild2/channels")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { id: "chan-other", name: "other-text", type: 0 },
+          ],
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => config,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE],
+      relevantCredTypes: ["discordApi"],
+    });
+    expect(ctx.facts).toHaveLength(2);
+    expect(ctx.facts[0]).toContain('Discord guild "2PM"');
+    expect(ctx.facts[0]).toContain("guild1");
+    expect(ctx.facts[0]).toContain("#general (chan-general)");
+    expect(ctx.facts[0]).not.toContain("voice"); // type !== 0 filtered
+    expect(ctx.facts[1]).toContain('Discord guild "TestServer"');
+    expect(ctx.facts[1]).toContain("#other-text (chan-other)");
+  });
+
+  it("emits gmail email fact when configured and a gmail node is in scope", async () => {
+    const config = makeConfig({
+      connectors: { gmail: { email: "user@example.com" } },
+    });
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => config,
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [GMAIL_NODE],
+      relevantCredTypes: ["gmailOAuth2"],
+    });
+    expect(ctx.facts).toEqual(["Connected Gmail account: user@example.com."]);
+  });
+
+  it("filters supportedCredentials by what the cred provider can actually resolve", async () => {
+    const credProvider = {
+      resolve: vi.fn(async (_userId: string, credType: string) => {
+        if (credType === "discordApi") {
+          return {
+            status: "credential_data" as const,
+            data: { botToken: "x" },
+          };
+        }
+        return {
+          status: "needs_auth" as const,
+          authUrl: "milady://settings/connectors/gmail",
+        };
+      }),
+    };
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => makeConfig(),
+      credProvider,
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE, GMAIL_NODE],
+      relevantCredTypes: ["discordApi", "gmailOAuth2"],
+    });
+    expect(ctx.supportedCredentials.map((c) => c.credType)).toEqual([
+      "discordApi",
+    ]);
+    expect(credProvider.resolve).toHaveBeenCalledWith(USER_ID, "discordApi");
+    expect(credProvider.resolve).toHaveBeenCalledWith(USER_ID, "gmailOAuth2");
+  });
+
+  it("swallows network failures and returns empty facts", async () => {
+    const config = makeConfig({
+      connectors: { discord: { token: "discord-bot-token" } },
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => config,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE],
+      relevantCredTypes: ["discordApi"],
+    });
+    expect(ctx.facts).toEqual([]);
+  });
+
+  it("does not query Discord REST when no Discord node is in scope", async () => {
+    const config = makeConfig({
+      connectors: { discord: { token: "discord-bot-token" } },
+    });
+    const fetchImpl = vi.fn();
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => config,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const ctx = await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [GMAIL_NODE],
+      relevantCredTypes: ["gmailOAuth2"],
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(ctx.facts).toEqual([]);
+  });
+
+  it("caches Discord REST responses across consecutive calls", async () => {
+    const config = makeConfig({
+      connectors: { discord: { token: "tok" } },
+    });
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (typeof url === "string" && url.endsWith("/users/@me/guilds")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ id: "g", name: "G" }],
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [],
+      } as unknown as Response;
+    });
+    const handle = startMiladyN8nRuntimeContextProvider(runtime, {
+      getConfig: () => config,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE],
+      relevantCredTypes: ["discordApi"],
+    });
+    const firstCallCount = fetchImpl.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThan(0);
+    await handle.service.getRuntimeContext({
+      userId: USER_ID,
+      relevantNodes: [DISCORD_NODE],
+      relevantCredTypes: ["discordApi"],
+    });
+    expect(fetchImpl.mock.calls.length).toBe(firstCallCount);
+  });
+});

--- a/packages/app-core/src/services/n8n-runtime-context-provider.ts
+++ b/packages/app-core/src/services/n8n-runtime-context-provider.ts
@@ -61,15 +61,19 @@ export interface ConnectorConfigLike {
  * Cred types this provider considers when filtering `supportedCredentials`
  * before returning them to the plugin. Hosts that can satisfy a different
  * set should pass their own filter via `credProvider.resolve()`.
+ *
+ * Kept in sync with `CRED_TYPE_FACTS` below — every entry here must also
+ * have a `CRED_TYPE_FACTS[type]` entry, otherwise it silently drops at the
+ * `!meta` guard in `computeSupportedCredentials` (Greptile P1 caught
+ * `discordWebhookApi` and `googleOAuth2Api` previously listed here without
+ * fact entries).
  */
 const MILADY_SUPPORTED_CRED_TYPES: ReadonlySet<string> = new Set([
   "discordApi",
   "discordBotApi",
-  "discordWebhookApi",
   "telegramApi",
   "gmailOAuth2",
   "gmailOAuth2Api",
-  "googleOAuth2Api",
   "googleSheetsOAuth2Api",
   "googleCalendarOAuth2Api",
   "googleDriveOAuth2Api",

--- a/packages/app-core/src/services/n8n-runtime-context-provider.ts
+++ b/packages/app-core/src/services/n8n-runtime-context-provider.ts
@@ -99,10 +99,28 @@ interface PluginNodeDefinition {
   credentials?: Array<{ name: string; required?: boolean }>;
 }
 
+/**
+ * Originating-conversation routing context. Hosts pass this when the workflow
+ * is being generated from inside a platform conversation (e.g. a Discord DM),
+ * so the LLM can target "this channel" / "back to me" without the user
+ * naming an ID.
+ *
+ * Mirrors the shape introduced upstream in `@elizaos/plugin-n8n-workflow` —
+ * the host duplicates the type so it doesn't need to import from the plugin.
+ */
+export interface TriggerContext {
+  source?: string;
+  discord?: { channelId?: string; guildId?: string; threadId?: string };
+  telegram?: { chatId?: string | number; threadId?: string | number };
+  slack?: { channelId?: string; teamId?: string };
+  resolvedNames?: { channel?: string; server?: string };
+}
+
 interface RuntimeContextProviderInput {
   userId: string;
   relevantNodes: PluginNodeDefinition[];
   relevantCredTypes: string[];
+  triggerContext?: TriggerContext;
 }
 
 /**
@@ -212,6 +230,40 @@ export interface MiladyN8nRuntimeContextProviderHandle {
 
 /** Re-exported for tests + runtime helpers. */
 export { SERVICE_TYPE as N8N_RUNTIME_CONTEXT_PROVIDER_SERVICE_TYPE };
+
+/**
+ * Render a trigger-source fact line the LLM can read as part of the
+ * `## Runtime Facts` block. Returns `undefined` when the trigger context
+ * is empty / has no actionable platform routing info.
+ */
+function formatTriggerContextFact(
+  ctx: TriggerContext | undefined,
+): string | undefined {
+  if (!ctx) return undefined;
+  const channelName = ctx.resolvedNames?.channel;
+  const serverName = ctx.resolvedNames?.server;
+
+  if (ctx.discord?.channelId) {
+    const channelLabel = channelName ? `#${channelName}` : "the channel";
+    const serverPart = ctx.discord.guildId
+      ? serverName
+        ? ` within "${serverName}" (id ${ctx.discord.guildId})`
+        : ` within guild id ${ctx.discord.guildId}`
+      : "";
+    return `This workflow was prompted from a Discord conversation in ${channelLabel} (id ${ctx.discord.channelId})${serverPart}. When the user references "this channel" or "back to here", target that channel ID.`;
+  }
+  if (ctx.telegram?.chatId !== undefined) {
+    return `This workflow was prompted from a Telegram chat (id ${ctx.telegram.chatId}). When the user references "this chat" or "back to here", target that chat ID.`;
+  }
+  if (ctx.slack?.channelId) {
+    const teamPart = ctx.slack.teamId ? ` in team ${ctx.slack.teamId}` : "";
+    return `This workflow was prompted from a Slack channel (id ${ctx.slack.channelId})${teamPart}. When the user references "this channel" or "back to here", target that channel ID.`;
+  }
+  if (ctx.source) {
+    return `This workflow was prompted from a ${ctx.source} conversation.`;
+  }
+  return undefined;
+}
 
 export function startMiladyN8nRuntimeContextProvider(
   runtime: AgentRuntime,
@@ -391,6 +443,14 @@ export function startMiladyN8nRuntimeContextProvider(
       if (email) {
         facts.push(`Connected Gmail account: ${email}.`);
       }
+    }
+
+    // Originating-conversation routing fact. Surfaced regardless of which
+    // nodes are in scope — the user might say "post the result back here"
+    // and the relevant node search has no way to anchor that intent.
+    const triggerFact = formatTriggerContextFact(input.triggerContext);
+    if (triggerFact) {
+      facts.push(triggerFact);
     }
 
     return { supportedCredentials, facts };

--- a/packages/app-core/src/services/n8n-runtime-context-provider.ts
+++ b/packages/app-core/src/services/n8n-runtime-context-provider.ts
@@ -1,0 +1,416 @@
+/**
+ * Milady n8n runtime-context provider — registers as service type
+ * `n8n_runtime_context_provider` so the patched `@elizaos/plugin-n8n-workflow`
+ * can pull connector facts (Discord guilds + channels, Gmail email, supported
+ * credential types) into the workflow-generation prompt.
+ *
+ * Why this exists (Session 19, post-dogfood):
+ *   The plugin's `WORKFLOW_GENERATION_SYSTEM_PROMPT` previously emitted
+ *   placeholders like `guildId: "={{YOUR_SERVER_ID}}"` because the LLM had
+ *   no way to know the user's actual Discord server/channel IDs. This service
+ *   surfaces real values so the LLM substitutes them verbatim and so the
+ *   credential block lands on every relevant node.
+ *
+ * Shape returned to the plugin:
+ *
+ *   getRuntimeContext({userId, relevantNodes, relevantCredTypes}) →
+ *     {
+ *       supportedCredentials: [{ credType, friendlyName, nodeTypes[] }, ...],
+ *       facts: [
+ *         "Discord guild \"2PM\" (id 1471687731594657792) channels: ...",
+ *         "Connected Gmail account: rodolfomanhaes@gmail.com.",
+ *         ...
+ *       ],
+ *     }
+ *
+ * Failures degrade silently (empty facts) — the plugin still generates a
+ * workflow, just without runtime substitutions.
+ */
+
+import type { AgentRuntime } from "@elizaos/core";
+
+const SERVICE_TYPE = "n8n_runtime_context_provider";
+
+/**
+ * Subset of `ElizaConfig.connectors` the provider reads. Inlined so this
+ * service has no compile-time dependency on a sibling credential provider —
+ * hosts that already have one can ignore this shape, hosts that don't can
+ * still register a getConfig() that returns a literal of this type.
+ */
+export interface ConnectorConfigLike {
+  connectors?: {
+    discord?: { enabled?: boolean; token?: string };
+    telegram?: { enabled?: boolean; botToken?: string };
+    gmail?: {
+      enabled?: boolean;
+      accessToken?: string;
+      refreshToken?: string;
+      expiresAt?: number;
+      email?: string;
+    };
+    slack?: {
+      enabled?: boolean;
+      accessToken?: string;
+      refreshToken?: string;
+      expiresAt?: number;
+    };
+  };
+}
+
+/**
+ * Cred types this provider considers when filtering `supportedCredentials`
+ * before returning them to the plugin. Hosts that can satisfy a different
+ * set should pass their own filter via `credProvider.resolve()`.
+ */
+const MILADY_SUPPORTED_CRED_TYPES: ReadonlySet<string> = new Set([
+  "discordApi",
+  "discordBotApi",
+  "discordWebhookApi",
+  "telegramApi",
+  "gmailOAuth2",
+  "gmailOAuth2Api",
+  "googleOAuth2Api",
+  "googleSheetsOAuth2Api",
+  "googleCalendarOAuth2Api",
+  "googleDriveOAuth2Api",
+  "slackApi",
+  "slackOAuth2Api",
+]);
+
+interface RuntimeContextSupportedCredential {
+  credType: string;
+  friendlyName: string;
+  nodeTypes: string[];
+}
+
+export interface RuntimeContext {
+  supportedCredentials: RuntimeContextSupportedCredential[];
+  facts: string[];
+}
+
+/** Mirrors the plugin's `NodeDefinition.credentials` shape (subset). */
+interface PluginNodeDefinition {
+  name: string;
+  displayName?: string;
+  credentials?: Array<{ name: string; required?: boolean }>;
+}
+
+interface RuntimeContextProviderInput {
+  userId: string;
+  relevantNodes: PluginNodeDefinition[];
+  relevantCredTypes: string[];
+}
+
+/**
+ * Static map: which n8n cred types match which n8n node types, plus a
+ * human-friendly name for the credential block. Filtered at runtime against
+ * `MILADY_SUPPORTED_CRED_TYPES` AND against which connectors are actually
+ * configured (no point listing `gmailOAuth2` as available when the user
+ * hasn't run the OAuth flow).
+ */
+const CRED_TYPE_FACTS: Record<
+  string,
+  { friendlyName: string; nodeTypes: string[] }
+> = {
+  discordApi: {
+    friendlyName: "Discord Bot",
+    nodeTypes: ["n8n-nodes-base.discord"],
+  },
+  discordBotApi: {
+    friendlyName: "Discord Bot",
+    nodeTypes: ["n8n-nodes-base.discord"],
+  },
+  telegramApi: {
+    friendlyName: "Telegram Bot",
+    nodeTypes: [
+      "n8n-nodes-base.telegram",
+      "n8n-nodes-base.telegramTrigger",
+    ],
+  },
+  gmailOAuth2: {
+    friendlyName: "Gmail Account",
+    nodeTypes: ["n8n-nodes-base.gmail", "n8n-nodes-base.gmailTrigger"],
+  },
+  gmailOAuth2Api: {
+    friendlyName: "Gmail Account",
+    nodeTypes: ["n8n-nodes-base.gmail", "n8n-nodes-base.gmailTrigger"],
+  },
+  googleSheetsOAuth2Api: {
+    friendlyName: "Google Sheets",
+    nodeTypes: ["n8n-nodes-base.googleSheets"],
+  },
+  googleCalendarOAuth2Api: {
+    friendlyName: "Google Calendar",
+    nodeTypes: ["n8n-nodes-base.googleCalendar"],
+  },
+  googleDriveOAuth2Api: {
+    friendlyName: "Google Drive",
+    nodeTypes: ["n8n-nodes-base.googleDrive"],
+  },
+  slackOAuth2Api: {
+    friendlyName: "Slack Workspace",
+    nodeTypes: ["n8n-nodes-base.slack"],
+  },
+  slackApi: {
+    friendlyName: "Slack Workspace",
+    nodeTypes: ["n8n-nodes-base.slack"],
+  },
+};
+
+/** Cache TTL for upstream REST lookups (Discord guilds/channels). */
+const FACT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CachedFacts {
+  expiresAt: number;
+  facts: string[];
+}
+
+/**
+ * Subset of the cred provider's resolve() return values. We only check
+ * whether a cred type is actually satisfiable (`credential_data`) vs not
+ * yet wired (`needs_auth`) so we can filter `supportedCredentials` to
+ * connectors the user has actually configured.
+ */
+type CredResolveResult =
+  | { status: "credential_data"; data: Record<string, unknown> }
+  | { status: "needs_auth"; authUrl: string }
+  | null;
+
+interface CredProviderLike {
+  resolve(userId: string, credType: string): Promise<CredResolveResult>;
+}
+
+export interface MiladyN8nRuntimeContextProviderOptions {
+  /** Re-read on every call so connector edits do not require a restart. */
+  getConfig: () => ConnectorConfigLike;
+  /**
+   * Reference to the credential provider so we can ask which cred types
+   * actually have data right now (vs `needs_auth`). Optional — without it
+   * we fall back to "config has connector token" heuristics.
+   */
+  credProvider?: CredProviderLike;
+  /** Test injection seam — defaults to fetch. */
+  fetchImpl?: typeof fetch;
+  /** Test injection seam — defaults to Date.now. */
+  now?: () => number;
+}
+
+export interface MiladyN8nRuntimeContextProviderHandle {
+  service: {
+    getRuntimeContext: (
+      input: RuntimeContextProviderInput,
+    ) => Promise<RuntimeContext>;
+    stop: () => Promise<void>;
+    capabilityDescription: string;
+  };
+  stop: () => void;
+}
+
+/** Re-exported for tests + runtime helpers. */
+export { SERVICE_TYPE as N8N_RUNTIME_CONTEXT_PROVIDER_SERVICE_TYPE };
+
+export function startMiladyN8nRuntimeContextProvider(
+  runtime: AgentRuntime,
+  options: MiladyN8nRuntimeContextProviderOptions,
+): MiladyN8nRuntimeContextProviderHandle {
+  const { getConfig, credProvider } = options;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+
+  // Per-token Discord cache. Discord guilds + channels rarely change; a
+  // 5-minute window is plenty for dogfood and avoids hammering REST during a
+  // generate→modify regeneration burst.
+  const discordCache = new Map<string, CachedFacts>();
+
+  /**
+   * Enumerate the Discord bot's guilds and (text) channels. Returns one
+   * compact fact line per guild. Network failures degrade to an empty array.
+   */
+  const fetchDiscordFacts = async (botToken: string): Promise<string[]> => {
+    const cached = discordCache.get(botToken);
+    if (cached && cached.expiresAt > now()) {
+      return cached.facts;
+    }
+    try {
+      const headers = { Authorization: `Bot ${botToken}` };
+      const guildsRes = await fetchImpl(
+        "https://discord.com/api/v10/users/@me/guilds",
+        { headers },
+      );
+      if (!guildsRes.ok) {
+        runtime.logger.warn?.(
+          {
+            src: "n8n-runtime-context-provider",
+            status: guildsRes.status,
+          },
+          "Discord guilds REST returned non-ok",
+        );
+        const facts: string[] = [];
+        discordCache.set(botToken, {
+          expiresAt: now() + FACT_CACHE_TTL_MS,
+          facts,
+        });
+        return facts;
+      }
+      const guilds = (await guildsRes.json()) as Array<{
+        id: string;
+        name: string;
+      }>;
+      const facts: string[] = [];
+      for (const guild of guilds) {
+        try {
+          const channelsRes = await fetchImpl(
+            `https://discord.com/api/v10/guilds/${guild.id}/channels`,
+            { headers },
+          );
+          if (!channelsRes.ok) {
+            facts.push(
+              `Discord guild "${guild.name}" (id ${guild.id}) — channels not enumerable (status ${channelsRes.status}).`,
+            );
+            continue;
+          }
+          const channels = (await channelsRes.json()) as Array<{
+            id: string;
+            name: string;
+            type: number;
+          }>;
+          // type === 0 is GUILD_TEXT, the only kind n8n's Discord node posts to.
+          const textChannels = channels
+            .filter((c) => c.type === 0)
+            .map((c) => `#${c.name} (${c.id})`)
+            .join(", ");
+          facts.push(
+            textChannels.length > 0
+              ? `Discord guild "${guild.name}" (id ${guild.id}) channels: ${textChannels}.`
+              : `Discord guild "${guild.name}" (id ${guild.id}) — no text channels visible to the bot.`,
+          );
+        } catch (err) {
+          runtime.logger.warn?.(
+            {
+              src: "n8n-runtime-context-provider",
+              guildId: guild.id,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "Discord channels REST threw",
+          );
+        }
+      }
+      discordCache.set(botToken, {
+        expiresAt: now() + FACT_CACHE_TTL_MS,
+        facts,
+      });
+      return facts;
+    } catch (err) {
+      runtime.logger.warn?.(
+        {
+          src: "n8n-runtime-context-provider",
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Discord guilds REST threw",
+      );
+      return [];
+    }
+  };
+
+  /**
+   * Filter the static CRED_TYPE_FACTS to types that are (a) listed in
+   * MILADY_SUPPORTED_CRED_TYPES, (b) appear in the requested
+   * `relevantCredTypes` (so we only advertise types the LLM might actually
+   * use), and (c) the cred provider can satisfy with `credential_data`
+   * (so we don't promise a credential the user hasn't wired up yet).
+   */
+  const computeSupportedCredentials = async (
+    userId: string,
+    relevantCredTypes: string[],
+  ): Promise<RuntimeContextSupportedCredential[]> => {
+    const out: RuntimeContextSupportedCredential[] = [];
+    for (const credType of relevantCredTypes) {
+      if (!MILADY_SUPPORTED_CRED_TYPES.has(credType)) continue;
+      const meta = CRED_TYPE_FACTS[credType];
+      if (!meta) continue;
+      if (credProvider) {
+        try {
+          const result = await credProvider.resolve(userId, credType);
+          if (!result || result.status !== "credential_data") continue;
+        } catch (err) {
+          runtime.logger.warn?.(
+            {
+              src: "n8n-runtime-context-provider",
+              credType,
+              err: err instanceof Error ? err.message : String(err),
+            },
+            "credential provider resolve() threw — skipping cred type",
+          );
+          continue;
+        }
+      }
+      out.push({
+        credType,
+        friendlyName: meta.friendlyName,
+        nodeTypes: meta.nodeTypes,
+      });
+    }
+    return out;
+  };
+
+  const getRuntimeContext = async (
+    input: RuntimeContextProviderInput,
+  ): Promise<RuntimeContext> => {
+    const config = getConfig();
+    const connectors = config.connectors ?? {};
+
+    const supportedCredentials = await computeSupportedCredentials(
+      input.userId,
+      input.relevantCredTypes,
+    );
+
+    const facts: string[] = [];
+
+    // Discord facts — only emit when at least one relevant node uses Discord.
+    const wantsDiscord = input.relevantNodes.some((n) =>
+      n.name.startsWith("n8n-nodes-base.discord"),
+    );
+    if (wantsDiscord) {
+      const token = connectors.discord?.token?.trim();
+      if (token) {
+        const discordFacts = await fetchDiscordFacts(token);
+        for (const f of discordFacts) facts.push(f);
+      }
+    }
+
+    // Gmail facts — only when a Gmail node is in scope.
+    const wantsGmail = input.relevantNodes.some((n) =>
+      n.name.startsWith("n8n-nodes-base.gmail"),
+    );
+    if (wantsGmail) {
+      const email = connectors.gmail?.email?.trim();
+      if (email) {
+        facts.push(`Connected Gmail account: ${email}.`);
+      }
+    }
+
+    return { supportedCredentials, facts };
+  };
+
+  const service = {
+    getRuntimeContext,
+    stop: async () => {
+      discordCache.clear();
+    },
+    capabilityDescription:
+      "Provides Milady runtime facts (Discord guilds/channels, Gmail email) and supported credential types to the n8n workflow generator.",
+  };
+
+  runtime.services.set(SERVICE_TYPE as never, [service as never]);
+
+  return {
+    service,
+    stop: () => {
+      try {
+        runtime.services.delete(SERVICE_TYPE as never);
+      } catch {
+        // ignore — symmetric with other Milady bridge stop hooks
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

When a workflow is generated from inside a platform conversation (e.g. a Discord DM or a Telegram chat), surface the originating channel or chat to the LLM as a `## Runtime Facts` line. The user can say *\"post the result back to this channel\"* and the generated send node targets the right Discord channel ID / Telegram chat ID without having to name it — closing the long-tail of the same NL ergonomics goal that motivated #7134's missing-credentials banner.

## End-to-end wiring

- **`client-types-chat.ts`**: extend `N8nWorkflowGenerateRequest` with optional `bridgeConversationId`. `AutomationsView` already had the id in scope (it uses it to bind the workflow to the originating conversation); now also forwards it on the generation request.
- **`n8n-routes.ts`**: when `bridgeConversationId` is present, read the originating conversation's tail inbound message metadata via `runtime.getMemories({ roomId, tableName: \"messages\", count: 12 })`, derive a `TriggerContext` (Discord channelId/guildId, Telegram chatId/threadId, Slack channelId/teamId), and thread it into `service.generateWorkflowDraft(prompt, { triggerContext })`. The helper reads **both** the canonical `metadata.discord.{channelId,guildId}` sub-object **and** the legacy flat `discordChannelId` / `discordServerId` fields — pre-existing schema gap (canonical wins when present, flat is the fallback so nothing today breaks).
- **`n8n-runtime-context-provider.ts`**: extend `RuntimeContextProviderInput` to accept the trigger context, render it as a fact line:

  > This workflow was prompted from a Discord conversation in #general (id 9876543210) within \"Cozy Devs\" (id 1234567890). When the user references \"this channel\" or \"back to here\", target that channel ID.

  Same pattern for Telegram chats and Slack channels. Empty/missing routing data → no fact line.

## Backward compatibility

- Routes still work without `bridgeConversationId` (no triggerContext threading, baseline behavior).
- Plugin still works with hosts that don't pass triggerContext (the optional `opts` arg on `generateWorkflowDraft` is unused — see elizaos-plugins/plugin-n8n-workflow#26).

## Depends on

- **Stacks on #7163** (n8n runtime-context provider). Until that merges, this PR's diff includes the dependency. Once #7163 merges, GitHub auto-rebases and the diff collapses to the trigger-context plumbing.
- **Runtime depends on elizaos-plugins/plugin-n8n-workflow#26** (TriggerContext on RuntimeContextProviderInput). Host code compiles fine without the plugin upgrade; falls through cleanly until the plugin pointer bumps.

## Test plan

- [ ] From a Discord DM: prompt *\"every weekday at 9am post the day's calendar agenda back to this channel\"*. Inspect the deployed workflow's `Discord Send` node — `channelId` equals the originating Discord channel id, not blank, not a placeholder.
- [ ] Same prompt from a Telegram chat → `Telegram Send` node `chatId` equals the originating Telegram chat id.
- [ ] No `bridgeConversationId` in the request → behavior unchanged.

## Out of scope (follow-up)

- Persist `originChannelContext` on the workflow's conversation metadata so re-runs without a fresh inbound message still target the same channel.
- Switch upstream plugin-discord/telegram from flat metadata fields to the canonical nested `metadata.discord.{channelId,guildId,messageId}` shape — this PR's helper handles both transitionally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires originating-conversation routing (Discord channel/guild, Telegram chat, Slack channel) into the n8n workflow generator so the LLM can resolve "post back to this channel" without the user supplying an ID. It also introduces the `n8n-runtime-context-provider` service (with tests) and registers it during agent boot.

The previously-flagged P1 (`fromId` used as Telegram `chatId` fallback) has been correctly addressed — the code now skips Telegram routing rather than guess. The `discordWebhookApi`/`googleOAuth2Api` inconsistency has also been resolved. Remaining notes are P2 quality items (memory ordering comment and missing `triggerContext` test coverage).

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking issues remain — all P1s from the previous review have been addressed

The Telegram fromId P1 is fixed and the discordWebhookApi/googleOAuth2Api P2 is also resolved. All remaining findings are P2: a misleading memory-ordering comment, a trivially redundant inner conditional, and missing test coverage for the new triggerContext path. None of these block correctness.

packages/app-core/src/api/n8n-routes.ts (memory ordering comment), packages/app-core/src/services/n8n-runtime-context-provider.test.ts (missing triggerContext tests)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/n8n-routes.ts | Adds buildTriggerContextFromConversation helper and threads triggerContext into generateWorkflowDraft; the Telegram fromId P1 has been addressed but memory ordering logic has a misleading comment |
| packages/app-core/src/services/n8n-runtime-context-provider.ts | New service file; surfaces Discord/Gmail/triggerContext facts to the n8n workflow generator; well-structured with caching and defensive fallbacks |
| packages/app-core/src/services/n8n-runtime-context-provider.test.ts | New test file covering registration, Discord facts, Gmail facts, credential filtering, network failures, and caching — but no test cases for the new triggerContext / formatTriggerContextFact path |
| packages/app-core/src/runtime/eliza.ts | Registers n8n runtime-context provider via ensureN8nRuntimeContextProvider; pattern mirrors existing bridge initializers; clean lifecycle management |
| packages/app-core/src/api/client-types-chat.ts | Adds optional bridgeConversationId field to N8nWorkflowGenerateRequest; straightforward and well-documented |
| packages/app-core/src/components/pages/AutomationsView.tsx | Forwards bridgeConversationId into the workflow generation request; minimal one-line change using existing in-scope variable |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as AutomationsView (client)
    participant Route as n8n-routes (server)
    participant Runtime as AgentRuntime
    participant CtxProvider as N8nRuntimeContextProvider
    participant Service as plugin-n8n-workflow

    Client->>Route: POST /generate {prompt, bridgeConversationId}
    Route->>Runtime: getMemories({roomId: bridgeConversationId, count: 12})
    Runtime-->>Route: Memory[] (messages)
    Note over Route: buildTriggerContextFromConversation()<br/>finds first non-agent message,<br/>reads metadata.discord / metadata.telegram / metadata.slack
    Route-->>Route: TriggerContext {source, discord/telegram/slack}
    Route->>Service: generateWorkflowDraft(prompt, {triggerContext})
    Service->>CtxProvider: getRuntimeContext({userId, relevantNodes, triggerContext})
    CtxProvider-->>Service: {facts: [This workflow was prompted from Discord...], supportedCredentials: [...]}
    Service-->>Route: WorkflowDraft (with channel IDs filled in)
    Route-->>Client: WorkflowDraft JSON
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `packages/app-core/src/api/n8n-routes.ts`, line 111-117 ([link](https://github.com/elizaos/eliza/blob/4cae1c5dfebabc071b953babb33dbd2477397a3f/packages/app-core/src/api/n8n-routes.ts#L111-L117)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`fromId` is not `chatId` in Telegram group contexts**

   `meta.fromId` is the Telegram sender's *user* ID, not the chat ID. In a private DM the two happen to be the same, but in a group chat or channel the chat ID is a distinct negative integer. Using `fromId` as the fallback `chatId` will cause the generated workflow to target the individual user's DM inbox instead of the originating group, silently breaking the "post back to this channel" feature for the majority of Telegram team-chat scenarios.

   If the canonical `metadata.telegram.chatId` isn't populated, the safest fallback is `undefined` (return no Telegram trigger context) rather than a value that may route to the wrong entity.

2. `packages/app-core/src/services/n8n-runtime-context-provider.ts`, line 641-654 ([link](https://github.com/elizaos/eliza/blob/4cae1c5dfebabc071b953babb33dbd2477397a3f/packages/app-core/src/services/n8n-runtime-context-provider.ts#L641-L654)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`discordWebhookApi` and `googleOAuth2Api` silently unresolvable**

   Both `discordWebhookApi` and `googleOAuth2Api` appear in `MILADY_SUPPORTED_CRED_TYPES` but have no corresponding entry in `CRED_TYPE_FACTS`. The guard `if (!meta) continue` at line 958 silently skips them, so they are never advertised in `supportedCredentials` even when the user has configured them. Either add entries to `CRED_TYPE_FACTS` or remove these types from `MILADY_SUPPORTED_CRED_TYPES` to keep the two sets consistent.

3. `packages/app-core/src/services/n8n-runtime-context-provider.test.ts`, line 351 ([link](https://github.com/elizaos/eliza/blob/4cae1c5dfebabc071b953babb33dbd2477397a3f/packages/app-core/src/services/n8n-runtime-context-provider.test.ts#L351)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No tests for `triggerContext` propagation**

   The test file exercises Discord facts, Gmail facts, credential filtering, caching, and network failures — but there are no test cases for the new `triggerContext` / `formatTriggerContextFact` path that this PR adds. Adding at least one test per platform (Discord channel, Telegram chat, Slack channel, and the empty-context case) would close the coverage gap and guard against regressions in the fact-line wording.

4. `packages/app-core/src/api/n8n-routes.ts`, line 84-89 ([link](https://github.com/elizaos/eliza/blob/4cae1c5dfebabc071b953babb33dbd2477397a3f/packages/app-core/src/api/n8n-routes.ts#L84-L89)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Memory ordering not defensively handled**

   The comment notes that `runtime.getMemories` "typically returns most-recent-first" but also says the code "defensively handles either order." In practice, `memories.find(m => m.entityId !== runtime.agentId)` returns the **first** matching element — if the API returns oldest-first, this yields the oldest inbound message rather than the most recent one. For an active conversation this could mean routing to a stale channel/chat ID. Consider sorting by a timestamp field (if available) or explicitly documenting the assumed ordering so a future reader knows when this assumption breaks.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(n8n): drop Telegram fromId fallback ..."](https://github.com/elizaos/eliza/commit/975dc2ce12977f594f1dac862d22d44eecf9b4ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30031781)</sub>

<!-- /greptile_comment -->