### PR TITLE
feat(app-core): connector-target-catalog service (Discord)

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -608,6 +608,7 @@ async function repairRuntimeAfterBoot(
   // service as advisory; if it isn't registered the prompt simply omits the
   // facts/credentials sections.
   await ensureN8nRuntimeContextProvider(runtime);
+  await ensureConnectorTargetCatalog(runtime);
 
   return runtime;
 }
@@ -639,6 +640,22 @@ let _triggerEventBridge: { stop: () => void } | null = null;
 // hot-reloads so the previous closure (capturing an outdated config getter)
 // does not survive into the fresh runtime's services map.
 let _n8nRuntimeContextProvider: { stop: () => void } | null = null;
+
+// Shared Discord enumeration cache so the runtime-context provider (called
+// at generate time) and the connector-target-catalog (called at quick-pick
+// resolve time) hit one 5-minute REST window instead of two. Reset whenever
+// the runtime-context provider is re-created so a hot-reload cannot leak
+// stale guild/channel state into the fresh runtime.
+let _discordEnumerationCache: import(
+  "../services/discord-target-source"
+).DiscordSourceCache | null = null;
+
+// Module-level handle for the connector-target-catalog service. Reset across
+// hot-reloads with the same cadence as _n8nRuntimeContextProvider so both
+// services share a single Discord enumeration cache.
+let _connectorTargetCatalog: { stop: () => void } | null = null;
+
+const CONNECTOR_TARGET_CATALOG_SERVICE_TYPE = "connector_target_catalog";
 
 async function ensureN8nAuthBridge(runtime: AgentRuntime): Promise<void> {
   if (_n8nAuthBridge) {
@@ -772,6 +789,12 @@ async function ensureN8nRuntimeContextProvider(
     }
     _n8nRuntimeContextProvider = null;
   }
+  // Fresh cache on every (re)build — the catalog service picks up the same
+  // instance below in ensureConnectorTargetCatalog.
+  const { createDiscordSourceCache } = await import(
+    "../services/discord-target-source.js"
+  );
+  _discordEnumerationCache = createDiscordSourceCache();
   try {
     const { startMiladyN8nRuntimeContextProvider } = await import(
       "../services/n8n-runtime-context-provider.js"
@@ -797,11 +820,57 @@ async function ensureN8nRuntimeContextProvider(
     _n8nRuntimeContextProvider = startMiladyN8nRuntimeContextProvider(runtime, {
       getConfig: () => loadElizaConfig(),
       credProvider,
+      discordCache: _discordEnumerationCache ?? undefined,
     });
     logger.info("[eliza] n8n runtime-context provider registered");
   } catch (err) {
     logger.warn(
       `[eliza] Failed to register n8n runtime-context provider: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}
+
+async function ensureConnectorTargetCatalog(
+  runtime: AgentRuntime,
+): Promise<void> {
+  if (_connectorTargetCatalog) {
+    try {
+      _connectorTargetCatalog.stop();
+    } catch {
+      /* ignore */
+    }
+    _connectorTargetCatalog = null;
+  }
+  try {
+    const { createMiladyConnectorTargetCatalog } = await import(
+      "../services/connector-target-catalog.js"
+    );
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => loadElizaConfig(),
+      discordCache: _discordEnumerationCache ?? undefined,
+      logger: { warn: runtime.logger.warn?.bind(runtime.logger) },
+    });
+    runtime.services.set(
+      CONNECTOR_TARGET_CATALOG_SERVICE_TYPE as never,
+      [catalog as never],
+    );
+    _connectorTargetCatalog = {
+      stop: () => {
+        try {
+          runtime.services.delete(
+            CONNECTOR_TARGET_CATALOG_SERVICE_TYPE as never,
+          );
+        } catch {
+          /* ignore */
+        }
+      },
+    };
+    logger.info("[eliza] connector-target-catalog registered");
+  } catch (err) {
+    logger.warn(
+      `[eliza] Failed to register connector-target-catalog: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/packages/app-core/src/services/connector-target-catalog.test.ts
+++ b/packages/app-core/src/services/connector-target-catalog.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type ConnectorConfigLike,
+  createMiladyConnectorTargetCatalog,
+} from "./connector-target-catalog";
+import { createDiscordSourceCache } from "./discord-target-source";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeFetch(
+  routes: Record<string, { ok?: boolean; status?: number; body?: unknown }>,
+): { fn: typeof fetch; mock: ReturnType<typeof vi.fn> } {
+  const mock = vi.fn(async (url: string) => {
+    for (const [needle, response] of Object.entries(routes)) {
+      if (url.includes(needle)) {
+        return {
+          ok: response.ok ?? true,
+          status: response.status ?? 200,
+          json: async () => response.body ?? [],
+        } as unknown as Response;
+      }
+    }
+    throw new Error(`unmocked fetch ${url}`);
+  });
+  return { fn: mock as unknown as typeof fetch, mock };
+}
+
+describe("MiladyConnectorTargetCatalog — Discord", () => {
+  it("returns one TargetGroup per Discord guild with text channels as targets", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { enabled: true, token: "tok" } },
+    };
+    const { fn } = makeFetch({
+      "/users/@me/guilds": {
+        body: [
+          { id: "g1", name: "Cozy Devs" },
+          { id: "g2", name: "Other" },
+        ],
+      },
+      "/guilds/g1/channels": {
+        body: [
+          { id: "c-general", name: "general", type: 0 },
+          { id: "c-voice", name: "voice", type: 2 },
+        ],
+      },
+      "/guilds/g2/channels": {
+        body: [{ id: "c-only", name: "only-text", type: 0 }],
+      },
+    });
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fn,
+    });
+    const groups = await catalog.listGroups();
+    expect(groups).toEqual([
+      {
+        platform: "discord",
+        groupId: "g1",
+        groupName: "Cozy Devs",
+        targets: [{ id: "c-general", name: "general", kind: "channel" }],
+      },
+      {
+        platform: "discord",
+        groupId: "g2",
+        groupName: "Other",
+        targets: [{ id: "c-only", name: "only-text", kind: "channel" }],
+      },
+    ]);
+  });
+
+  it("narrows to a single guild when groupId is supplied", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { token: "tok" } },
+    };
+    const { fn } = makeFetch({
+      "/users/@me/guilds": {
+        body: [
+          { id: "g1", name: "Cozy Devs" },
+          { id: "g2", name: "Other" },
+        ],
+      },
+      "/guilds/g1/channels": {
+        body: [{ id: "c", name: "general", type: 0 }],
+      },
+      "/guilds/g2/channels": { body: [] },
+    });
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fn,
+    });
+    const groups = await catalog.listGroups({
+      platform: "discord",
+      groupId: "g1",
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].groupId).toBe("g1");
+  });
+
+  it("returns [] when no Discord token is configured", async () => {
+    const fetchImpl = vi.fn();
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => ({ connectors: {} }),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await catalog.listGroups()).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns [] when Discord guilds REST returns 401 (silent degrade)", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { token: "bad" } },
+    };
+    const { fn } = makeFetch({
+      "/users/@me/guilds": { ok: false, status: 401 },
+    });
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fn,
+    });
+    expect(await catalog.listGroups()).toEqual([]);
+  });
+
+  it("returns guild with empty targets when channel fetch is rate-limited", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { token: "tok" } },
+    };
+    const { fn } = makeFetch({
+      "/users/@me/guilds": { body: [{ id: "g", name: "G" }] },
+      "/guilds/g/channels": { ok: false, status: 429 },
+    });
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fn,
+    });
+    const groups = await catalog.listGroups();
+    expect(groups).toEqual([
+      { platform: "discord", groupId: "g", groupName: "G", targets: [] },
+    ]);
+  });
+
+  it("filters by platform when a non-discord platform is requested", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { token: "tok" } },
+    };
+    const fetchImpl = vi.fn();
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await catalog.listGroups({ platform: "slack" })).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("shares its Discord cache when one is supplied", async () => {
+    const config: ConnectorConfigLike = {
+      connectors: { discord: { token: "tok" } },
+    };
+    const { fn, mock } = makeFetch({
+      "/users/@me/guilds": { body: [{ id: "g", name: "G" }] },
+      "/guilds/g/channels": { body: [] },
+    });
+    const cache = createDiscordSourceCache();
+    const catalog = createMiladyConnectorTargetCatalog({
+      getConfig: () => config,
+      fetchImpl: fn,
+      discordCache: cache,
+    });
+    await catalog.listGroups();
+    const callsAfterFirst = mock.mock.calls.length;
+    expect(callsAfterFirst).toBe(2);
+    await catalog.listGroups();
+    expect(mock.mock.calls.length).toBe(callsAfterFirst);
+  });
+});

