### PR TITLE
fix(api-worker): preserve legacy birdeye redirect before auth

### DIFF
--- a/cloud/apps/api/src/middleware/auth.ts
+++ b/cloud/apps/api/src/middleware/auth.ts
@@ -1,13 +1,13 @@
 /**
- * Global auth middleware — Hono auth gate. Steward cookie/session resolution
+ * Global auth middleware, Hono auth gate. Steward cookie/session resolution
  * lives in `getCurrentUser` (`packages/lib/auth/workers-hono-auth.ts`).
  *
  * Behavior:
  *   - Public paths pass through with no auth.
- *   - Programmatic auth (X-API-Key, Bearer eliza_*) — pass through; per-route
+ *   - Programmatic auth (X-API-Key, Bearer eliza_*), pass through; per-route
  *     handlers validate the key against the DB.
- *   - Steward cookie / Steward Bearer JWT — verify via `getCurrentUser` and
- *     fall through on success. Failure on a protected /api/ path → 401.
+ *   - Steward cookie / Steward Bearer JWT, verify via `getCurrentUser` and
+ *     fall through on success. Failure on a protected /api/ path returns 401.
  *
  * This middleware is mounted globally before the router in src/index.ts.
  */
@@ -92,6 +92,15 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   if (!pathname.startsWith("/api/")) {
     await next();
     return;
+  }
+
+  if (c.req.method === "GET" && pathname.startsWith("/api/v1/proxy/birdeye/")) {
+    const redirectUrl = new URL(c.req.url);
+    redirectUrl.pathname = redirectUrl.pathname.replace(
+      "/api/v1/proxy/birdeye",
+      "/api/v1/apis/birdeye",
+    );
+    return c.redirect(redirectUrl.toString(), 308);
   }
 
   if (isPublicPath(pathname)) {


### PR DESCRIPTION
## Bug

After the Worker bundle AWS SDK import issue was fixed on develop, the Worker e2e suite reached the legacy Birdeye route and showed that `GET /api/v1/proxy/birdeye/*` is blocked by the global auth gate before it can issue its documented redirect.

## Symptom

Cloud CF Deploy `Run Worker e2e` expected `GET /api/v1/proxy/birdeye/defi/price?address=foo` with `redirect: "manual"` to return 308, then following the redirect to the canonical `/api/v1/apis/birdeye/*` route should return 401 when unauthenticated.

## Fix

Handle the legacy Birdeye GET redirect in the global auth middleware before protected route auth runs. The canonical `/api/v1/apis/birdeye/*` route remains protected, so redirect-follow requests still get the expected 401.

## Verification

- `cd cloud && bun run lint:check`
- `cd cloud && bun run --cwd apps/api typecheck`
- `cd cloud && bun run test:e2e:worker`, passes 412/412, skips 3

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR inserts a 308 permanent redirect for `GET /api/v1/proxy/birdeye/*` → `/api/v1/apis/birdeye/*` inside the global auth middleware, placing it before the auth gate so unauthenticated clients still receive the redirect rather than a premature 401. The canonical `/api/v1/apis/birdeye/*` route remains auth-protected, so following the redirect without credentials still yields 401. The change is narrowly scoped (one condition, one file) and the redirect preserves query parameters correctly via `new URL`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped, does not weaken auth on any path, and the e2e suite passes 412/412.

Single-condition pre-auth redirect; canonical route remains protected; query params preserved via URL object mutation; no redirect loop; method-gated to GET only; no security surface change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/apps/api/src/middleware/auth.ts | Adds a pre-auth 308 redirect for legacy GET /api/v1/proxy/birdeye/* to canonical /api/v1/apis/birdeye/* path; query params preserved, no redirect loop possible, auth protection on the canonical route is unchanged. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant MW as authMiddleware
    participant R as Router (/api/v1/apis/birdeye/*)

    C->>MW: GET /api/v1/proxy/birdeye/defi/price?address=foo
    Note over MW: NEW: pre-auth birdeye check
    MW-->>C: 308 Redirect → /api/v1/apis/birdeye/defi/price?address=foo

    C->>MW: GET /api/v1/apis/birdeye/defi/price?address=foo
    Note over MW: isPublicPath? No
    Note over MW: API key / eliza bearer? No
    Note over MW: getCurrentUser → null (unauthenticated)
    MW-->>C: 401 Unauthorized

    C->>MW: GET /api/v1/apis/birdeye/defi/price?address=foo (with auth)
    Note over MW: getCurrentUser → user OK
    MW->>R: next()
    R-->>C: 200 OK
```

<sub>Reviews (1): Last reviewed commit: ["fix(api-worker): redirect legacy birdeye..."](https://github.com/elizaos/eliza/commit/28fe31576391be81c5beb8236e297589b98c9985) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30594267)</sub>

<!-- /greptile_comment -->