### PR TITLE
feat(automations): hero centerpiece overview + UX restoration

### DIFF
--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -17,6 +17,7 @@ import {
   SidebarContent,
   SidebarPanel,
   SidebarScrollRegion,
+  Spinner,
   StatusBadge,
   StatusDot,
   Textarea,
@@ -67,6 +68,7 @@ import {
   type AutomationItem as CatalogAutomationItem,
   type Conversation,
   isMissingCredentialsResponse,
+  isNeedsClarificationResponse,
   type N8nStatusResponse,
   type N8nWorkflow,
   type N8nWorkflowMissingCredential,
@@ -979,8 +981,9 @@ function useAutomationsViewController() {
     }
   };
 
-  const onDeleteTrigger = async () => {
-    if (!editingId) return;
+  const onDeleteTrigger = async (triggerId?: string) => {
+    const targetId = triggerId ?? editingId;
+    if (!targetId) return;
     const confirmed = await confirmDesktopAction({
       title: t("heartbeatsview.deleteTitle"),
       message: t("heartbeatsview.deleteMessage", { name: form.displayName }),
@@ -990,15 +993,17 @@ function useAutomationsViewController() {
     });
     if (!confirmed) return;
 
-    const deleted = await deleteTrigger(editingId);
+    const deleted = await deleteTrigger(targetId);
     if (!deleted) return;
 
-    if (selectedItemId === `trigger:${editingId}`) {
+    if (selectedItemId === `trigger:${targetId}`) {
       setSelectedItemId(null);
       setSelectedItemKind(null);
     }
     await refreshAutomations();
-    closeEditor();
+    if (targetId === editingId) {
+      closeEditor();
+    }
   };
 
   const onDeleteTask = async (taskId: string) => {
@@ -2424,6 +2429,124 @@ function OverviewListItem({
   );
 }
 
+function HeroEmptyState({
+  ideas,
+  onSubmit,
+  drafts,
+  onSelectDraft,
+  onDeleteDraft,
+  t,
+}: {
+  ideas: AutomationExample[];
+  onSubmit: (text: string) => void;
+  drafts: AutomationItem[];
+  onSelectDraft: (item: AutomationItem) => void;
+  onDeleteDraft?: (item: AutomationItem) => void | Promise<void>;
+  t: AutomationsViewController["t"];
+}) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const submit = useCallback(() => {
+    const text = value.trim();
+    if (text.length === 0) return;
+    setValue("");
+    onSubmit(text);
+  }, [onSubmit, value]);
+
+  const handleChipSelect = useCallback((idea: AutomationExample) => {
+    setValue(idea.prompt);
+    textareaRef.current?.focus();
+  }, []);
+
+  const canSubmit = value.trim().length > 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 px-6 py-10">
+      <div className="w-full max-w-[560px] space-y-3">
+        <div className="relative">
+          <Textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="Describe a task or workflow…"
+            rows={2}
+            variant="form"
+            className="resize-none pr-12"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="absolute bottom-2 right-2 h-7 w-7 p-0"
+            onClick={submit}
+            disabled={!canSubmit}
+            aria-label="Submit"
+          >
+            <ArrowRight className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {ideas.map((idea) => (
+            <button
+              key={idea.label}
+              type="button"
+              onClick={() => handleChipSelect(idea)}
+              className="rounded-full border border-border/50 bg-bg-accent px-2.5 py-1 text-xs text-txt transition-colors hover:border-accent/40 hover:bg-accent/5"
+            >
+              {idea.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {drafts.length > 0 && (
+        <div className="w-full max-w-[560px]">
+          <DetailSection title="Drafts in progress">
+            <div className="divide-y divide-border/20">
+              {drafts.map((item) => (
+                <div key={item.id} className="flex items-stretch gap-1">
+                  <div className="min-w-0 flex-1">
+                    <OverviewListItem
+                      onClick={() => onSelectDraft(item)}
+                      title={getOverviewDisplayTitle(item)}
+                      badge="Draft"
+                      meta={formatRelativePast(item.updatedAt, t)}
+                      detail={
+                        item.description.trim() ||
+                        "Open it and keep shaping it in the sidebar agent."
+                      }
+                      tone="warning"
+                    />
+                  </div>
+                  {onDeleteDraft && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="h-auto w-8 shrink-0 self-center text-muted hover:bg-danger/10 hover:text-danger"
+                      onClick={() => void onDeleteDraft(item)}
+                      aria-label="Delete draft"
+                      title="Delete draft"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </DetailSection>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function AutomationsDashboard({
   items,
   onSelectItem,
@@ -2931,10 +3054,12 @@ function AutomationDraftPane({
   automation,
   onSeedPrompt,
   onDeleteDraft,
+  isGenerating,
 }: {
   automation: AutomationItem;
   onSeedPrompt: (prompt: string) => void;
   onDeleteDraft: (item: AutomationItem) => Promise<void>;
+  isGenerating?: boolean;
 }) {
   const chatChrome = useAppWorkspaceChatChrome();
 
@@ -2948,6 +3073,20 @@ function AutomationDraftPane({
 
   return (
     <div className="space-y-4 px-4 pt-6">
+      {isGenerating && (
+        <div className="flex items-start gap-3 rounded-xl border border-accent/40 bg-accent/5 px-4 py-3 text-sm">
+          <Spinner className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+          <div className="min-w-0 flex-1">
+            <div className="font-semibold text-txt">
+              Building your workflow…
+            </div>
+            <div className="mt-0.5 text-xs text-muted">
+              Generations usually take 10–30 seconds. Hooking up connectors,
+              picking nodes, and wiring the graph.
+            </div>
+          </div>
+        </div>
+      )}
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-1">
           <h2 className="text-lg font-semibold text-txt">
@@ -3227,6 +3366,7 @@ function TriggerAutomationDetailPane({
     openEditTrigger,
     onRunSelectedTrigger,
     onToggleTriggerEnabled,
+    onDeleteTrigger,
     loadTriggerRuns,
     triggerRunsById,
     setForm,
@@ -3328,6 +3468,12 @@ function TriggerAutomationDetailPane({
               label="Compile to Workflow"
               onClick={() => void onPromoteToWorkflow(automation)}
               icon={<GitBranch className="h-3.5 w-3.5" />}
+            />
+            <IconAction
+              label={t("common.delete")}
+              onClick={() => void onDeleteTrigger(trigger.id)}
+              icon={<Trash2 className="h-3.5 w-3.5" />}
+              tone="danger"
             />
           </>
         }
@@ -4587,6 +4733,12 @@ function AutomationsLayout() {
           setMissingCredentials(result.missingCredentials);
           return null;
         }
+        if (isNeedsClarificationResponse(result)) {
+          setPageNotice(
+            "Workflow needs more details before it can deploy. Continue in the chat to clarify.",
+          );
+          return null;
+        }
         if (conversation) {
           await bindConversationToWorkflow(
             conversation,
@@ -5272,7 +5424,7 @@ function AutomationsLayout() {
                       size="sm"
                       variant="outline"
                       onClick={() => {
-                        setTab("settings");
+                        setTab("connectors");
                         dispatchFocusConnector(
                           providerFromCredType(cred.credType),
                         );
@@ -5362,28 +5514,24 @@ function AutomationsLayout() {
         ) : activeSubpage === "node-catalog" ? (
           <AutomationNodeCatalogPane nodes={automationNodes} />
         ) : showDashboard ? (
-          <AutomationsDashboard
-            items={ctx.allItems}
-            onSelectItem={selectItem}
-            onCreateTask={handleZeroStateNewTask}
-            onCreateWorkflow={() => void createWorkflowDraft()}
-            onDescribeAutomation={handleDescribeAutomation}
-            onUseIdea={(idea) => {
-              if (idea.kind === "workflow") {
-                void createWorkflowDraft({
-                  title: idea.label,
-                  initialPrompt: idea.prompt,
-                });
-                return;
-              }
-              openSeededTask(idea);
-            }}
+          <HeroEmptyState
+            ideas={AUTOMATION_DRAFT_EXAMPLES}
+            onSubmit={(text) =>
+              void createWorkflowDraft({ initialPrompt: text })
+            }
+            drafts={ctx.allItems
+              .filter((item) => item.isDraft)
+              .slice(0, 4)}
+            onSelectDraft={selectItem}
+            onDeleteDraft={handleDeleteDraft}
+            t={t}
           />
         ) : resolvedSelectedItem?.type === "automation_draft" ? (
           <AutomationDraftPane
             automation={resolvedSelectedItem}
             onSeedPrompt={(prompt) => prefillPageChat(prompt, { select: true })}
             onDeleteDraft={handleDeleteDraft}
+            isGenerating={workflowOpsBusy}
           />
         ) : resolvedSelectedItem?.type === "n8n_workflow" ? (
           <WorkflowAutomationDetailPane


### PR DESCRIPTION
## Summary

Restores the NL-first hero centerpiece as the primary Automations Overview surface, plus several inline UX fixes that compound the workflow-creation path. Implements Section 3 of \`packages/app-core/docs/automations-ux-redesign.md\` (Single Creation Input) — the existing redesign doc explicitly calls for one prominent command input as the most important simplification, but the shipped overview routed users to a structured task-creation form first.

## Changes (single commit, several focused diffs)

**Hero centerpiece (replaces empty / dashboard branches on Overview):**
- New \`HeroEmptyState\` component — centered \`<Textarea placeholder=\"Describe a task or workflow…\">\` with submit arrow, sample-prompt chips populated from \`AUTOMATION_DRAFT_EXAMPLES\`, and a \"Drafts in progress\" section. Submit calls \`createWorkflowDraft({ initialPrompt })\`, which kicks off the slice-1 progress card.
- Drafts in the hero list now have an inline trash button (calls \`handleDeleteDraft\`).

**Connect-credentials banner deep-link (bug fix):**
- The missing-credentials banner's \"Connect → \" button used \`setTab(\"settings\")\`, but Settings has no connector cards. Connector cards live on the dedicated \`connectors\` tab (per \`packages/app-core/src/App.tsx:454\`). Changed to \`setTab(\"connectors\")\` so the deep-link actually lands on the right surface; the existing \`dispatchFocusConnector\` event still flashes the right card.

**Trigger detail pane delete:**
- \`TriggerAutomationDetailPane\` previously had no delete affordance (only Pause/Run/Edit/Duplicate/Compile-to-Workflow). Added a Trash IconAction calling \`onDeleteTrigger(trigger.id)\`. Widened \`onDeleteTrigger\` signature to optionally take a \`triggerId\` so it can be invoked outside the editor's editingId context — the existing form-driven path stays compatible (defaults to \`editingId\` when no arg is passed).

**Generation progress card on draft pane:**
- \`AutomationDraftPane\` now accepts an \`isGenerating\` prop and renders a \"Building your workflow…\" spinner card at the top while \`workflowOpsBusy\` is true (the same flag the trigger-edit-form already exposes via \`onWorkflowOpsBusyChange\`). Closes the visual-feedback gap during the synchronous \`createWorkflowDraft({ initialPrompt })\` → \`generateWorkflowFromPrompt\` window.

**Type narrowing for slice-2 backend (#7316):**
- Adds the \`isNeedsClarificationResponse\` type guard usage in \`generateWorkflowFromPrompt\` so the function compiles cleanly against the widened \`N8nWorkflowGenerateResponse\` union.

## Stacking

**Depends on #7316** (\`milady/n8n-resolve-clarification\`) for the \`isNeedsClarificationResponse\` type guard. Reviewers comparing this PR's diff should focus on the \`AutomationsView.tsx\` changes — the route + types changes belong to #7316 and will collapse when that merges.

## Test plan

- [x] Vite hot-reload picks up the changes
- [x] \`bun run typecheck\` clean in \`packages/app-core\`
- [x] Manual: typing into the hero textarea + Enter creates a draft with progress card visible while the LLM call runs; deletes are confirmable; Connect button navigates to \`/connectors\`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores a NL-first hero centerpiece (`HeroEmptyState`) as the primary Automations overview, adds a delete affordance to `TriggerAutomationDetailPane`, wires a generation progress spinner into `AutomationDraftPane`, fixes the credentials-banner deep-link (`settings` → `connectors`), and adds the `isNeedsClarificationResponse` type guard to `generateWorkflowFromPrompt`.

- **P1 — spinner misattributed across drafts:** `workflowOpsBusy` is a global flag; passing it verbatim as `isGenerating` causes any draft pane the user navigates to during generation to show \"Building your workflow…\" even though the operation belongs to a different draft. A per-draft `generatingDraftId` is needed.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge; one P1 UX bug (spinner misattribution) that is cosmetically confusing but not data-destructive.

Single P1 finding (wrong draft shows generating spinner) caps the score at 4. The remaining findings are P2 (hardcoded i18n strings). Core logic changes — deep-link fix, delete wiring, type guard — are correct.

packages/app-core/src/components/pages/AutomationsView.tsx — the isGenerating={workflowOpsBusy} prop on AutomationDraftPane and the new hardcoded strings.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/AutomationsView.tsx | Adds HeroEmptyState component and wires several UX fixes; a global `workflowOpsBusy` flag is passed as `isGenerating` to AutomationDraftPane, causing the spinner to appear on the wrong draft when the user navigates away during generation (P1). Several new hardcoded English strings bypass i18n (P2). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on Automations Overview] --> B{showDashboard?}
    B -- yes --> C[HeroEmptyState\nTextarea + chips + draft list]
    C -- submit text --> D[createWorkflowDraft\ninitialPrompt]
    D --> E[setShowDashboard false\nsetSelectedItemId workflow-draft:id\nworkflowOpsBusy = true]
    E --> F[AutomationDraftPane\nisGenerating=workflowOpsBusy ⚠️]
    F -- user navigates to different draft --> G[Other AutomationDraftPane\nisGenerating=workflowOpsBusy ⚠️ wrong!]
    E --> H[generateWorkflowFromPrompt]
    H -- isMissingCredentials --> I[setMissingCredentials\nCredentials banner → connectors tab ✅]
    H -- isNeedsClarification --> J[setPageNotice\nhardcoded EN string ⚠️]
    H -- success --> K[refreshAutomations\nselectWorkflowById\nworkflowOpsBusy = false]
    B -- no --> L{resolvedSelectedItem type?}
    L -- automation_draft --> F
    L -- n8n_workflow --> M[WorkflowAutomationDetailPane]
    L -- trigger --> N[TriggerAutomationDetailPane\n+ Delete button ✅]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/components/pages/AutomationsView.tsx`, line 1494-1508 ([link](https://github.com/elizaos/eliza/blob/a39d78e67d9623793c6c3e4057cd570c519ef48c/packages/app-core/src/components/pages/AutomationsView.tsx#L1494-L1508)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hero textarea placeholder is not i18n'd**

   The `HeroEmptyState` component receives the `t` translation helper as a prop and uses it for `"Drafts in progress"` and related labels, but the textarea `placeholder` is a hardcoded English string. This will not be translated in non-English locales.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(automations): hero centerpiece as p..."](https://github.com/elizaos/eliza/commit/46e61b5b523172f737460eca77a878f9ed2c1895) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30604491)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->