### PR TITLE
feat(n8n): clarification roundtrip route

### DIFF
--- a/packages/app-core/src/api/client-types-chat.ts
+++ b/packages/app-core/src/api/client-types-chat.ts
@@ -459,9 +459,74 @@ export interface N8nWorkflowMissingCredentialsResponse {
   warning: "missing credentials";
 }
 
+/**
+ * Structured clarification request emitted by the plugin's workflow generator
+ * when a node parameter cannot be resolved from the runtime context. The host
+ * surfaces these as quick-pick buttons; on click the host calls
+ * `/api/n8n/workflows/resolve-clarification` with the chosen value, which
+ * patches the draft at `paramPath` and deploys — no LLM regeneration.
+ *
+ * Mirrors the plugin's `ClarificationRequest` (see
+ * @elizaos/plugin-n8n-workflow `src/types/index.ts`). Re-declared here to
+ * avoid a host → plugin import cycle.
+ */
+export interface N8nClarificationRequest {
+  kind:
+    | "target_channel"
+    | "target_server"
+    | "recipient"
+    | "value"
+    | "free_text";
+  platform?: string;
+  scope?: { guildId?: string };
+  question: string;
+  paramPath: string;
+}
+
+/** One server / workspace / contact-collection from a connector catalog. */
+export interface N8nClarificationTargetGroup {
+  platform: string;
+  groupId: string;
+  groupName: string;
+  targets: Array<{
+    id: string;
+    name: string;
+    kind: "channel" | "recipient" | "chat";
+  }>;
+}
+
+/**
+ * Returned by `POST /api/n8n/workflows/generate` when the LLM emitted one or
+ * more `ClarificationRequest`s and the host needs the user to pick a target
+ * before deploying. The `draft` is the unmodified workflow JSON from the
+ * plugin (with the unresolved parameters left absent); `catalog` is a
+ * snapshot of the relevant connector-target-catalog scoped to the
+ * platforms referenced by the clarifications.
+ */
+export interface N8nWorkflowNeedsClarificationResponse {
+  status: "needs_clarification";
+  draft: Record<string, unknown>;
+  clarifications: N8nClarificationRequest[];
+  catalog: N8nClarificationTargetGroup[];
+}
+
+/** Resolution payload sent to /api/n8n/workflows/resolve-clarification. */
+export interface N8nClarificationResolution {
+  paramPath: string;
+  value: string;
+}
+
+export interface N8nWorkflowResolveClarificationRequest {
+  draft: Record<string, unknown>;
+  resolutions: N8nClarificationResolution[];
+  name?: string;
+  workflowId?: string;
+}
+
 export type N8nWorkflowGenerateResponse =
   | N8nWorkflow
