### PR TITLE
test(app-core): remove api module mocks

### DIFF
--- a/packages/app-core/src/api/client-base.test.ts
+++ b/packages/app-core/src/api/client-base.test.ts
@@ -1,44 +1,26 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
 
-vi.mock("../config/boot-config", () => {
-  let _config: Record<string, unknown> = {};
-  return {
-    getBootConfig: () => _config,
-    setBootConfig: (c: Record<string, unknown>) => {
-      _config = { ..._config, ...c };
-    },
-  };
-});
-
-vi.mock("../utils/eliza-globals", () => ({
-  setElizaApiToken: vi.fn(),
-  clearElizaApiToken: vi.fn(),
-  getElizaApiToken: vi.fn(() => null),
-  setElizaApiBase: vi.fn(),
-  clearElizaApiBase: vi.fn(),
-  getElizaApiBase: vi.fn(() => ""),
-}));
-
-import { getBootConfig, setBootConfig } from "../config/boot-config";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
-  clearElizaApiToken,
-  setElizaApiToken,
-} from "../utils/eliza-globals";
-
-// ElizaClient is a class with constructor side effects; import after mocks.
-const { ElizaClient } = await import("./client-base");
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "../config/boot-config";
+import { clearElizaApiToken, getElizaApiToken } from "../utils/eliza-globals";
+import { ElizaClient } from "./client-base";
 
 describe("ElizaClient.setToken", () => {
   let client: InstanceType<typeof ElizaClient>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    setBootConfig({});
+    clearElizaApiToken();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
     client = new ElizaClient();
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    clearElizaApiToken();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
   });
 
   it("writes apiToken to bootConfig", () => {
@@ -48,7 +30,7 @@ describe("ElizaClient.setToken", () => {
 
   it("calls setElizaApiToken with the trimmed token", () => {
     client.setToken("  spaced  ");
-    expect(setElizaApiToken).toHaveBeenCalledWith("spaced");
+    expect(getElizaApiToken()).toBe("spaced");
   });
 
   it("clears apiToken from bootConfig when null", () => {
@@ -58,18 +40,20 @@ describe("ElizaClient.setToken", () => {
   });
 
   it("calls clearElizaApiToken when token is null", () => {
+    client.setToken("my-token");
     client.setToken(null);
-    expect(clearElizaApiToken).toHaveBeenCalled();
+    expect(getElizaApiToken()).toBeUndefined();
   });
 
   it("calls clearElizaApiToken when token is empty string", () => {
+    client.setToken("my-token");
     client.setToken("");
-    expect(clearElizaApiToken).toHaveBeenCalled();
+    expect(getElizaApiToken()).toBeUndefined();
   });
 
   it("trims whitespace from token", () => {
     client.setToken("  hello  ");
     expect(getBootConfig().apiToken).toBe("hello");
-    expect(setElizaApiToken).toHaveBeenCalledWith("hello");
+    expect(getElizaApiToken()).toBe("hello");
   });
 });

--- a/packages/app-core/src/api/csrf-client.test.ts
+++ b/packages/app-core/src/api/csrf-client.test.ts
@@ -10,28 +10,12 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-// We import the constant from the sessions module so the test is in sync.
+import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";
 import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from "./auth/sessions";
 import { fetchWithCsrf, readCsrfTokenFromCookie } from "./csrf-client";
 
-vi.mock("../config/boot-config", () => {
-  let _config: Record<string, unknown> = {};
-  return {
-    getBootConfig: () => _config,
-    setBootConfig: (c: Record<string, unknown>) => {
-      _config = c;
-    },
-    _setTestConfig: (c: Record<string, unknown>) => {
-      _config = c;
-    },
-  };
-});
-
-// ── readCsrfTokenFromCookie ───────────────────────────────────────────────────
-
 describe("readCsrfTokenFromCookie", () => {
   afterEach(() => {
-    // Remove the test cookie by setting Max-Age=0.
     document.cookie = `${CSRF_COOKIE_NAME}=; Max-Age=0; path=/`;
   });
 
@@ -52,20 +36,19 @@ describe("readCsrfTokenFromCookie", () => {
   });
 });
 
-// ── fetchWithCsrf ─────────────────────────────────────────────────────────────
-
 describe("fetchWithCsrf", () => {
   let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
 
   beforeEach(() => {
     fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
-    // Plant a CSRF cookie for mutation-method tests.
+    setBootConfig(DEFAULT_BOOT_CONFIG);
     document.cookie = `${CSRF_COOKIE_NAME}=csrf-test-value; path=/`;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    setBootConfig(DEFAULT_BOOT_CONFIG);
     document.cookie = `${CSRF_COOKIE_NAME}=; Max-Age=0; path=/`;
   });
 
@@ -99,7 +82,6 @@ describe("fetchWithCsrf", () => {
   });
 
   it("POST does not attach x-milady-csrf when cookie absent", async () => {
-    // Remove the cookie.
     document.cookie = `${CSRF_COOKIE_NAME}=; Max-Age=0; path=/`;
     await fetchWithCsrf("/api/test", { method: "POST" });
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -108,7 +90,6 @@ describe("fetchWithCsrf", () => {
   });
 
   it("defaults to GET when no method supplied", async () => {
-    // No method in init — treated as GET, no CSRF.
     await fetchWithCsrf("/api/test", {});
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = new Headers(init.headers);
@@ -117,28 +98,22 @@ describe("fetchWithCsrf", () => {
   });
 });
 
-// ── Bearer token layering ─────────────────────────────────────────────────────
-
 describe("fetchWithCsrf — bearer token", () => {
   let fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
-  // biome-ignore lint/suspicious/noExplicitAny: test mock helper
-  let _setTestConfig: (c: any) => void;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchMock);
-    const mod = await import("../config/boot-config");
-    _setTestConfig = (mod as Record<string, unknown>)._setTestConfig as typeof _setTestConfig;
-    _setTestConfig({});
+    setBootConfig(DEFAULT_BOOT_CONFIG);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    _setTestConfig({});
+    setBootConfig(DEFAULT_BOOT_CONFIG);
   });
 
   it("attaches Authorization: Bearer when apiToken is set", async () => {
-    _setTestConfig({ apiToken: "my-secret-token" });
+    setBootConfig({ ...DEFAULT_BOOT_CONFIG, apiToken: "my-secret-token" });
     await fetchWithCsrf("/api/test");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = new Headers(init.headers);
@@ -146,7 +121,7 @@ describe("fetchWithCsrf — bearer token", () => {
   });
 
   it("does not overwrite an explicit Authorization header", async () => {
-    _setTestConfig({ apiToken: "my-secret-token" });
+    setBootConfig({ ...DEFAULT_BOOT_CONFIG, apiToken: "my-secret-token" });
     await fetchWithCsrf("/api/test", {
       headers: { Authorization: "Bearer explicit-token" },
     });
@@ -156,7 +131,7 @@ describe("fetchWithCsrf — bearer token", () => {
   });
 
   it("does not attach Authorization when apiToken is absent", async () => {
-    _setTestConfig({});
+    setBootConfig(DEFAULT_BOOT_CONFIG);
     await fetchWithCsrf("/api/test");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = new Headers(init.headers);
@@ -164,7 +139,7 @@ describe("fetchWithCsrf — bearer token", () => {
   });
 
   it("trims whitespace from apiToken", async () => {
-    _setTestConfig({ apiToken: "  spaced-token  " });
+    setBootConfig({ ...DEFAULT_BOOT_CONFIG, apiToken: "  spaced-token  " });
     await fetchWithCsrf("/api/test");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const headers = new Headers(init.headers);


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `vi.mock` overrides for `boot-config` and `eliza-globals` in the `app-core` API tests, replacing them with the real module implementations backed by proper `beforeEach`/`afterEach` teardown (`setBootConfig(DEFAULT_BOOT_CONFIG)` and `clearElizaApiToken()`). Mock-call assertions (`toHaveBeenCalledWith`) are replaced with state-based assertions (`getElizaApiToken()`), and a `// @vitest-environment jsdom` directive is added to `client-base.test.ts` so window-global helpers are exercised correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — test-only changes with no production code impact.

Both files are test files only. The real implementations are consistent with what the mocks approximated, teardown is handled in both beforeEach and afterEach, and the new jsdom directive is correctly placed at the top of the file. No logic issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/client-base.test.ts | Removes module mocks for boot-config and eliza-globals in favour of real implementations; adds `// @vitest-environment jsdom` directive (required for window-based globals) and switches to state-based assertions. |
| packages/app-core/src/api/csrf-client.test.ts | Removes boot-config mock and the test-only `_setTestConfig` escape hatch; replaces with real `setBootConfig(DEFAULT_BOOT_CONFIG)` resets in beforeEach/afterEach, and updates bearer-token setup to spread DEFAULT_BOOT_CONFIG. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[beforeEach] --> B[clearElizaApiToken\nclear window globals]
    A --> C[setBootConfig DEFAULT_BOOT_CONFIG\nreset global store]
    A --> D[new ElizaClient]
    D --> E[Test body\nstate-based assertions]
    E --> F[afterEach]
    F --> G[clearElizaApiToken]
    F --> H[setBootConfig DEFAULT_BOOT_CONFIG]

    subgraph "Removed vi.mock"
        M1[mock boot-config\n_setTestConfig escape hatch]
        M2[mock eliza-globals\ntoHaveBeenCalled assertions]
    end

    subgraph "Real implementations used"
        R1[getBootConfig / setBootConfig\nSymbol-keyed global store]
        R2[getElizaApiToken / clearElizaApiToken\nwindow.__ELIZAOS_API_TOKEN__]
    end
```

<sub>Reviews (1): Last reviewed commit: ["test(app-core): remove api module mocks"](https://github.com/elizaos/eliza/commit/3c9787114936322a8b6fffd2d0631e4fbede8690) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30504300)</sub>

<!-- /greptile_comment -->