### PR TITLE
fix(lint): biome format plugin-tee + plugin-twitch actions

### DIFF
--- a/plugins/plugin-tee/src/actions/remoteAttestation.ts
+++ b/plugins/plugin-tee/src/actions/remoteAttestation.ts
@@ -43,9 +43,7 @@ export const remoteAttestationAction: Action = {
       __avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
     const __avRegex = new RegExp("\\b(?:remote|attestation)\\b", "i");
     const __avRegexOk = __avRegex.test(__avText);
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/joinChannel.ts
+++ b/plugins/plugin-twitch/src/actions/joinChannel.ts
@@ -56,9 +56,7 @@ export const joinChannel: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/leaveChannel.ts
+++ b/plugins/plugin-twitch/src/actions/leaveChannel.ts
@@ -63,9 +63,7 @@ export const leaveChannel: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/listChannels.ts
+++ b/plugins/plugin-twitch/src/actions/listChannels.ts
@@ -40,9 +40,7 @@ export const listChannels: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/sendMessage.ts
+++ b/plugins/plugin-twitch/src/actions/sendMessage.ts
@@ -69,9 +69,7 @@ export const sendMessage: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource


### PR DESCRIPTION
## Bug

Biome format check is failing on action validator output in both plugin-tee and plugin-twitch files.

## Symptom

Quality Extended `Format Check (biome)` reports formatting differences in `plugins/plugin-tee/src/actions/remoteAttestation.ts` and the plugin-twitch action files.

## Fix

Run the repo Biome formatter on the affected action files only.

Per-file notes:

- `plugins/plugin-tee/src/actions/remoteAttestation.ts`: collapses the multiline `String(message?.content?.source ?? "")` expression to the single-line form expected by Biome 1.x.
- `plugins/plugin-twitch/src/actions/joinChannel.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/leaveChannel.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/listChannels.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/sendMessage.ts`: applies the same Biome 1.x single-line `String()` formatting.

## Verification

- `bun run --cwd plugins/plugin-tee format`
- `bun run --cwd plugins/plugin-twitch format`

Co-authored-by: wakesync <shadow@shad0w.xyz>
