### PR TITLE
fix(registry): rename apps/polymarket id to avoid collision with plugins/polymarket

### DIFF
--- a/packages/app-core/src/registry/entries/apps/polymarket.json
+++ b/packages/app-core/src/registry/entries/apps/polymarket.json
@@ -1,10 +1,15 @@
 {
-  "id": "polymarket",
+  "id": "polymarket-app",
   "name": "Polymarket",
   "description": "Native Polymarket market discovery and trading readiness for prediction markets.",
   "npmName": "@elizaos/app-polymarket",
   "source": "bundled",
-  "tags": ["trading", "polymarket", "prediction-markets", "wallet"],
+  "tags": [
+    "trading",
+    "polymarket",
+    "prediction-markets",
+    "wallet"
+  ],
   "config": {},
   "render": {
     "visible": true,
@@ -13,15 +18,25 @@
     "icon": "Landmark",
     "group": "Curated",
     "groupOrder": 8,
-    "actions": ["launch", "configure"]
+    "actions": [
+      "launch",
+      "configure"
+    ]
   },
   "resources": {},
-  "dependsOn": ["wallet"],
+  "dependsOn": [
+    "wallet"
+  ],
   "kind": "app",
   "subtype": "trading",
   "launch": {
     "type": "server-launch",
-    "capabilities": ["polymarket", "prediction-markets", "trading", "wallet"],
+    "capabilities": [
+      "polymarket",
+      "prediction-markets",
+      "trading",
+      "wallet"
+    ],
     "curatedSlug": "polymarket",
     "routePlugin": {
       "specifier": "@elizaos/app-polymarket/plugin",


### PR DESCRIPTION
## what

both `apps/polymarket.json` and `plugins/polymarket.json` carry id `polymarket`. the registry validator (`every registry entry must have a unique id`) refuses to load this state and throws `Runtime bootstrap failed (Registry entry at packages/app-core/src/registry/entries/plugins/polymarket.json failed validation: duplicate id 'polymarket')` on every boot.

## why

introduced today (2026-04-29) in `a8ed9f5b1d` *chore(eliza): commit app registry and cleanup agent work* — the new `apps/polymarket.json` was added with the same id the plugin entry already used.

## fix

rename the apps entry id to `polymarket-app`. plugin keeps `polymarket` (it's the larger, older entry).

## verification

local milady runtime that previously crash-looped on bootstrap now boots clean and the agent reaches `status: running`.

alternative considered: making the validator namespace-aware (allow same id across apps/ vs plugins/). that's a bigger architectural change; the rename is the surgical fix for now.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a boot-time crash by renaming the `id` field in `apps/polymarket.json` from `"polymarket"` to `"polymarket-app"`, resolving the duplicate-id validation error thrown when both `apps/polymarket.json` and `plugins/polymarket.json` carry the same id. The change is surgical and correct.

- `generate-apps.ts` (the one-off migration script that originally produced the JSON) still declares `id: \"polymarket\"` at line 234 and has not been deleted. Re-running it would regenerate the collision.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the JSON rename directly fixes the boot-time crash with no functional regressions.

Single-file change with a clear, targeted fix. The only concern is that the now-stale migration script `generate-apps.ts` retains the old id and could reintroduce the problem if re-run, but this is a P2 hygiene issue rather than a blocking defect.

packages/app-core/src/registry/generate-apps.ts — still declares `id: "polymarket"` for the app entry; should be updated or deleted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/registry/entries/apps/polymarket.json | Renames `id` from `"polymarket"` to `"polymarket-app"` to resolve a duplicate-id collision with `plugins/polymarket.json`; also reformats arrays to multi-line style. The fix is correct, but the source migration script `generate-apps.ts` still carries the old id and could regenerate the collision if re-run. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Registry bootstrap] --> B{Validate all entry ids}
    B -->|Before fix| C["apps/polymarket.json id='polymarket'\nplugins/polymarket.json id='polymarket'"]
    C --> D["❌ Duplicate id 'polymarket'\nRuntime bootstrap failed"]
    B -->|After fix| E["apps/polymarket.json id='polymarket-app'\nplugins/polymarket.json id='polymarket'"]
    E --> F["✅ All ids unique\nAgent reaches status: running"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(registry): rename apps/polymarket id..."](https://github.com/elizaos/eliza/commit/0c19ae584606f1509cda347f1f3c82c5c3ab6de2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30155194)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->