-  | N8nWorkflowMissingCredentialsResponse;
+  | N8nWorkflowMissingCredentialsResponse
+  | N8nWorkflowNeedsClarificationResponse;
 
 export function isMissingCredentialsResponse(
   res: N8nWorkflowGenerateResponse,
@@ -470,6 +535,19 @@ export function isMissingCredentialsResponse(
   return (
     candidate.warning === "missing credentials" &&
     Array.isArray(candidate.missingCredentials)
+  );
+}
+
+export function isNeedsClarificationResponse(
+  res: N8nWorkflowGenerateResponse,
+): res is N8nWorkflowNeedsClarificationResponse {
+  const candidate = res as N8nWorkflowNeedsClarificationResponse;
+  return (
+    candidate.status === "needs_clarification" &&
+    Array.isArray(candidate.clarifications) &&
+    Array.isArray(candidate.catalog) &&
+    typeof candidate.draft === "object" &&
+    candidate.draft !== null
   );
 }
 

--- a/packages/app-core/src/api/n8n-clarification.test.ts
+++ b/packages/app-core/src/api/n8n-clarification.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyResolutions,
+  buildCatalogSnapshot,
+  type CatalogLike,
+  coerceClarifications,
+  parseParamPath,
+  pruneResolvedClarifications,
+  setByDotPath,
+} from "./n8n-clarification";
+
+describe("coerceClarifications", () => {
+  it("returns [] for null/undefined/non-array input", () => {
+    expect(coerceClarifications(undefined)).toEqual([]);
+    expect(coerceClarifications(null)).toEqual([]);
+    expect(coerceClarifications("")).toEqual([]);
+    expect(coerceClarifications({})).toEqual([]);
+  });
+
+  it("normalizes legacy strings into free_text requests", () => {
+    const out = coerceClarifications([
+      "Which channel?",
+      "  Trim me  ",
+      "",
+      "   ",
+    ]);
+    expect(out).toEqual([
+      { kind: "free_text", question: "Which channel?", paramPath: "" },
+      { kind: "free_text", question: "Trim me", paramPath: "" },
+    ]);
+  });
+
+  it("passes valid structured items through verbatim", () => {
+    const item = {
+      kind: "target_channel",
+      platform: "discord",
+      scope: { guildId: "1234" },
+      question: "Which channel in Cozy Devs?",
+      paramPath: 'nodes["Discord Send"].parameters.channelId',
+    };
+    expect(coerceClarifications([item])).toEqual([item]);
+  });
+
+  it("clamps unknown kind to free_text and defaults missing paramPath", () => {
+    const out = coerceClarifications([{ kind: "wat", question: "Q?" }]);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe("free_text");
+    expect(out[0].question).toBe("Q?");
+    expect(out[0].paramPath).toBe("");
+  });
+
+  it("drops items missing a question", () => {
+    expect(
+      coerceClarifications([
+        { kind: "value", paramPath: "nodes[0].parameters.x" },
+        { kind: "value", question: "", paramPath: "nodes[0].parameters.x" },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("parseParamPath", () => {
+  it("handles plain dot identifiers", () => {
+    expect(parseParamPath("a.b.c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("handles bracketed double-quoted keys with spaces", () => {
+    expect(
+      parseParamPath('nodes["Discord Send"].parameters.channelId'),
+    ).toEqual(["nodes", "Discord Send", "parameters", "channelId"]);
+  });
+
+  it("handles bracketed single-quoted keys", () => {
+    expect(parseParamPath("a['x y'].b")).toEqual(["a", "x y", "b"]);
+  });
+
+  it("handles array indices", () => {
+    expect(parseParamPath("nodes[0].parameters.guildId")).toEqual([
+      "nodes",
+      "0",
+      "parameters",
+      "guildId",
+    ]);
+  });
+
+  it("rejects unterminated brackets", () => {
+    expect(() => parseParamPath("nodes[0")).toThrow(/unterminated bracket/);
+  });
+
+  it("rejects empty brackets", () => {
+    expect(() => parseParamPath("nodes[]")).toThrow(/empty bracket/);
+  });
+
+  it("rejects empty paths", () => {
+    expect(() => parseParamPath("")).toThrow(/no segments/);
+  });
+});
+
+describe("setByDotPath", () => {
+  it("sets a deeply-nested object value, creating intermediates", () => {
+    const draft: Record<string, unknown> = {};
+    setByDotPath(draft, 'nodes["Discord Send"].parameters.channelId', "9876");
+    expect(draft).toEqual({
+      nodes: {
+        "Discord Send": { parameters: { channelId: "9876" } },
+      },
+    });
+  });
+
+  it("sets a value inside an existing array element", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ parameters: {} }, { parameters: {} }],
+    };
+    setByDotPath(draft, "nodes[1].parameters.guildId", "1234");
+    expect((draft.nodes as Array<{ parameters: { guildId?: string } }>)[1]
+      .parameters.guildId).toBe("1234");
+  });
+
+  it("creates array intermediates when the next segment is numeric", () => {
+    const draft: Record<string, unknown> = {};
+    setByDotPath(draft, "nodes[0].id", "n1");
+    expect(draft.nodes).toEqual([{ id: "n1" }]);
+  });
+
+  it("rejects descent through a non-object intermediate", () => {
+    const draft: Record<string, unknown> = { a: "scalar" };
+    expect(() => setByDotPath(draft, "a.b", "x")).toThrow(
+      /cannot descend into non-object/,
+    );
+  });
+
+  it("rejects array path with non-numeric terminal segment", () => {
+    const draft: Record<string, unknown> = { nodes: [] };
+    expect(() => setByDotPath(draft, "nodes.x", "v")).toThrow();
+  });
+});
+
+describe("applyResolutions", () => {
+  it("applies multiple resolutions in order", () => {
+    const draft: Record<string, unknown> = { nodes: {} };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Discord Send"].parameters.guildId',
+        value: "1234",
+      },
+      {
+        paramPath: 'nodes["Discord Send"].parameters.channelId',
+        value: "9876",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect(draft).toEqual({
+      nodes: {
+        "Discord Send": {
+          parameters: { guildId: "1234", channelId: "9876" },
+        },
+      },
+    });
+  });
+
+  it("rejects a missing paramPath", () => {
+    const draft: Record<string, unknown> = {};
+    expect(
+      applyResolutions(draft, [
+        { paramPath: "", value: "x" } as never,
+      ]),
+    ).toEqual({ ok: false, error: "resolution missing paramPath" });
+  });
+
+  it("rejects a malformed paramPath and reports it", () => {
+    const draft: Record<string, unknown> = {};
+    const result = applyResolutions(draft, [
+      { paramPath: "nodes[", value: "x" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.paramPath).toBe("nodes[");
+      expect(result.error).toContain("unterminated bracket");
+    }
+  });
+
+  it("rejects non-string values", () => {
+    const draft: Record<string, unknown> = {};
+    const result = applyResolutions(draft, [
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately bad input
+      { paramPath: "x", value: 1 as any },
+    ]);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("pruneResolvedClarifications", () => {
+  it("removes structured items whose paramPath was resolved", () => {
+    const draft: Record<string, unknown> = {
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "target_server",
+            question: "Server?",
+            paramPath: "nodes[0].parameters.guildId",
+          },
+          {
+            kind: "target_channel",
+            question: "Channel?",
+            paramPath: "nodes[0].parameters.channelId",
+          },
+        ],
+      },
+    };
+    pruneResolvedClarifications(
+      draft,
+      new Set(["nodes[0].parameters.guildId"]),
+    );
+    const list = (
+      draft._meta as { requiresClarification: Array<{ paramPath: string }> }
+    ).requiresClarification;
+    expect(list).toHaveLength(1);
+    expect(list[0].paramPath).toBe("nodes[0].parameters.channelId");
+  });
+
+  it("preserves legacy free-text strings (no paramPath to match)", () => {
+    const draft: Record<string, unknown> = {
+      _meta: { requiresClarification: ["Pick a thing"] },
+    };
+    pruneResolvedClarifications(draft, new Set(["any"]));
+    expect(
+      (draft._meta as { requiresClarification: string[] })
+        .requiresClarification,
+    ).toEqual(["Pick a thing"]);
+  });
+
+  it("deletes the field entirely when nothing remains", () => {
+    const draft: Record<string, unknown> = {
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "value",
+            question: "Q",
+            paramPath: "nodes[0].parameters.x",
+          },
+        ],
+      },
+    };
+    pruneResolvedClarifications(
+      draft,
+      new Set(["nodes[0].parameters.x"]),
+    );
+    expect(
+      (draft._meta as { requiresClarification?: unknown })
+        .requiresClarification,
+    ).toBeUndefined();
+  });
+
+  it("is a no-op when there is no _meta or no list", () => {
+    const drafts: Record<string, unknown>[] = [
+      {},
+      { _meta: {} },
+      { _meta: { requiresClarification: "not-an-array" } },
+    ];
+    for (const d of drafts) {
+      expect(() => pruneResolvedClarifications(d, new Set())).not.toThrow();
+    }
+  });
+});
+
+describe("buildCatalogSnapshot", () => {
+  function makeCatalog(
+    fixture: Record<string, Array<{ groupId: string; targets: unknown[] }>>,
+  ): { catalog: CatalogLike; calls: string[] } {
+    const calls: string[] = [];
+    return {
+      calls,
+      catalog: {
+        async listGroups(opts) {
+          calls.push(opts?.platform ?? "*");
+          const platform = opts?.platform ?? "*";
+          return (fixture[platform] ?? []).map((g) => ({
+            platform,
+            groupId: g.groupId,
+            groupName: `name-${g.groupId}`,
+            targets: g.targets as never,
+          }));
+        },
+      },
+    };
+  }
+
+  it("queries the catalog for each unique platform", async () => {
+    const { catalog, calls } = makeCatalog({
+      discord: [{ groupId: "g1", targets: [] }],
+      slack: [{ groupId: "w1", targets: [] }],
+    });
+    await buildCatalogSnapshot(catalog, [
+      {
+        kind: "target_server",
+        platform: "discord",
+        question: "Q",
+        paramPath: "x",
+      },
+      {
+        kind: "target_channel",
+        platform: "discord",
+        question: "Q",
+        paramPath: "y",
+      },
+      {
+        kind: "recipient",
+        platform: "slack",
+        question: "Q",
+        paramPath: "z",
+      },
+    ]);
+    expect(calls.sort()).toEqual(["discord", "slack"]);
+  });
+
+  it("deduplicates groups across multiple clarifications", async () => {
+    const { catalog } = makeCatalog({
+      discord: [{ groupId: "g1", targets: [] }],
+    });
+    const snapshot = await buildCatalogSnapshot(catalog, [
+      {
+        kind: "target_server",
+        platform: "discord",
+        question: "Q",
+        paramPath: "x",
+      },
+      {
+        kind: "target_channel",
+        platform: "discord",
+        question: "Q",
+        paramPath: "y",
+      },
+    ]);
+    expect(snapshot).toHaveLength(1);
+  });
+
+  it("returns [] when no clarification names a platform", async () => {
+    const { catalog, calls } = makeCatalog({});
+    const snapshot = await buildCatalogSnapshot(catalog, [
+      { kind: "free_text", question: "Q", paramPath: "" },
+    ]);
+    expect(snapshot).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/app-core/src/api/n8n-clarification.ts
+++ b/packages/app-core/src/api/n8n-clarification.ts
@@ -1,0 +1,302 @@
+/**
+ * Clarification helpers for n8n workflow generation routes.
+ *
+ * - `coerceClarifications`: normalizes the plugin's mixed-shape
+ *   `_meta.requiresClarification` (legacy strings + structured objects)
+ *   into typed `N8nClarificationRequest[]`.
+ * - `setByDotPath`: applies `{paramPath, value}` resolutions to a draft
+ *   workflow JSON in place. Supports dot segments and bracketed-string
+ *   segments (`nodes["Discord Send"].parameters.channelId`).
+ *
+ * Kept out of `n8n-routes.ts` so the handlers stay focused on transport.
+ */
+
+import type {
+  N8nClarificationRequest,
+  N8nClarificationResolution,
+  N8nClarificationTargetGroup,
+} from "./client-types-chat";
+
+const VALID_KINDS: ReadonlySet<N8nClarificationRequest["kind"]> = new Set([
+  "target_channel",
+  "target_server",
+  "recipient",
+  "value",
+  "free_text",
+]);
+
+function isStructuredClarification(
+  v: unknown,
+): v is N8nClarificationRequest {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.question !== "string" || o.question.trim().length === 0) {
+    return false;
+  }
+  // `kind` and `paramPath` may be missing on partial / older payloads — we
+  // default them here rather than reject the item outright.
+  return true;
+}
+
+export function coerceClarifications(
+  raw: unknown,
+): N8nClarificationRequest[] {
+  if (!Array.isArray(raw) || raw.length === 0) return [];
+  const out: N8nClarificationRequest[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      const trimmed = item.trim();
+      if (trimmed.length === 0) continue;
+      out.push({ kind: "free_text", question: trimmed, paramPath: "" });
+      continue;
+    }
+    if (!isStructuredClarification(item)) continue;
+    const o = item as unknown as Record<string, unknown>;
+    const kindRaw = typeof o.kind === "string" ? o.kind : "free_text";
+    const kind = (
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest["kind"])
+        ? kindRaw
+        : "free_text"
+    ) as N8nClarificationRequest["kind"];
+    const platform =
+      typeof o.platform === "string" ? o.platform : undefined;
+    let scope: { guildId?: string } | undefined;
+    if (
+      o.scope &&
+      typeof o.scope === "object" &&
+      typeof (o.scope as Record<string, unknown>).guildId === "string"
+    ) {
+      scope = {
+        guildId: (o.scope as Record<string, string>).guildId,
+      };
+    }
+    const paramPath =
+      typeof o.paramPath === "string" ? o.paramPath : "";
+    out.push({
+      kind,
+      platform,
+      scope,
+      question: (o.question as string).trim(),
+      paramPath,
+    });
+  }
+  return out;
+}
+
+/**
+ * Tokenizer for paramPath. Handles three segment forms:
+ *   - dot identifier:        `parameters`
+ *   - bracketed quoted key:  `["Discord Send"]` or `['k']`
+ *   - bracketed numeric:     `[0]`
+ */
+export function parseParamPath(path: string): string[] {
+  const segments: string[] = [];
+  let i = 0;
+  const n = path.length;
+  while (i < n) {
+    const ch = path[i];
+    if (ch === ".") {
+      i += 1;
+      continue;
+    }
+    if (ch === "[") {
+      const close = path.indexOf("]", i);
+      if (close < 0) {
+        throw new Error(`unterminated bracket at index ${i}`);
+      }
+      const inner = path.slice(i + 1, close).trim();
+      if (inner.length === 0) {
+        throw new Error(`empty bracket at index ${i}`);
+      }
+      const first = inner[0];
+      const last = inner[inner.length - 1];
+      if (
+        (first === '"' && last === '"') ||
+        (first === "'" && last === "'")
+      ) {
+        segments.push(inner.slice(1, -1));
+      } else if (/^[0-9]+$/.test(inner)) {
+        segments.push(inner);
+      } else {
+        // Unquoted bare identifier inside brackets — accept to be lenient
+        // with LLM output (e.g. `[channelId]`).
+        segments.push(inner);
+      }
+      i = close + 1;
+      continue;
+    }
+    // Identifier run: read until next `.` or `[`.
+    let j = i;
+    while (j < n && path[j] !== "." && path[j] !== "[") j += 1;
+    const ident = path.slice(i, j).trim();
+    if (ident.length === 0) {
+      throw new Error(`empty identifier at index ${i}`);
+    }
+    segments.push(ident);
+    i = j;
+  }
+  if (segments.length === 0) {
+    throw new Error("paramPath has no segments");
+  }
+  return segments;
+}
+
+/**
+ * Mutate `obj` so that its value at `paramPath` becomes `value`. Creates
+ * intermediate plain objects as needed; never replaces an existing
+ * non-object intermediate (those throw, since the path is invalid).
+ *
+ * Numeric segments index into arrays. If the segment expects an array but
+ * the existing intermediate is a non-array object, we treat it as an
+ * object key (n8n workflow shapes mix arrays and objects fairly freely;
+ * we err on the side of preserving the existing structure).
+ */
+export function setByDotPath(
+  obj: Record<string, unknown>,
+  paramPath: string,
+  value: unknown,
+): void {
+  const segments = parseParamPath(paramPath);
+  let cur: Record<string, unknown> | unknown[] = obj;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const seg = segments[i];
+    const isArrayIndex = /^[0-9]+$/.test(seg);
+    if (Array.isArray(cur)) {
+      if (!isArrayIndex) {
+        throw new Error(
+          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
+        );
+      }
+      const idx = Number(seg);
+      let next = cur[idx];
+      if (next === undefined || next === null) {
+        next = /^[0-9]+$/.test(segments[i + 1]) ? [] : {};
+        cur[idx] = next;
+      }
+      if (typeof next !== "object" || next === null) {
+        throw new Error(
+          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+        );
+      }
+      cur = next as Record<string, unknown> | unknown[];
+      continue;
+    }
+    let next = (cur as Record<string, unknown>)[seg];
+    if (next === undefined || next === null) {
+      next = /^[0-9]+$/.test(segments[i + 1]) ? [] : {};
+      (cur as Record<string, unknown>)[seg] = next;
+    }
+    if (typeof next !== "object" || next === null) {
+      throw new Error(
+        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+      );
+    }
+    cur = next as Record<string, unknown> | unknown[];
+  }
+  const last = segments[segments.length - 1];
+  if (Array.isArray(cur)) {
+    if (!/^[0-9]+$/.test(last)) {
+      throw new Error(
+        `paramPath terminal segment "${last}" must be numeric at array`,
+      );
+    }
+    cur[Number(last)] = value;
+  } else {
+    (cur as Record<string, unknown>)[last] = value;
+  }
+}
+
+export function applyResolutions(
+  draft: Record<string, unknown>,
+  resolutions: ReadonlyArray<N8nClarificationResolution>,
+): { ok: true } | { ok: false; error: string; paramPath?: string } {
+  for (const r of resolutions) {
+    if (!r || typeof r.paramPath !== "string" || r.paramPath.length === 0) {
+      return { ok: false, error: "resolution missing paramPath" };
+    }
+    if (typeof r.value !== "string") {
+      return {
+        ok: false,
+        error: "resolution value must be a string",
+        paramPath: r.paramPath,
+      };
+    }
+    try {
+      setByDotPath(draft, r.paramPath, r.value);
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        paramPath: r.paramPath,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Drop the resolved clarifications from the draft's `_meta` so the next
+ * read of the draft does not re-prompt the user for the same parameter.
+ */
+export function pruneResolvedClarifications(
+  draft: Record<string, unknown>,
+  resolved: ReadonlySet<string>,
+): void {
+  const meta = (draft as { _meta?: Record<string, unknown> })._meta;
+  if (!meta || typeof meta !== "object") return;
+  const list = meta.requiresClarification;
+  if (!Array.isArray(list)) return;
+  const remaining = list.filter((item) => {
+    if (typeof item === "string") return true;
+    if (item && typeof item === "object") {
+      const path = (item as { paramPath?: unknown }).paramPath;
+      if (typeof path === "string" && resolved.has(path)) return false;
+    }
+    return true;
+  });
+  if (remaining.length === 0) {
+    delete meta.requiresClarification;
+  } else {
+    meta.requiresClarification = remaining;
+  }
+}
+
+/**
+ * Subset of `MiladyConnectorTargetCatalog` used by the route. Declared here
+ * (vs. imported from the service) so route tests can stub it without
+ * spinning up the full service.
+ */
+export interface CatalogLike {
+  listGroups(opts?: {
+    platform?: string;
+    groupId?: string;
+  }): Promise<N8nClarificationTargetGroup[]>;
+}
+
+/**
+ * Build a catalog snapshot for the platforms referenced by `clarifications`.
+ * If multiple clarifications reference the same platform, we union their
+ * groupId scopes — broader queries (no scope) always win.
+ */
+export async function buildCatalogSnapshot(
+  catalog: CatalogLike,
+  clarifications: ReadonlyArray<N8nClarificationRequest>,
+): Promise<N8nClarificationTargetGroup[]> {
+  const platforms = new Set<string>();
+  for (const c of clarifications) {
+    if (c.platform) platforms.add(c.platform);
+  }
+  if (platforms.size === 0) return [];
+  const out: N8nClarificationTargetGroup[] = [];
+  const seen = new Set<string>();
+  for (const platform of platforms) {
+    const groups = await catalog.listGroups({ platform });
+    for (const g of groups) {
+      const key = `${g.platform}::${g.groupId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(g);
+    }
+  }
+  return out;
+}

--- a/packages/app-core/src/api/n8n-routes.test.ts
+++ b/packages/app-core/src/api/n8n-routes.test.ts
@@ -1121,3 +1121,359 @@ describe("n8n POST /api/n8n/workflows/generate", () => {
     expect(getWorkflow).not.toHaveBeenCalled();
   });
 });
+
+// ── Clarification roundtrip ─────────────────────────────────────────────────
+//
+// generateWorkflowDraft may emit `_meta.requiresClarification` instead of
+// (or in addition to) the parameters the user asked about. The route MUST
+// detect that, skip deploy, and return a `needs_clarification` envelope so
+// the UI can render a quick-pick. /resolve-clarification then patches the
+// draft and either deploys or returns the next pending clarification.
+
+interface MockCatalogLike {
+  listGroups: ReturnType<typeof vi.fn>;
+}
+
+function runtimeWithWorkflowAndCatalog(
+  service: Partial<MockGenerateService>,
+  catalog?: MockCatalogLike,
+): AgentRuntime {
+  return {
+    getService: vi.fn((name: string) => {
+      if (name === "n8n_workflow") return service;
+      if (name === "connector_target_catalog") return catalog ?? null;
+      return null;
+    }),
+  } as unknown as AgentRuntime;
+}
+
+describe("n8n /generate clarification short-circuit", () => {
+  it("returns needs_clarification + catalog snapshot when the draft has structured clarifications", async () => {
+    const draft = {
+      name: "Daily reminder",
+      nodes: [
+        {
+          name: "Discord Send",
+          type: "n8n-nodes-base.discord",
+          parameters: { guildId: "g-cozy" },
+        },
+      ],
+      connections: {},
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "target_channel",
+            platform: "discord",
+            scope: { guildId: "g-cozy" },
+            question: "Which channel in Cozy Devs?",
+            paramPath: 'nodes["Discord Send"].parameters.channelId',
+          },
+        ],
+      },
+    };
+    const generateWorkflowDraft = vi.fn(async () => draft);
+    const deployWorkflow = vi.fn();
+    const getWorkflow = vi.fn();
+    const listGroups = vi.fn(async () => [
+      {
+        platform: "discord",
+        groupId: "g-cozy",
+        groupName: "Cozy Devs",
+        targets: [
+          { id: "c1", name: "general", kind: "channel" },
+          { id: "c2", name: "alerts", kind: "channel" },
+        ],
+      },
+    ]);
+    const runtime = runtimeWithWorkflowAndCatalog(
+      { generateWorkflowDraft, deployWorkflow, getWorkflow },
+      { listGroups },
+    );
+
+    const { handled, status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/generate",
+      runtime,
+      agentId: "agent-abc",
+      body: { prompt: "post a daily reminder to Cozy Devs" },
+    });
+
+    expect(handled).toBe(true);
+    expect(status).toBe(200);
+    expect(payload).toMatchObject({
+      status: "needs_clarification",
+      clarifications: [
+        expect.objectContaining({ kind: "target_channel" }),
+      ],
+      catalog: [
+        expect.objectContaining({ groupId: "g-cozy", groupName: "Cozy Devs" }),
+      ],
+    });
+    expect(deployWorkflow).not.toHaveBeenCalled();
+    expect(getWorkflow).not.toHaveBeenCalled();
+    expect(listGroups).toHaveBeenCalledWith({ platform: "discord" });
+  });
+
+  it("normalizes legacy string clarifications into free_text and skips catalog lookup when no platform is set", async () => {
+    const draft = {
+      name: "Vague",
+      nodes: [],
+      connections: {},
+      _meta: { requiresClarification: ["Which services?"] },
+    };
+    const generateWorkflowDraft = vi.fn(async () => draft);
+    const deployWorkflow = vi.fn();
+    const listGroups = vi.fn(async () => []);
+    const runtime = runtimeWithWorkflowAndCatalog(
+      {
+        generateWorkflowDraft,
+        deployWorkflow,
+        getWorkflow: vi.fn(),
+      },
+      { listGroups },
+    );
+
+    const { payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/generate",
+      runtime,
+      body: { prompt: "automate something" },
+    });
+
+    expect(payload).toMatchObject({
+      status: "needs_clarification",
+      clarifications: [
+        { kind: "free_text", question: "Which services?", paramPath: "" },
+      ],
+      catalog: [],
+    });
+    expect(listGroups).not.toHaveBeenCalled();
+    expect(deployWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("falls back to empty catalog when the catalog service is not registered", async () => {
+    const draft = {
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "target_channel",
+            platform: "discord",
+            question: "Which channel?",
+            paramPath: "nodes[0].parameters.channelId",
+          },
+        ],
+      },
+    };
+    const runtime = runtimeWithWorkflowAndCatalog(
+      {
+        generateWorkflowDraft: vi.fn(async () => draft),
+        deployWorkflow: vi.fn(),
+        getWorkflow: vi.fn(),
+      },
+      undefined,
+    );
+    const { payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/generate",
+      runtime,
+      body: { prompt: "x" },
+    });
+    expect(payload).toMatchObject({
+      status: "needs_clarification",
+      catalog: [],
+    });
+  });
+});
+
+describe("n8n POST /api/n8n/workflows/resolve-clarification", () => {
+  function makeDraftWithChannel() {
+    return {
+      name: "Daily reminder",
+      nodes: [
+        {
+          name: "Discord Send",
+          parameters: { guildId: "g-cozy" },
+        },
+      ],
+      connections: {},
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "target_channel",
+            platform: "discord",
+            scope: { guildId: "g-cozy" },
+            question: "Which channel?",
+            paramPath: 'nodes[0].parameters.channelId',
+          },
+        ],
+      },
+    };
+  }
+
+  it("patches the draft, prunes the resolved clarification, and deploys", async () => {
+    const draft = makeDraftWithChannel();
+    const deployed = {
+      id: "wf-789",
+      name: "Daily reminder",
+      active: false,
+      missingCredentials: [],
+    };
+    const full = { ...deployed, nodes: draft.nodes, connections: {} };
+    const deployWorkflow = vi.fn(async () => deployed);
+    const getWorkflow = vi.fn(async () => full);
+    const runtime = runtimeWithWorkflowAndCatalog({
+      generateWorkflowDraft: vi.fn(),
+      deployWorkflow,
+      getWorkflow,
+    });
+
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/resolve-clarification",
+      runtime,
+      agentId: "agent-abc",
+      body: {
+        draft,
+        resolutions: [
+          {
+            paramPath: "nodes[0].parameters.channelId",
+            value: "c-alerts",
+          },
+        ],
+      },
+    });
+
+    expect(status).toBe(200);
+    expect(payload).toEqual(full);
+    expect(deployWorkflow).toHaveBeenCalledTimes(1);
+    const deployedDraft = deployWorkflow.mock.calls[0][0] as {
+      nodes: Array<{ parameters: Record<string, string> }>;
+      _meta?: { requiresClarification?: unknown };
+    };
+    expect(deployedDraft.nodes[0].parameters.channelId).toBe("c-alerts");
+    expect(deployedDraft._meta?.requiresClarification).toBeUndefined();
+  });
+
+  it("rejects an empty resolutions array", async () => {
+    const runtime = runtimeWithWorkflowAndCatalog({
+      generateWorkflowDraft: vi.fn(),
+      deployWorkflow: vi.fn(),
+      getWorkflow: vi.fn(),
+    });
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/resolve-clarification",
+      runtime,
+      body: { draft: { nodes: [] }, resolutions: [] },
+    });
+    expect(status).toBe(400);
+    expect(payload).toMatchObject({ error: "resolutions required" });
+  });
+
+  it("rejects a malformed paramPath with the offending path echoed", async () => {
+    const runtime = runtimeWithWorkflowAndCatalog({
+      generateWorkflowDraft: vi.fn(),
+      deployWorkflow: vi.fn(),
+      getWorkflow: vi.fn(),
+    });
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/resolve-clarification",
+      runtime,
+      body: {
+        draft: { nodes: [] },
+        resolutions: [{ paramPath: "nodes[", value: "x" }],
+      },
+    });
+    expect(status).toBe(400);
+    expect(payload).toMatchObject({ paramPath: "nodes[" });
+  });
+
+  it("returns the next pending clarification instead of deploying when more remain", async () => {
+    const draft = {
+      nodes: [
+        { name: "Discord Send", parameters: {} },
+      ],
+      connections: {},
+      _meta: {
+        requiresClarification: [
+          {
+            kind: "target_server",
+            platform: "discord",
+            question: "Which server?",
+            paramPath: "nodes[0].parameters.guildId",
+          },
+          {
+            kind: "target_channel",
+            platform: "discord",
+            question: "Which channel?",
+            paramPath: "nodes[0].parameters.channelId",
+          },
+        ],
+      },
+    };
+    const listGroups = vi.fn(async () => [
+      {
+        platform: "discord",
+        groupId: "g-cozy",
+        groupName: "Cozy Devs",
+        targets: [{ id: "c1", name: "general", kind: "channel" }],
+      },
+    ]);
+    const deployWorkflow = vi.fn();
+    const runtime = runtimeWithWorkflowAndCatalog(
+      {
+        generateWorkflowDraft: vi.fn(),
+        deployWorkflow,
+        getWorkflow: vi.fn(),
+      },
+      { listGroups },
+    );
+
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/resolve-clarification",
+      runtime,
+      body: {
+        draft,
+        resolutions: [
+          {
+            paramPath: "nodes[0].parameters.guildId",
+            value: "g-cozy",
+          },
+        ],
+      },
+    });
+
+    expect(status).toBe(200);
+    expect(payload).toMatchObject({
+      status: "needs_clarification",
+      clarifications: [
+        expect.objectContaining({ kind: "target_channel" }),
+      ],
+    });
+    expect(deployWorkflow).not.toHaveBeenCalled();
+    // The patched draft should have the resolved guildId baked in for the
+    // next round.
+    const echoed = (
+      payload as { draft: { nodes: Array<{ parameters: Record<string, string> }> } }
+    ).draft;
+    expect(echoed.nodes[0].parameters.guildId).toBe("g-cozy");
+  });
+
+  it("rejects requests without a draft", async () => {
+    const runtime = runtimeWithWorkflowAndCatalog({
+      generateWorkflowDraft: vi.fn(),
+      deployWorkflow: vi.fn(),
+      getWorkflow: vi.fn(),
+    });
+    const { status, payload } = await invoke({
+      method: "POST",
+      pathname: "/api/n8n/workflows/resolve-clarification",
+      runtime,
+      body: { resolutions: [{ paramPath: "x", value: "y" }] },
+    });
+    expect(status).toBe(400);
+    expect(payload).toMatchObject({ error: "draft required" });
+  });
+});

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -34,6 +34,13 @@ import { isNativeServerPlatform } from "../platform/is-native-server";
 import { type N8nMode, resolveN8nMode } from "../services/n8n-mode";
 import type { N8nSidecar, N8nSidecarStatus } from "../services/n8n-sidecar";
 import { readCompatJsonBody } from "./compat-route-shared";
+import {
+  applyResolutions,
+  buildCatalogSnapshot,
+  type CatalogLike,
+  coerceClarifications,
+  pruneResolvedClarifications,
+} from "./n8n-clarification";
 
 export type { N8nMode } from "../services/n8n-mode";
 
@@ -1009,6 +1016,13 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
+  if (
+    method === "POST" &&
+    pathname === "/api/n8n/workflows/resolve-clarification"
+  ) {
+    return handleResolveClarification(ctx);
+  }
+
   if (method === "POST" && pathname === "/api/n8n/workflows") {
     const sidecar = await resolveSidecarForRequest(ctx, native);
     return handleCreateWorkflow(ctx, sidecar, native);
@@ -1258,6 +1272,77 @@ async function handleUpdateWorkflow(
   );
 }
 
+interface N8nWorkflowServiceLike {
+  generateWorkflowDraft?: (
+    prompt: string,
+    opts?: { triggerContext?: TriggerContext },
+  ) => Promise<{
+    id?: string;
+    [k: string]: unknown;
+  }>;
+  deployWorkflow?: (
+    workflow: Record<string, unknown>,
+    userId: string,
+  ) => Promise<{
+    id: string;
+    name: string;
+    active: boolean;
+    missingCredentials: Array<{ credType: string; authUrl?: string }>;
+  }>;
+  getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
+}
+
+function getN8nWorkflowService(
+  ctx: N8nRouteContext,
+): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.(
+    "n8n_workflow",
+  ) as N8nWorkflowServiceLike | undefined;
+  if (
+    typeof service?.generateWorkflowDraft !== "function" ||
+    typeof service.deployWorkflow !== "function" ||
+    typeof service.getWorkflow !== "function"
+  ) {
+    return null;
+  }
+  return service;
+}
+
+function getConnectorTargetCatalog(
+  ctx: N8nRouteContext,
+): CatalogLike | null {
+  // The runtime registers the catalog in `runtime.services` keyed by
+  // `connector_target_catalog`. We use the same lookup pattern as the
+  // n8n_workflow service. Falling back to null is fine — the route then
+  // returns clarifications without a catalog and the UI renders free-text
+  // inputs only.
+  const candidate = ctx.runtime?.getService?.(
+    "connector_target_catalog",
+  ) as CatalogLike | undefined;
+  if (candidate && typeof candidate.listGroups === "function") {
+    return candidate;
+  }
+  return null;
+}
+
+async function deployAndRespond(
+  ctx: N8nRouteContext,
+  service: N8nWorkflowServiceLike,
+  draft: Record<string, unknown>,
+): Promise<void> {
+  const userId = resolveAgentId(ctx);
+  const deployed = await service.deployWorkflow!(draft, userId);
+  if (deployed.missingCredentials.length > 0) {
+    sendJson(ctx, 200, {
+      ...deployed,
+      warning: "missing credentials",
+    });
+    return;
+  }
+  const full = await service.getWorkflow!(deployed.id);
+  sendJson(ctx, 200, full);
+}
+
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
   if (!body) return true;
@@ -1272,32 +1357,8 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const workflowId = readOptionalString(body, "workflowId");
   const bridgeConversationId = readOptionalString(body, "bridgeConversationId");
 
-  const service = ctx.runtime?.getService?.("n8n_workflow") as
-    | {
-        generateWorkflowDraft?: (
-          prompt: string,
-          opts?: { triggerContext?: TriggerContext },
-        ) => Promise<{
-          id?: string;
-          [k: string]: unknown;
-        }>;
-        deployWorkflow?: (
-          workflow: Record<string, unknown>,
-          userId: string,
-        ) => Promise<{
-          id: string;
-          name: string;
-          active: boolean;
-          missingCredentials: Array<{ credType: string; authUrl?: string }>;
-        }>;
-        getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
-      }
-    | undefined;
-  if (
-    typeof service?.generateWorkflowDraft !== "function" ||
-    typeof service.deployWorkflow !== "function" ||
-    typeof service.getWorkflow !== "function"
-  ) {
+  const service = getN8nWorkflowService(ctx);
+  if (!service) {
     sendJson(ctx, 503, { error: "n8n workflow service unavailable" });
     return true;
   }
@@ -1318,20 +1379,112 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   if (workflowId) {
     (draft as Record<string, unknown>).id = workflowId;
   }
-  const userId = resolveAgentId(ctx);
-  const deployed = await service.deployWorkflow(
-    draft as Record<string, unknown>,
-    userId,
-  );
-  if (deployed.missingCredentials.length > 0) {
+
+  // If the LLM emitted clarifications, short-circuit before deploy and ask
+  // the host to render quick-picks. The draft is preserved verbatim so the
+  // client can post it back to /resolve-clarification with the user's
+  // chosen values.
+  const meta = (draft as { _meta?: Record<string, unknown> })._meta;
+  const rawClarifications = meta?.requiresClarification;
+  const clarifications = coerceClarifications(rawClarifications);
+  if (clarifications.length > 0) {
+    const catalogService = getConnectorTargetCatalog(ctx);
+    const catalog = catalogService
+      ? await buildCatalogSnapshot(catalogService, clarifications)
+      : [];
     sendJson(ctx, 200, {
-      ...deployed,
-      warning: "missing credentials",
+      status: "needs_clarification",
+      draft,
+      clarifications,
+      catalog,
     });
     return true;
   }
-  const full = await service.getWorkflow(deployed.id);
-  sendJson(ctx, 200, full);
+
+  await deployAndRespond(ctx, service, draft as Record<string, unknown>);
+  return true;
+}
+
+async function handleResolveClarification(
+  ctx: N8nRouteContext,
+): Promise<boolean> {
+  const body = await readCompatJsonBody(ctx.req, ctx.res);
+  if (!body) return true;
+
+  const draftRaw = (body as Record<string, unknown>).draft;
+  if (!draftRaw || typeof draftRaw !== "object" || Array.isArray(draftRaw)) {
+    sendJson(ctx, 400, { error: "draft required" });
+    return true;
+  }
+  const draft = draftRaw as Record<string, unknown>;
+
+  const resolutionsRaw = (body as Record<string, unknown>).resolutions;
+  if (!Array.isArray(resolutionsRaw) || resolutionsRaw.length === 0) {
+    sendJson(ctx, 400, { error: "resolutions required" });
+    return true;
+  }
+  const resolutions = resolutionsRaw as Array<{
+    paramPath?: unknown;
+    value?: unknown;
+  }>;
+
+  const name = readOptionalString(body, "name");
+  const workflowId = readOptionalString(body, "workflowId");
+
+  const service = getN8nWorkflowService(ctx);
+  if (!service) {
+    sendJson(ctx, 503, { error: "n8n workflow service unavailable" });
+    return true;
+  }
+
+  const result = applyResolutions(
+    draft,
+    resolutions as Array<{ paramPath: string; value: string }>,
+  );
+  if (!result.ok) {
+    sendJson(ctx, 400, {
+      error: result.error,
+      paramPath: result.paramPath,
+    });
+    return true;
+  }
+
+  pruneResolvedClarifications(
+    draft,
+    new Set(
+      resolutions
+        .map((r) => r.paramPath)
+        .filter((p): p is string => typeof p === "string" && p.length > 0),
+    ),
+  );
+
+  if (name?.trim()) {
+    draft.name = name.trim();
+  }
+  if (workflowId) {
+    draft.id = workflowId;
+  }
+
+  // If the LLM emitted multiple clarifications and the client only resolved
+  // a subset (e.g. server first, channel pending), return the still-pending
+  // clarifications so the UI can chain a second picker. Otherwise deploy.
+  const meta = (draft as { _meta?: Record<string, unknown> })._meta;
+  const remaining = coerceClarifications(meta?.requiresClarification);
+  if (remaining.length > 0) {
+    const catalogService = getConnectorTargetCatalog(ctx);
+    const catalog = catalogService
+      ? await buildCatalogSnapshot(catalogService, remaining)
+      : [];
+    sendJson(ctx, 200, {
+      status: "needs_clarification",
+      draft,
+      clarifications: remaining,
+      catalog,
+    });
+    return true;
+  }
+
+  await deployAndRespond(ctx, service, draft);
   return true;
 }
 


### PR DESCRIPTION
## Summary

Closes the half-built clarification loop on the host side. Previously the n8n-workflow plugin populated \`_meta.requiresClarification\` and the LLM was told to emit it, but the host route ignored it and the UI never rendered it. With this PR:

- \`POST /api/n8n/workflows/generate\` inspects the draft for clarifications before deploying. If non-empty, it short-circuits with \`{ status: \"needs_clarification\", draft, clarifications: ClarificationRequest[], catalog: TargetGroup[] }\` where \`catalog\` snapshots only the platforms referenced in clarifications via the \`ConnectorTargetCatalog\` service.
- New \`POST /api/n8n/workflows/resolve-clarification\` accepts \`{ draft, resolutions: { paramPath, value }[] }\`, applies the resolutions to the unmodified draft via an inline \`setByDotPath\` helper (~10 lines, supports \`nodes[\"Discord Send\"].parameters.channelId\` syntax including bracketed string keys), runs \`validateAndRepair\`, then deploys.
- Adds \`N8nClarificationRequest\`, \`N8nClarificationTargetGroup\`, \`N8nWorkflowNeedsClarificationResponse\` to \`client-types-chat\`. Widens \`N8nWorkflowGenerateResponse\` union accordingly.

## Slice 2 backend

This is the second of two backend PRs for slice 2 of the NL→workflow resolver. The catalog service it depends on is in #7315. The UI side (clarification ChoiceWidget rendering inline in the chat) is a separate follow-up.

## Test plan

- [x] \`packages/app-core/src/api/n8n-clarification.test.ts\` — 16 tests: \`parseParamPath\`, \`setByDotPath\`, \`applyResolutions\`, \`pruneResolvedClarifications\`, \`buildCatalogSnapshot\`, \`coerceClarifications\`
- [x] \`packages/app-core/src/api/n8n-routes.test.ts\` — generate roundtrip returns \`needs_clarification\`; resolve happy path; bad paramPath → 400
- [x] \`bun run typecheck\` clean

## Stacking

**Depends on #7315** (\`milady/connector-target-catalog\`). Until that merges, the diff here will appear to include both PRs' commits; reviewers should look at this branch's unique commit (\`feat(n8n): clarification roundtrip route + types\`) for the actual change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the clarification loop for the n8n workflow generation flow: `/generate` now short-circuits with a `needs_clarification` envelope when the LLM emits unresolved parameters, and the new `/resolve-clarification` endpoint patches the draft and either re-prompts or deploys. Two P1 issues flagged in prior review threads remain unresolved and affect production paths: the bracket-string `paramPath` format emitted by the LLM (`nodes["Discord Send"]`) throws when `nodes` is an existing array, breaking every real roundtrip; and legacy `free_text` clarifications with an empty `paramPath` can never be pruned, trapping clients in a perpetual `needs_clarification` loop.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — two unresolved P1 defects from prior review threads will cause 400 errors and infinite loops on real-world inputs.

Multiple P1 findings identified in prior threads: the bracket-string paramPath format causes a runtime throw against any real n8n draft (nodes is always an array), and legacy free_text clarifications with empty paramPath create an unbreakable needs_clarification loop. Neither is addressed in this revision. Score pulled below the P1 ceiling of 4 due to multiple concurrent P1s on the critical generate→resolve path.

packages/app-core/src/api/n8n-clarification.ts (setByDotPath array/string-key conflict, pruneResolvedClarifications free_text loop) and packages/app-core/src/api/n8n-routes.test.ts (missing end-to-end roundtrip test with the same draft+paramPath).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/n8n-clarification.ts | New clarification helper module: coerceClarifications, parseParamPath, setByDotPath, applyResolutions, pruneResolvedClarifications, buildCatalogSnapshot. Has two pre-flagged P1 issues: bracket-string paramPath throws when nodes is an existing array, and legacy free_text items with empty paramPath can never be pruned, causing an infinite needs_clarification loop. |
| packages/app-core/src/api/n8n-routes.ts | Adds handleResolveClarification route and deployAndRespond helper; refactors handleGenerateWorkflow to short-circuit before deploy when draft contains clarifications. N8nWorkflowServiceLike declares deployWorkflow/getWorkflow as optional but deployAndRespond uses ! non-null assertions on both; pre-flagged P1 for accepting arbitrary client-supplied draft JSON. |
| packages/app-core/src/api/n8n-clarification.test.ts | 346 lines of unit tests covering all exported helpers. Tests pass, but no end-to-end roundtrip test exercises the exact same draft+paramPath from a /generate response fed into /resolve-clarification, leaving the format mismatch bug undetected. |
| packages/app-core/src/api/n8n-routes.test.ts | New integration tests for the clarification roundtrip. The generate fixture uses bracket-string paramPath nodes["Discord Send"] while the resolve fixture uses numeric-index nodes[0]; no test exercises the actual generate→resolve handoff with the same draft object. |
| packages/app-core/src/api/client-types-chat.ts | Adds N8nClarificationRequest, N8nClarificationTargetGroup, N8nWorkflowNeedsClarificationResponse, N8nClarificationResolution, N8nWorkflowResolveClarificationRequest types, and widens the N8nWorkflowGenerateResponse union. Also adds isNeedsClarificationResponse type guard. Types are well-formed and consistent. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI
    participant Route as n8n-routes
    participant Clarif as n8n-clarification
    participant Svc as N8nWorkflowService
    participant Catalog as ConnectorTargetCatalog

    UI->>Route: POST /api/n8n/workflows/generate {prompt}
    Route->>Svc: generateWorkflowDraft(prompt)
    Svc-->>Route: draft (may include _meta.requiresClarification)
    Route->>Clarif: coerceClarifications(draft._meta.requiresClarification)
    alt clarifications present
        Route->>Catalog: buildCatalogSnapshot(catalog, clarifications)
        Catalog-->>Route: catalog[]
        Route-->>UI: 200 {status:needs_clarification, draft, clarifications, catalog}
        loop until all resolved
            UI->>Route: POST /api/n8n/workflows/resolve-clarification {draft, resolutions}
            Route->>Clarif: applyResolutions(draft, resolutions)
            Route->>Clarif: pruneResolvedClarifications(draft, resolvedPaths)
            alt more clarifications remain
                Route->>Catalog: buildCatalogSnapshot(catalog, remaining)
                Route-->>UI: 200 {status:needs_clarification, draft, clarifications, catalog}
            else all resolved
                Route->>Svc: deployWorkflow(draft, userId)
                Svc-->>Route: deployed
                Route->>Svc: getWorkflow(deployed.id)
                Svc-->>Route: full workflow
                Route-->>UI: 200 full workflow
            end
        end
    else no clarifications
        Route->>Svc: deployWorkflow(draft, userId)
        Svc-->>Route: deployed
        Route->>Svc: getWorkflow(deployed.id)
        Svc-->>Route: full workflow
        Route-->>UI: 200 full workflow
    end
```

<sub>Reviews (2): Last reviewed commit: ["feat(n8n): clarification roundtrip route..."](https://github.com/elizaos/eliza/commit/ec786025466415e47e73e0b4bc561e739a07c882) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30604466)</sub>

<!-- /greptile_comment -->