### PR TITLE
fix(cloud): align steward-sync test mocks with current service types

### DIFF
--- a/cloud/packages/tests/unit/steward-sync.test.ts
+++ b/cloud/packages/tests/unit/steward-sync.test.ts
@@ -9,6 +9,7 @@ import { invitesService } from "@/lib/services/invites";
 import { organizationsService } from "@/lib/services/organizations";
 import { usersService } from "@/lib/services/users";
 import { syncUserFromSteward } from "@/lib/steward-sync";
+import type { UserWithOrganization } from "@/lib/types";
 
 const BASE_ORG = {
   id: "org-1",
@@ -19,35 +20,60 @@ const BASE_ORG = {
 
 describe("syncUserFromSteward", () => {
   beforeEach(() => {
-    usersService.getByStewardId = async () => undefined;
-    usersService.getByStewardIdForWrite = async () => undefined;
-    usersService.getByEmailWithOrganization = async () => undefined;
-    usersService.getByWalletAddress = async () => undefined;
-    usersService.getByWalletAddressWithOrganization = async () => undefined;
-    usersService.create = async (data) => ({ id: "created-user", ...data });
-    usersService.update = async (id, data) => ({ id, ...data });
-    usersService.linkStewardId = async () => {};
-    usersService.upsertStewardIdentity = async () => {};
+    usersService.getByStewardId = (async () => undefined) as typeof usersService.getByStewardId;
+    usersService.getByStewardIdForWrite = (async () =>
+      undefined) as typeof usersService.getByStewardIdForWrite;
+    usersService.getByEmailWithOrganization = (async () =>
+      undefined) as typeof usersService.getByEmailWithOrganization;
+    usersService.getByWalletAddress = (async () =>
+      undefined) as typeof usersService.getByWalletAddress;
+    usersService.getByWalletAddressWithOrganization = (async () =>
+      undefined) as typeof usersService.getByWalletAddressWithOrganization;
+    usersService.create = (async (data) => ({
+      id: "created-user",
+      ...data,
+    })) as typeof usersService.create;
+    usersService.update = (async (id, data) => ({
+      id,
+      ...data,
+    })) as typeof usersService.update;
+    usersService.linkStewardId = (async () => {}) as typeof usersService.linkStewardId;
+    usersService.upsertStewardIdentity =
+      (async () => {}) as typeof usersService.upsertStewardIdentity;
 
-    invitesService.findPendingInviteByEmail = async () => undefined;
-    organizationInvitesRepository.markAsAccepted = async () => {};
+    invitesService.findPendingInviteByEmail = (async () =>
+      undefined) as typeof invitesService.findPendingInviteByEmail;
+    organizationInvitesRepository.markAsAccepted =
+      (async () => {}) as typeof organizationInvitesRepository.markAsAccepted;
 
-    organizationsService.getBySlug = async () => undefined;
-    organizationsService.create = async (data) => ({
+    organizationsService.getBySlug = (async () =>
+      undefined) as typeof organizationsService.getBySlug;
+    organizationsService.create = (async (data) => ({
       id: "new-org",
       billing_email: null,
       ...data,
-    });
-    organizationsService.update = async (id, data) => ({ id, ...data });
-    organizationsService.delete = async () => {};
+    })) as typeof organizationsService.create;
+    organizationsService.update = (async (id, data) => ({
+      id,
+      ...data,
+    })) as typeof organizationsService.update;
+    organizationsService.delete = (async () => {}) as typeof organizationsService.delete;
 
-    creditsService.addCredits = async () => {};
-    emailService.sendWelcomeEmail = async () => {};
-    discordService.logUserSignup = async () => {};
-    apiKeysService.listByOrganization = async () => [];
-    apiKeysService.create = async () => ({ id: "api-key-1" });
-    charactersService.listByOrganization = async () => [];
-    charactersService.create = async () => ({ id: "char-1" });
+    creditsService.addCredits = (async () => {}) as unknown as typeof creditsService.addCredits;
+    emailService.sendWelcomeEmail =
+      (async () => {}) as unknown as typeof emailService.sendWelcomeEmail;
+    discordService.logUserSignup =
+      (async () => {}) as unknown as typeof discordService.logUserSignup;
+    apiKeysService.listByOrganization =
+      (async () => []) as typeof apiKeysService.listByOrganization;
+    apiKeysService.create = (async () => ({
+      id: "api-key-1",
+    })) as unknown as typeof apiKeysService.create;
+    charactersService.listByOrganization =
+      (async () => []) as typeof charactersService.listByOrganization;
+    charactersService.create = (async () => ({
+      id: "char-1",
+    })) as unknown as typeof charactersService.create;
   });
 
   test("links an existing wallet user for wallet-only Steward sessions", async () => {
@@ -66,32 +92,32 @@ describe("syncUserFromSteward", () => {
       ...existingUser,
       steward_user_id: "stwd-wallet-1",
       organization: BASE_ORG,
-    };
+    } as unknown as UserWithOrganization;
 
     let linked = false;
     let upserted = false;
 
-    usersService.getByWalletAddress = async (address) => {
+    usersService.getByWalletAddress = (async (address) => {
       expect(address).toBe("0xabc123");
       return existingUser;
-    };
-    usersService.linkStewardId = async (userId, stewardUserId) => {
+    }) as typeof usersService.getByWalletAddress;
+    usersService.linkStewardId = (async (userId, stewardUserId) => {
       expect(userId).toBe(existingUser.id);
       expect(stewardUserId).toBe("stwd-wallet-1");
       linked = true;
-    };
-    usersService.upsertStewardIdentity = async (userId, stewardUserId) => {
+    }) as typeof usersService.linkStewardId;
+    usersService.upsertStewardIdentity = (async (userId, stewardUserId) => {
       expect(userId).toBe(existingUser.id);
       expect(stewardUserId).toBe("stwd-wallet-1");
       upserted = true;
-    };
-    usersService.getByStewardIdForWrite = async (stewardUserId) => {
+    }) as typeof usersService.upsertStewardIdentity;
+    usersService.getByStewardIdForWrite = (async (stewardUserId) => {
       expect(stewardUserId).toBe("stwd-wallet-1");
       return linkedUser;
-    };
-    usersService.create = async () => {
+    }) as typeof usersService.getByStewardIdForWrite;
+    usersService.create = (async () => {
       throw new Error("create should not run when wallet match exists");
-    };
+    }) as typeof usersService.create;
 
     const result = await syncUserFromSteward({
       stewardUserId: "stwd-wallet-1",
@@ -104,7 +130,7 @@ describe("syncUserFromSteward", () => {
   });
 
   test("creates a new wallet-only user when no wallet match exists", async () => {
-    let createdPayload;
+    let createdPayload: Parameters<typeof usersService.create>[0] | undefined;
     const createdUser = {
       id: "wallet-new-user",
       steward_user_id: "stwd-wallet-2",
@@ -125,18 +151,19 @@ describe("syncUserFromSteward", () => {
         slug: "wallet-0xdef456-test",
         billing_email: null,
       },
-    };
+    } as unknown as UserWithOrganization;
 
-    organizationsService.create = async (data) => ({
+    organizationsService.create = (async (data) => ({
       id: "new-org",
       billing_email: null,
       ...data,
-    });
-    usersService.create = async (data) => {
+    })) as typeof organizationsService.create;
+    usersService.create = (async (data) => {
       createdPayload = data;
       return { id: "wallet-new-user", ...data };
-    };
-    usersService.getByStewardIdForWrite = async () => createdUserWithOrg;
+    }) as typeof usersService.create;
+    usersService.getByStewardIdForWrite = (async () =>
+      createdUserWithOrg) as unknown as typeof usersService.getByStewardIdForWrite;
 
     const result = await syncUserFromSteward({
       stewardUserId: "stwd-wallet-2",
@@ -144,10 +171,10 @@ describe("syncUserFromSteward", () => {
     });
 
     expect(result).toEqual(createdUserWithOrg);
-    expect(createdPayload.wallet_address).toBe("0xdef456");
-    expect(createdPayload.wallet_chain_type).toBe("ethereum");
-    expect(createdPayload.wallet_verified).toBe(true);
-    expect(createdPayload.email).toBeNull();
+    expect(createdPayload?.wallet_address).toBe("0xdef456");
+    expect(createdPayload?.wallet_chain_type).toBe("ethereum");
+    expect(createdPayload?.wallet_verified).toBe(true);
+    expect(createdPayload?.email).toBeNull();
   });
 
   test("still links existing email users without breaking the legacy path", async () => {
@@ -166,27 +193,27 @@ describe("syncUserFromSteward", () => {
     const linkedUser = {
       ...existingByEmail,
       steward_user_id: "stwd-email-1",
-    };
+    } as unknown as UserWithOrganization;
 
-    let updatedPayload;
+    let updatedPayload: Parameters<typeof usersService.update>[1] | undefined;
 
-    usersService.getByEmailWithOrganization = async (email) => {
+    usersService.getByEmailWithOrganization = (async (email) => {
       expect(email).toBe("shadow@example.com");
       return existingByEmail;
-    };
-    usersService.update = async (id, data) => {
+    }) as typeof usersService.getByEmailWithOrganization;
+    usersService.update = (async (id, data) => {
       expect(id).toBe(existingByEmail.id);
       updatedPayload = data;
       return { ...existingByEmail, ...data };
-    };
-    usersService.upsertStewardIdentity = async (userId, stewardUserId) => {
+    }) as typeof usersService.update;
+    usersService.upsertStewardIdentity = (async (userId, stewardUserId) => {
       expect(userId).toBe(existingByEmail.id);
       expect(stewardUserId).toBe("stwd-email-1");
-    };
-    usersService.getByStewardIdForWrite = async (stewardUserId) => {
+    }) as typeof usersService.upsertStewardIdentity;
+    usersService.getByStewardIdForWrite = (async (stewardUserId) => {
       expect(stewardUserId).toBe("stwd-email-1");
       return linkedUser;
-    };
+    }) as typeof usersService.getByStewardIdForWrite;
 
     const result = await syncUserFromSteward({
       stewardUserId: "stwd-email-1",
@@ -194,6 +221,6 @@ describe("syncUserFromSteward", () => {
     });
 
     expect(result).toEqual(linkedUser);
-    expect(updatedPayload.steward_user_id).toBe("stwd-email-1");
+    expect(updatedPayload?.steward_user_id).toBe("stwd-email-1");
   });
 });


### PR DESCRIPTION
## Summary

Resolves the ~25 TypeScript errors in [packages/tests/unit/steward-sync.test.ts](cloud/packages/tests/unit/steward-sync.test.ts) that have been blocking the **Cloud Tests / lint-and-types** job on `develop`.

The mocks in this file were defined as terse partial objects (e.g. `async () => ({ id: "..." })`) but the real service methods now return fully-typed `User`, `UserWithOrganization`, `NewApiKey`, etc. Drift between the mocks and the schema accumulated over time.

## Approach

Two casts, applied per mock:
1. `as typeof <service>.<method>` — when the mock body is structurally compatible with the real signature (most cases).
2. `as unknown as typeof <service>.<method>` — when the mock returns a strict subset that TS won't widen on its own (`creditsService.addCredits`, `emailService.sendWelcomeEmail`, `discordService.logUserSignup`, `apiKeysService.create`, `charactersService.create`, the `getByStewardIdForWrite` overrides).

Plus:
- `let createdPayload: Parameters<typeof usersService.create>[0] | undefined` instead of `let createdPayload;` — fixes the TS18048 "possibly undefined" warnings.
- `linkedUser` / `createdUserWithOrg` literals cast to `UserWithOrganization` so `toEqual(...)` no longer fails the overload resolution.

No runtime behavior change; the mocks return the same values as before.

## Test plan

- [x] `bun run typecheck` filtered to `steward-sync.test.ts` → **zero errors** (was ~25)
- [x] `bunx biome check` on the file → clean
- [ ] Cloud Tests / lint-and-types runs against this PR

## Out of scope

`apps/api/auth/siwe/{nonce,verify}/route.ts` and related files (introduced by #7327, just before this branch) still emit 3 TS2345 errors and 3 biome format errors in `cloud/`. Those will need a separate fix before Cloud Tests goes fully green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes ~25 TypeScript errors in `cloud/packages/tests/unit/steward-sync.test.ts` by aligning test mock signatures with the current service types. The approach uses `as typeof service.method` for structurally-compatible mocks and `as unknown as typeof service.method` for strict-subset returns, with no runtime behavior changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — test-only file with no runtime behavior changes, purely fixing TypeScript type errors in mock signatures.

All changes are confined to a single test file, correcting type casts on mock functions to match current service signatures. No logic, runtime behavior, or production code is altered. The `as unknown as` casts are appropriate for test stubs returning structural subsets. The optional-chaining additions (`?.`) on possibly-undefined payload variables correctly guard previously unguarded accesses.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/tests/unit/steward-sync.test.ts | Test mock types aligned with real service signatures using `as typeof` and `as unknown as` casts; minor inconsistency in `getByStewardIdForWrite` cast style between tests (one uses `as unknown as`, others don't) with no runtime impact |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant syncUserFromSteward
    participant usersService
    participant organizationsService
    participant creditsService
    participant emailService
    participant discordService

    Test->>syncUserFromSteward: call(stewardUserId, walletAddress?)
    syncUserFromSteward->>usersService: getByWalletAddress / getByEmailWithOrganization
    alt existing user found
        syncUserFromSteward->>usersService: linkStewardId(userId, stewardUserId)
        syncUserFromSteward->>usersService: upsertStewardIdentity(userId, stewardUserId)
    else no user found
        syncUserFromSteward->>organizationsService: create(data)
        syncUserFromSteward->>usersService: create(data)
        syncUserFromSteward->>creditsService: addCredits(...)
        syncUserFromSteward->>emailService: sendWelcomeEmail(...)
        syncUserFromSteward->>discordService: logUserSignup(...)
    end
    syncUserFromSteward->>usersService: getByStewardIdForWrite(stewardUserId)
    usersService-->>syncUserFromSteward: UserWithOrganization
    syncUserFromSteward-->>Test: UserWithOrganization
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): align steward-sync test mock..."](https://github.com/elizaos/eliza/commit/36571efe4e2581f5101c55d79c574012e22e38df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30619439)</sub>

<!-- /greptile_comment -->