### PR TITLE
fix(lint): biome format plugin-tee + plugin-twitch actions

### DIFF
--- a/plugins/plugin-tee/src/actions/remoteAttestation.ts
+++ b/plugins/plugin-tee/src/actions/remoteAttestation.ts
@@ -43,9 +43,7 @@ export const remoteAttestationAction: Action = {
       __avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
     const __avRegex = new RegExp("\\b(?:remote|attestation)\\b", "i");
     const __avRegexOk = __avRegex.test(__avText);
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/joinChannel.ts
+++ b/plugins/plugin-twitch/src/actions/joinChannel.ts
@@ -56,9 +56,7 @@ export const joinChannel: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/leaveChannel.ts
+++ b/plugins/plugin-twitch/src/actions/leaveChannel.ts
@@ -63,9 +63,7 @@ export const leaveChannel: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/listChannels.ts
+++ b/plugins/plugin-twitch/src/actions/listChannels.ts
@@ -40,9 +40,7 @@ export const listChannels: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource

--- a/plugins/plugin-twitch/src/actions/sendMessage.ts
+++ b/plugins/plugin-twitch/src/actions/sendMessage.ts
@@ -69,9 +69,7 @@ export const sendMessage: Action = {
     const __avRegexOk =
       __avRegex.test(__avText) ||
       String(message?.content?.source ?? "") === "twitch";
-    const __avSource = String(
-      message?.content?.source ?? "",
-    );
+    const __avSource = String(message?.content?.source ?? "");
     const __avExpectedSource = "twitch";
     const __avSourceOk = __avExpectedSource
       ? __avSource === __avExpectedSource


### PR DESCRIPTION
## Bug

Biome format check is failing on action validator output in both plugin-tee and plugin-twitch files.

## Symptom

Quality Extended `Format Check (biome)` reports formatting differences in `plugins/plugin-tee/src/actions/remoteAttestation.ts` and the plugin-twitch action files.

## Fix

Run the repo Biome formatter on the affected action files only.

Per-file notes:

- `plugins/plugin-tee/src/actions/remoteAttestation.ts`: collapses the multiline `String(message?.content?.source ?? "")` expression to the single-line form expected by Biome 1.x.
- `plugins/plugin-twitch/src/actions/joinChannel.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/leaveChannel.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/listChannels.ts`: applies the same Biome 1.x single-line `String()` formatting.
- `plugins/plugin-twitch/src/actions/sendMessage.ts`: applies the same Biome 1.x single-line `String()` formatting.

## Verification

- `bun run --cwd plugins/plugin-tee format`
- `bun run --cwd plugins/plugin-twitch format`

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies Biome 1.x formatter fixes across five action files in `plugin-tee` and `plugin-twitch`, collapsing the three-line `String(message?.content?.source ?? "")` expression into its single-line equivalent. The changes are purely cosmetic with no logic or behavior modifications.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely cosmetic formatting with no logic changes.

All five changes are identical single-line collapses of a String() expression; no logic, types, or behavior is altered. No issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-tee/src/actions/remoteAttestation.ts | Collapses multiline String() expression to single line — formatting only, no logic change. |
| plugins/plugin-twitch/src/actions/joinChannel.ts | Collapses multiline String() expression to single line — formatting only, no logic change. |
| plugins/plugin-twitch/src/actions/leaveChannel.ts | Collapses multiline String() expression to single line — formatting only, no logic change. |
| plugins/plugin-twitch/src/actions/listChannels.ts | Collapses multiline String() expression to single line — formatting only, no logic change. |
| plugins/plugin-twitch/src/actions/sendMessage.ts | Collapses multiline String() expression to single line — formatting only, no logic change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Biome Format Check CI] -->|Fails on 5 files| B[Multiline String expression]
    B --> C["String(\n  message?.content?.source ?? '',\n)"]
    C -->|Biome 1.x reformats| D["String(message?.content?.source ?? '')"]
    D --> E[Format Check Passes]

    subgraph "Affected Files"
        F[plugin-tee/remoteAttestation.ts]
        G[plugin-twitch/joinChannel.ts]
        H[plugin-twitch/leaveChannel.ts]
        I[plugin-twitch/listChannels.ts]
        J[plugin-twitch/sendMessage.ts]
    end

    D --> F & G & H & I & J
```

<sub>Reviews (1): Last reviewed commit: ["fix(lint): biome format plugin-tee and t..."](https://github.com/elizaos/eliza/commit/ee1348b1b6acb44195b6a9045ed1a675f2958b17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30594387)</sub>

<!-- /greptile_comment -->