### PR TITLE
fix(plugin-local-ai): correct tsconfig extends path

### DIFF
--- a/plugins/plugin-local-ai/tsconfig.json
+++ b/plugins/plugin-local-ai/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",


### PR DESCRIPTION
## Bug

`plugins/plugin-local-ai/tsconfig.json` extended `../../../tsconfig.json`. From `plugins/plugin-local-ai`, that walks three levels up and resolves above the repo root, where there is no `tsconfig.json`.

## Symptom

Plugin Tests fail during `@elizaos/plugin-local-ai#test` with `[TSCONFIG_ERROR] Error: Failed to load tsconfig for '__tests__/index.test.ts': Tsconfig not found`. Since the Vitest transform cannot load the package tsconfig, the turbo Plugin Tests pipeline stops at this package.

## Fix

Change the tsconfig extend path to `../../tsconfig.json`, matching the repo layout for plugins under `plugins/<name>`.

## Verification

- `bun run --cwd plugins/plugin-local-ai test`, passes 17/17 tests
- `grep -rl '"extends": "../../../tsconfig"' plugins/` returns no other affected plugins

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-character path bug in `plugins/plugin-local-ai/tsconfig.json` where the `extends` path walked three levels up (above the repository root) instead of two, causing TypeScript/Vitest to fail to load any tsconfig for the package's tests. The change from `../../../tsconfig.json` to `../../tsconfig.json` correctly targets the repo-root `tsconfig.json` and is consistent with how other plugins under `plugins/<name>/` are structured.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line config fix with verified correct path and confirmed test pass.

The change is a trivial one-level path correction with no logic, no security implications, and a confirmed test pass (17/17). The correct depth (`../../`) aligns with the repo directory structure and other plugin tsconfigs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-ai/tsconfig.json | Corrects the `extends` path from `../../../tsconfig.json` (above repo root, non-existent) to `../../tsconfig.json` (repo-root tsconfig), fixing Vitest/TypeScript resolution failures. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["plugins/plugin-local-ai/tsconfig.json"] -->|"extends (before)"| B["../../../tsconfig.json\n❌ above repo root — not found"]
    A -->|"extends (after)"| C["../../tsconfig.json\n✅ repo root tsconfig"]
    C --> D["TypeScript / Vitest resolves config"]
    D --> E["Tests pass (17/17)"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-local-ai): correct tsconfig e..."](https://github.com/elizaos/eliza/commit/240a88d1fa36d4faae0c3ff197ee804d89f533b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30594380)</sub>

<!-- /greptile_comment -->