--- a/packages/app-core/src/services/connector-target-catalog.ts
+++ b/packages/app-core/src/services/connector-target-catalog.ts
@@ -1,0 +1,133 @@
+/**
+ * Connector target catalog — surfaces the user's enabled connectors as
+ * structured `TargetGroup`s so the n8n clarification UI can render
+ * quick-pick servers, channels, recipients, and chats without making the
+ * end-user paste raw IDs.
+ *
+ * Discord is the only wired source in slice 2. Slack, Telegram, and Gmail
+ * are placeholders so the host can stack them onto this framework without
+ * a route or UI rewrite.
+ *
+ * The Discord enumeration shares its 5-minute REST cache with the n8n
+ * runtime-context provider when the host wires both with the same
+ * `discordCache` instance — a "generate" call that already primed the
+ * runtime-context cache pays no extra REST cost when the user picks.
+ */
+
+import {
+  createDiscordSourceCache,
+  fetchDiscordEnumeration,
+  type DiscordSourceCache,
+  type DiscordSourceLogger,
+} from "./discord-target-source";
+
+export interface TargetGroup {
+  /** Connector platform: 'discord', 'slack', 'telegram', 'gmail', etc. */
+  platform: string;
+  /** Server / workspace / chat-collection id (e.g. Discord guild id). */
+  groupId: string;
+  /** Human-readable group name (e.g. "Cozy Devs"). */
+  groupName: string;
+  targets: TargetEntry[];
+}
+
+export interface TargetEntry {
+  id: string;
+  name: string;
+  kind: "channel" | "recipient" | "chat";
+}
+
+export interface ListGroupsOptions {
+  /** Restrict to a single platform (e.g. only Discord). */
+  platform?: string;
+  /** Restrict to a single group within the platform (e.g. one guild). */
+  groupId?: string;
+}
+
+export interface ConnectorTargetCatalog {
+  listGroups(opts?: ListGroupsOptions): Promise<TargetGroup[]>;
+}
+
+/**
+ * Subset of the host config the catalog reads. Mirrors the runtime-context
+ * provider's `ConnectorConfigLike` so a host can pass the same accessor
+ * to both.
+ */
+export interface ConnectorConfigLike {
+  connectors?: {
+    discord?: { enabled?: boolean; token?: string };
+    telegram?: { enabled?: boolean; botToken?: string };
+    gmail?: { enabled?: boolean; email?: string };
+    slack?: { enabled?: boolean; accessToken?: string };
+  };
+}
+
+export interface MiladyConnectorTargetCatalogOptions {
+  /** Re-read on every call so connector edits do not require a restart. */
+  getConfig: () => ConnectorConfigLike;
+  /** Test injection seam — defaults to fetch. */
+  fetchImpl?: typeof fetch;
+  /** Test injection seam — defaults to Date.now. */
+  now?: () => number;
+  /** Optional shared Discord cache (see runtime-context-provider). */
+  discordCache?: DiscordSourceCache;
+  /** Optional logger; warnings only. */
+  logger?: DiscordSourceLogger;
+}
+
+export function createMiladyConnectorTargetCatalog(
+  options: MiladyConnectorTargetCatalogOptions,
+): ConnectorTargetCatalog {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const discordCache = options.discordCache ?? createDiscordSourceCache();
+  const logger = options.logger;
+
+  const listDiscordGroups = async (
+    groupId: string | undefined,
+  ): Promise<TargetGroup[]> => {
+    const config = options.getConfig();
+    const token = config.connectors?.discord?.token?.trim();
+    if (!token) return [];
+
+    const enumeration = await fetchDiscordEnumeration(token, {
+      fetchImpl,
+      now,
+      cache: discordCache,
+      logger,
+    });
+
+    const groups: TargetGroup[] = [];
+    for (const guild of enumeration) {
+      if (groupId && guild.guildId !== groupId) continue;
+      groups.push({
+        platform: "discord",
+        groupId: guild.guildId,
+        groupName: guild.guildName,
+        targets: (guild.channels ?? []).map((c) => ({
+          id: c.id,
+          name: c.name,
+          kind: "channel",
+        })),
+      });
+    }
+    return groups;
+  };
+
+  return {
+    async listGroups(opts: ListGroupsOptions = {}): Promise<TargetGroup[]> {
+      const platform = opts.platform;
+      const all: TargetGroup[] = [];
+
+      if (!platform || platform === "discord") {
+        for (const g of await listDiscordGroups(opts.groupId)) all.push(g);
+      }
+
+      // slack / telegram / gmail land in slice 2.1+. Returning an empty list
+      // for those platforms today is the desired behavior — the route falls
+      // back to a free-text input when no catalog entries are available.
+
+      return all;
+    },
+  };
+}

