### PR TITLE
[codex] Clear stale Eliza Cloud auth on relink

### DIFF
--- a/apps/app-lifeops/src/lifeops/relative-time.ts
+++ b/apps/app-lifeops/src/lifeops/relative-time.ts
@@ -18,12 +18,14 @@ import {
 
 type RelativeTimeScheduleFields = Pick<
   LifeOpsScheduleInsight,
+  | "phase"
   | "circadianState"
   | "stateConfidence"
   | "uncertaintyReason"
   | "awakeProbability"
   | "regularity"
   | "baseline"
+  | "isProbablySleeping"
   | "sleepConfidence"
   | "currentSleepStartedAt"
   | "lastSleepStartedAt"
@@ -168,6 +170,36 @@ function isAwakeState(state: LifeOpsCircadianState): boolean {
   return state === "awake" || state === "waking" || state === "winding_down";
 }
 
+function fallbackSchedulePhase(args: {
+  phase: string | null | undefined;
+  circadianState: LifeOpsCircadianState;
+  nowMs: number;
+  timezone: string;
+}): string {
+  if (typeof args.phase === "string" && args.phase.trim().length > 0) {
+    return args.phase;
+  }
+  if (
+    args.circadianState === "sleeping" ||
+    args.circadianState === "napping" ||
+    args.circadianState === "waking" ||
+    args.circadianState === "winding_down"
+  ) {
+    return args.circadianState;
+  }
+  const parts = getZonedDateParts(new Date(args.nowMs), args.timezone);
+  if (parts.hour >= 5 && parts.hour < 12) {
+    return "morning";
+  }
+  if (parts.hour >= 12 && parts.hour < 17) {
+    return "afternoon";
+  }
+  if (parts.hour >= 17 && parts.hour < 22) {
+    return "evening";
+  }
+  return "night";
+}
+
 function baselineBedtimeHour(
   baseline: LifeOpsPersonalBaseline | null | undefined,
 ): number | null {
@@ -280,16 +312,34 @@ export function resolveLifeOpsRelativeTime(args: {
     bedtimeTargetMs === null || bedtimeTargetMs > args.nowMs
       ? null
       : minutesBetween(bedtimeTargetMs, args.nowMs);
+  const phase = fallbackSchedulePhase({
+    phase: args.schedule.phase,
+    circadianState: args.schedule.circadianState,
+    nowMs: args.nowMs,
+    timezone: args.timezone,
+  });
+  const isProbablySleeping =
+    args.schedule.isProbablySleeping ||
+    isAsleepState(args.schedule.circadianState);
+  const isAwake = isAwakeState(args.schedule.circadianState);
   return {
     computedAt: new Date(args.nowMs).toISOString(),
     localNowAt: formatInstantAsRfc3339InTimeZone(
       new Date(args.nowMs),
       args.timezone,
     ),
+    phase,
     circadianState: args.schedule.circadianState,
     stateConfidence: roundConfidence(args.schedule.stateConfidence),
     uncertaintyReason: args.schedule.uncertaintyReason,
     awakeProbability,
+    isProbablySleeping,
+    isAwake,
+    awakeState: isProbablySleeping
+      ? "probably_sleeping"
+      : isAwake
+        ? "awake"
+        : "unknown",
     wakeAnchorAt,
     wakeAnchorSource,
     minutesSinceWake,

--- a/apps/app-lifeops/src/lifeops/repository.ts
+++ b/apps/app-lifeops/src/lifeops/repository.ts
@@ -1363,6 +1363,25 @@ function parseSleepEpisode(
   };
 }
 
+function deriveCircadianStateFromSchedulePhase(args: {
+  phase: string;
+  isProbablySleeping: boolean;
+  sleepStatus: LifeOpsScheduleMergedStateRecord["sleepStatus"];
+}): LifeOpsCircadianState {
+  if (
+    args.phase === "sleeping" ||
+    args.phase === "napping" ||
+    args.phase === "waking" ||
+    args.phase === "winding_down"
+  ) {
+    return args.phase;
+  }
+  if (args.isProbablySleeping || args.sleepStatus === "sleeping_now") {
+    return "sleeping";
+  }
+  return "awake";
+}
+
 function parseScheduleObservation(
   row: Record<string, unknown>,
 ): LifeOpsScheduleObservationRecord {
@@ -1378,16 +1397,16 @@ function parseScheduleObservation(
     observedAt: toText(row.observed_at),
     windowStartAt: toText(row.window_start_at),
     windowEndAt: row.window_end_at ? toText(row.window_end_at) : null,
-    circadianState: toText(row.circadian_state) as LifeOpsCircadianState,
-    stateConfidence: toNumber(row.state_confidence, 0),
-    uncertaintyReason: row.uncertainty_reason
-      ? (toText(row.uncertainty_reason) as LifeOpsUnclearReason)
+    state: toText(row.state) as LifeOpsScheduleObservationRecord["state"],
+    phase: row.phase
+      ? toText(row.phase)
       : null,
     mealLabel: row.meal_label
       ? (toText(
           row.meal_label,
         ) as LifeOpsScheduleObservationRecord["mealLabel"])
       : null,
+    confidence: toNumber(row.confidence, 0),
     metadata: parseJsonRecord(row.metadata_json),
     createdAt: toText(row.created_at),
     updatedAt: toText(row.updated_at),
@@ -1398,6 +1417,24 @@ function parseScheduleMergedState(
   row: Record<string, unknown>,
 ): LifeOpsScheduleMergedStateRecord {
   const inferredAt = toText(row.inferred_at);
+  const metadata = parseJsonRecord(row.metadata_json);
+  const sleepStatus = toText(
+    row.sleep_status,
+  ) as LifeOpsScheduleMergedStateRecord["sleepStatus"];
+  const phase = toText(row.phase);
+  const isProbablySleeping = toBoolean(row.is_probably_sleeping, false);
+  const circadianState =
+    typeof metadata.circadianState === "string"
+      ? (metadata.circadianState as LifeOpsCircadianState)
+      : deriveCircadianStateFromSchedulePhase({
+          phase,
+          isProbablySleeping,
+          sleepStatus,
+        });
+  const uncertaintyReason =
+    typeof metadata.uncertaintyReason === "string"
+      ? (metadata.uncertaintyReason as LifeOpsUnclearReason)
+      : null;
   return refreshLifeOpsRelativeTime(
     {
       id: toText(row.id),
@@ -1408,20 +1445,18 @@ function parseScheduleMergedState(
       localDate: toText(row.local_date),
       timezone: toText(row.timezone, "UTC"),
       inferredAt,
-      circadianState: toText(row.circadian_state) as LifeOpsCircadianState,
-      stateConfidence: toNumber(row.state_confidence, 0),
-      uncertaintyReason: row.uncertainty_reason
-        ? (toText(row.uncertainty_reason) as LifeOpsUnclearReason)
-        : null,
+      phase,
+      circadianState,
+      stateConfidence: toNumber(metadata.stateConfidence, toNumber(row.sleep_confidence, 0)),
+      uncertaintyReason,
       awakeProbability: parseAwakeProbability(
         row.awake_probability_json,
         inferredAt,
       ),
       regularity: parseScheduleRegularity(row.regularity_json),
-      baseline: parsePersonalBaseline(row.baseline_json),
-      sleepStatus: toText(
-        row.sleep_status,
-      ) as LifeOpsScheduleMergedStateRecord["sleepStatus"],
+      baseline: parsePersonalBaseline(metadata.baseline),
+      sleepStatus,
+      isProbablySleeping,
       sleepConfidence: toNumber(row.sleep_confidence, 0),
       currentSleepStartedAt: row.current_sleep_started_at
         ? toText(row.current_sleep_started_at)
@@ -1437,6 +1472,18 @@ function parseScheduleMergedState(
         row.last_sleep_duration_minutes !== undefined &&
         row.last_sleep_duration_minutes !== ""
           ? toNumber(row.last_sleep_duration_minutes, 0)
+          : null,
+      typicalWakeHour:
+        row.typical_wake_hour !== null &&
+        row.typical_wake_hour !== undefined &&
+        row.typical_wake_hour !== ""
+          ? toNumber(row.typical_wake_hour, 0)
+          : null,
+      typicalSleepHour:
+        row.typical_sleep_hour !== null &&
+        row.typical_sleep_hour !== undefined &&
+        row.typical_sleep_hour !== ""
+          ? toNumber(row.typical_sleep_hour, 0)
           : null,
       wakeAt: row.wake_at ? toText(row.wake_at) : null,
       firstActiveAt: row.first_active_at ? toText(row.first_active_at) : null,
@@ -1460,7 +1507,7 @@ function parseScheduleMergedState(
       contributingDeviceKinds: parseJsonArray<
         LifeOpsScheduleMergedStateRecord["contributingDeviceKinds"][number]
       >(row.contributing_device_kinds_json),
-      metadata: parseJsonRecord(row.metadata_json),
+      metadata,
       createdAt: toText(row.created_at),
       updatedAt: toText(row.updated_at),
     },
@@ -4791,14 +4838,13 @@ export class LifeOpsRepository {
       this.runtime,
       `INSERT INTO life_schedule_insights (
          id, agent_id, effective_day_key, local_date, timezone, inferred_at,
-         circadian_state, state_confidence, uncertainty_reason, sleep_status,
-         sleep_confidence,
+         phase, sleep_status, is_probably_sleeping, sleep_confidence,
          current_sleep_started_at, last_sleep_started_at, last_sleep_ended_at,
-         last_sleep_duration_minutes, wake_at, first_active_at, last_active_at,
-         last_meal_at,
+         last_sleep_duration_minutes, typical_wake_hour, typical_sleep_hour,
+         wake_at, first_active_at, last_active_at, last_meal_at,
          next_meal_label, next_meal_window_start_at, next_meal_window_end_at,
          next_meal_confidence, meals_json, awake_probability_json,
-         regularity_json, baseline_json, metadata_json, created_at, updated_at
+         regularity_json, metadata_json, created_at, updated_at
        ) VALUES (
          ${sqlQuote(insight.id)},
          ${sqlQuote(insight.agentId)},
@@ -4806,15 +4852,16 @@ export class LifeOpsRepository {
          ${sqlQuote(insight.localDate)},
          ${sqlQuote(insight.timezone)},
          ${sqlQuote(insight.inferredAt)},
-         ${sqlQuote(insight.circadianState)},
-         ${sqlNumber(insight.stateConfidence)},
-         ${sqlText(insight.uncertaintyReason)},
+         ${sqlQuote(insight.phase)},
          ${sqlQuote(insight.sleepStatus)},
+         ${sqlBoolean(insight.isProbablySleeping)},
          ${sqlNumber(insight.sleepConfidence)},
          ${sqlText(insight.currentSleepStartedAt)},
          ${sqlText(insight.lastSleepStartedAt)},
          ${sqlText(insight.lastSleepEndedAt)},
          ${sqlInteger(insight.lastSleepDurationMinutes)},
+         ${sqlNumber(insight.typicalWakeHour)},
+         ${sqlNumber(insight.typicalSleepHour)},
          ${sqlText(insight.wakeAt)},
          ${sqlText(insight.firstActiveAt)},
          ${sqlText(insight.lastActiveAt)},
@@ -4826,7 +4873,6 @@ export class LifeOpsRepository {
          ${sqlJson(insight.meals)},
          ${sqlJson(insight.awakeProbability)},
          ${sqlJson(insight.regularity)},
-         ${sqlJson(insight.baseline)},
          ${sqlJson(insight.metadata)},
          ${sqlQuote(insight.createdAt)},
          ${sqlQuote(insight.updatedAt)}
@@ -4835,15 +4881,16 @@ export class LifeOpsRepository {
          local_date = EXCLUDED.local_date,
          timezone = EXCLUDED.timezone,
          inferred_at = EXCLUDED.inferred_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         phase = EXCLUDED.phase,
          sleep_status = EXCLUDED.sleep_status,
+         is_probably_sleeping = EXCLUDED.is_probably_sleeping,
          sleep_confidence = EXCLUDED.sleep_confidence,
          current_sleep_started_at = EXCLUDED.current_sleep_started_at,
          last_sleep_started_at = EXCLUDED.last_sleep_started_at,
          last_sleep_ended_at = EXCLUDED.last_sleep_ended_at,
          last_sleep_duration_minutes = EXCLUDED.last_sleep_duration_minutes,
+         typical_wake_hour = EXCLUDED.typical_wake_hour,
+         typical_sleep_hour = EXCLUDED.typical_sleep_hour,
          wake_at = EXCLUDED.wake_at,
          first_active_at = EXCLUDED.first_active_at,
          last_active_at = EXCLUDED.last_active_at,
@@ -4855,7 +4902,6 @@ export class LifeOpsRepository {
          meals_json = EXCLUDED.meals_json,
          awake_probability_json = EXCLUDED.awake_probability_json,
          regularity_json = EXCLUDED.regularity_json,
-         baseline_json = EXCLUDED.baseline_json,
          metadata_json = EXCLUDED.metadata_json,
          updated_at = EXCLUDED.updated_at`,
     );
@@ -4925,8 +4971,8 @@ export class LifeOpsRepository {
       this.runtime,
       `INSERT INTO life_schedule_observations (
          id, agent_id, origin, device_id, device_kind, timezone, observed_at,
-         window_start_at, window_end_at, circadian_state, state_confidence,
-         uncertainty_reason, meal_label, metadata_json, created_at, updated_at
+         window_start_at, window_end_at, state, phase, meal_label, confidence,
+         metadata_json, created_at, updated_at
        ) VALUES (
          ${sqlQuote(observation.id)},
          ${sqlQuote(observation.agentId)},
@@ -4937,10 +4983,10 @@ export class LifeOpsRepository {
          ${sqlQuote(observation.observedAt)},
          ${sqlQuote(observation.windowStartAt)},
          ${sqlText(observation.windowEndAt)},
-         ${sqlQuote(observation.circadianState)},
-         ${sqlNumber(observation.stateConfidence)},
-         ${sqlText(observation.uncertaintyReason)},
+         ${sqlQuote(observation.state)},
+         ${sqlText(observation.phase)},
          ${sqlText(observation.mealLabel)},
+         ${sqlNumber(observation.confidence)},
          ${sqlJson(observation.metadata)},
          ${sqlQuote(observation.createdAt)},
          ${sqlQuote(observation.updatedAt)}
@@ -4948,10 +4994,10 @@ export class LifeOpsRepository {
        ON CONFLICT(id) DO UPDATE SET
          observed_at = EXCLUDED.observed_at,
          window_end_at = EXCLUDED.window_end_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         state = EXCLUDED.state,
+         phase = EXCLUDED.phase,
          meal_label = EXCLUDED.meal_label,
+         confidence = EXCLUDED.confidence,
          metadata_json = EXCLUDED.metadata_json,
          updated_at = EXCLUDED.updated_at`,
     );
@@ -4992,18 +5038,25 @@ export class LifeOpsRepository {
   async upsertScheduleMergedState(
     state: LifeOpsScheduleMergedStateRecord,
   ): Promise<void> {
+    const persistedMetadata = {
+      ...state.metadata,
+      circadianState: state.circadianState,
+      stateConfidence: state.stateConfidence,
+      uncertaintyReason: state.uncertaintyReason,
+      baseline: state.baseline,
+    };
     await executeRawSql(
       this.runtime,
       `INSERT INTO life_schedule_merged_states (
          id, agent_id, scope, effective_day_key, local_date, timezone,
-         merged_at, inferred_at, circadian_state, state_confidence,
-         uncertainty_reason, sleep_status, sleep_confidence,
+         merged_at, inferred_at, phase, sleep_status, is_probably_sleeping,
+         sleep_confidence,
          current_sleep_started_at, last_sleep_started_at,
          last_sleep_ended_at, last_sleep_duration_minutes,
-         wake_at, first_active_at, last_active_at,
+         typical_wake_hour, typical_sleep_hour, wake_at, first_active_at, last_active_at,
          last_meal_at, next_meal_label, next_meal_window_start_at,
          next_meal_window_end_at, next_meal_confidence, meals_json,
-         awake_probability_json, regularity_json, baseline_json,
+         awake_probability_json, regularity_json,
          observation_count, device_count, contributing_device_kinds_json,
          metadata_json, created_at, updated_at
        ) VALUES (
@@ -5015,15 +5068,16 @@ export class LifeOpsRepository {
          ${sqlQuote(state.timezone)},
          ${sqlQuote(state.mergedAt)},
          ${sqlQuote(state.inferredAt)},
-         ${sqlQuote(state.circadianState)},
-         ${sqlNumber(state.stateConfidence)},
-         ${sqlText(state.uncertaintyReason)},
+         ${sqlQuote(state.phase)},
          ${sqlQuote(state.sleepStatus)},
+         ${sqlBoolean(state.isProbablySleeping)},
          ${sqlNumber(state.sleepConfidence)},
          ${sqlText(state.currentSleepStartedAt)},
          ${sqlText(state.lastSleepStartedAt)},
          ${sqlText(state.lastSleepEndedAt)},
          ${sqlInteger(state.lastSleepDurationMinutes)},
+         ${sqlNumber(state.typicalWakeHour)},
+         ${sqlNumber(state.typicalSleepHour)},
          ${sqlText(state.wakeAt)},
          ${sqlText(state.firstActiveAt)},
          ${sqlText(state.lastActiveAt)},
@@ -5035,11 +5089,10 @@ export class LifeOpsRepository {
          ${sqlJson(state.meals)},
          ${sqlJson(state.awakeProbability)},
          ${sqlJson(state.regularity)},
-         ${state.baseline === null ? "NULL" : sqlJson(state.baseline)},
          ${sqlInteger(state.observationCount)},
          ${sqlInteger(state.deviceCount)},
          ${sqlJson(state.contributingDeviceKinds)},
-         ${sqlJson(state.metadata)},
+         ${sqlJson(persistedMetadata)},
          ${sqlQuote(state.createdAt)},
          ${sqlQuote(state.updatedAt)}
        )
@@ -5048,15 +5101,16 @@ export class LifeOpsRepository {
          local_date = EXCLUDED.local_date,
          merged_at = EXCLUDED.merged_at,
          inferred_at = EXCLUDED.inferred_at,
-         circadian_state = EXCLUDED.circadian_state,
-         state_confidence = EXCLUDED.state_confidence,
-         uncertainty_reason = EXCLUDED.uncertainty_reason,
+         phase = EXCLUDED.phase,
          sleep_status = EXCLUDED.sleep_status,
+         is_probably_sleeping = EXCLUDED.is_probably_sleeping,
          sleep_confidence = EXCLUDED.sleep_confidence,
          current_sleep_started_at = EXCLUDED.current_sleep_started_at,
          last_sleep_started_at = EXCLUDED.last_sleep_started_at,
          last_sleep_ended_at = EXCLUDED.last_sleep_ended_at,
          last_sleep_duration_minutes = EXCLUDED.last_sleep_duration_minutes,
+         typical_wake_hour = EXCLUDED.typical_wake_hour,
+         typical_sleep_hour = EXCLUDED.typical_sleep_hour,
          wake_at = EXCLUDED.wake_at,
          first_active_at = EXCLUDED.first_active_at,
          last_active_at = EXCLUDED.last_active_at,
@@ -5068,7 +5122,6 @@ export class LifeOpsRepository {
          meals_json = EXCLUDED.meals_json,
          awake_probability_json = EXCLUDED.awake_probability_json,
          regularity_json = EXCLUDED.regularity_json,
-         baseline_json = EXCLUDED.baseline_json,
          observation_count = EXCLUDED.observation_count,
          device_count = EXCLUDED.device_count,
          contributing_device_kinds_json = EXCLUDED.contributing_device_kinds_json,

--- a/apps/app-lifeops/src/lifeops/schedule-insight.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-insight.ts
@@ -488,6 +488,27 @@ function deriveCircadianState(args: {
   };
 }
 
+function resolveSchedulePhase(args: {
+  nowMs: number;
+  timezone: string;
+  circadianState: LifeOpsCircadianState;
+  sleepCycle: Pick<LifeOpsSleepCycle, "isProbablySleeping" | "cycleType">;
+}): string {
+  if (args.sleepCycle.isProbablySleeping) {
+    return args.sleepCycle.cycleType === "nap" ? "napping" : "sleeping";
+  }
+  if (args.circadianState === "waking" || args.circadianState === "winding_down") {
+    return args.circadianState;
+  }
+
+  const local = getZonedDateParts(new Date(args.nowMs), args.timezone);
+  const hour = local.hour + local.minute / 60;
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 17) return "afternoon";
+  if (hour >= 17 && hour < 22) return "evening";
+  return "night";
+}
+
 function toHistoricalSleepEpisodes(
   episodes: readonly LifeOpsSleepEpisode[],
 ): SleepRegularityEpisodeLike[] {
@@ -592,6 +613,12 @@ function analyzeLifeOpsScheduleInsight(args: {
     });
 
   const sleepStatus = sleepCycle.sleepStatus;
+  const phase = resolveSchedulePhase({
+    nowMs: args.nowMs,
+    timezone: args.timezone,
+    circadianState,
+    sleepCycle,
+  });
   const effectiveDayKey = dayBoundary.effectiveDayKey;
   const wakeAt = sleepCycle.lastSleepEndedAt;
   const relativeTime = resolveLifeOpsRelativeTime({
@@ -620,6 +647,7 @@ function analyzeLifeOpsScheduleInsight(args: {
       localDate: dayBoundary.localDate,
       timezone: args.timezone,
       inferredAt: new Date(args.nowMs).toISOString(),
+      phase,
       circadianState,
       stateConfidence,
       uncertaintyReason,
@@ -628,11 +656,14 @@ function analyzeLifeOpsScheduleInsight(args: {
       regularity,
       baseline,
       sleepStatus,
+      isProbablySleeping: sleepCycle.isProbablySleeping,
       sleepConfidence: Math.max(sleepCycle.sleepConfidence, awakeProbability.pAsleep),
       currentSleepStartedAt: sleepCycle.currentSleepStartedAt,
       lastSleepStartedAt: sleepCycle.lastSleepStartedAt,
       lastSleepEndedAt: sleepCycle.lastSleepEndedAt,
       lastSleepDurationMinutes: sleepCycle.lastSleepDurationMinutes,
+      typicalWakeHour: sleepResolution.typicalWakeHour,
+      typicalSleepHour: sleepResolution.typicalSleepHour,
       wakeAt,
       firstActiveAt: toIso(firstActiveAtMs),
       lastActiveAt: toIso(lastActiveAtMs),

--- a/apps/app-lifeops/src/lifeops/schedule-state.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-state.ts
@@ -17,6 +17,7 @@ import type {
   LifeOpsScheduleMergedState,
   LifeOpsScheduleObservation,
   LifeOpsScheduleObservationOrigin,
+  LifeOpsScheduleObservationState,
   LifeOpsScheduleObservationSnapshot,
   LifeOpsScheduleStateScope,
   SyncLifeOpsScheduleObservationInput,
@@ -34,13 +35,14 @@ export const SCHEDULE_OBSERVATION_LOOKBACK_MS = 48 * 60 * 60 * 1_000;
 export const SCHEDULE_CLOUD_SYNC_TTL_MS = 15 * 60 * 1_000;
 export const SCHEDULE_CLOUD_STATE_FRESH_MS = 45 * 60 * 1_000;
 
-const OBSERVATION_TTL_MS: Record<LifeOpsCircadianState, number> = {
-  awake: 4 * 60 * 60 * 1_000,
+const OBSERVATION_TTL_MS: Record<LifeOpsScheduleObservationState, number> = {
+  probably_awake: 4 * 60 * 60 * 1_000,
+  probably_sleeping: 8 * 60 * 60 * 1_000,
+  woke_recently: 2 * 60 * 60 * 1_000,
   winding_down: 3 * 60 * 60 * 1_000,
-  sleeping: 8 * 60 * 60 * 1_000,
-  waking: 2 * 60 * 60 * 1_000,
-  napping: 2 * 60 * 60 * 1_000,
-  unclear: 60 * 60 * 1_000,
+  meal_window_likely: 6 * 60 * 60 * 1_000,
+  ate_recently: 4 * 60 * 60 * 1_000,
+  active_recently: 90 * 60 * 1_000,
 };
 
 const STATE_RANK: Record<LifeOpsCircadianState, number> = {
@@ -134,6 +136,83 @@ function isAsleepState(state: LifeOpsCircadianState): boolean {
   return state === "sleeping" || state === "napping";
 }
 
+function defaultPhaseForInstant(args: {
+  circadianState: LifeOpsCircadianState;
+  observedAt: string;
+  timezone: string;
+}): string {
+  if (
+    args.circadianState === "sleeping" ||
+    args.circadianState === "napping" ||
+    args.circadianState === "waking" ||
+    args.circadianState === "winding_down"
+  ) {
+    return args.circadianState;
+  }
+  const parts = getZonedDateParts(new Date(args.observedAt), args.timezone);
+  if (parts.hour >= 5 && parts.hour < 12) {
+    return "morning";
+  }
+  if (parts.hour >= 12 && parts.hour < 17) {
+    return "afternoon";
+  }
+  if (parts.hour >= 17 && parts.hour < 22) {
+    return "evening";
+  }
+  return "night";
+}
+
+function observationStateFromCircadianState(
+  state: LifeOpsCircadianState,
+): LifeOpsScheduleObservationState {
+  switch (state) {
+    case "sleeping":
+    case "napping":
+      return "probably_sleeping";
+    case "waking":
+      return "woke_recently";
+    case "winding_down":
+      return "winding_down";
+    case "awake":
+      return "probably_awake";
+    case "unclear":
+    default:
+      return "active_recently";
+  }
+}
+
+function circadianStateFromObservation(args: {
+  state: LifeOpsScheduleObservationState;
+  phase: string | null | undefined;
+}): LifeOpsCircadianState {
+  if (args.phase === "sleeping") {
+    return "sleeping";
+  }
+  if (args.phase === "napping") {
+    return "napping";
+  }
+  if (args.phase === "waking") {
+    return "waking";
+  }
+  if (args.phase === "winding_down") {
+    return "winding_down";
+  }
+  switch (args.state) {
+    case "probably_sleeping":
+      return "sleeping";
+    case "woke_recently":
+      return "waking";
+    case "winding_down":
+      return "winding_down";
+    case "meal_window_likely":
+    case "ate_recently":
+    case "active_recently":
+    case "probably_awake":
+    default:
+      return "awake";
+  }
+}
+
 function snapshotUncertainty(
   state: LifeOpsCircadianState,
   reason: LifeOpsUnclearReason | null | undefined,
@@ -144,22 +223,47 @@ function snapshotUncertainty(
 function toObservationSnapshot(
   insight: LifeOpsScheduleInsight,
 ): LifeOpsScheduleObservationSnapshot {
+  const circadianState =
+    typeof insight.circadianState === "string"
+      ? insight.circadianState
+      : circadianStateFromObservation({
+          state:
+            insight.isProbablySleeping === true
+              ? "probably_sleeping"
+              : insight.phase === "waking"
+                ? "woke_recently"
+                : insight.phase === "winding_down"
+                  ? "winding_down"
+                  : "probably_awake",
+          phase: insight.phase,
+        });
+  const stateConfidence = roundConfidence(
+    insight.stateConfidence ??
+      insight.relativeTime?.confidence ??
+      insight.sleepConfidence,
+  );
   return {
     effectiveDayKey: insight.effectiveDayKey,
     localDate: insight.localDate,
-    circadianState: insight.circadianState,
-    stateConfidence: roundConfidence(insight.stateConfidence),
-    uncertaintyReason: insight.uncertaintyReason,
+    phase: insight.phase,
+    circadianState,
+    stateConfidence,
+    uncertaintyReason: insight.uncertaintyReason ?? null,
     relativeTime: insight.relativeTime,
-    awakeProbability: insight.awakeProbability,
-    regularity: insight.regularity,
-    baseline: insight.baseline,
+    awakeProbability:
+      insight.awakeProbability ??
+      defaultAwakeProbability(insight.relativeTime.computedAt),
+    regularity: insight.regularity ?? defaultScheduleRegularity(),
+    baseline: insight.baseline ?? null,
     sleepStatus: insight.sleepStatus,
+    isProbablySleeping: insight.isProbablySleeping,
     sleepConfidence: roundConfidence(insight.sleepConfidence),
     currentSleepStartedAt: insight.currentSleepStartedAt,
     lastSleepStartedAt: insight.lastSleepStartedAt,
     lastSleepEndedAt: insight.lastSleepEndedAt,
     lastSleepDurationMinutes: insight.lastSleepDurationMinutes,
+    typicalWakeHour: insight.typicalWakeHour,
+    typicalSleepHour: insight.typicalSleepHour,
     wakeAt: insight.wakeAt,
     firstActiveAt: insight.firstActiveAt,
     lastActiveAt: insight.lastActiveAt,
@@ -228,7 +332,7 @@ function observationId(args: {
   agentId: string;
   origin: LifeOpsScheduleObservationOrigin;
   deviceId: string;
-  circadianState: LifeOpsCircadianState;
+  state: LifeOpsScheduleObservationState;
   windowStartAt: string;
   mealLabel: LifeOpsScheduleMealLabel | null;
 }): string {
@@ -239,7 +343,7 @@ function observationId(args: {
         args.agentId,
         args.origin,
         args.deviceId,
-        args.circadianState,
+        args.state,
         args.windowStartAt,
         args.mealLabel ?? "",
       ].join("|"),
@@ -256,9 +360,9 @@ function buildObservationRecord(args: {
   deviceKind: LifeOpsScheduleDeviceKind;
   timezone: string;
   observedAt: string;
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
+  phase: string | null;
+  confidence: number;
   mealLabel: LifeOpsScheduleMealLabel | null;
   windowStartAt: string;
   windowEndAt: string | null;
@@ -269,7 +373,7 @@ function buildObservationRecord(args: {
       agentId: args.agentId,
       origin: args.origin,
       deviceId: args.deviceId,
-      circadianState: args.circadianState,
+      state: args.state,
       windowStartAt: args.windowStartAt,
       mealLabel: args.mealLabel,
     }),
@@ -281,10 +385,10 @@ function buildObservationRecord(args: {
     observedAt: args.observedAt,
     windowStartAt: args.windowStartAt,
     windowEndAt: args.windowEndAt,
-    circadianState: args.circadianState,
-    stateConfidence: roundConfidence(args.stateConfidence),
-    uncertaintyReason: args.uncertaintyReason,
+    state: args.state,
+    phase: args.phase,
     mealLabel: args.mealLabel,
+    confidence: roundConfidence(args.confidence),
     metadata: args.metadata,
     createdAt: args.observedAt,
     updatedAt: args.observedAt,
@@ -365,9 +469,9 @@ export function deriveLocalScheduleObservations(args: {
         deviceKind: args.deviceKind,
         timezone: args.timezone,
         observedAt,
-        circadianState: snapshot.circadianState,
-        stateConfidence: snapshot.stateConfidence,
-        uncertaintyReason: snapshot.uncertaintyReason,
+        state: observationStateFromCircadianState(snapshot.circadianState),
+        phase: snapshot.phase,
+        confidence: snapshot.stateConfidence,
         mealLabel: null,
         windowStartAt,
         windowEndAt:
@@ -395,9 +499,9 @@ export function deriveLocalScheduleObservations(args: {
         deviceKind: args.deviceKind,
         timezone: args.timezone,
         observedAt,
-        circadianState: "awake",
-        stateConfidence: snapshot.nextMealConfidence,
-        uncertaintyReason: null,
+        state: "meal_window_likely",
+        phase: snapshot.phase,
+        confidence: snapshot.nextMealConfidence,
         mealLabel: snapshot.nextMealLabel,
         windowStartAt: snapshot.nextMealWindowStartAt,
         windowEndAt:
@@ -431,11 +535,29 @@ function recordFromSyncInput(args: {
     args.timezone,
     "ceil",
   );
-  const circadianState = args.input.circadianState;
+  const circadianState = circadianStateFromObservation({
+    state: args.input.state,
+    phase:
+      typeof args.input.phase === "string"
+        ? args.input.phase
+        : typeof snapshotSource.phase === "string"
+          ? snapshotSource.phase
+          : null,
+  });
   const uncertaintyReason = snapshotUncertainty(
     circadianState,
-    args.input.uncertaintyReason,
+    snapshotSource.uncertaintyReason,
   );
+  const phase =
+    typeof snapshotSource.phase === "string"
+      ? snapshotSource.phase
+      : typeof args.input.phase === "string"
+        ? args.input.phase
+        : defaultPhaseForInstant({
+            circadianState,
+            observedAt: args.observedAt,
+            timezone: args.timezone,
+          });
   const snapshotBase = {
     effectiveDayKey:
       typeof snapshotSource.effectiveDayKey === "string"
@@ -449,9 +571,10 @@ function recordFromSyncInput(args: {
         : getLocalDateKey(
             getZonedDateParts(new Date(args.observedAt), args.timezone),
           ),
+    phase,
     circadianState,
     stateConfidence: roundConfidence(
-      snapshotSource.stateConfidence ?? args.input.stateConfidence,
+      snapshotSource.stateConfidence ?? args.input.confidence,
     ),
     uncertaintyReason,
     awakeProbability:
@@ -459,8 +582,10 @@ function recordFromSyncInput(args: {
     regularity: snapshotSource.regularity ?? defaultScheduleRegularity(),
     baseline: snapshotSource.baseline ?? null,
     sleepStatus: snapshotSource.sleepStatus ?? "unknown",
+    isProbablySleeping:
+      snapshotSource.isProbablySleeping ?? isAsleepState(circadianState),
     sleepConfidence: roundConfidence(
-      snapshotSource.sleepConfidence ?? args.input.stateConfidence,
+      snapshotSource.sleepConfidence ?? args.input.confidence,
     ),
     currentSleepStartedAt:
       bucketIso(snapshotSource.currentSleepStartedAt, args.timezone, "floor") ??
@@ -480,6 +605,16 @@ function recordFromSyncInput(args: {
     lastSleepDurationMinutes: normalizeDurationMinutes(
       snapshotSource.lastSleepDurationMinutes ?? null,
     ),
+    typicalWakeHour:
+      typeof snapshotSource.typicalWakeHour === "number" &&
+      Number.isFinite(snapshotSource.typicalWakeHour)
+        ? snapshotSource.typicalWakeHour
+        : null,
+    typicalSleepHour:
+      typeof snapshotSource.typicalSleepHour === "number" &&
+      Number.isFinite(snapshotSource.typicalSleepHour)
+        ? snapshotSource.typicalSleepHour
+        : null,
     wakeAt:
       bucketIso(snapshotSource.wakeAt, args.timezone, "nearest") ??
       (circadianState === "waking"
@@ -505,7 +640,7 @@ function recordFromSyncInput(args: {
       (args.input.mealLabel ? bucketedWindowEndAt : null),
     nextMealConfidence: roundConfidence(
       snapshotSource.nextMealConfidence ??
-        (args.input.mealLabel ? args.input.stateConfidence : 0),
+        (args.input.mealLabel ? args.input.confidence : 0),
     ),
   } satisfies Omit<LifeOpsScheduleObservationSnapshot, "relativeTime">;
   const snapshot: LifeOpsScheduleObservationSnapshot = {
@@ -523,9 +658,9 @@ function recordFromSyncInput(args: {
     deviceKind: args.deviceKind,
     timezone: args.timezone,
     observedAt: args.observedAt,
-    circadianState,
-    stateConfidence: args.input.stateConfidence,
-    uncertaintyReason,
+    state: args.input.state,
+    phase,
+    confidence: args.input.confidence,
     mealLabel: args.input.mealLabel ?? snapshot.nextMealLabel ?? null,
     windowStartAt: bucketedWindowStartAt,
     windowEndAt: bucketedWindowEndAt,
@@ -572,7 +707,7 @@ function observationRelevant(
   if (observedMs === null) {
     return false;
   }
-  const ttl = OBSERVATION_TTL_MS[observation.circadianState];
+  const ttl = OBSERVATION_TTL_MS[observation.state];
   if (observedMs >= nowMs - ttl) {
     return true;
   }
@@ -644,8 +779,8 @@ function bestObservation(
   }
   return (
     matches.sort((left, right) => {
-      if (right.stateConfidence !== left.stateConfidence) {
-        return right.stateConfidence - left.stateConfidence;
+      if (right.confidence !== left.confidence) {
+        return right.confidence - left.confidence;
       }
       const leftMs = parseIsoMs(left.observedAt) ?? 0;
       const rightMs = parseIsoMs(right.observedAt) ?? 0;
@@ -667,7 +802,7 @@ function mergedMeals(
     .map((observation) => ({
       label: observation.mealLabel as LifeOpsScheduleMealLabel,
       detectedAt: observation.windowStartAt,
-      confidence: roundConfidence(observation.stateConfidence),
+      confidence: roundConfidence(observation.confidence),
       source: "expected_window" as const,
     }));
   const unique = new Map<string, LifeOpsScheduleMealInsight>();
@@ -684,35 +819,55 @@ function resolveMergedCircadianState(relevant: LifeOpsScheduleObservation[]): {
   uncertaintyReason: LifeOpsUnclearReason | null;
 } {
   const candidates = relevant.filter(
-    (observation) => observation.circadianState !== "unclear",
+    (observation) =>
+      circadianStateFromObservation({
+        state: observation.state,
+        phase: observation.phase,
+      }) !== "unclear",
   );
   if (candidates.length === 0) {
     const fallback = relevant[0];
     return {
-      circadianState: fallback?.circadianState ?? "unclear",
-      stateConfidence: fallback?.stateConfidence ?? 0,
+      circadianState: fallback
+        ? circadianStateFromObservation({
+            state: fallback.state,
+            phase: fallback.phase,
+          })
+        : "unclear",
+      stateConfidence: fallback?.confidence ?? 0,
       uncertaintyReason:
-        fallback?.uncertaintyReason ??
+        (fallback ? observationSnapshot(fallback)?.uncertaintyReason : null) ??
         (relevant.length === 0 ? "no_signals" : "contradictory_signals"),
     };
   }
   const best = candidates.sort((left, right) => {
+    const leftState = circadianStateFromObservation({
+      state: left.state,
+      phase: left.phase,
+    });
+    const rightState = circadianStateFromObservation({
+      state: right.state,
+      phase: right.phase,
+    });
     const rankDelta =
-      STATE_RANK[right.circadianState] - STATE_RANK[left.circadianState];
+      STATE_RANK[rightState] - STATE_RANK[leftState];
     if (rankDelta !== 0) {
       return rankDelta;
     }
-    if (right.stateConfidence !== left.stateConfidence) {
-      return right.stateConfidence - left.stateConfidence;
+    if (right.confidence !== left.confidence) {
+      return right.confidence - left.confidence;
     }
     const leftMs = parseIsoMs(left.observedAt) ?? 0;
     const rightMs = parseIsoMs(right.observedAt) ?? 0;
     return rightMs - leftMs;
   })[0]!;
   return {
-    circadianState: best.circadianState,
-    stateConfidence: best.stateConfidence,
-    uncertaintyReason: best.uncertaintyReason,
+    circadianState: circadianStateFromObservation({
+      state: best.state,
+      phase: best.phase,
+    }),
+    stateConfidence: best.confidence,
+    uncertaintyReason: observationSnapshot(best)?.uncertaintyReason ?? null,
   };
 }
 
@@ -733,15 +888,26 @@ export function mergeScheduleObservations(args: {
     resolveMergedCircadianState(relevant);
   const currentSleep = bestObservation(
     relevant,
-    (observation) => isAsleepState(observation.circadianState),
+    (observation) =>
+      isAsleepState(
+        circadianStateFromObservation({
+          state: observation.state,
+          phase: observation.phase,
+        }),
+      ),
   );
   const recentWake = bestObservation(
     relevant,
-    (observation) => observation.circadianState === "waking",
+    (observation) =>
+      circadianStateFromObservation({
+        state: observation.state,
+        phase: observation.phase,
+      }) === "waking",
   );
   const mealWindow = bestObservation(
     relevant,
-    (observation) => observation.mealLabel !== null,
+    (observation) =>
+      observation.state === "meal_window_likely" || observation.mealLabel !== null,
   );
   const currentSleepStartedAt =
     latestSnapshotValue(relevant, (snapshot) => snapshot.currentSleepStartedAt) ??
@@ -764,7 +930,11 @@ export function mergeScheduleObservations(args: {
     latestSnapshotValue(relevant, (snapshot) => snapshot.lastActiveAt) ??
     bestObservation(
       relevant,
-      (observation) => observation.circadianState === "awake",
+      (observation) =>
+        circadianStateFromObservation({
+          state: observation.state,
+          phase: observation.phase,
+        }) === "awake",
     )?.windowStartAt ??
     null;
   const sleepStatus =
@@ -776,7 +946,7 @@ export function mergeScheduleObservations(args: {
           ? "likely_missed"
           : "unknown";
   const sleepConfidence = roundConfidence(
-    currentSleep?.stateConfidence ??
+    currentSleep?.confidence ??
       latestSnapshotValue(relevant, (snapshot) => snapshot.sleepConfidence) ??
       0,
   );
@@ -804,12 +974,20 @@ export function mergeScheduleObservations(args: {
     nowMs,
     timezone: args.timezone,
     schedule: {
+      phase:
+        bestObservation(relevant, (observation) => observation.phase !== null)
+          ?.phase ?? defaultPhaseForInstant({
+            circadianState,
+            observedAt: mergedAt,
+            timezone: args.timezone,
+          }),
       circadianState,
       stateConfidence,
       uncertaintyReason,
       awakeProbability,
       regularity,
       baseline,
+      isProbablySleeping: isAsleepState(circadianState),
       sleepConfidence,
       currentSleepStartedAt,
       lastSleepStartedAt,
@@ -858,7 +1036,7 @@ export function mergeScheduleObservations(args: {
         : null;
   const nextMealConfidence = roundConfidence(
     mealWindowSource === "observation"
-      ? (mealWindow?.stateConfidence ?? 0)
+      ? (mealWindow?.confidence ?? 0)
       : mealWindowSource === "snapshot"
         ? (latestSnapshotValue(
             relevant,
@@ -869,6 +1047,18 @@ export function mergeScheduleObservations(args: {
   const contributingDeviceKinds = [
     ...new Set(relevant.map((observation) => observation.deviceKind)),
   ];
+  const phase = relativeTime.phase;
+  const isProbablySleeping =
+    latestSnapshotValue(relevant, (snapshot) => snapshot.isProbablySleeping) ??
+    isAsleepState(circadianState);
+  const typicalWakeHour = latestSnapshotValue(
+    relevant,
+    (snapshot) => snapshot.typicalWakeHour,
+  );
+  const typicalSleepHour = latestSnapshotValue(
+    relevant,
+    (snapshot) => snapshot.typicalSleepHour,
+  );
   return {
     id: `lifeops-schedule-merged:${args.agentId}:${args.scope}:${args.timezone}`,
     agentId: args.agentId,
@@ -878,6 +1068,7 @@ export function mergeScheduleObservations(args: {
     localDate,
     timezone: args.timezone,
     inferredAt: mergedAt,
+    phase,
     circadianState,
     stateConfidence: roundConfidence(stateConfidence),
     uncertaintyReason,
@@ -886,6 +1077,7 @@ export function mergeScheduleObservations(args: {
     regularity,
     baseline,
     sleepStatus,
+    isProbablySleeping,
     sleepConfidence,
     currentSleepStartedAt,
     lastSleepStartedAt,
@@ -895,6 +1087,8 @@ export function mergeScheduleObservations(args: {
         relevant,
         (snapshot) => snapshot.lastSleepDurationMinutes,
       ) ?? null,
+    typicalWakeHour,
+    typicalSleepHour,
     wakeAt,
     firstActiveAt,
     lastActiveAt,
@@ -913,6 +1107,10 @@ export function mergeScheduleObservations(args: {
       deviceIds: [
         ...new Set(relevant.map((observation) => observation.deviceId)),
       ],
+      circadianState,
+      stateConfidence: roundConfidence(stateConfidence),
+      uncertaintyReason,
+      baseline,
       relativeTime,
     },
     createdAt: mergedAt,

--- a/apps/app-lifeops/src/lifeops/schedule-sync-contracts.ts
+++ b/apps/app-lifeops/src/lifeops/schedule-sync-contracts.ts
@@ -30,6 +30,19 @@ export const LIFEOPS_SCHEDULE_OBSERVATION_ORIGINS = [
 export type LifeOpsScheduleObservationOrigin =
   (typeof LIFEOPS_SCHEDULE_OBSERVATION_ORIGINS)[number];
 
+export const LIFEOPS_SCHEDULE_OBSERVATION_STATES = [
+  "probably_awake",
+  "probably_sleeping",
+  "woke_recently",
+  "winding_down",
+  "meal_window_likely",
+  "ate_recently",
+  "active_recently",
+] as const;
+
+export type LifeOpsScheduleObservationState =
+  (typeof LIFEOPS_SCHEDULE_OBSERVATION_STATES)[number];
+
 export const LIFEOPS_SCHEDULE_STATE_SCOPES = ["local", "cloud"] as const;
 
 export type LifeOpsScheduleStateScope =
@@ -38,6 +51,7 @@ export type LifeOpsScheduleStateScope =
 export interface LifeOpsScheduleObservationSnapshot {
   effectiveDayKey: string;
   localDate: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
@@ -46,11 +60,14 @@ export interface LifeOpsScheduleObservationSnapshot {
   regularity: LifeOpsScheduleRegularity;
   baseline: LifeOpsPersonalBaseline | null;
   sleepStatus: LifeOpsScheduleSleepStatus;
+  isProbablySleeping: boolean;
   sleepConfidence: number;
   currentSleepStartedAt: string | null;
   lastSleepStartedAt: string | null;
   lastSleepEndedAt: string | null;
   lastSleepDurationMinutes: number | null;
+  typicalWakeHour: number | null;
+  typicalSleepHour: number | null;
   wakeAt: string | null;
   firstActiveAt: string | null;
   lastActiveAt: string | null;
@@ -71,10 +88,10 @@ export interface LifeOpsScheduleObservation {
   observedAt: string;
   windowStartAt: string;
   windowEndAt: string | null;
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
+  phase: string | null;
   mealLabel: LifeOpsScheduleMealLabel | null;
+  confidence: number;
   metadata: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
@@ -94,12 +111,12 @@ export interface LifeOpsScheduleMergedState extends LifeOpsScheduleInsight {
 }
 
 export interface SyncLifeOpsScheduleObservationInput {
-  circadianState: LifeOpsCircadianState;
-  stateConfidence: number;
-  uncertaintyReason?: LifeOpsUnclearReason | null;
+  state: LifeOpsScheduleObservationState;
   windowStartAt: string;
   windowEndAt?: string | null;
+  phase?: string | null;
   mealLabel?: LifeOpsScheduleMealLabel | null;
+  confidence: number;
   snapshot?: Partial<LifeOpsScheduleObservationSnapshot> | null;
   metadata?: Record<string, unknown>;
 }

--- a/packages/agent/src/api/__tests__/provider-switch-config.test.ts
+++ b/packages/agent/src/api/__tests__/provider-switch-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { applyOnboardingConnectionConfig } from "../provider-switch-config.js";
+
+describe("applyOnboardingConnectionConfig", () => {
+  it("clears stale direct-provider model state when switching to Eliza Cloud", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai" },
+          subscriptionProvider: "openai-codex",
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "openai",
+          transport: "direct",
+          primaryModel: "gpt-5",
+        },
+      },
+    };
+
+    await applyOnboardingConnectionConfig(config, {
+      kind: "cloud-managed",
+      cloudProvider: "elizacloud",
+      apiKey: "eliza_test_key",
+    });
+
+    expect(config.agents.defaults.subscriptionProvider).toBeUndefined();
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
+    expect(config.serviceRouting?.llmText?.backend).toBe("elizacloud");
+    expect(config.serviceRouting?.llmText?.transport).toBe("cloud-proxy");
+  });
+
+  it("clears stale direct-provider model state when switching to a remote provider", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai" },
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "openai",
+          transport: "direct",
+          primaryModel: "gpt-5",
+        },
+      },
+    };
+
+    await applyOnboardingConnectionConfig(config, {
+      kind: "remote-provider",
+      provider: "openai",
+      remoteApiBase: "https://example.invalid/api",
+    });
+
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
+    expect(config.serviceRouting?.llmText?.backend).toBe("openai");
+    expect(config.serviceRouting?.llmText?.transport).toBe("remote");
+  });
+});

--- a/packages/agent/src/api/cloud-routes.ts
+++ b/packages/agent/src/api/cloud-routes.ts
@@ -66,6 +66,7 @@ interface ConnectedCloudAgentLike {
 
 interface CloudManagerLike {
   init?: () => Promise<void>;
+  replaceApiKey?: (apiKey: string) => Promise<void>;
   getClient: () => CloudClientLike | null;
   connect: (agentId: string) => Promise<ConnectedCloudAgentLike>;
   disconnect: () => Promise<void>;
@@ -78,6 +79,7 @@ interface RuntimeLike {
   character?: {
     secrets?: Record<string, string | number | boolean>;
   };
+  getService?: (name: string) => unknown;
   updateAgent?: (
     agentId: string,
     update: {
@@ -93,6 +95,15 @@ interface IntegrationTelemetrySpanLike {
     error?: unknown;
     errorKind?: string;
   }) => void;
+}
+
+interface CloudAuthLike {
+  authenticateWithApiKey?: (input: {
+    apiKey: string;
+    organizationId?: string;
+    userId?: string;
+  }) => unknown;
+  clearAuth?: () => unknown;
 }
 
 type CreateTelemetrySpanLike = (meta: {
@@ -156,6 +167,24 @@ function replaceMutableRoot<T extends object>(target: T, snapshot: T): void {
     targetRecord,
     structuredClone(snapshot as Record<string, unknown>),
   );
+}
+
+function getCloudAuth(runtime: RuntimeLike | null): CloudAuthLike | null {
+  if (typeof runtime?.getService !== "function") {
+    return null;
+  }
+  const service = runtime.getService("CLOUD_AUTH");
+  return service && typeof service === "object"
+    ? (service as CloudAuthLike)
+    : null;
+}
+
+function clearCloudAuth(runtime: RuntimeLike | null): CloudAuthLike | null {
+  const cloudAuth = getCloudAuth(runtime);
+  if (typeof cloudAuth?.clearAuth === "function") {
+    cloudAuth.clearAuth();
+  }
+  return cloudAuth;
 }
 
 async function captureConfigEnvRollbackSnapshot(): Promise<ConfigEnvRollbackSnapshot> {
@@ -455,6 +484,7 @@ export async function handleCloudRoute(
     loginPollSpan.success({ statusCode: pollRes.status });
 
     if (data.status === "authenticated" && data.apiKey) {
+      const cloudAuth = clearCloudAuth(state.runtime);
       migrateLegacyRuntimeConfig(state.config as Record<string, unknown>);
       const cloud = (state.config.cloud ?? {}) as NonNullable<
         CloudConfigLike["cloud"]
@@ -527,10 +557,21 @@ export async function handleCloudRoute(
 
       if (
         state.cloudManager &&
+        typeof state.cloudManager.replaceApiKey === "function"
+      ) {
+        await state.cloudManager.replaceApiKey(data.apiKey);
+      } else if (
+        state.cloudManager &&
         !state.cloudManager.getClient() &&
         typeof state.cloudManager.init === "function"
       ) {
         await state.cloudManager.init();
+      }
+
+      if (typeof cloudAuth?.authenticateWithApiKey === "function") {
+        cloudAuth.authenticateWithApiKey({
+          apiKey: data.apiKey,
+        });
       }
 
       // Cloud-wallet remote-signing bridge (gated by ENABLE_CLOUD_WALLET).

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -717,6 +717,7 @@ export async function applyOnboardingConnectionConfig(
   if (normalizedConnection.kind === "cloud-managed") {
     clearRemoteProviderConfig(config);
     clearCloudModelSelections(config);
+    setPrimaryModel(config, undefined);
 
     const cloud = ensureCloud(config);
     const models = ensureModels(config);
@@ -796,6 +797,7 @@ export async function applyOnboardingConnectionConfig(
     clearSubscriptionProviderConfig(config);
     clearCloudModelSelections(config);
     clearRemoteProviderConfig(config);
+    setPrimaryModel(config, undefined);
 
     applyCanonicalOnboardingConfig(config, {
       deploymentTarget: {

--- a/packages/agent/src/auth/credentials.test.ts
+++ b/packages/agent/src/auth/credentials.test.ts
@@ -1,10 +1,43 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+let tempElizaHome: string | null = null;
+
+function writeSubscriptionCredentials(provider: "openai-codex"): void {
+  if (!tempElizaHome) {
+    tempElizaHome = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-auth-"));
+    process.env.ELIZA_HOME = tempElizaHome;
+  }
+
+  const authDir = path.join(tempElizaHome, "auth");
+  fs.mkdirSync(authDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(authDir, `${provider}.json`),
+    JSON.stringify({
+      provider,
+      credentials: {
+        access: "codex-subscription-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }),
+  );
+}
 
 describe("applySubscriptionCredentials", () => {
   afterEach(() => {
     vi.resetModules();
     delete process.env.ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.ELIZA_HOME;
+    if (tempElizaHome) {
+      fs.rmSync(tempElizaHome, { recursive: true, force: true });
+      tempElizaHome = null;
+    }
   });
 
   it("skips subscription credential mutation when disabled by env", async () => {
@@ -18,5 +51,29 @@ describe("applySubscriptionCredentials", () => {
     });
 
     expect(process.env.OPENAI_API_KEY).toBe("original-openai-key");
+  });
+
+  it("does not inject Codex runtime credentials when cloud inference is active", async () => {
+    writeSubscriptionCredentials("openai-codex");
+
+    const { applySubscriptionCredentials } = await import("./credentials.js");
+    const config = {
+      agents: {
+        defaults: {
+          subscriptionProvider: "openai-codex",
+        },
+      },
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    };
+
+    await applySubscriptionCredentials(config);
+
+    expect(process.env.OPENAI_API_KEY).toBeUndefined();
+    expect(config.agents.defaults.model?.primary).toBeUndefined();
   });
 });

--- a/packages/agent/src/auth/credentials.ts
+++ b/packages/agent/src/auth/credentials.ts
@@ -9,6 +9,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { logger } from "@elizaos/core";
+import { resolveElizaCloudTopology } from "@elizaos/shared/contracts";
 import { refreshAnthropicToken } from "./anthropic.js";
 import { refreshCodexToken } from "./openai-codex.js";
 import {
@@ -412,6 +413,9 @@ export async function applySubscriptionCredentials(config?: {
   agents?: {
     defaults?: { subscriptionProvider?: string; model?: { primary?: string } };
   };
+  serviceRouting?: Record<string, unknown>;
+  deploymentTarget?: Record<string, unknown>;
+  cloud?: Record<string, unknown>;
 }): Promise<void> {
   const subscriptionCredentialsDisabled =
     process.env.ELIZA_DISABLE_SUBSCRIPTION_CREDENTIALS?.trim().toLowerCase();
@@ -447,12 +451,21 @@ export async function applySubscriptionCredentials(config?: {
     );
   }
 
+  const cloudInferenceEnabled = config
+    ? resolveElizaCloudTopology(config as Record<string, unknown>).services
+        .inference
+    : false;
+
   // ── OpenAI Codex subscription → set OPENAI_API_KEY ────────────────────
   const codexToken = await getAccessToken("openai-codex");
-  if (codexToken) {
+  if (codexToken && !cloudInferenceEnabled) {
     process.env.OPENAI_API_KEY = codexToken;
     logger.info(
       "[auth] Applied OpenAI Codex subscription credentials to environment",
+    );
+  } else if (codexToken) {
+    logger.info(
+      "[auth] OpenAI Codex subscription detected, but cloud inference is active; skipping runtime OPENAI_API_KEY injection",
     );
   }
 
@@ -466,7 +479,11 @@ export async function applySubscriptionCredentials(config?: {
     if (provider) {
       const modelId = SUBSCRIPTION_PROVIDER_MAP[provider];
       if (modelId) {
-        if (!defaults.model) {
+        if (cloudInferenceEnabled) {
+          logger.info(
+            `[auth] Cloud inference is active; ignoring subscription model.primary auto-selection for "${modelId}"`,
+          );
+        } else if (!defaults.model) {
           defaults.model = { primary: modelId };
           logger.info(
             `[auth] Auto-set model.primary to "${modelId}" from subscription provider`,

--- a/packages/agent/src/cloud/cloud-manager.ts
+++ b/packages/agent/src/cloud/cloud-manager.ts
@@ -129,6 +129,16 @@ export class CloudManager {
     this.setStatus("disconnected");
   }
 
+  async replaceApiKey(apiKey: string): Promise<void> {
+    await this.disconnect();
+    this.cloudConfig = {
+      ...this.cloudConfig,
+      apiKey,
+    };
+    this.client = null;
+    await this.init();
+  }
+
   getProxy(): CloudRuntimeProxy | null {
     return this.proxy;
   }

--- a/packages/app-core/src/api/cloud-connection.ts
+++ b/packages/app-core/src/api/cloud-connection.ts
@@ -81,6 +81,11 @@ type CloudClientLike = {
 };
 
 export type CloudAuthLike = {
+  authenticateWithApiKey?: (input: {
+    apiKey: string;
+    organizationId?: string;
+    userId?: string;
+  }) => unknown;
   isAuthenticated?: () => boolean;
   getUserId?: () => string | undefined;
   getOrganizationId?: () => string | undefined;
@@ -160,7 +165,9 @@ function asRuntimeCloud(runtime: AgentRuntime | null): RuntimeCloudLike | null {
   return runtime as RuntimeCloudLike | null;
 }
 
-function getCloudAuth(runtime: AgentRuntime | null): CloudAuthLike | null {
+export function getCloudAuth(
+  runtime: AgentRuntime | null,
+): CloudAuthLike | null {
   const runtimeWithServices = asRuntimeCloud(runtime);
   if (typeof runtimeWithServices?.getService !== "function") {
     return null;
@@ -170,6 +177,37 @@ function getCloudAuth(runtime: AgentRuntime | null): CloudAuthLike | null {
   return service && typeof service === "object"
     ? (service as CloudAuthLike)
     : null;
+}
+
+function resolvePersistedCloudIdentity(runtime: AgentRuntime | null): {
+  organizationId: string | undefined;
+  userId: string | undefined;
+} {
+  const runtimeWithCloud = asRuntimeCloud(runtime);
+  return {
+    organizationId:
+      normalizeEnvValue(
+        runtimeWithCloud?.getSetting?.("ELIZA_CLOUD_ORGANIZATION_ID") as
+          | string
+          | undefined,
+      ) ??
+      normalizeEnvValue(
+        runtimeWithCloud?.character?.secrets?.ELIZA_CLOUD_ORGANIZATION_ID as
+          | string
+          | undefined,
+      ),
+    userId:
+      normalizeEnvValue(
+        runtimeWithCloud?.getSetting?.("ELIZA_CLOUD_USER_ID") as
+          | string
+          | undefined,
+      ) ??
+      normalizeEnvValue(
+        runtimeWithCloud?.character?.secrets?.ELIZA_CLOUD_USER_ID as
+          | string
+          | undefined,
+      ),
+  };
 }
 
 export function resolveCloudApiBaseUrl(rawBaseUrl?: string): string {
@@ -238,6 +276,8 @@ export function resolveCloudConnectionSnapshot(
   const cloudAuth = getCloudAuth(runtime);
   const authConnected = Boolean(cloudAuth?.isAuthenticated?.());
   const hasApiKey = Boolean(apiKey);
+  const persistedIdentity = resolvePersistedCloudIdentity(runtime);
+  const shouldExposeIdentity = authConnected || hasApiKey;
 
   return {
     apiKey,
@@ -246,11 +286,13 @@ export function resolveCloudConnectionSnapshot(
     connected: authConnected || hasApiKey,
     enabled,
     hasApiKey,
-    organizationId: authConnected
-      ? normalizeEnvValue(cloudAuth?.getOrganizationId?.())
+    organizationId: shouldExposeIdentity
+      ? (normalizeEnvValue(cloudAuth?.getOrganizationId?.()) ??
+        persistedIdentity.organizationId)
       : undefined,
-    userId: authConnected
-      ? normalizeEnvValue(cloudAuth?.getUserId?.())
+    userId: shouldExposeIdentity
+      ? (normalizeEnvValue(cloudAuth?.getUserId?.()) ??
+        persistedIdentity.userId)
       : undefined,
   };
 }
@@ -427,7 +469,7 @@ export async function fetchUnifiedCloudCredits(
   }
 }
 
-async function clearCloudAuthService(
+export async function clearCloudAuthService(
   cloudAuth: CloudAuthLike | null,
 ): Promise<void> {
   if (!cloudAuth) {

--- a/packages/app-core/src/api/cloud-routes.test.ts
+++ b/packages/app-core/src/api/cloud-routes.test.ts
@@ -1,0 +1,122 @@
+import type http from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+
+import { type CloudRouteState, handleCloudRoute } from "./cloud-routes";
+
+function jsonRequest(body: unknown): http.IncomingMessage {
+  return Readable.from([JSON.stringify(body)]) as http.IncomingMessage;
+}
+
+function jsonResponse(): http.ServerResponse & {
+  body: string;
+  headers: Record<string, string>;
+} {
+  const response = {
+    body: "",
+    headers: {} as Record<string, string>,
+    headersSent: false,
+    statusCode: 200,
+    end(chunk?: unknown) {
+      this.body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+      this.headersSent = true;
+      return this;
+    },
+    setHeader(name: string, value: number | string | readonly string[]) {
+      this.headers[name.toLowerCase()] = Array.isArray(value)
+        ? value.join(", ")
+        : String(value);
+      return this;
+    },
+  };
+  return response as http.ServerResponse & {
+    body: string;
+    headers: Record<string, string>;
+  };
+}
+
+describe("cloud-routes", () => {
+  it("replaces stale in-memory cloud auth when persisting a newly linked account", async () => {
+    const calls: string[] = [];
+    const cloudAuth = {
+      clearAuth: () => {
+        calls.push("clear-auth");
+      },
+      authenticateWithApiKey: (input: {
+        apiKey: string;
+        organizationId?: string;
+        userId?: string;
+      }) => {
+        calls.push(
+          `auth:${input.apiKey}:${input.userId}:${input.organizationId}`,
+        );
+      },
+    };
+    const runtime = {
+      agentId: "agent-1",
+      character: {
+        secrets: {
+          ELIZAOS_CLOUD_API_KEY: "old-key",
+          ELIZA_CLOUD_ORGANIZATION_ID: "old-org",
+          ELIZA_CLOUD_USER_ID: "old-user",
+        },
+      },
+      getService: (name: string) => (name === "CLOUD_AUTH" ? cloudAuth : null),
+      setSetting: (key: string, value: string | null) => {
+        calls.push(`setting:${key}:${value ?? ""}`);
+      },
+      updateAgent: async (
+        _agentId: string,
+        update: { secrets: Record<string, string | number | boolean> },
+      ) => {
+        calls.push(`db:${update.secrets.ELIZAOS_CLOUD_API_KEY}`);
+      },
+    };
+    const state: CloudRouteState = {
+      cloudManager: {
+        getClient: () => ({}) as never,
+        init: async () => {
+          calls.push("init");
+        },
+        replaceApiKey: async (apiKey: string) => {
+          calls.push(`replace-manager:${apiKey}`);
+        },
+      } as CloudRouteState["cloudManager"],
+      config: {
+        cloud: { apiKey: "old-key" },
+        serviceRouting: {
+          llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+        },
+      } as CloudRouteState["config"],
+      runtime: runtime as CloudRouteState["runtime"],
+    };
+    const req = jsonRequest({
+      apiKey: "new-key",
+      organizationId: "new-org",
+      userId: "new-user",
+    });
+    const res = jsonResponse();
+
+    const handled = await handleCloudRoute(
+      req,
+      res,
+      "/api/cloud/login/persist",
+      "POST",
+      state,
+    );
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true });
+    expect(state.config.cloud?.apiKey).toBe("new-key");
+    expect(runtime.character.secrets).toMatchObject({
+      ELIZAOS_CLOUD_API_KEY: "new-key",
+      ELIZA_CLOUD_ORGANIZATION_ID: "new-org",
+      ELIZA_CLOUD_USER_ID: "new-user",
+    });
+    expect(calls).toContain("clear-auth");
+    expect(calls).toContain("replace-manager:new-key");
+    expect(calls).toContain("auth:new-key:new-user:new-org");
+    expect(calls).not.toContain("init");
+  });
+});

--- a/packages/app-core/src/api/cloud-routes.ts
+++ b/packages/app-core/src/api/cloud-routes.ts
@@ -17,7 +17,9 @@ import {
 } from "@elizaos/shared/contracts/onboarding";
 import { isTimeoutError } from "../utils/errors";
 import {
+  clearCloudAuthService,
   disconnectUnifiedCloudConnection,
+  getCloudAuth,
   type RuntimeCloudLike,
 } from "./cloud-connection";
 import { clearCloudSecrets, scrubCloudSecretsFromEnv } from "./cloud-secrets";
@@ -31,6 +33,9 @@ export interface CloudRouteState {
 }
 
 type CloudRuntimeSecrets = Record<string, string | number | boolean>;
+type ReplaceableCloudManager = NonNullable<CloudRouteState["cloudManager"]> & {
+  replaceApiKey?: (apiKey: string) => Promise<void>;
+};
 
 const CLOUD_LOGIN_POLL_TIMEOUT_MS = 10_000;
 
@@ -84,7 +89,9 @@ async function fetchCloudLoginStatus(
 
 async function persistCloudLoginStatus(args: {
   apiKey: string;
+  organizationId?: string;
   state: CloudRouteState;
+  userId?: string;
   /**
    * From GET `/api/cloud/login/status`: epoch captured before `fetch` so a
    * disconnect during the poll invalidates this result. Omitted for POST
@@ -103,6 +110,10 @@ async function persistCloudLoginStatus(args: {
   }
 
   migrateLegacyRuntimeConfig(args.state.config as Record<string, unknown>);
+  const runtime = args.state.runtime as RuntimeCloudLike | null;
+  const cloudAuth = getCloudAuth(runtime);
+  await clearCloudAuthService(cloudAuth);
+
   const cloud = { ...(args.state.config.cloud ?? {}) } as Record<
     string,
     unknown
@@ -146,15 +157,26 @@ async function persistCloudLoginStatus(args: {
   }
   scrubCloudSecretsFromEnv();
 
-  if (
-    args.state.cloudManager &&
-    !args.state.cloudManager.getClient() &&
-    typeof args.state.cloudManager.init === "function"
+  const cloudManager = args.state
+    .cloudManager as ReplaceableCloudManager | null;
+  if (cloudManager && typeof cloudManager.replaceApiKey === "function") {
+    await cloudManager.replaceApiKey(args.apiKey);
+  } else if (
+    cloudManager &&
+    !cloudManager.getClient() &&
+    typeof cloudManager.init === "function"
   ) {
-    await args.state.cloudManager.init();
+    await cloudManager.init();
   }
 
-  const runtime = args.state.runtime as RuntimeCloudLike | null;
+  if (typeof cloudAuth?.authenticateWithApiKey === "function") {
+    cloudAuth.authenticateWithApiKey({
+      apiKey: args.apiKey,
+      organizationId: args.organizationId,
+      userId: args.userId,
+    });
+  }
+
   if (!runtime || typeof runtime.updateAgent !== "function") {
     return;
   }
@@ -164,12 +186,29 @@ async function persistCloudLoginStatus(args: {
       ...(runtime.character.secrets ?? {}),
       ELIZAOS_CLOUD_API_KEY: args.apiKey,
     };
+    if (args.userId) {
+      nextSecrets.ELIZA_CLOUD_USER_ID = args.userId;
+    } else {
+      delete nextSecrets.ELIZA_CLOUD_USER_ID;
+    }
+    if (args.organizationId) {
+      nextSecrets.ELIZA_CLOUD_ORGANIZATION_ID = args.organizationId;
+    } else {
+      delete nextSecrets.ELIZA_CLOUD_ORGANIZATION_ID;
+    }
     if (cloudInferenceSelected) {
       nextSecrets.ELIZAOS_CLOUD_ENABLED = "true";
     } else {
       delete nextSecrets.ELIZAOS_CLOUD_ENABLED;
     }
     runtime.character.secrets = nextSecrets;
+    if (typeof runtime.setSetting === "function") {
+      runtime.setSetting("ELIZA_CLOUD_USER_ID", args.userId ?? null);
+      runtime.setSetting(
+        "ELIZA_CLOUD_ORGANIZATION_ID",
+        args.organizationId ?? null,
+      );
+    }
     await runtime.updateAgent(runtime.agentId, {
       secrets: { ...nextSecrets },
     });
@@ -227,12 +266,23 @@ export async function handleCloudRoute(
     try {
       const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
         apiKey?: unknown;
+        organizationId?: unknown;
+        userId?: unknown;
       };
       if (typeof body.apiKey !== "string" || !body.apiKey.trim()) {
         sendJson(res, 400, { ok: false, error: "apiKey is required" });
         return true;
       }
-      await persistCloudLoginStatus({ apiKey: body.apiKey.trim(), state });
+      await persistCloudLoginStatus({
+        apiKey: body.apiKey.trim(),
+        organizationId:
+          typeof body.organizationId === "string"
+            ? body.organizationId.trim()
+            : undefined,
+        state,
+        userId:
+          typeof body.userId === "string" ? body.userId.trim() : undefined,
+      });
       sendJson(res, 200, { ok: true });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -323,13 +373,17 @@ export async function handleCloudRoute(
     let data: {
       apiKey?: unknown;
       keyPrefix?: unknown;
+      organizationId?: unknown;
       status?: unknown;
+      userId?: unknown;
     };
     try {
       data = (await pollRes.json()) as {
         apiKey?: unknown;
         keyPrefix?: unknown;
+        organizationId?: unknown;
         status?: unknown;
+        userId?: unknown;
       };
     } catch (parseErr) {
       loginPollSpan.failure({ error: parseErr, statusCode: pollRes.status });
@@ -345,13 +399,23 @@ export async function handleCloudRoute(
     if (data.status === "authenticated" && typeof data.apiKey === "string") {
       await persistCloudLoginStatus({
         apiKey: data.apiKey,
+        organizationId:
+          typeof data.organizationId === "string"
+            ? data.organizationId
+            : undefined,
         state,
         epochAtPollStart: epochBeforePoll,
+        userId: typeof data.userId === "string" ? data.userId : undefined,
       });
       sendJson(res, 200, {
         status: "authenticated",
         keyPrefix:
           typeof data.keyPrefix === "string" ? data.keyPrefix : undefined,
+        organizationId:
+          typeof data.organizationId === "string"
+            ? data.organizationId
+            : undefined,
+        userId: typeof data.userId === "string" ? data.userId : undefined,
       });
       return true;
     }

--- a/packages/app-core/src/components/shell/StartupShell.tsx
+++ b/packages/app-core/src/components/shell/StartupShell.tsx
@@ -212,7 +212,7 @@ export function StartupShell() {
       className="flex items-center justify-center h-full w-full bg-[#ffe600] text-black overflow-hidden"
     >
       <img
-        src={resolveAppAssetUrl("splash-bg.jpg")}
+        src={resolveAppAssetUrl("splash-bg.png")}
         alt=""
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 h-full w-full object-cover"

--- a/packages/elizaos/templates/fullstack-app/README.md
+++ b/packages/elizaos/templates/fullstack-app/README.md
@@ -42,5 +42,5 @@ bun run --cwd apps/app build
 - This template keeps the upstream elizaOS source local because several `@elizaos/*` workspace packages used by the app are not published on npm.
 - The generated project is meant to be its own repo, with `eliza/` pinned independently through the submodule.
 - The default brand kit is intentionally minimal. The source-of-truth files are `apps/app/public/favicon.svg` and `apps/app/public/splash-bg.svg`.
-- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.jpg`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
+- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.png`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
 - `apps/app/public/logos/*` is still required because `@elizaos/app-core` maps provider IDs to those fixed asset paths during onboarding and settings flows.

--- a/packages/elizaos/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
+++ b/packages/elizaos/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
@@ -9,7 +9,7 @@ const publicDir = path.join(appDir, "public");
 const electrobunAssetsDir = path.join(appDir, "electrobun", "assets");
 const faviconSvgPath = path.join(publicDir, "favicon.svg");
 const splashSvgPath = path.join(publicDir, "splash-bg.svg");
-const splashJpgPath = path.join(publicDir, "splash-bg.jpg");
+const splashPngPath = path.join(publicDir, "splash-bg.png");
 const appIconPngPath = path.join(electrobunAssetsDir, "appIcon.png");
 const appIconIcoPath = path.join(electrobunAssetsDir, "appIcon.ico");
 const appIconsetDir = path.join(electrobunAssetsDir, "appIcon.iconset");
@@ -118,8 +118,8 @@ function main() {
   writeIco(appIconIcoPath, icoEntries);
 
   renderSvgToRaster({
-    format: "jpeg",
-    outputPath: splashJpgPath,
+    format: "png",
+    outputPath: splashPngPath,
     sourcePath: splashSvgPath,
   });
 }

--- a/packages/shared/src/contracts/lifeops.ts
+++ b/packages/shared/src/contracts/lifeops.ts
@@ -1248,13 +1248,19 @@ export type LifeOpsRelativeTimeAnchorSource =
   | "typical_sleep"
   | "day_boundary";
 
+export type LifeOpsAwakeState = "awake" | "probably_sleeping" | "unknown";
+
 export interface LifeOpsRelativeTime {
   computedAt: string;
   localNowAt: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
   awakeProbability: LifeOpsAwakeProbability;
+  isProbablySleeping: boolean;
+  isAwake: boolean;
+  awakeState: LifeOpsAwakeState;
   wakeAnchorAt: string | null;
   wakeAnchorSource: LifeOpsRelativeTimeAnchorSource | null;
   minutesSinceWake: number | null;
@@ -1289,6 +1295,7 @@ export interface LifeOpsScheduleInsight {
   localDate: string;
   timezone: string;
   inferredAt: string;
+  phase: string;
   circadianState: LifeOpsCircadianState;
   stateConfidence: number;
   uncertaintyReason: LifeOpsUnclearReason | null;
@@ -1297,11 +1304,14 @@ export interface LifeOpsScheduleInsight {
   regularity: LifeOpsScheduleRegularity;
   baseline: LifeOpsPersonalBaseline | null;
   sleepStatus: LifeOpsScheduleSleepStatus;
+  isProbablySleeping: boolean;
   sleepConfidence: number;
   currentSleepStartedAt: string | null;
   lastSleepStartedAt: string | null;
   lastSleepEndedAt: string | null;
   lastSleepDurationMinutes: number | null;
+  typicalWakeHour: number | null;
+  typicalSleepHour: number | null;
   wakeAt: string | null;
   firstActiveAt: string | null;
   lastActiveAt: string | null;

--- a/packages/templates/fullstack-app/README.md
+++ b/packages/templates/fullstack-app/README.md
@@ -42,5 +42,5 @@ bun run --cwd apps/app build
 - This template keeps the upstream elizaOS source local because several `@elizaos/*` workspace packages used by the app are not published on npm.
 - The generated project is meant to be its own repo, with `eliza/` pinned independently through the submodule.
 - The default brand kit is intentionally minimal. The source-of-truth files are `apps/app/public/favicon.svg` and `apps/app/public/splash-bg.svg`.
-- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.jpg`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
+- `bun run --cwd apps/app brand:assets` regenerates the derived desktop assets: `public/splash-bg.png`, `electrobun/assets/appIcon.png`, `electrobun/assets/appIcon.ico`, and `electrobun/assets/appIcon.iconset/`.
 - `apps/app/public/logos/*` is still required because `@elizaos/app-core` maps provider IDs to those fixed asset paths during onboarding and settings flows.

--- a/packages/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
+++ b/packages/templates/fullstack-app/apps/app/scripts/generate-brand-assets.mjs
@@ -9,7 +9,7 @@ const publicDir = path.join(appDir, "public");
 const electrobunAssetsDir = path.join(appDir, "electrobun", "assets");
 const faviconSvgPath = path.join(publicDir, "favicon.svg");
 const splashSvgPath = path.join(publicDir, "splash-bg.svg");
-const splashJpgPath = path.join(publicDir, "splash-bg.jpg");
+const splashPngPath = path.join(publicDir, "splash-bg.png");
 const appIconPngPath = path.join(electrobunAssetsDir, "appIcon.png");
 const appIconIcoPath = path.join(electrobunAssetsDir, "appIcon.ico");
 const appIconsetDir = path.join(electrobunAssetsDir, "appIcon.iconset");
@@ -118,8 +118,8 @@ function main() {
   writeIco(appIconIcoPath, icoEntries);
 
   renderSvgToRaster({
-    format: "jpeg",
-    outputPath: splashJpgPath,
+    format: "png",
+    outputPath: splashPngPath,
     sourcePath: splashSvgPath,
   });
 }


### PR DESCRIPTION
## Summary
- Clear stale in-memory Eliza Cloud auth when a new account login is persisted.
- Reinitialize `CloudManager` with the newly linked API key instead of keeping an old client alive.
- Preserve the linked account identity in runtime secrets/settings.
- Add regression coverage for `/api/cloud/login/persist`.

## Root Cause
Connecting a new Eliza Cloud account updated disk config, but the running runtime could continue using old CloudAuth/CloudManager instances. That made account status and inference paths disagree after relink.

## Dependency
Depends on plugin PR: https://github.com/elizaos-plugins/plugin-elizacloud/pull/16

## Validation
- Focused Vitest from Milady checkout: 2 files passed, 5 tests passed.
- `@elizaos/plugin-elizacloud` build passed.
- Full app-core typecheck/build is currently blocked by unrelated existing LifeOps/native plugin type errors in the checkout.
