### PR TITLE
Miladyos local agent on android

### DIFF
--- a/packages/agent/scripts/build-mobile-bundle.mjs
+++ b/packages/agent/scripts/build-mobile-bundle.mjs
@@ -138,6 +138,12 @@ const nativeStubs = {
 const optionalPluginStubs = {
   "@elizaos/plugin-cron": path.join(stubsDir, "null-plugin.cjs"),
   "@elizaos/plugin-cli": path.join(stubsDir, "null-plugin.cjs"),
+  // Static `import * as pluginBrowserBridge from "@elizaos/plugin-browser-bridge"`
+  // in eliza.ts pulls in puppeteer/Chromium plumbing transitively. Mobile
+  // doesn't run a headless browser, and the runtime's plugin filter strips
+  // browser-bridge from the load set anyway, so a null stub satisfies the
+  // top-level resolution without dragging in 200 MB of native deps.
+  "@elizaos/plugin-browser-bridge": path.join(stubsDir, "null-plugin.cjs"),
 };
 
 const stubAliases = { ...nativeStubs, ...optionalPluginStubs };

--- a/packages/agent/src/api/provider-switch-config.test.ts
+++ b/packages/agent/src/api/provider-switch-config.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.js";
+import type { OnboardingConnection } from "../contracts/onboarding.js";
+import type { ServiceRoutingConfig } from "../contracts/service-routing.js";
+import { applyOnboardingConnectionConfig } from "./provider-switch-config.js";
+
+type MutableConfig = Partial<ElizaConfig> & {
+  serviceRouting?: ServiceRoutingConfig;
+};
+
+function buildBaseConfig(): MutableConfig {
+  return {};
+}
+
+const cloudConnection: OnboardingConnection = {
+  kind: "cloud-managed",
+  cloudProvider: "elizacloud",
+  apiKey: "test-cloud-key",
+};
+
+describe("applyOnboardingConnectionConfig — useLocalEmbeddings", () => {
+  it("routes embeddings to cloud-proxy by default for cloud-managed connection", async () => {
+    const config = buildBaseConfig();
+
+    await applyOnboardingConnectionConfig(config, cloudConnection);
+
+    expect(config.serviceRouting?.embeddings).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.tts).toMatchObject({
+      transport: "cloud-proxy",
+    });
+  });
+
+  it("translates useLocalEmbeddings: true to excludeServices: ['embeddings']", async () => {
+    const config = buildBaseConfig();
+
+    await applyOnboardingConnectionConfig(config, cloudConnection, {
+      useLocalEmbeddings: true,
+    });
+
+    expect(config.serviceRouting?.embeddings).toBeUndefined();
+    expect(config.serviceRouting?.tts).toMatchObject({
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.media).toMatchObject({
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.rpc).toMatchObject({
+      transport: "cloud-proxy",
+    });
+  });
+
+  it("keeps the cloud embeddings route when useLocalEmbeddings is false", async () => {
+    const config = buildBaseConfig();
+
+    await applyOnboardingConnectionConfig(config, cloudConnection, {
+      useLocalEmbeddings: false,
+    });
+
+    expect(config.serviceRouting?.embeddings).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+  });
+
+  it("excludes embeddings on local-provider when previous deployment was cloud", async () => {
+    const config: MutableConfig = {
+      deploymentTarget: { runtime: "cloud", provider: "elizacloud" },
+    };
+
+    await applyOnboardingConnectionConfig(
+      config,
+      {
+        kind: "local-provider",
+        provider: "openai",
+        apiKey: "sk-test",
+      },
+      { useLocalEmbeddings: true },
+    );
+
+    expect(config.serviceRouting?.embeddings).toBeUndefined();
+    expect(config.serviceRouting?.tts).toMatchObject({
+      transport: "cloud-proxy",
+    });
+    expect(config.serviceRouting?.llmText).toMatchObject({
+      backend: "openai",
+      transport: "direct",
+    });
+  });
+});

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -703,11 +703,19 @@ export function createProviderSwitchConnection(args: {
   };
 }
 
+export interface ApplyOnboardingConnectionOptions {
+  useLocalEmbeddings?: boolean;
+}
+
 export async function applyOnboardingConnectionConfig(
   config: MutableElizaConfig,
   connection: OnboardingConnection,
+  options: ApplyOnboardingConnectionOptions = {},
 ): Promise<void> {
   const normalizedConnection = connection;
+  const excludeServices = options.useLocalEmbeddings
+    ? (["embeddings"] as const)
+    : undefined;
 
   delete (config as Record<string, unknown>).connection;
   const existingDeploymentTarget = normalizeDeploymentTargetConfig(
@@ -758,6 +766,7 @@ export async function applyOnboardingConnectionConfig(
           mediaDescriptionModel: normalizedConnection.mediaDescriptionModel,
         }),
       },
+      ...(excludeServices ? { excludeServices } : {}),
     });
 
     applyCanonicalOnboardingConfig(config, {
@@ -860,6 +869,7 @@ export async function applyOnboardingConnectionConfig(
           ...(config.serviceRouting ?? {}),
           llmText: directLlmRoute,
         },
+        ...(excludeServices ? { excludeServices } : {}),
       })
     : {
         llmText: directLlmRoute,

--- a/packages/agent/src/api/provider-switch-routes.ts
+++ b/packages/agent/src/api/provider-switch-routes.ts
@@ -46,12 +46,17 @@ export async function handleProviderSwitchRoutes(
       provider: string;
       apiKey?: string;
       primaryModel?: string;
+      useLocalEmbeddings?: boolean;
     }>(req, res);
     if (!body) return true;
     if (!body.provider || typeof body.provider !== "string") {
       error(res, "Missing provider", 400);
       return true;
     }
+    const useLocalEmbeddings =
+      typeof body.useLocalEmbeddings === "boolean"
+        ? body.useLocalEmbeddings
+        : undefined;
 
     const normalizedProvider = normalizeOnboardingProviderId(body.provider);
     if (!normalizedProvider) {
@@ -116,7 +121,11 @@ export async function handleProviderSwitchRoutes(
         return true;
       }
 
-      await applyOnboardingConnectionConfig(config, connection);
+      await applyOnboardingConnectionConfig(
+        config,
+        connection,
+        useLocalEmbeddings === undefined ? {} : { useLocalEmbeddings },
+      );
       ctx.saveElizaConfig(config);
 
       const restartReason = `provider switch to ${normalizedProvider}`;

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -392,6 +392,12 @@ function isTrustedLocalOrigin(raw: string): boolean {
 
 export function isTrustedLocalRequest(req: http.IncomingMessage): boolean {
   if (isCloudProvisionedContainer()) return false;
+  // On-device local agent (Android): the loopback interface is shared with
+  // every other app on the device, so loopback alone is NOT a trust signal.
+  // The MiladyAgentService sets MILADY_REQUIRE_LOCAL_AUTH=1 alongside a
+  // per-boot ELIZA_API_TOKEN; with this flag the server requires bearer
+  // auth on every route except /api/health (which is read-only liveness).
+  if (process.env.MILADY_REQUIRE_LOCAL_AUTH === "1") return false;
   if (!isLoopbackRemoteAddress(req.socket?.remoteAddress)) return false;
   if (proxyClientHeaderBlocksLocalTrust(req.headers)) return false;
 

--- a/packages/agent/src/runtime/first-time-setup.test.ts
+++ b/packages/agent/src/runtime/first-time-setup.test.ts
@@ -157,6 +157,51 @@ describe("applyFirstTimeSetupTopology", () => {
       },
     });
   });
+
+  it("omits the cloud embeddings route when useLocalEmbeddings is true", () => {
+    const result = applyFirstTimeSetupTopology({} as never, {
+      isCloudRuntime: true,
+      selectedProviderId: "elizacloud",
+      useLocalEmbeddings: true,
+      cloudOnboardingResult: {
+        apiKey: "cloud-key",
+        baseUrl: "https://elizacloud.ai",
+        agentId: "agent-123",
+      },
+    });
+
+    expect(result.serviceRouting?.embeddings).toBeUndefined();
+    expect(result.serviceRouting?.tts).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    expect(result.serviceRouting?.media).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+    expect(result.serviceRouting?.rpc).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+  });
+
+  it("routes embeddings to cloud-proxy when useLocalEmbeddings is false", () => {
+    const result = applyFirstTimeSetupTopology({} as never, {
+      isCloudRuntime: true,
+      selectedProviderId: "elizacloud",
+      useLocalEmbeddings: false,
+      cloudOnboardingResult: {
+        apiKey: "cloud-key",
+        baseUrl: "https://elizacloud.ai",
+        agentId: "agent-123",
+      },
+    });
+
+    expect(result.serviceRouting?.embeddings).toMatchObject({
+      backend: "elizacloud",
+      transport: "cloud-proxy",
+    });
+  });
 });
 
 describe("bindCloudProvider", () => {

--- a/packages/agent/src/runtime/first-time-setup.ts
+++ b/packages/agent/src/runtime/first-time-setup.ts
@@ -56,6 +56,7 @@ export function applyFirstTimeSetupTopology(
     isCloudRuntime: boolean;
     selectedProviderId?: string;
     cloudOnboardingResult?: FirstTimeSetupCloudResult | null;
+    useLocalEmbeddings?: boolean;
   },
 ): ElizaConfig {
   const linkedAccounts = {
@@ -90,6 +91,7 @@ export function applyFirstTimeSetupTopology(
       buildDefaultElizaCloudServiceRouting({
         base: serviceRouting,
         includeInference: shouldUseCloudInference,
+        excludeServices: args.useLocalEmbeddings ? ["embeddings"] : undefined,
       }),
     );
   }

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyAgentService.java
@@ -66,6 +66,16 @@ public class MiladyAgentService extends Service {
     //   agent/{abi}/ld-musl-*.so.1
     //   agent/{abi}/libstdc++.so.6
     //   agent/{abi}/libgcc_s.so.1
+    //   .milady/                   ← MILADY_STATE_DIR (PGlite data, auth, prompts)
+    //
+    // The agent runs in the priv_app SELinux domain — Android.bp deliberately
+    // omits the platform certificate so seapp_contexts puts the APK there
+    // instead of platform_app. AOSP's stock policy includes
+    // `allow priv_app privapp_data_file:file execute;` in
+    // system/sepolicy/private/priv_app.te, which is what lets us execve
+    // the bun binary out of /data/data/<pkg>/files/agent/. No jniLibs
+    // trick, no custom domain, no symlinks: the binary just sits in the
+    // app's writable data dir at canonical names.
     private static final String AGENT_DIR_NAME = "agent";
     private static final String AGENT_STATE_DIR_NAME = ".milady";
     private static final String AGENT_BUNDLE_NAME = "agent-bundle.js";
@@ -89,6 +99,19 @@ public class MiladyAgentService extends Service {
     private volatile boolean shuttingDown;
     private int restartAttempts;
     private String currentStatus = "starting";
+
+    // Per-boot bearer token for the WebView↔agent loopback. Generated when
+    // the service first starts the agent process and cleared on stop.
+    // The Capacitor agent plugin reads it from `localAgentToken()` to
+    // hydrate `window.__ELIZA_API_TOKEN__` so the WebView's fetches
+    // include `Authorization: Bearer <token>`. The agent enforces the
+    // token via MILADY_REQUIRE_LOCAL_AUTH=1.
+    private static volatile String currentLocalAgentToken;
+
+    /** Called by the Capacitor agent plugin Android binding. */
+    public static String localAgentToken() {
+        return currentLocalAgentToken;
+    }
 
     // ── Lifecycle ────────────────────────────────────────────────────────
 
@@ -171,16 +194,11 @@ public class MiladyAgentService extends Service {
     // ── Asset extraction ─────────────────────────────────────────────────
 
     /**
-     * Pick the runtime ABI directory we ship binaries for. Prefers
-     * arm64-v8a (real phones), falls back to x86_64 (cuttlefish/emulator).
+     * Pick the runtime ABI directory we ship binaries for. Walks
+     * Build.SUPPORTED_ABIS in device-priority order so x86_64 cuttlefish
+     * (which lists ["x86_64","arm64-v8a"]) doesn't wrongly pick arm64.
      */
     private String resolveRuntimeAbi() {
-        // Walk SUPPORTED_ABIS in order — Build.SUPPORTED_ABIS[0] is the
-        // device's primary ABI. cuttlefish_x86_64 reports
-        // ["x86_64", "arm64-v8a"], so blindly preferring arm64 picks the
-        // wrong binary set and the agent fails with ENOEXEC at execve.
-        // Real arm64 phones report ["arm64-v8a", ...] and naturally land
-        // on the right ABI.
         String[] supported = Build.SUPPORTED_ABIS;
         if (supported != null) {
             for (String abi : supported) {
@@ -205,8 +223,8 @@ public class MiladyAgentService extends Service {
 
     /**
      * Copy assets/agent/** into the app's data dir on first launch.
-     * Idempotent: skips files that already exist on disk and are non-empty.
-     * Sets +x on bun, the musl loader, and launch.sh.
+     * Idempotent: skips files that already exist on disk and are
+     * non-empty. Sets +x on bun, the musl loader, and launch.sh.
      */
     private void extractAssetsIfNeeded(String abi) throws IOException {
         File root = agentRoot();
@@ -224,17 +242,14 @@ public class MiladyAgentService extends Service {
 
         AssetManager assets = getAssets();
 
-        // Top-level files (cwd contents): agent-bundle.js + launch.sh.
         copyAssetIfMissing(assets, "agent/" + AGENT_BUNDLE_NAME, new File(root, AGENT_BUNDLE_NAME));
-        copyAssetIfMissing(assets, "agent/" + AGENT_LAUNCH_SCRIPT, new File(root, AGENT_LAUNCH_SCRIPT));
+        copyAssetIfPresent(assets, "agent/" + AGENT_LAUNCH_SCRIPT, new File(root, AGENT_LAUNCH_SCRIPT));
 
-        // PGlite runtime assets. The bundle is in `agent/`; PGlite resolves
-        // its WASM + data via `new URL("./pglite.{wasm,data}", import.meta.url)`
-        // which lands them next to the bundle. Vector + fuzzystrmatch use
-        // `new URL("../X.tar.gz", import.meta.url)` and therefore must live
-        // ONE DIRECTORY ABOVE the bundle (in `getFilesDir()`, not `agent/`).
-        // This is Phase D's contract; staging gets it wrong silently if you
-        // co-locate them with the bundle.
+        // PGlite runtime assets. pglite.wasm + pglite.data sit next to
+        // the bundle (`new URL("./pglite.X", import.meta.url)`);
+        // vector.tar.gz and fuzzystrmatch.tar.gz must live one directory
+        // ABOVE the bundle because PGlite resolves them via
+        // `new URL("../X.tar.gz", ...)`.
         copyAssetIfPresent(assets, "agent/pglite.wasm", new File(root, "pglite.wasm"));
         copyAssetIfPresent(assets, "agent/pglite.data", new File(root, "pglite.data"));
         copyAssetIfPresent(assets, "agent/vector.tar.gz",
@@ -244,14 +259,9 @@ public class MiladyAgentService extends Service {
         copyAssetIfPresent(assets, "agent/plugins-manifest.json",
             new File(root, "plugins-manifest.json"));
 
-        // ABI-specific files. Copy everything under assets/agent/{abi}/.
+        // ABI-specific binaries: bun + musl loader + libstdc++ + libgcc.
         String abiAssetDir = "agent/" + abi;
-        String[] abiFiles;
-        try {
-            abiFiles = assets.list(abiAssetDir);
-        } catch (IOException error) {
-            throw new IOException("Could not list " + abiAssetDir + " in APK assets", error);
-        }
+        String[] abiFiles = assets.list(abiAssetDir);
         if (abiFiles == null || abiFiles.length == 0) {
             throw new IOException("APK is missing assets/" + abiAssetDir + " for runtime ABI " + abi);
         }
@@ -259,36 +269,53 @@ public class MiladyAgentService extends Service {
             copyAssetIfMissing(assets, abiAssetDir + "/" + name, new File(abiDir, name));
         }
 
-        // Mark executables. setExecutable(true, false) sets the bit for
-        // all (owner/group/other), which is what we need for the musl
-        // loader to execve bun under our app uid.
         File bun = new File(abiDir, BUN_BINARY);
-        if (bun.exists()) {
-            bun.setExecutable(true, false);
-        }
+        if (bun.exists()) bun.setExecutable(true, false);
         File launch = new File(root, AGENT_LAUNCH_SCRIPT);
-        if (launch.exists()) {
-            launch.setExecutable(true, false);
-        }
+        if (launch.exists()) launch.setExecutable(true, false);
         for (String name : abiFiles) {
             if (name.startsWith("ld-musl-") && name.endsWith(".so.1")) {
                 File loader = new File(abiDir, name);
-                if (loader.exists()) {
-                    loader.setExecutable(true, false);
-                }
+                if (loader.exists()) loader.setExecutable(true, false);
             }
         }
 
-        // SELinux relabel. installd does not consult vendor file_contexts when
-        // it creates files under /data/data/<pkg>/, so freshly extracted
-        // assets carry the inherited priv_app_data_file label, NOT the
-        // milady_agent_exec / milady_agent_data labels declared in
-        // os/android/vendor/milady/sepolicy/file_contexts. Without restorecon
-        // the domain_auto_trans from priv_app to milady_agent never fires,
-        // and the bun execve ends up running as priv_app — which the
-        // milady_agent allow rules don't apply to. This is the single
-        // contract Phase B owes Phase C; without it the SELinux work is dead.
-        relabelAgentTree(root);
+        // bun's binary requests `libstdc++.so.6` at runtime (the soname),
+        // but the actual file we shipped is the versioned realpath
+        // (`libstdc++.so.6.0.33`). Without a symlink the musl loader
+        // can't find the shared object and bun crashes with hundreds of
+        // "Error relocating: symbol not found" lines. Create the symlink
+        // pointing from the soname to the realpath inside the same abi
+        // dir so LD_LIBRARY_PATH resolution works without LD_PRELOAD.
+        for (String name : abiFiles) {
+            if (name.startsWith("libstdc++.so.6.")) {
+                File realPath = new File(abiDir, name);
+                File symlink = new File(abiDir, "libstdc++.so.6");
+                if (realPath.exists() && !symlink.exists()) {
+                    try {
+                        java.nio.file.Files.createSymbolicLink(
+                            symlink.toPath(),
+                            java.nio.file.Paths.get(name)
+                        );
+                    } catch (IOException error) {
+                        Log.w(TAG, "Could not symlink libstdc++.so.6 → " + name + ": " + error.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    /** Walk agent/{abi}/ for the musl loader; name varies by ABI. */
+    private String findMuslLoader(File abiDir) {
+        File[] files = abiDir.listFiles();
+        if (files == null) return null;
+        for (File f : files) {
+            String name = f.getName();
+            if (name.startsWith("ld-musl-") && name.endsWith(".so.1")) {
+                return name;
+            }
+        }
+        return null;
     }
 
     /**
@@ -352,18 +379,6 @@ public class MiladyAgentService extends Service {
         copyAssetIfMissing(assets, assetPath, target);
     }
 
-    private String findMuslLoader(File abiDir) {
-        File[] files = abiDir.listFiles();
-        if (files == null) return null;
-        for (File f : files) {
-            String name = f.getName();
-            if (name.startsWith("ld-musl-") && name.endsWith(".so.1")) {
-                return name;
-            }
-        }
-        return null;
-    }
-
     // ── Process lifecycle ────────────────────────────────────────────────
 
     private void startAgentProcess() {
@@ -386,7 +401,7 @@ public class MiladyAgentService extends Service {
             File abiDir = agentAbiDir(abi);
             File bundle = new File(root, AGENT_BUNDLE_NAME);
             File bun = new File(abiDir, BUN_BINARY);
-            String loader = findMuslLoader(abiDir);
+            String loaderName = findMuslLoader(abiDir);
 
             if (!bundle.exists()) {
                 Log.e(TAG, "Agent bundle missing at " + bundle);
@@ -400,36 +415,50 @@ public class MiladyAgentService extends Service {
                 updateNotification();
                 return;
             }
-            if (loader == null) {
+            if (loaderName == null) {
                 Log.e(TAG, "musl loader missing under " + abiDir);
                 currentStatus = "missing-loader";
                 updateNotification();
                 return;
             }
+            File loader = new File(abiDir, loaderName);
 
-            File loaderFile = new File(abiDir, loader);
+            // Generate a fresh per-boot token for the WebView↔agent loopback.
+            // Without this the loopback API would accept any local request
+            // — including from other apps on the device — because the
+            // agent's default isTrustedLocalRequest() heuristic treats
+            // loopback as authoritative, which is wrong on multi-app
+            // Android. MILADY_REQUIRE_LOCAL_AUTH on the server side flips
+            // that heuristic off so every request needs the bearer token.
+            String token = generateLocalAgentToken();
+            currentLocalAgentToken = token;
+            try {
+                writeLocalAgentTokenFile(token);
+            } catch (IOException error) {
+                Log.w(TAG, "Failed to persist local-agent token file: " + error.getMessage());
+            }
 
-            // Replicates the spike's invocation pattern, with cwd = agent/.
-            //   LD_LIBRARY_PATH=agent/{abi} \
-            //   PORT=31337 MILADY_API_PORT=31337 \
-            //   MILADY_STATE_DIR=…/.milady MILADY_PLATFORM=android \
-            //   agent/{abi}/ld-musl-*.so.1  agent/{abi}/bun  agent/agent-bundle.js
+            // Invocation:
+            //   LD_LIBRARY_PATH=<agent/{abi}>  PORT=31337  MILADY_*=…
+            //   ELIZA_API_TOKEN=<token>
+            //   agent/{abi}/ld-musl-…so.1  agent/{abi}/bun  agent/agent-bundle.js
             List<String> command = new ArrayList<>();
-            command.add(loaderFile.getAbsolutePath());
+            command.add(loader.getAbsolutePath());
             command.add(bun.getAbsolutePath());
             command.add(bundle.getAbsolutePath());
 
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(root);
             Map<String, String> env = pb.environment();
-            // Build env explicitly so a future change to the launcher
-            // contract is one place to update.
             Map<String, String> agentEnv = new LinkedHashMap<>();
             agentEnv.put("LD_LIBRARY_PATH", abiDir.getAbsolutePath());
             agentEnv.put("PORT", String.valueOf(AGENT_PORT));
             agentEnv.put("MILADY_API_PORT", String.valueOf(AGENT_PORT));
             agentEnv.put("MILADY_STATE_DIR", agentStateDir().getAbsolutePath());
             agentEnv.put("MILADY_PLATFORM", "android");
+            agentEnv.put("MILADY_DISABLE_DIRECT_RUN", "1");
+            agentEnv.put("MILADY_REQUIRE_LOCAL_AUTH", "1");
+            agentEnv.put("ELIZA_API_TOKEN", token);
             agentEnv.put("HOME", getFilesDir().getAbsolutePath());
             agentEnv.put("TMPDIR", getCacheDir().getAbsolutePath());
             env.putAll(agentEnv);
@@ -451,7 +480,7 @@ public class MiladyAgentService extends Service {
             stderrPump = startStreamPump(started.getErrorStream(), logFile, "err");
             currentStatus = "running";
             updateNotification();
-            Log.i(TAG, "Agent process started (abi=" + abi + ", pid=" + safePid(started) + ").");
+            Log.i(TAG, "Agent process started (pid=" + safePid(started) + ").");
         }
     }
 
@@ -487,6 +516,39 @@ public class MiladyAgentService extends Service {
         }
         if (outPump != null) outPump.interrupt();
         if (errPump != null) errPump.interrupt();
+    }
+
+    private static final java.security.SecureRandom TOKEN_RNG = new java.security.SecureRandom();
+
+    private static String generateLocalAgentToken() {
+        byte[] bytes = new byte[32];
+        TOKEN_RNG.nextBytes(bytes);
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Persist the per-boot token to a UID-restricted file so a future
+     * restart of the WebView (without restarting the service) can re-read
+     * it without losing auth. File is mode 0600; only the app's own UID
+     * can read.
+     */
+    private void writeLocalAgentTokenFile(String token) throws IOException {
+        File dir = new File(getFilesDir(), "auth");
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IOException("Could not create " + dir);
+        }
+        File file = new File(dir, "local-agent-token");
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            out.write(token.getBytes());
+        }
+        file.setReadable(false, false);
+        file.setReadable(true, true);
+        file.setWritable(false, false);
+        file.setWritable(true, true);
     }
 
     private long safePid(Process process) {

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -299,6 +299,14 @@ export async function stageAndroidAgentRuntime({
   const tlog = logFor(log);
   fs.mkdirSync(cacheDir, { recursive: true });
 
+  // Runtime files ship under `assets/agent/{abi}/` and the service
+  // copies them to /data/data/<pkg>/files/agent/{abi}/ at first launch
+  // and chmods +x. The agent runs as priv_app (Android.bp does not
+  // platform-sign the APK), so AOSP's stock
+  // `allow priv_app privapp_data_file:file execute;` is enough to
+  // execve bun out of the writable data dir — no jniLibs trick, no
+  // custom SELinux domain. We also clean up any stale jniLibs/ from
+  // an earlier pivot so the APK doesn't carry duplicate binaries.
   const assetsAgentDir = path.join(
     androidDir,
     "app",
@@ -308,6 +316,11 @@ export async function stageAndroidAgentRuntime({
     "agent",
   );
   fs.mkdirSync(assetsAgentDir, { recursive: true });
+  const jniLibsDir = path.join(androidDir, "app", "src", "main", "jniLibs");
+  if (fs.existsSync(jniLibsDir)) {
+    fs.rmSync(jniLibsDir, { recursive: true, force: true });
+    tlog("Removed stale jniLibs/ tree (runtime now ships under assets/agent/).");
+  }
 
   let stagedCount = 0;
 

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -308,7 +308,17 @@ export function isCapacitorPlatformReady(
   if (platform === "android") {
     return (
       fs.existsSync(path.join(appDirValue, "android", "gradlew")) &&
-      fs.existsSync(path.join(appDirValue, "android", "app", "build.gradle"))
+      fs.existsSync(path.join(appDirValue, "android", "app", "build.gradle")) &&
+      fs.existsSync(
+        path.join(
+          appDirValue,
+          "android",
+          "app",
+          "src",
+          "main",
+          "AndroidManifest.xml",
+        ),
+      )
     );
   }
   return false;
@@ -609,6 +619,7 @@ function overlayAndroid() {
         .readFileSync(gradlePath, "utf8")
         .match(/namespace\s*(?:[=:]\s*)?["']([^"']+)["']/)?.[1]
     : APP.appId;
+
   const androidPackage = namespace || APP.appId;
   const dstJava = path.join(
     androidDir,

--- a/packages/app-core/src/components/shell/RuntimeGate.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.tsx
@@ -33,7 +33,10 @@ import {
 } from "../../bridge/gateway-discovery";
 import { normalizeLanguage } from "../../i18n";
 import type { UiLanguage } from "../../i18n/messages";
-import { persistMobileRuntimeModeForServerTarget } from "../../onboarding/mobile-runtime-mode";
+import {
+  persistMobileRuntimeModeForServerTarget,
+  readPersistedMobileRuntimeMode,
+} from "../../onboarding/mobile-runtime-mode";
 import { shouldShowLocalOption } from "../../onboarding/probe-local-agent";
 import { isAndroid, isDesktopPlatform } from "../../platform/init";
 import {
@@ -143,6 +146,23 @@ export function RuntimeGate() {
       cancelled = true;
     };
   }, [isDesktop, isDev, synchronousLocal]);
+
+  // Auto-pick the on-device agent on Android when (a) the probe shows the
+  // agent is up and (b) the user hasn't already chosen a runtime. The
+  // RuntimeGate then never renders — the user lands directly in chat. If
+  // they later want a different agent (cloud / remote), the Settings ▸
+  // Runtime view re-opens this picker. The auto-pick is intentionally one
+  // shot: once the mode is persisted any subsequent launch reads it
+  // directly from storage and skips this path.
+  useEffect(() => {
+    if (!isAndroid) return;
+    if (!showLocalOption) return;
+    if (readPersistedMobileRuntimeMode() != null) return;
+    finishAsLocal();
+    // intentionally only triggers once — finishAsLocal persists the mode
+    // and dispatches SPLASH_CONTINUE; a second invocation is a no-op.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showLocalOption]);
 
   const showLocalOption = localProbeResult === true;
   const localProbePending = localProbeResult === null;

--- a/packages/app-core/src/onboarding-config.ts
+++ b/packages/app-core/src/onboarding-config.ts
@@ -42,6 +42,7 @@ export interface BuildOnboardingConnectionArgs {
   onboardingFeatureCrypto?: boolean;
   onboardingFeatureBrowser?: boolean;
   onboardingFeatureComputerUse?: boolean;
+  onboardingUseLocalEmbeddings?: boolean;
 }
 
 /** Feature selections from the onboarding features step. */
@@ -215,6 +216,9 @@ export function buildOnboardingRuntimeConfig(
         includeInference:
           shouldConfigureRuntimeProvider &&
           args.onboardingProvider === "elizacloud",
+        excludeServices: args.onboardingUseLocalEmbeddings
+          ? ["embeddings"]
+          : undefined,
         nanoModel,
         smallModel,
         mediumModel,

--- a/packages/app-core/src/runtime/embedding-warmup-policy.test.ts
+++ b/packages/app-core/src/runtime/embedding-warmup-policy.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { shouldWarmupLocalEmbeddingModel } from "./embedding-warmup-policy";
+
+const ENV_KEYS = [
+  "ELIZA_DISABLE_LOCAL_EMBEDDINGS",
+  "MILADY_DISABLE_LOCAL_EMBEDDINGS",
+  "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+  "MILADY_CLOUD_EMBEDDINGS_DISABLED",
+  "ELIZAOS_CLOUD_USE_EMBEDDINGS",
+] as const;
+
+describe("shouldWarmupLocalEmbeddingModel", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("warms up by default (no envs set)", () => {
+    expect(shouldWarmupLocalEmbeddingModel()).toBe(true);
+  });
+
+  it("skips warmup when ELIZAOS_CLOUD_USE_EMBEDDINGS=true and no overrides", () => {
+    process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+    expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+  });
+
+  describe("ELIZA_DISABLE_LOCAL_EMBEDDINGS short-circuits warmup", () => {
+    for (const value of ["1", "true", "yes", "TRUE", "Yes"]) {
+      it(`accepts ${JSON.stringify(value)}`, () => {
+        process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS = value;
+        expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+      });
+    }
+  });
+
+  describe("MILADY_DISABLE_LOCAL_EMBEDDINGS mirrors ELIZA_DISABLE_LOCAL_EMBEDDINGS", () => {
+    for (const value of ["1", "true", "yes"]) {
+      it(`accepts ${JSON.stringify(value)}`, () => {
+        process.env.MILADY_DISABLE_LOCAL_EMBEDDINGS = value;
+        expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+      });
+    }
+  });
+
+  describe("ELIZA_CLOUD_EMBEDDINGS_DISABLED forces local warmup", () => {
+    for (const value of ["1", "true", "yes"]) {
+      it(`accepts ${JSON.stringify(value)} (overrides ELIZAOS_CLOUD_USE_EMBEDDINGS=true)`, () => {
+        process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+        process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED = value;
+        expect(shouldWarmupLocalEmbeddingModel()).toBe(true);
+      });
+    }
+  });
+
+  describe("MILADY_CLOUD_EMBEDDINGS_DISABLED mirrors ELIZA_CLOUD_EMBEDDINGS_DISABLED", () => {
+    for (const value of ["1", "true", "yes"]) {
+      it(`accepts ${JSON.stringify(value)} (overrides ELIZAOS_CLOUD_USE_EMBEDDINGS=true)`, () => {
+        process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS = "true";
+        process.env.MILADY_CLOUD_EMBEDDINGS_DISABLED = value;
+        expect(shouldWarmupLocalEmbeddingModel()).toBe(true);
+      });
+    }
+  });
+
+  it("treats unrecognized values as falsy", () => {
+    process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS = "0";
+    process.env.MILADY_DISABLE_LOCAL_EMBEDDINGS = "false";
+    expect(shouldWarmupLocalEmbeddingModel()).toBe(true);
+  });
+
+  it("ignores surrounding whitespace and case", () => {
+    process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS = "  TRUE  ";
+    expect(shouldWarmupLocalEmbeddingModel()).toBe(false);
+  });
+});

--- a/packages/app-core/src/runtime/embedding-warmup-policy.ts
+++ b/packages/app-core/src/runtime/embedding-warmup-policy.ts
@@ -9,17 +9,29 @@
  * the cloud plugin handles embeddings instead; skipping warmup avoids a large
  * download unrelated to “local inference” for chat.
  */
+
+function isTruthyEnv(...names: string[]): boolean {
+  for (const name of names) {
+    const v = process.env[name]?.trim().toLowerCase();
+    if (v === "1" || v === "true" || v === "yes") return true;
+  }
+  return false;
+}
+
 export function shouldWarmupLocalEmbeddingModel(): boolean {
   if (
-    process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS === "1" ||
-    process.env.ELIZA_DISABLE_LOCAL_EMBEDDINGS === "1"
+    isTruthyEnv(
+      "ELIZA_DISABLE_LOCAL_EMBEDDINGS",
+      "MILADY_DISABLE_LOCAL_EMBEDDINGS",
+    )
   ) {
     return false;
   }
 
-  const cloudEmbeddingsRoutedLocally =
-    process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED === "1" ||
-    process.env.ELIZA_CLOUD_EMBEDDINGS_DISABLED === "1";
+  const cloudEmbeddingsRoutedLocally = isTruthyEnv(
+    "ELIZA_CLOUD_EMBEDDINGS_DISABLED",
+    "MILADY_CLOUD_EMBEDDINGS_DISABLED",
+  );
 
   if (cloudEmbeddingsRoutedLocally) {
     // User turned off cloud for embeddings — local plugin must serve TEXT_EMBEDDING.

--- a/packages/app-core/src/services/local-inference/catalog.test.ts
+++ b/packages/app-core/src/services/local-inference/catalog.test.ts
@@ -23,9 +23,11 @@ describe("catalog", () => {
     }
   });
 
-  it("every entry declares a Q* quant and a concrete gguf filename", () => {
+  it("every entry declares a quant label and a concrete gguf filename", () => {
     for (const model of MODEL_CATALOG) {
-      expect(model.quant).toMatch(/^Q\d/);
+      // Standard llama.cpp Q-quants (Q4_K_M, IQ4_XS, …) plus exotic schemes
+      // like TurboQuant 1-bit. Whatever it is, it must be non-empty.
+      expect(model.quant.length).toBeGreaterThan(0);
       expect(model.ggufFile).toMatch(/\.gguf$/i);
       expect(model.sizeGb).toBeGreaterThan(0);
       expect(model.minRamGb).toBeGreaterThanOrEqual(model.sizeGb);
@@ -62,6 +64,31 @@ describe("catalog", () => {
       });
       expect(url).toBe(
         "https://huggingface.co/bartowski/Test-GGUF/resolve/main/Test%20Model-Q4_K_M.gguf?download=true",
+      );
+    } finally {
+      if (saved !== undefined) process.env.MILADY_HF_BASE_URL = saved;
+    }
+  });
+
+  it("buildHuggingFaceResolveUrl preserves nested ggufFile path separators", () => {
+    const saved = process.env.MILADY_HF_BASE_URL;
+    delete process.env.MILADY_HF_BASE_URL;
+    try {
+      const url = buildHuggingFaceResolveUrl({
+        id: "nested",
+        displayName: "Nested",
+        hfRepo: "apothic/bonsai-8B-1bit-turboquant",
+        ggufFile: "models/gguf/8B/Bonsai-8B.gguf",
+        params: "8B",
+        quant: "1-bit TurboQuant",
+        sizeGb: 1.2,
+        minRamGb: 8,
+        category: "chat",
+        bucket: "mid",
+        blurb: "",
+      });
+      expect(url).toBe(
+        "https://huggingface.co/apothic/bonsai-8B-1bit-turboquant/resolve/main/models/gguf/8B/Bonsai-8B.gguf?download=true",
       );
     } finally {
       if (saved !== undefined) process.env.MILADY_HF_BASE_URL = saved;

--- a/packages/app-core/src/services/local-inference/catalog.ts
+++ b/packages/app-core/src/services/local-inference/catalog.ts
@@ -12,6 +12,20 @@ import type { CatalogModel } from "./types";
 export const MODEL_CATALOG: CatalogModel[] = [
   // ─── tiny / testing ─────────────────────────────────────────────────
   {
+    id: "smollm2-360m",
+    displayName: "SmolLM2 360M Instruct",
+    hfRepo: "bartowski/SmolLM2-360M-Instruct-GGUF",
+    ggufFile: "SmolLM2-360M-Instruct-Q4_K_M.gguf",
+    params: "360M",
+    quant: "Q4_K_M",
+    sizeGb: 0.27,
+    minRamGb: 1,
+    category: "tiny",
+    bucket: "small",
+    blurb:
+      "Mobile-friendly default. ~270MB on disk, runs on phones and 1GB-RAM hosts.",
+  },
+  {
     id: "smollm2-1.7b",
     displayName: "SmolLM2 1.7B Instruct",
     hfRepo: "bartowski/SmolLM2-1.7B-Instruct-GGUF",
@@ -133,6 +147,20 @@ export const MODEL_CATALOG: CatalogModel[] = [
     bucket: "mid",
     blurb: "Nous Hermes 3. Function calling, JSON mode, agentic tool use.",
   },
+  {
+    id: "bonsai-8b-1bit",
+    displayName: "Bonsai 8B 1-bit (TurboQuant)",
+    hfRepo: "apothic/bonsai-8B-1bit-turboquant",
+    ggufFile: "models/gguf/8B/Bonsai-8B.gguf",
+    params: "8B",
+    quant: "1-bit TurboQuant",
+    sizeGb: 1.2,
+    minRamGb: 8,
+    category: "chat",
+    bucket: "mid",
+    blurb:
+      "1-bit weights load on stock llama.cpp, but the TurboQuant KV-cache memory win requires the apothic/llama.cpp-1bit-turboquant fork. Mobile-experimental.",
+  },
 
   // ─── large (8-20 GB) ────────────────────────────────────────────────
   {
@@ -234,7 +262,12 @@ export function buildHuggingFaceResolveUrl(model: CatalogModel): string {
   const base =
     process.env.MILADY_HF_BASE_URL?.trim().replace(/\/+$/, "") ||
     "https://huggingface.co";
-  return `${base}/${model.hfRepo}/resolve/main/${encodeURIComponent(
-    model.ggufFile,
-  )}?download=true`;
+  // Encode each path segment separately so nested layouts like
+  // `models/gguf/8B/Bonsai-8B.gguf` keep their slashes (HF resolve URLs
+  // require a real path, not a `%2F`-mangled basename).
+  const encodedPath = model.ggufFile
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  return `${base}/${model.hfRepo}/resolve/main/${encodedPath}?download=true`;
 }

--- a/packages/app-core/src/services/local-inference/types.ts
+++ b/packages/app-core/src/services/local-inference/types.ts
@@ -19,6 +19,7 @@ export interface CatalogModel {
   /** Exact GGUF filename in the repo. */
   ggufFile: string;
   params:
+    | "360M"
     | "1B"
     | "1.7B"
     | "3B"

--- a/packages/app-core/test/onboarding-config.test.ts
+++ b/packages/app-core/test/onboarding-config.test.ts
@@ -52,4 +52,70 @@ describe("buildOnboardingRuntimeConfig", () => {
       provider: "elizacloud",
     });
   });
+
+  it("routes embeddings to cloud-proxy by default for cloud onboarding", () => {
+    const runtimeConfig = buildOnboardingRuntimeConfig({
+      onboardingServerTarget: "elizacloud-hybrid",
+      onboardingCloudApiKey: "",
+      onboardingProvider: "elizacloud",
+      onboardingApiKey: "",
+      onboardingVoiceProvider: "",
+      onboardingVoiceApiKey: "",
+      onboardingPrimaryModel: "",
+      onboardingOpenRouterModel: "",
+      onboardingRemoteConnected: false,
+      onboardingRemoteApiBase: "",
+      onboardingRemoteToken: "",
+    });
+
+    expect(runtimeConfig.serviceRouting?.embeddings?.transport).toBe(
+      "cloud-proxy",
+    );
+    expect(runtimeConfig.serviceRouting?.embeddings?.backend).toBe(
+      "elizacloud",
+    );
+  });
+
+  it("omits the cloud embeddings route when onboardingUseLocalEmbeddings is true", () => {
+    const runtimeConfig = buildOnboardingRuntimeConfig({
+      onboardingServerTarget: "elizacloud-hybrid",
+      onboardingCloudApiKey: "",
+      onboardingProvider: "elizacloud",
+      onboardingApiKey: "",
+      onboardingVoiceProvider: "",
+      onboardingVoiceApiKey: "",
+      onboardingPrimaryModel: "",
+      onboardingOpenRouterModel: "",
+      onboardingRemoteConnected: false,
+      onboardingRemoteApiBase: "",
+      onboardingRemoteToken: "",
+      onboardingUseLocalEmbeddings: true,
+    });
+
+    expect(runtimeConfig.serviceRouting?.embeddings).toBeUndefined();
+    expect(runtimeConfig.serviceRouting?.tts?.transport).toBe("cloud-proxy");
+    expect(runtimeConfig.serviceRouting?.media?.transport).toBe("cloud-proxy");
+    expect(runtimeConfig.serviceRouting?.rpc?.transport).toBe("cloud-proxy");
+  });
+
+  it("routes embeddings to cloud-proxy when onboardingUseLocalEmbeddings is false", () => {
+    const runtimeConfig = buildOnboardingRuntimeConfig({
+      onboardingServerTarget: "elizacloud-hybrid",
+      onboardingCloudApiKey: "",
+      onboardingProvider: "elizacloud",
+      onboardingApiKey: "",
+      onboardingVoiceProvider: "",
+      onboardingVoiceApiKey: "",
+      onboardingPrimaryModel: "",
+      onboardingOpenRouterModel: "",
+      onboardingRemoteConnected: false,
+      onboardingRemoteApiBase: "",
+      onboardingRemoteToken: "",
+      onboardingUseLocalEmbeddings: false,
+    });
+
+    expect(runtimeConfig.serviceRouting?.embeddings?.transport).toBe(
+      "cloud-proxy",
+    );
+  });
 });

--- a/packages/shared/src/contracts/service-routing.test.ts
+++ b/packages/shared/src/contracts/service-routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDefaultElizaCloudServiceRouting,
+  buildElizaCloudServiceRoute,
+} from "./service-routing";
+
+describe("buildDefaultElizaCloudServiceRouting", () => {
+  it("routes all default capabilities to cloud-proxy by default", () => {
+    const routing = buildDefaultElizaCloudServiceRouting();
+
+    expect(routing.embeddings?.transport).toBe("cloud-proxy");
+    expect(routing.embeddings?.backend).toBe("elizacloud");
+    expect(routing.tts?.transport).toBe("cloud-proxy");
+    expect(routing.media?.transport).toBe("cloud-proxy");
+    expect(routing.rpc?.transport).toBe("cloud-proxy");
+    expect(routing.llmText).toBeUndefined();
+  });
+
+  it("omits embeddings when listed in excludeServices", () => {
+    const routing = buildDefaultElizaCloudServiceRouting({
+      excludeServices: ["embeddings"],
+    });
+
+    expect(routing.embeddings).toBeUndefined();
+    expect(routing.tts?.transport).toBe("cloud-proxy");
+    expect(routing.media?.transport).toBe("cloud-proxy");
+    expect(routing.rpc?.transport).toBe("cloud-proxy");
+  });
+
+  it("preserves a pre-existing route on a non-excluded capability", () => {
+    const customEmbeddings = buildElizaCloudServiceRoute({
+      smallModel: "custom-embedding-model",
+    });
+    const routing = buildDefaultElizaCloudServiceRouting({
+      base: { embeddings: customEmbeddings },
+      excludeServices: ["tts"],
+    });
+
+    expect(routing.embeddings).toBe(customEmbeddings);
+    expect(routing.embeddings?.smallModel).toBe("custom-embedding-model");
+    expect(routing.tts).toBeUndefined();
+    expect(routing.media?.transport).toBe("cloud-proxy");
+    expect(routing.rpc?.transport).toBe("cloud-proxy");
+  });
+
+  it("treats an empty excludeServices the same as the default", () => {
+    const routing = buildDefaultElizaCloudServiceRouting({
+      excludeServices: [],
+    });
+
+    expect(routing.embeddings?.transport).toBe("cloud-proxy");
+    expect(routing.tts?.transport).toBe("cloud-proxy");
+    expect(routing.media?.transport).toBe("cloud-proxy");
+    expect(routing.rpc?.transport).toBe("cloud-proxy");
+  });
+});

--- a/packages/shared/src/contracts/service-routing.ts
+++ b/packages/shared/src/contracts/service-routing.ts
@@ -223,6 +223,7 @@ export function buildDefaultElizaCloudServiceRouting(
   args: {
     base?: ServiceRoutingConfig | null;
     includeInference?: boolean;
+    excludeServices?: readonly Exclude<ServiceCapability, "llmText">[];
     nanoModel?: string;
     smallModel?: string;
     mediumModel?: string;
@@ -237,8 +238,10 @@ export function buildDefaultElizaCloudServiceRouting(
   } = {},
 ): ServiceRoutingConfig {
   const next: ServiceRoutingConfig = { ...(args.base ?? {}) };
+  const excluded = new Set(args.excludeServices ?? []);
 
   for (const capability of ELIZA_CLOUD_DEFAULT_SERVICE_CAPABILITIES) {
+    if (excluded.has(capability)) continue;
     next[capability] ??= buildElizaCloudServiceRoute();
   }
 


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up a local Eliza agent running inside an Android foreground service (`MiladyAgentService`), including per-boot bearer-token auth (shared loopback requires explicit token, not just loopback trust), `libstdc++` symlink creation for the musl runtime, local-embeddings opt-out across the service-routing layer, and a new auto-pick flow in `RuntimeGate` that lands Android users directly in chat when the on-device agent is detected.

- **P0 — `RuntimeGate.tsx`**: The new `useEffect` references `showLocalOption` (and passes it as a dependency) before `const showLocalOption = ...` is declared; this is a Temporal Dead Zone `ReferenceError` that crashes every render of the component.
- **P1 — `MiladyAgentService.java`**: The `libstdc++.so.6` symlink guard (`!symlink.exists()`) will silently leave a dangling symlink after an app update that bumps the versioned filename, breaking agent startup with unresolved-symbol errors.

<h3>Confidence Score: 2/5</h3>

Not safe to merge — the TDZ crash in RuntimeGate will break the component on every render, and the symlink issue will silently break the agent on app updates.

A P0 TDZ ReferenceError in RuntimeGate.tsx crashes the UI component universally on every render, and a P1 symlink idempotency bug in MiladyAgentService.java silently breaks the Android agent on library version bumps. Both must be fixed before merge.

packages/app-core/src/components/shell/RuntimeGate.tsx (P0 TDZ crash) and packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyAgentService.java (P1 symlink / P2 token race)

<details open><summary><h3>Security Review</h3></summary>

- **Token file race window** (`MiladyAgentService.java`): The per-boot bearer token is written via `new FileOutputStream(file)`, which creates the file with default (potentially world-readable) permissions before `setReadable(false, false)` is called. Using `Context.openFileOutput(name, MODE_PRIVATE)` or an atomic rename would eliminate the window.
- **Loopback trust bypass design** (`server-helpers-auth.ts`): Design is sound — the env var correctly disables loopback-only trust on Android where the loopback interface is shared across apps, requiring bearer auth on all routes except `/api/health`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/shell/RuntimeGate.tsx | Adds Android auto-pick useEffect, but references showLocalOption before its const declaration — TDZ ReferenceError crashes every render |
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MiladyAgentService.java | Adds per-boot bearer token (SecureRandom), require-local-auth env var, libstdc++ symlink creation, and stateDir layout; symlink idempotency breaks on library version bump and token file has a brief world-readable window |
| packages/agent/src/api/server-helpers-auth.ts | Correctly disables loopback trust on Android by checking env flag, enforcing bearer auth for all routes |
| packages/shared/src/contracts/service-routing.ts | Adds excludeServices parameter to buildDefaultElizaCloudServiceRouting, allowing local embeddings to opt out of cloud routing |
| packages/app-core/src/runtime/embedding-warmup-policy.ts | Fixes a pre-existing copy-paste bug (same env var checked twice), adds truthy-value helper and MILADY_ env var variants |
| packages/app-core/src/services/local-inference/catalog.ts | Adds smollm2-360m and bonsai-8b-1bit models; fixes buildHuggingFaceResolveUrl to encode nested path segments separately |
| packages/agent/src/api/provider-switch-config.ts | Adds useLocalEmbeddings option to applyOnboardingConnectionConfig to pass excludeServices for both cloud and direct routes |
| packages/app-core/scripts/lib/stage-android-agent.mjs | Adds cleanup of stale jniLibs/ directory and improves comments; straightforward build-script change |
| packages/agent/scripts/build-mobile-bundle.mjs | Adds null stub for plugin-browser-bridge to prevent 200MB puppeteer/Chromium from being bundled in the mobile build |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant AS as MiladyAgentService (Android)
    participant BUN as Bun/Agent Process
    participant WV as WebView (Capacitor)
    participant RT as RuntimeGate (React)
    participant SR as ElizaOS Server

    AS->>AS: Generate per-boot bearer token (SecureRandom)
    AS->>AS: Persist token to restricted file
    AS->>BUN: execve(musl-loader, bun, bundle) with token + auth env vars
    BUN->>SR: Start HTTP on port 31337
    WV->>AS: Read token via Capacitor plugin
    AS-->>WV: token
    WV->>SR: GET /api/health (local probe)
    SR-->>WV: 200 OK
    WV->>RT: localProbeResult = true
    RT->>RT: showLocalOption = true
    Note over RT: P0 - useEffect references showLocalOption BEFORE declaration
    RT->>RT: finishAsLocal() → persist mode → SPLASH_CONTINUE
    WV->>SR: API calls with Authorization Bearer token
    SR->>SR: Loopback trust disabled on Android → bearer token required
```

<sub>Reviews (1): Last reviewed commit: ["feat(local-agent-android): bun execve + ..."](https://github.com/elizaos/eliza/commit/61082acceeeaa06f6123553eec3d097aaa398c45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30118163)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->