### PR TITLE
fix(automations): pass triggerName to onDeleteTrigger from detail pane

### DIFF
--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -981,12 +981,14 @@ function useAutomationsViewController() {
     }
   };
 
-  const onDeleteTrigger = async (triggerId?: string) => {
+  const onDeleteTrigger = async (triggerId?: string, displayName?: string) => {
     const targetId = triggerId ?? editingId;
     if (!targetId) return;
     const confirmed = await confirmDesktopAction({
       title: t("heartbeatsview.deleteTitle"),
-      message: t("heartbeatsview.deleteMessage", { name: form.displayName }),
+      message: t("heartbeatsview.deleteMessage", {
+        name: displayName ?? form.displayName,
+      }),
       confirmLabel: t("common.delete"),
       cancelLabel: t("common.cancel"),
       type: "warning",
@@ -3472,7 +3474,9 @@ function TriggerAutomationDetailPane({
             />
             <IconAction
               label={t("common.delete")}
-              onClick={() => void onDeleteTrigger(trigger.id)}
+              onClick={() =>
+                void onDeleteTrigger(trigger.id, trigger.displayName)
+              }
               icon={<Trash2 className="h-3.5 w-3.5" />}
               tone="danger"
             />


### PR DESCRIPTION
## Summary

Greptile flagged a P1 bug on #7317 that shipped unfixed when the PR merged: `TriggerAutomationDetailPane`'s delete button calls `onDeleteTrigger(trigger.id)`, but the confirmation dialog reads `form.displayName` — which reflects the trigger-edit form state, not the trigger shown in the pane. When deleting a trigger that is not currently being edited, the dialog displays a stale or empty name.

## Fix

Extend the signature to `onDeleteTrigger(triggerId?: string, displayName?: string)` and let the caller pass the target name. The detail-pane caller now passes `trigger.displayName`. The form-driven caller (`HeartbeatForm.onDelete: () => Promise<void>`) keeps working unchanged because both params are optional and fall back to `editingId` + `form.displayName` when omitted.

Surface change: 7 insertions, 3 deletions in a single file.

## Test plan

- [x] `bun run typecheck` clean in `packages/app-core`
- [ ] Manual: open Automations → click a trigger → click trash icon in detail pane header → confirmation dialog displays the trigger's name correctly (previously stale/empty)
- [ ] Manual: click a trigger → Edit → click trash inside form → confirmation dialog still works (regression check on the form-driven path)

## Greptile context

P1 callout from https://github.com/elizaOS/eliza/pull/7317#issuecomment (Greptile review): `onDeleteTrigger(trigger.id) called from the detail pane reads form.displayName for the confirmation message, but form reflects the edit form state, not the trigger shown in the pane — the dialog will display a stale or empty name when the editor is not open for that trigger.`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a P1 bug where the delete confirmation dialog in `TriggerAutomationDetailPane` displayed a stale or empty trigger name, because it was reading `form.displayName` (the edit-form state) instead of the name of the trigger shown in the detail pane. The fix extends `onDeleteTrigger` to accept an optional `displayName` parameter and passes `trigger.displayName` from the detail-pane call site, while the form-driven path (HeartbeatForm calls `onDelete()` with no args) continues to fall back to `form.displayName` unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, focused fix with no regressions on existing paths.

Single-file change with 7 insertions and 3 deletions. Both call sites are accounted for: the detail-pane path now correctly passes trigger.displayName, and the form-driven path continues to work unchanged via optional-parameter fallback. TypeScript compatibility is maintained since a function with optional params is assignable to () => Promise<void>. No logic changes beyond the display-name resolution.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/AutomationsView.tsx | Adds optional `displayName` param to `onDeleteTrigger` and passes `trigger.displayName` from the detail-pane call site; form-driven path is unaffected since both new params are optional. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant DP as TriggerAutomationDetailPane
    participant HF as HeartbeatForm
    participant ODT as onDeleteTrigger
    participant DLG as confirmDesktopAction

    Note over DP: Detail-pane path (fixed)
    U->>DP: Click trash icon
    DP->>ODT: onDeleteTrigger(trigger.id, trigger.displayName)
    ODT->>DLG: confirm({ name: trigger.displayName })
    DLG-->>U: Dialog shows correct trigger name

    Note over HF: Form-driven path (unchanged)
    U->>HF: Click delete in edit form
    HF->>ODT: onDelete() [no args]
    ODT->>DLG: confirm({ name: form.displayName })
    DLG-->>U: Dialog shows form displayName
```

<sub>Reviews (1): Last reviewed commit: ["fix(automations): pass triggerName to on..."](https://github.com/elizaos/eliza/commit/b0383b9e77e45f58804e824f24982c2580488e9a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30623940)</sub>

<!-- /greptile_comment -->