### PR TITLE
fix(plugin-local-ai): correct tsconfig extends path

### DIFF
--- a/plugins/plugin-local-ai/tsconfig.json
+++ b/plugins/plugin-local-ai/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",


### PR DESCRIPTION
## Bug

`plugins/plugin-local-ai/tsconfig.json` had:
```json
"extends": "../../../tsconfig.json"
```

Three levels up resolves to *above* the repo root, where no `tsconfig.json` exists.

## Symptom

`Plugin Tests` workflow on develop HEAD fails at the very first plugin tested with:
```
[TSCONFIG_ERROR] Error: Failed to load tsconfig for '__tests__/index.test.ts': Tsconfig not found
```

This kills the entire `@elizaos/plugin-local-ai#test` turbo step, which fails-fast the rest of the plugin test suite.

## Fix

Two levels up (matches every other plugin in the workspace, since plugins live at `plugins/<name>` two dirs below the root):

```diff
- "extends": "../../../tsconfig.json"
+ "extends": "../../tsconfig.json"
```

## Verification

`bun run test` in `plugins/plugin-local-ai` now passes 17/17.

`grep -rl '"extends": "../../../tsconfig"' plugins/` returns nothing else, so this was the only plugin with the broken path.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-character typo in `plugins/plugin-local-ai/tsconfig.json` where the `extends` path pointed three levels up (above the repo root) instead of two levels up (the actual repo root). The broken path caused the TypeScript config to fail to load, which was blocking the entire plugin test suite via a fail-fast in the Turbo pipeline.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-character path fix with no logic changes or side effects.

The change is a trivially verifiable one-line correction; the root tsconfig.json exists at the corrected path, and the previous path resolved above the repo root where no file exists. No other files are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-ai/tsconfig.json | Corrects the `extends` path from `../../../tsconfig.json` (above repo root, non-existent) to `../../tsconfig.json` (repo root), matching every other plugin in the workspace. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["plugins/plugin-local-ai/tsconfig.json"] -->|"Before: extends '../../../tsconfig.json'"| B["❌ Above repo root\n(no file exists)"]
    A -->|"After: extends '../../tsconfig.json'"| C["✅ /tsconfig.json\n(repo root)"]
    C --> D["TypeScript config loads successfully"]
    D --> E["@elizaos/plugin-local-ai#test passes"]
    E --> F["Turbo plugin test suite unblocked"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-local-ai): correct tsconfig e..."](https://github.com/elizaos/eliza/commit/14ca0651632d7d791021a281475679d097f47419) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30592974)</sub>

<!-- /greptile_comment -->