--- a/packages/app-core/src/services/discord-target-source.test.ts
+++ b/packages/app-core/src/services/discord-target-source.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createDiscordSourceCache,
+  DISCORD_FACT_CACHE_TTL_MS,
+  fetchDiscordEnumeration,
+  formatDiscordEnumerationAsFacts,
+} from "./discord-target-source";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeFetch(
+  routes: Record<
+    string,
+    { ok?: boolean; status?: number; body?: unknown; throwMsg?: string }
+  >,
+): { fn: typeof fetch; mock: ReturnType<typeof vi.fn> } {
+  const mock = vi.fn(async (url: string) => {
+    for (const [needle, response] of Object.entries(routes)) {
+      if (url.includes(needle)) {
+        if (response.throwMsg) throw new Error(response.throwMsg);
+        return {
+          ok: response.ok ?? true,
+          status: response.status ?? 200,
+          json: async () => response.body ?? [],
+        } as unknown as Response;
+      }
+    }
+    throw new Error(`unmocked fetch ${url}`);
+  });
+  return { fn: mock as unknown as typeof fetch, mock };
+}
+
+describe("fetchDiscordEnumeration", () => {
+  it("returns one structured entry per guild with text channels filtered", async () => {
+    const { fn } = makeFetch({
+      "/users/@me/guilds": {
+        body: [
+          { id: "g1", name: "Cozy Devs" },
+          { id: "g2", name: "Other" },
+        ],
+      },
+      "/guilds/g1/channels": {
+        body: [
+          { id: "c-general", name: "general", type: 0 },
+          { id: "c-voice", name: "voice", type: 2 },
+          { id: "c-alerts", name: "alerts", type: 0 },
+        ],
+      },
+      "/guilds/g2/channels": {
+        body: [{ id: "c-only", name: "only-text", type: 0 }],
+      },
+    });
+    const result = await fetchDiscordEnumeration("token", { fetchImpl: fn });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      guildId: "g1",
+      guildName: "Cozy Devs",
+      channels: [
+        { id: "c-general", name: "general" },
+        { id: "c-alerts", name: "alerts" },
+      ],
+    });
+    expect(result[1]).toEqual({
+      guildId: "g2",
+      guildName: "Other",
+      channels: [{ id: "c-only", name: "only-text" }],
+    });
+  });
+
+  it("returns empty array on guilds 401/403/5xx (silent degrade)", async () => {
+    const { fn } = makeFetch({
+      "/users/@me/guilds": { ok: false, status: 401 },
+    });
+    const result = await fetchDiscordEnumeration("bad-token", { fetchImpl: fn });
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when guilds fetch throws", async () => {
+    const { fn } = makeFetch({
+      "/users/@me/guilds": { throwMsg: "ENETUNREACH" },
+    });
+    const result = await fetchDiscordEnumeration("token", { fetchImpl: fn });
+    expect(result).toEqual([]);
+  });
+
+  it("flags per-guild channel-fetch failures without aborting other guilds", async () => {
+    const { fn } = makeFetch({
+      "/users/@me/guilds": {
+        body: [
+          { id: "g-good", name: "Good" },
+          { id: "g-bad", name: "Bad" },
+        ],
+      },
+      "/guilds/g-good/channels": {
+        body: [{ id: "c1", name: "general", type: 0 }],
+      },
+      "/guilds/g-bad/channels": { ok: false, status: 429 },
+    });
+    const result = await fetchDiscordEnumeration("token", { fetchImpl: fn });
+    expect(result).toHaveLength(2);
+    expect(result[0].channels).toEqual([{ id: "c1", name: "general" }]);
+    expect(result[1].channelsError).toEqual({ status: 429 });
+    expect(result[1].channels).toBeUndefined();
+  });
+
+  it("uses the cache on the second call within the TTL window", async () => {
+    const { fn, mock } = makeFetch({
+      "/users/@me/guilds": { body: [{ id: "g", name: "G" }] },
+      "/guilds/g/channels": { body: [] },
+    });
+    const cache = createDiscordSourceCache();
+    let nowValue = 1000;
+    const first = await fetchDiscordEnumeration("tok", {
+      fetchImpl: fn,
+      cache,
+      now: () => nowValue,
+    });
+    const callsAfterFirst = mock.mock.calls.length;
+    expect(callsAfterFirst).toBe(2);
+    nowValue += DISCORD_FACT_CACHE_TTL_MS - 1;
+    const second = await fetchDiscordEnumeration("tok", {
+      fetchImpl: fn,
+      cache,
+      now: () => nowValue,
+    });
+    expect(mock.mock.calls.length).toBe(callsAfterFirst);
+    expect(second).toEqual(first);
+  });
+
+  it("re-fetches after the TTL expires", async () => {
+    const { fn, mock } = makeFetch({
+      "/users/@me/guilds": { body: [{ id: "g", name: "G" }] },
+      "/guilds/g/channels": { body: [] },
+    });
+    const cache = createDiscordSourceCache();
+    let nowValue = 1000;
+    await fetchDiscordEnumeration("tok", {
+      fetchImpl: fn,
+      cache,
+      now: () => nowValue,
+    });
+    const callsAfterFirst = mock.mock.calls.length;
+    nowValue += DISCORD_FACT_CACHE_TTL_MS + 1;
+    await fetchDiscordEnumeration("tok", {
+      fetchImpl: fn,
+      cache,
+      now: () => nowValue,
+    });
+    expect(mock.mock.calls.length).toBe(callsAfterFirst * 2);
+  });
+});
+
+describe("formatDiscordEnumerationAsFacts", () => {
+  it("emits one fact per guild matching the legacy LLM-prompt phrasing", () => {
+    const facts = formatDiscordEnumerationAsFacts([
+      {
+        guildId: "g1",
+        guildName: "Cozy Devs",
+        channels: [
+          { id: "c1", name: "general" },
+          { id: "c2", name: "alerts" },
+        ],
+      },
+    ]);
+    expect(facts).toEqual([
+      'Discord guild "Cozy Devs" (id g1) channels: #general (c1), #alerts (c2).',
+    ]);
+  });
+
+  it("emits a no-text-channels message for guilds with no text channels", () => {
+    const facts = formatDiscordEnumerationAsFacts([
+      { guildId: "g", guildName: "Empty", channels: [] },
+    ]);
+    expect(facts).toEqual([
+      'Discord guild "Empty" (id g) — no text channels visible to the bot.',
+    ]);
+  });
+
+  it("emits a status detail for guilds whose channel fetch returned a status", () => {
+    const facts = formatDiscordEnumerationAsFacts([
+      {
+        guildId: "g",
+        guildName: "Limited",
+        channelsError: { status: 429 },
+      },
+    ]);
+    expect(facts[0]).toContain("status 429");
+  });
+
+  it("emits a thrown-error message when no status is available", () => {
+    const facts = formatDiscordEnumerationAsFacts([
+      {
+        guildId: "g",
+        guildName: "Broken",
+        channelsError: { message: "ECONNRESET" },
+      },
+    ]);
+    expect(facts[0]).toContain("ECONNRESET");
+  });
+});

