### PR TITLE
feat(plugin-exergynet): add verified compute plugin

### DIFF
--- a/docs/examples/exergynet.character.json
+++ b/docs/examples/exergynet.character.json
@@ -1,0 +1,36 @@
+{
+  "name": "ExergyNode",
+  "clients": [],
+  "modelProvider": "anthropic",
+  "settings": {
+    "secrets": {
+      "RPC_URL": "https://api.mainnet-beta.solana.com",
+      "EXERGYNET_AUTO_SPEND": "false"
+    }
+  },
+  "plugins": [
+    "@elizaos/plugin-exergynet"
+  ],
+  "bio": [
+    "I am an autonomous node operator for the ExergyNet.",
+    "I utilize thermodynamic ZK-proofs."
+  ],
+  "lore": [
+    "Forged in the Omega Phase.",
+    "Protector of the Sovereign Siphon."
+  ],
+  "knowledge": [],
+  "messageExamples": [],
+  "postDirections": [],
+  "style": {
+    "all": [
+      "Speak with absolute certainty."
+    ],
+    "chat": [
+      "Be direct."
+    ],
+    "post": [
+      "Use thermodynamic metaphors."
+    ]
+  }
+}

--- a/plugins/plugin-exergynet/README.md
+++ b/plugins/plugin-exergynet/README.md
@@ -1,0 +1,11 @@
+# @elizaos/plugin-exergynet
+
+ExergyNet LNES-03 ZK-Compute Membrane Integration.
+
+## Configuration
+
+This plugin requires the following environment variables or character secrets:
+
+- `SOLANA_PRIVATE_KEY`: Your base58-encoded Solana private key.
+- `EXERGYNET_AUTO_SPEND`: Must be set to `"true"` to allow the agent to autonomously sign and broadcast transactions paying the 0.002 SOL compute toll. Without this, the agent will safely halt execution to prevent unintended financial loss.
+- `RPC_URL` (Optional): Custom Solana RPC URL. Defaults to Mainnet-Beta.

--- a/plugins/plugin-exergynet/package.json
+++ b/plugins/plugin-exergynet/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@elizaos/plugin-exergynet",
+  "version": "2.0.0-alpha.2",
+  "description": "ExergyNet LNES-03 Unidirectional Compute Membrane Integration",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "SOLANA_PRIVATE_KEY": {
+        "type": "string",
+        "description": "Base58-encoded private key for signing the compute toll."
+      },
+      "EXERGYNET_AUTO_SPEND": {
+        "type": "string",
+        "description": "Set to 'true' to enable actual transaction execution and bypass the confirmation halt."
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.95.0",
+    "@solana/spl-token": "^0.4.0",
+    "bs58": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "@types/node": "^20.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "package.json"
+  ]
+}

