### PR TITLE
fix(registry): rename plugin polymarket id to avoid app/plugin collision

### DIFF
--- a/packages/app-core/src/registry/entries/plugins/polymarket.json
+++ b/packages/app-core/src/registry/entries/plugins/polymarket.json
@@ -1,5 +1,5 @@
 {
-  "id": "polymarket",
+  "id": "plugin-polymarket",
   "name": "Polymarket",
   "description": "Multi-language Polymarket prediction markets plugin for elizaOS",
   "npmName": "@elizaos/plugin-polymarket",


### PR DESCRIPTION
## Summary

`packages/app-core/src/registry/entries/` has BOTH an app entry and a plugin entry with `id: \"polymarket\"`. The registry loader enforces globally-unique ids across all entries (`packages/app-core/src/registry/loader.ts:46-65`), so this combination throws \`Registry validation failed: duplicate id \"polymarket\"\` at runtime startup, blocking the agent from booting.

## Fix

Rename the plugin entry's id to \`plugin-polymarket\` (matches its npm name \`@elizaos/plugin-polymarket\` for consistency). The app entry keeps the canonical \`polymarket\` id.

## Test

- Boot the runtime → no registry validation error
- App registry still resolves \`polymarket\` for the app launcher path
- Plugin registry still resolves \`@elizaos/plugin-polymarket\` via npmName lookup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renames the plugin registry entry's `id` from `"polymarket"` to `"plugin-polymarket"` to resolve a duplicate-id collision with the app entry (`apps/polymarket.json`), which caused `loadRegistryFromRawEntries` to throw at boot. All existing code references to the string `"polymarket"` target the app entry (resolved via `byId`) or domain strings, not the plugin (resolved via `npmName: "@elizaos/plugin-polymarket"`), so no other changes are needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix for a confirmed boot-blocking crash with no side effects.

Single-field JSON change that directly resolves a duplicate-id validation error. No remaining duplicate ids exist in the registry after the change, and all existing "polymarket" string references in TypeScript resolve to the app entry (unchanged). Plugin lookup via npmName is unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/registry/entries/plugins/polymarket.json | Single-field rename of `id` from `"polymarket"` to `"plugin-polymarket"` to eliminate the duplicate-id boot crash; `npmName` lookup path is unaffected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["loadRegistryFromRawEntries()"] --> B["Parse each entry with Zod"]
    B --> C{"seenIds.has(entry.id)?"}
    C -- "Yes (old: both 'polymarket')" --> D["throw RegistryValidationError\n'duplicate id polymarket'"]
    C -- "No (after fix)" --> E["seenIds.add(entry.id)"]
    E --> F["indexEntries(all)"]
    F --> G["byId: 'polymarket' → app entry"]
    F --> H["byId: 'plugin-polymarket' → plugin entry"]
    F --> I["byNpmName: '@elizaos/plugin-polymarket' → plugin entry"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(registry): rename plugin polymarket ..."](https://github.com/elizaos/eliza/commit/4dbed29003c90af18dc0a51356f897bf91414019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30604439)</sub>

<!-- /greptile_comment -->