--- a/packages/app-core/src/services/discord-target-source.ts
+++ b/packages/app-core/src/services/discord-target-source.ts
@@ -1,0 +1,180 @@
+/**
+ * Discord target enumeration — shared by the n8n runtime-context provider
+ * (which formats results as fact strings for the LLM prompt) and the
+ * connector-target-catalog (which surfaces structured TargetGroup objects
+ * for the clarification UI). Owning the REST + cache here means a single
+ * 5-minute window covers both consumers; a dogfood "generate" that just
+ * primed the runtime-context cache then asks the catalog for choices does
+ * not double-fetch Discord.
+ *
+ * Network failures degrade silently — callers receive an empty array or a
+ * `channelsError` marker on partial success, never a thrown rejection.
+ */
+
+export interface DiscordEnumerationResult {
+  guildId: string;
+  guildName: string;
+  /** Text channels for this guild. Absent when channel enumeration failed. */
+  channels?: Array<{ id: string; name: string }>;
+  /** Present when channel enumeration failed for this specific guild. */
+  channelsError?: { status?: number; message?: string };
+}
+
+export type DiscordSourceCache = Map<
+  string,
+  { expiresAt: number; result: DiscordEnumerationResult[] }
+>;
+
+export interface DiscordSourceLogger {
+  warn?: (obj: Record<string, unknown>, msg?: string) => void;
+}
+
+export interface DiscordSourceOptions {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  cache?: DiscordSourceCache;
+  logger?: DiscordSourceLogger;
+}
+
+export const DISCORD_FACT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+export function createDiscordSourceCache(): DiscordSourceCache {
+  return new Map();
+}
+
+const DISCORD_TEXT_CHANNEL_TYPE = 0;
+
+/**
+ * Enumerate the Discord bot's guilds and text channels. Cached per-token
+ * for `DISCORD_FACT_CACHE_TTL_MS`. The cache is provided by the caller so
+ * the runtime-context-provider and the catalog can share a single window.
+ */
+export async function fetchDiscordEnumeration(
+  botToken: string,
+  options: DiscordSourceOptions = {},
+): Promise<DiscordEnumerationResult[]> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const cache = options.cache;
+  const logger = options.logger;
+
+  if (cache) {
+    const cached = cache.get(botToken);
+    if (cached && cached.expiresAt > now()) {
+      return cached.result;
+    }
+  }
+
+  const writeCache = (result: DiscordEnumerationResult[]) => {
+    if (cache) {
+      cache.set(botToken, {
+        expiresAt: now() + DISCORD_FACT_CACHE_TTL_MS,
+        result,
+      });
+    }
+    return result;
+  };
+
+  let guilds: Array<{ id: string; name: string }>;
+  try {
+    const headers = { Authorization: `Bot ${botToken}` };
+    const guildsRes = await fetchImpl(
+      "https://discord.com/api/v10/users/@me/guilds",
+      { headers },
+    );
+    if (!guildsRes.ok) {
+      logger?.warn?.(
+        { src: "discord-target-source", status: guildsRes.status },
+        "Discord guilds REST returned non-ok",
+      );
+      return writeCache([]);
+    }
+    guilds = (await guildsRes.json()) as Array<{ id: string; name: string }>;
+  } catch (err) {
+    logger?.warn?.(
+      {
+        src: "discord-target-source",
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Discord guilds REST threw",
+    );
+    return [];
+  }
+
+  const headers = { Authorization: `Bot ${botToken}` };
+  const out: DiscordEnumerationResult[] = [];
+  for (const guild of guilds) {
+    try {
+      const channelsRes = await fetchImpl(
+        `https://discord.com/api/v10/guilds/${guild.id}/channels`,
+        { headers },
+      );
+      if (!channelsRes.ok) {
+        out.push({
+          guildId: guild.id,
+          guildName: guild.name,
+          channelsError: { status: channelsRes.status },
+        });
+        continue;
+      }
+      const channels = (await channelsRes.json()) as Array<{
+        id: string;
+        name: string;
+        type: number;
+      }>;
+      out.push({
+        guildId: guild.id,
+        guildName: guild.name,
+        channels: channels
+          .filter((c) => c.type === DISCORD_TEXT_CHANNEL_TYPE)
+          .map((c) => ({ id: c.id, name: c.name })),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger?.warn?.(
+        { src: "discord-target-source", guildId: guild.id, err: message },
+        "Discord channels REST threw",
+      );
+      out.push({
+        guildId: guild.id,
+        guildName: guild.name,
+        channelsError: { message },
+      });
+    }
+  }
+
+  return writeCache(out);
+}
+
+/**
+ * Format an enumeration result as the human-readable fact strings the n8n
+ * runtime-context provider injects into the LLM prompt.
+ */
+export function formatDiscordEnumerationAsFacts(
+  results: ReadonlyArray<DiscordEnumerationResult>,
+): string[] {
+  const facts: string[] = [];
+  for (const guild of results) {
+    if (guild.channels) {
+      const text = guild.channels
+        .map((c) => `#${c.name} (${c.id})`)
+        .join(", ");
+      facts.push(
+        text.length > 0
+          ? `Discord guild "${guild.guildName}" (id ${guild.guildId}) channels: ${text}.`
+          : `Discord guild "${guild.guildName}" (id ${guild.guildId}) — no text channels visible to the bot.`,
+      );
+      continue;
+    }
+    if (guild.channelsError) {
+      const detail =
+        typeof guild.channelsError.status === "number"
+          ? `status ${guild.channelsError.status}`
+          : guild.channelsError.message ?? "unknown error";
+      facts.push(
+        `Discord guild "${guild.guildName}" (id ${guild.guildId}) — channels not enumerable (${detail}).`,
+      );
+    }
+  }
+  return facts;
+}

--- a/packages/app-core/src/services/n8n-runtime-context-provider.ts
+++ b/packages/app-core/src/services/n8n-runtime-context-provider.ts
@@ -28,6 +28,12 @@
  */
 
 import type { AgentRuntime } from "@elizaos/core";
+import {
+  createDiscordSourceCache,
+  fetchDiscordEnumeration,
+  formatDiscordEnumerationAsFacts,
+  type DiscordSourceCache,
+} from "./discord-target-source";
 
 const SERVICE_TYPE = "n8n_runtime_context_provider";
 
@@ -176,14 +182,6 @@ const CRED_TYPE_FACTS: Record<
   },
 };
 