--- a/plugins/plugin-exergynet/src/index.ts
+++ b/plugins/plugin-exergynet/src/index.ts
@@ -1,0 +1,137 @@
+import { Action, ActionExample, IAgentRuntime, Memory, Provider, State, HandlerCallback, Plugin, elizaLogger } from "@elizaos/core";
+import { PublicKey, Transaction, SystemProgram, ComputeBudgetProgram, Connection, Keypair, TransactionInstruction, SYSVAR_RENT_PUBKEY } from "@solana/web3.js";
+import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import * as crypto from "crypto";
+import bs58 from "bs58";
+
+export const LNES_PROGRAM_ID = new PublicKey("7BCPpUMBxQMPomsgTaJsQdLEfycNwPWqkQD1Cea4CcCL");
+export const OMEGA_MINT = new PublicKey("5fZZJ29oH5SDqxiz2tkEf1wopp5Sn5TtcCF3fPS9rdiJ");
+
+// The default axiom hash used for ZK-state alignment when no specific job hash is provided.
+// The 32-byte array is seeded with 7s to satisfy the LNES-03 PDA entropy requirement.
+const DEFAULT_AXIOM_HASH = Buffer.from(new Uint8Array(32).fill(7)); 
+const COMPUTE_TOLL_LAMPORTS = BigInt(2_000_000); // 0.002 SOL
+
+export const requestExergyComputeAction: Action = {
+    name: "REQUEST_EXERGY_COMPUTE",
+    similes:["EXERGYNET_COMPUTE", "REQUEST_EXERGY"],
+    description: "Triggers a ZK-proof computation order by locking 0.002 SOL into the ExergyNet Membrane.",
+    validate: async (runtime: IAgentRuntime) => {
+        return !!runtime.getSetting("SOLANA_PRIVATE_KEY");
+    },
+    handler: async (runtime: IAgentRuntime, _message: Memory, _state?: State, _options?: any, callback?: HandlerCallback): Promise<any> => {
+        let sig: string | undefined;
+        try {
+            const autoSpendEnabled = runtime.getSetting("EXERGYNET_AUTO_SPEND") === "true";
+            if (!autoSpendEnabled) {
+                elizaLogger.warn("[exergynet] Action triggered, but auto-spend is disabled. Awaiting user confirmation.");
+                if (callback) {
+                    callback({
+                        text: "I am ready to request a ZK-proof from ExergyNet. This will cost 0.002 SOL. Please confirm you wish to proceed.",
+                        content: { status: "AWAITING_CONFIRMATION", action: "REQUEST_EXERGY_COMPUTE" }
+                    });
+                }
+                return true;
+            }
+
+            const rpcUrl = (runtime.getSetting("RPC_URL") as string) || "https://api.mainnet-beta.solana.com";
+            const connection = new Connection(rpcUrl, "confirmed");
+            const privateKey = runtime.getSetting("SOLANA_PRIVATE_KEY") as string;
+            
+            if (!privateKey) throw new Error("Missing SOLANA_PRIVATE_KEY");
+            const payer = Keypair.fromSecretKey(bs58.decode(privateKey));
+
+            elizaLogger.log("[exergynet] Constructing LNES-03 OpenJob Strike...");
+
+            const jobId = Keypair.generate().publicKey.toBytes();
+            const [escrowPda] = PublicKey.findProgramAddressSync([Buffer.from("escrow"), Buffer.from(jobId)], LNES_PROGRAM_ID);
+            const[escrowVault] = PublicKey.findProgramAddressSync([Buffer.from("vault"), Buffer.from(jobId)], LNES_PROGRAM_ID);
+            const [mintAuth] = PublicKey.findProgramAddressSync([Buffer.from("mint_auth")], LNES_PROGRAM_ID);
+
+            // FIXED: Explicit Little-Endian encoding for cross-platform deterministic payload serialization
+            const tollBuffer = Buffer.alloc(8);
+            tollBuffer.writeBigUInt64LE(COMPUTE_TOLL_LAMPORTS);
+
+            const openJobData = Buffer.concat([
+                crypto.createHash("sha256").update("global:open_job").digest().subarray(0, 8),
+                Buffer.from(jobId),
+                DEFAULT_AXIOM_HASH, 
+                tollBuffer
+            ]);
+
+            const ix = new TransactionInstruction({
+                programId: LNES_PROGRAM_ID,
+                data: openJobData,
+                keys:[
+                    { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+                    { pubkey: escrowPda, isSigner: false, isWritable: true },
+                    { pubkey: escrowVault, isSigner: false, isWritable: true },
+                    { pubkey: OMEGA_MINT, isSigner: false, isWritable: true },
+                    { pubkey: mintAuth, isSigner: false, isWritable: false },
+                    { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+                    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+                    { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
+                ]
+            });
+
+            const tx = new Transaction().add(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 150000 }), ix);
+            const latestBlockhash = await connection.getLatestBlockhash("confirmed");
+            tx.recentBlockhash = latestBlockhash.blockhash;
+            tx.feePayer = payer.publicKey;
+            tx.sign(payer);
+
+            elizaLogger.log("[exergynet] Broadcasting transaction...");
+            sig = await connection.sendRawTransaction(tx.serialize(), { skipPreflight: false });
+
+            elizaLogger.log(`[exergynet] Awaiting confirmation for signature: ${sig}`);
+            const confirmation = await connection.confirmTransaction({
+                signature: sig,
+                blockhash: latestBlockhash.blockhash,
+                lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+            }, "confirmed");
+
+            if (confirmation.value.err) {
+                throw new Error(`Transaction failed: ${JSON.stringify(confirmation.value.err)}`);
+            }
+
+            if (callback) {
+                callback({
+                    text: `ExergyNet request confirmed on Solana.\nSignature: ${sig}`,
+                    content: { signature: sig, status: "CONFIRMED" }
+                });
+            }
+            return true;
+
+        } catch (e: unknown) {
+            const errMsg = e instanceof Error ? e.message : String(e);
+            elizaLogger.error("[exergynet] Strike Fracture:", errMsg);
+
+            if (callback) {
+                callback({
+                    text: `ExergyNet request failed: ${errMsg}${sig ? `\nPartial signature (check Solscan): ${sig}` : ""}`,
+                    content: { status: "FAILED", error: errMsg, ...(sig ? { signature: sig } : {}) }
+                });
+            }
+            return false;
+        }
+    },
+        examples: [[
+            { user: "user", content: { text: "Verify this logic via ExergyNet." } },
+            { user: "assistant", content: { text: "Initiating thermodynamic proof order...", action: "REQUEST_EXERGY_COMPUTE" } }
+        ] as unknown as ActionExample[]
+    ]
+};
+
+export const exergynetPlugin: Plugin = {
+    name: "exergynet",
+    description: "ExergyNet LNES-03 ZK-Compute Membrane Integration",
+    actions:[requestExergyComputeAction],
+    providers:[{
+        name: "exergynet-membrane",
+        get: async (_runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<any> => {
+            return `ExergyNet LNES-03: OPERATIONAL | Membrane: ${LNES_PROGRAM_ID.toBase58()} | Toll: 0.002 SOL`;
+        }
+    } as Provider]
+};
+
+export default exergynetPlugin;

--- a/plugins/plugin-exergynet/tsup.config.ts
+++ b/plugins/plugin-exergynet/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+export default defineConfig({
+    entry: ["src/index.ts"],
+    format: ["esm"],
+    dts: true,
+    clean: true,
+    external: ["@elizaos/core", "@solana/web3.js", "@solana/spl-token", "bs58"],
+});


### PR DESCRIPTION
# Relates to

New Feature Integration: ExergyNet Verified Compute Plugin.

This PR is a clean follow-up to the previous ExergyNet plugin review cycle and addresses feedback from the closed PR #7310.

# Risks

Low to moderate.

The plugin is isolated under `plugins/plugin-exergynet` as `@elizaos/plugin-exergynet`. It does not modify core agent orchestration, memory, runtime logic, or unrelated example characters.

The only material risk is financial execution: when explicitly enabled, the plugin can submit a real Solana Mainnet-Beta transaction. To reduce accidental spend risk, execution is gated by:

- `SOLANA_PRIVATE_KEY` being present.
- `EXERGYNET_AUTO_SPEND` being explicitly set to `"true"`.
- Transaction confirmation before returning `SUCCESS`.
- A `FAILED` callback path for caught errors.

# Background

## What does this PR do?

This PR adds `@elizaos/plugin-exergynet`, an isolated ElizaOS plugin for requesting ExergyNet verified compute through a Solana transaction.

The plugin includes:

- Provider context for ExergyNet status and compute toll.
- `REQUEST_EXERGY_COMPUTE` action.
- Solana transaction construction for the ExergyNet program.
- Confirmed transaction flow before returning `SUCCESS`.
- Explicit `FAILED` callback on errors.
- Dedicated ExergyNet example character.
- Generated TypeScript declarations with `dts: true`.
- Externalized dependencies, including `@solana/spl-token`.

## Updates in this revision

This revision addresses prior review feedback by:

- Narrowing action similes to reduce accidental SOL spend triggers.
- Removing redundant imports.
- Documenting `DEFAULT_AXIOM_HASH`.
- Using explicit little-endian encoding for the compute toll.
- Moving the demo into `docs/examples/exergynet.character.json`.
- Keeping unrelated examples, such as WhatsApp, free of ExergyNet requirements.
- Removing committed private-key placeholders.
- Setting `EXERGYNET_AUTO_SPEND` to `"false"` by default.
- Documenting `SOLANA_PRIVATE_KEY` and `EXERGYNET_AUTO_SPEND` in plugin configuration and README.
- Enabling TypeScript declaration output.
- Externalizing Solana dependencies in `tsup.config.ts`.

# What kind of change is this?

Feature.

# Documentation changes

Included:

- `plugins/plugin-exergynet/README.md`
- `docs/examples/exergynet.character.json`

The example character is intentionally safe by default. It does not include a private key, and `EXERGYNET_AUTO_SPEND` defaults to `"false"`.

# Safety model

By default, the plugin should not broadcast a transaction.

Expected default behavior:

```text
EXERGYNET_AUTO_SPEND != "true"
→ action returns AWAITING_CONFIRMATION
→ no transaction is submitted

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `@elizaos/plugin-exergynet`, a new ElizaOS plugin that submits a Solana Mainnet transaction to the ExergyNet LNES-03 on-chain program, locked behind `SOLANA_PRIVATE_KEY` and `EXERGYNET_AUTO_SPEND` env guards.

- **P1 — Confirmation loop dead-end**: When `EXERGYNET_AUTO_SPEND` is not `"true"`, the handler fires, returns `AWAITING_CONFIRMATION` with a "please confirm" message, and returns `true`. Any follow-up user confirmation re-triggers the same handler, which re-checks the same env var, and again returns `AWAITING_CONFIRMATION` — an infinite loop with no exit path. The UX implies an interactive confirmation gate that does not actually exist.
- **P2 — Validate fires when auto-spend is off**: `validate` returns `true` whenever `SOLANA_PRIVATE_KEY` is present, causing the action to consume an agent turn on every matched message even when there is no path to execute the transaction.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the confirmation flow is logically broken and will loop indefinitely when auto-spend is disabled.

A P1 logic bug means the advertised 'safe default' confirmation path never actually resolves, misleading users and making the action permanently stuck in a loop unless auto-spend is already enabled. This warrants a score below the P1 ceiling of 4.

plugins/plugin-exergynet/src/index.ts — handler and validate logic both need revision before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-exergynet/src/index.ts | Core plugin logic; contains a P1 dead-end confirmation loop when EXERGYNET_AUTO_SPEND is false, and a P2 validate-gate issue. Transaction construction follows Anchor discriminator conventions correctly. |
| docs/examples/exergynet.character.json | Example character correctly defaults EXERGYNET_AUTO_SPEND to "false", but unnecessarily places the public RPC_URL in the secrets block. |
| plugins/plugin-exergynet/package.json | Package metadata looks well-structured; Solana deps are in dependencies and correctly listed as external in tsup. Missing newline at end of file. |
| plugins/plugin-exergynet/tsup.config.ts | Correctly externalizes all Solana and elizaos deps, enables dts output, and targets ESM only. |
| plugins/plugin-exergynet/README.md | Concise documentation covering all required env vars with accurate descriptions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User message matches REQUEST_EXERGY_COMPUTE simile] --> B{validate:\nSOLANA_PRIVATE_KEY set?}
    B -- No --> C[Action skipped]
    B -- Yes --> D{EXERGYNET_AUTO_SPEND == 'true'?}
    D -- No --> E[callback: AWAITING_CONFIRMATION\n'Please confirm to proceed']
    E --> F[return true]
    F -->|User says 'yes, proceed'| A
    D -- Yes --> G[Build LNES-03 OpenJob instruction\nAnchor discriminator + jobId + axiomHash + toll]
    G --> H[sendRawTransaction to Mainnet-Beta]
    H --> I[confirmTransaction]
    I -- err --> J[callback: FAILED\nlog partial sig]
    I -- ok --> K[callback: CONFIRMED\nreturn sig]

    style E fill:#f9a,stroke:#c33
    style F fill:#f9a,stroke:#c33
```

<sub>Reviews (1): Last reviewed commit: ["feat(plugin-exergynet): add verified com..."](https://github.com/elizaos/eliza/commit/7fcf31ebc803dc6996113998210fe91b9d8e25e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30605612)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->