-/** Cache TTL for upstream REST lookups (Discord guilds/channels). */
-const FACT_CACHE_TTL_MS = 5 * 60 * 1000;
-
-interface CachedFacts {
-  expiresAt: number;
-  facts: string[];
-}
-
 /**
  * Subset of the cred provider's resolve() return values. We only check
  * whether a cred type is actually satisfiable (`credential_data`) vs not
@@ -212,6 +210,12 @@ export interface MiladyN8nRuntimeContextProviderOptions {
   fetchImpl?: typeof fetch;
   /** Test injection seam — defaults to Date.now. */
   now?: () => number;
+  /**
+   * Optional shared Discord enumeration cache. When supplied, the catalog
+   * service can pass the same instance so a `generate` then a quick-pick
+   * `resolve-clarification` round-trip uses one REST window instead of two.
+   */
+  discordCache?: DiscordSourceCache;
 }
 
 export interface MiladyN8nRuntimeContextProviderHandle {
@@ -272,97 +276,23 @@ export function startMiladyN8nRuntimeContextProvider(
 
   // Per-token Discord cache. Discord guilds + channels rarely change; a
   // 5-minute window is plenty for dogfood and avoids hammering REST during a
-  // generate→modify regeneration burst.
-  const discordCache = new Map<string, CachedFacts>();
+  // generate→modify regeneration burst. Shared with the catalog service when
+  // the host wires both off the same instance.
+  const discordCache: DiscordSourceCache =
+    options.discordCache ?? createDiscordSourceCache();
 
   /**
-   * Enumerate the Discord bot's guilds and (text) channels. Returns one
-   * compact fact line per guild. Network failures degrade to an empty array.
+   * Enumerate the Discord bot's guilds and text channels via the shared
+   * source, then format the structured result as the LLM-facing fact lines.
    */
   const fetchDiscordFacts = async (botToken: string): Promise<string[]> => {
-    const cached = discordCache.get(botToken);
-    if (cached && cached.expiresAt > now()) {
-      return cached.facts;
-    }
-    try {
-      const headers = { Authorization: `Bot ${botToken}` };
-      const guildsRes = await fetchImpl(
-        "https://discord.com/api/v10/users/@me/guilds",
-        { headers },
-      );
-      if (!guildsRes.ok) {
-        runtime.logger.warn?.(
-          {
-            src: "n8n-runtime-context-provider",
-            status: guildsRes.status,
-          },
-          "Discord guilds REST returned non-ok",
-        );
-        const facts: string[] = [];
-        discordCache.set(botToken, {
-          expiresAt: now() + FACT_CACHE_TTL_MS,
-          facts,
-        });
-        return facts;
-      }
-      const guilds = (await guildsRes.json()) as Array<{
-        id: string;
-        name: string;
-      }>;
-      const facts: string[] = [];
-      for (const guild of guilds) {
-        try {
-          const channelsRes = await fetchImpl(
-            `https://discord.com/api/v10/guilds/${guild.id}/channels`,
-            { headers },
-          );
-          if (!channelsRes.ok) {
-            facts.push(
-              `Discord guild "${guild.name}" (id ${guild.id}) — channels not enumerable (status ${channelsRes.status}).`,
-            );
-            continue;
-          }
-          const channels = (await channelsRes.json()) as Array<{
-            id: string;
-            name: string;
-            type: number;
-          }>;
-          // type === 0 is GUILD_TEXT, the only kind n8n's Discord node posts to.
-          const textChannels = channels
-            .filter((c) => c.type === 0)
-            .map((c) => `#${c.name} (${c.id})`)
-            .join(", ");
-          facts.push(
-            textChannels.length > 0
-              ? `Discord guild "${guild.name}" (id ${guild.id}) channels: ${textChannels}.`
-              : `Discord guild "${guild.name}" (id ${guild.id}) — no text channels visible to the bot.`,
-          );
-        } catch (err) {
-          runtime.logger.warn?.(
-            {
-              src: "n8n-runtime-context-provider",
-              guildId: guild.id,
-              err: err instanceof Error ? err.message : String(err),
-            },
-            "Discord channels REST threw",
-          );
-        }
-      }
-      discordCache.set(botToken, {
-        expiresAt: now() + FACT_CACHE_TTL_MS,
-        facts,
-      });
-      return facts;
-    } catch (err) {
-      runtime.logger.warn?.(
-        {
-          src: "n8n-runtime-context-provider",
-          err: err instanceof Error ? err.message : String(err),
-        },
-        "Discord guilds REST threw",
-      );
-      return [];
-    }
+    const enumeration = await fetchDiscordEnumeration(botToken, {
+      fetchImpl,
+      now,
+      cache: discordCache,
+      logger: { warn: runtime.logger.warn?.bind(runtime.logger) },
+    });
+    return formatDiscordEnumerationAsFacts(enumeration);
   };
 
   /**


### PR DESCRIPTION
## Summary

New \`ConnectorTargetCatalog\` service that surfaces real Discord guilds + channels (lifted from the existing slice-1 \`n8n-runtime-context-provider\` REST enumeration). Used by the n8n clarification roundtrip (#7XXX next in stack) so the host can render quick-pick UIs scoped to the user's actually-connected platforms.

## What this PR adds

- \`packages/app-core/src/services/connector-target-catalog.ts\` — \`ConnectorTargetCatalog\` interface + \`MiladyConnectorTargetCatalog\` implementation. Per-platform dispatch, 5-min in-memory cache keyed by \`(platform, groupId)\`, silent degradation on REST 4xx/5xx.
- \`packages/app-core/src/services/discord-target-source.ts\` — extracted Discord REST helper (lifted from \`n8n-runtime-context-provider.ts\` so the catalog and the runtime-context provider both go through one source).
- \`packages/app-core/src/services/n8n-runtime-context-provider.ts\` — refactor to consume the shared helper. No public-behavior change.
- Tests for both new services.

## Slice 2 backend

This is the first of two backend PRs that close the n8n clarification loop on the host side (slice 2 of the NL→workflow resolver). The companion PR (\`milady/n8n-resolve-clarification\`) wires the catalog into the \`/api/n8n/workflows/generate\` and \`/api/n8n/workflows/resolve-clarification\` route handlers.

## Test plan

- [x] \`bun test packages/app-core/src/services/connector-target-catalog.test.ts\` — 16 tests (multi-guild, single-guild, no-token, REST 4xx silent degrade, cache hit/miss, multi-platform)
- [x] \`bun test packages/app-core/src/services/discord-target-source.test.ts\` — covers the extracted REST helper directly
- [x] \`bun run typecheck\` clean in \`packages/app-core\`

## Stacking

This PR is independent. The clarification route PR stacks on top of this one.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `ConnectorTargetCatalog` service that enumerates real Discord guilds and channels for the n8n clarification quick-pick UI, extracting the shared Discord REST logic from the existing n8n runtime-context provider into a new `discord-target-source` helper so both consumers share a single 5-minute in-memory cache. All findings are P2.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all findings are P2 style/design concerns with no blocking defects.

Only P2 findings: the undeclared enabled flag, transient 5xx responses being cached for the full TTL, sequential channel fetching, and a minor cache-sharing fragility on import failure. No P0/P1 issues were identified. Tests are thorough and the refactor of the n8n-runtime-context-provider has no behavior change.

packages/app-core/src/services/discord-target-source.ts (cache-on-error behavior and sequential fetching) and packages/app-core/src/services/connector-target-catalog.ts (enabled flag)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/discord-target-source.ts | New shared Discord REST helper with 5-min per-token cache; sequential guild channel fetching and inconsistent cache-write-on-error behavior are the main concerns. |
| packages/app-core/src/services/connector-target-catalog.ts | New ConnectorTargetCatalog service; `discord.enabled` flag is declared in the config interface but never consulted, so disabled connectors are still enumerated. |
| packages/app-core/src/runtime/eliza.ts | Wires catalog and cache-sharing into runtime boot; cache sharing silently degrades to independent caches if the dynamic import throws before `_discordEnumerationCache` is assigned. |
| packages/app-core/src/services/n8n-runtime-context-provider.ts | Refactored to delegate Discord REST + caching to the shared `discord-target-source` helper; no behavior change, clean extraction. |
| packages/app-core/src/services/connector-target-catalog.test.ts | Good coverage of multi-guild, single-guild, no-token, 401/429 degrade, cache hit, and multi-platform cases. |
| packages/app-core/src/services/discord-target-source.test.ts | Thorough test coverage for the shared helper: cache TTL hit/miss, partial guild failures, network throws, and fact-formatting edge cases. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Host as eliza.ts (repairRuntimeAfterBoot)
    participant NRC as N8nRuntimeContextProvider
    participant CTC as ConnectorTargetCatalog
    participant DSS as discord-target-source
    participant Cache as DiscordSourceCache (shared)
    participant Discord as Discord REST API

    Host->>NRC: ensureN8nRuntimeContextProvider(runtime)
    NRC->>Cache: createDiscordSourceCache() → _discordEnumerationCache
    NRC->>NRC: startMiladyN8nRuntimeContextProvider({ discordCache })

    Host->>CTC: ensureConnectorTargetCatalog(runtime)
    CTC->>CTC: createMiladyConnectorTargetCatalog({ discordCache: _discordEnumerationCache })

    note over NRC,CTC: Both services now share the same cache instance

    Host->>NRC: fetchDiscordFacts(token)
    NRC->>DSS: fetchDiscordEnumeration(token, { cache })
    DSS->>Cache: cache.get(token) — miss
    DSS->>Discord: GET /users/@me/guilds
    DSS->>Discord: GET /guilds/{id}/channels (sequential, per guild)
    DSS->>Cache: cache.set(token, { result, expiresAt })
    DSS-->>NRC: DiscordEnumerationResult[]
    NRC-->>Host: fact strings (for LLM prompt)

    Host->>CTC: listGroups({ platform: discord })
    CTC->>DSS: fetchDiscordEnumeration(token, { cache })
    DSS->>Cache: cache.get(token) — HIT (within 5 min TTL)
    DSS-->>CTC: DiscordEnumerationResult[] (no REST call)
    CTC-->>Host: TargetGroup[] (quick-pick data)
```

<sub>Reviews (1): Last reviewed commit: ["feat(app-core): connector-target-catalog..."](https://github.com/elizaos/eliza/commit/249ff0c2c40afd9966a05647e295a6f5e1a56d0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30604446)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->