### PR TITLE
feat(automations): clarification quick-pick UI

### DIFF
--- a/packages/app-core/src/api/client-n8n.ts
+++ b/packages/app-core/src/api/client-n8n.ts
@@ -12,6 +12,7 @@ import type {
   N8nWorkflow,
   N8nWorkflowGenerateRequest,
   N8nWorkflowGenerateResponse,
+  N8nWorkflowResolveClarificationRequest,
   N8nWorkflowWriteRequest,
 } from "./client-types-chat";
 
@@ -31,6 +32,9 @@ declare module "./client-base" {
     ): Promise<N8nWorkflow>;
     generateN8nWorkflow(
       request: N8nWorkflowGenerateRequest,
+    ): Promise<N8nWorkflowGenerateResponse>;
+    resolveN8nClarification(
+      request: N8nWorkflowResolveClarificationRequest,
     ): Promise<N8nWorkflowGenerateResponse>;
     activateN8nWorkflow(id: string): Promise<N8nWorkflow>;
     deactivateN8nWorkflow(id: string): Promise<N8nWorkflow>;
@@ -103,6 +107,24 @@ ElizaClient.prototype.generateN8nWorkflow = async function (
   // the backend would have succeeded a few seconds later.
   return this.fetch<N8nWorkflowGenerateResponse>(
     "/api/n8n/workflows/generate",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+    { timeoutMs: 120_000 },
+  );
+};
+
+ElizaClient.prototype.resolveN8nClarification = async function (
+  this: ElizaClient,
+  request: N8nWorkflowResolveClarificationRequest,
+): Promise<N8nWorkflowGenerateResponse> {
+  // Patch + deploy is server-side and synchronous from the user's view, but
+  // it still runs validateAndRepair + a deploy round-trip. Reuse the same
+  // generous timeout as the generate call so a slow n8n write does not
+  // surface as a misleading "Request timed out" toast.
+  return this.fetch<N8nWorkflowGenerateResponse>(
+    "/api/n8n/workflows/resolve-clarification",
     {
       method: "POST",
       body: JSON.stringify(request),

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -69,9 +69,12 @@ import {
   type Conversation,
   isMissingCredentialsResponse,
   isNeedsClarificationResponse,
+  type N8nClarificationRequest,
+  type N8nClarificationTargetGroup,
   type N8nStatusResponse,
   type N8nWorkflow,
   type N8nWorkflowMissingCredential,
+  type N8nWorkflowNeedsClarificationResponse,
   type N8nWorkflowWriteRequest,
   type TriggerSummary,
   type WorkbenchTask,
@@ -91,6 +94,7 @@ import { formatDateTime, formatDurationMs } from "../../utils/format";
 // (warning: "reexported through module ... while both modules are
 // dependencies of each other"); the direct import skips it.
 import { WidgetHost } from "../../widgets/WidgetHost";
+import { ChoiceWidget } from "../chat/widgets/ChoiceWidget";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
 import {
   AppWorkspaceChrome,
@@ -1677,6 +1681,185 @@ function TaskForm() {
         )}
       </div>
     </PagePanel>
+  );
+}
+
+/**
+ * Render a single clarification ("Which channel in Cozy Devs?") with a row
+ * of quick-pick buttons drawn from the catalog. Falls back to a hint when
+ * the catalog has no entries for the clarification's platform/scope (e.g.
+ * the user only configured Discord but the LLM asked about Slack), since
+ * the user has nothing to pick from in that case.
+ */
+function ClarificationPanel({
+  state,
+  onChoose,
+  onDismiss,
+}: {
+  state: {
+    response: N8nWorkflowNeedsClarificationResponse;
+    currentIndex: number;
+    busy: boolean;
+    error?: string;
+  };
+  onChoose: (paramPath: string, value: string) => void;
+  onDismiss: () => void;
+}) {
+  const current = state.response.clarifications[state.currentIndex];
+  if (!current) return null;
+
+  const options = optionsForClarification(state.response.catalog, current);
+  // Stable id derived from the paramPath so React preserves selection state
+  // across renders and the ChoiceWidget's internal "locked after first
+  // click" semantics behave correctly.
+  const choiceId = `n8n-clarification-${current.paramPath || "free-text"}`;
+
+  return (
+    <PagePanel
+      variant="padded"
+      className="mb-4 border border-accent/40 bg-accent/5"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-2 min-w-0 flex-1">
+          <p className="text-sm font-semibold text-txt">{current.question}</p>
+          {state.response.clarifications.length > 1 ? (
+            <p className="text-2xs text-muted">
+              Step {state.currentIndex + 1} of{" "}
+              {state.response.clarifications.length}
+            </p>
+          ) : null}
+          {options.length > 0 ? (
+            <ChoiceWidget
+              id={choiceId}
+              scope="n8n-clarification"
+              options={options}
+              onChoose={(value) => {
+                if (state.busy) return;
+                onChoose(current.paramPath, value);
+              }}
+            />
+          ) : (
+            <ClarificationFreeTextInput
+              busy={state.busy}
+              onSubmit={(value) => onChoose(current.paramPath, value)}
+              placeholderHint={current.platform}
+            />
+          )}
+          {state.error ? (
+            <p className="text-2xs text-danger">{state.error}</p>
+          ) : null}
+          {state.busy ? (
+            <p className="text-2xs text-muted">Applying choice…</p>
+          ) : null}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-muted hover:text-txt"
+          onClick={onDismiss}
+          disabled={state.busy}
+        >
+          Cancel
+        </Button>
+      </div>
+    </PagePanel>
+  );
+}
+
+/**
+ * Filter the catalog snapshot down to the picker options for one
+ * clarification. Channel pickers narrow to a single guild via
+ * `scope.guildId`. Server pickers list one entry per group. Free-text and
+ * value clarifications fall back to a text input (returns []).
+ */
+function optionsForClarification(
+  catalog: ReadonlyArray<N8nClarificationTargetGroup>,
+  clarification: N8nClarificationRequest,
+): Array<{ value: string; label: string }> {
+  const platform = clarification.platform;
+  if (!platform) return [];
+  const groups = catalog.filter((g) => g.platform === platform);
+  if (groups.length === 0) return [];
+
+  switch (clarification.kind) {
+    case "target_server":
+      return groups.map((g) => ({
+        value: g.groupId,
+        label: g.groupName,
+      }));
+    case "target_channel": {
+      const guildId = clarification.scope?.guildId;
+      const scoped = guildId
+        ? groups.filter((g) => g.groupId === guildId)
+        : groups;
+      const out: Array<{ value: string; label: string }> = [];
+      for (const g of scoped) {
+        for (const t of g.targets) {
+          if (t.kind !== "channel") continue;
+          // When we have multiple guilds in scope, prefix the label so the
+          // user can disambiguate same-named channels.
+          const label =
+            scoped.length > 1 ? `${g.groupName}/#${t.name}` : `#${t.name}`;
+          out.push({ value: t.id, label });
+        }
+      }
+      return out;
+    }
+    case "recipient": {
+      const out: Array<{ value: string; label: string }> = [];
+      for (const g of groups) {
+        for (const t of g.targets) {
+          if (t.kind !== "recipient") continue;
+          out.push({ value: t.id, label: t.name });
+        }
+      }
+      return out;
+    }
+    default:
+      return [];
+  }
+}
+
+function ClarificationFreeTextInput({
+  busy,
+  onSubmit,
+  placeholderHint,
+}: {
+  busy: boolean;
+  onSubmit: (value: string) => void;
+  placeholderHint?: string;
+}) {
+  const [value, setValue] = useState("");
+  const trimmed = value.trim();
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (busy || trimmed.length === 0) return;
+        onSubmit(trimmed);
+      }}
+      className="mt-1 flex items-center gap-2"
+    >
+      <Input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={
+          placeholderHint
+            ? `Enter a value for ${placeholderHint}…`
+            : "Type your answer…"
+        }
+        disabled={busy}
+        className="h-8 text-xs"
+      />
+      <Button
+        type="submit"
+        size="sm"
+        variant="outline"
+        disabled={busy || trimmed.length === 0}
+      >
+        Apply
+      </Button>
+    </form>
   );
 }
 
@@ -4369,6 +4552,18 @@ function AutomationsLayout() {
   const [missingCredentials, setMissingCredentials] = useState<
     N8nWorkflowMissingCredential[] | null
   >(null);
+  // Active clarification state — populated when /generate or
+  // /resolve-clarification returns `needs_clarification`. The draft is the
+  // unmodified workflow JSON the route returned; clarifications drive the
+  // ChoiceWidget renders below; catalog supplies the picker options;
+  // currentIndex chains successive pickers (server-then-channel etc.) by
+  // surfacing one clarification at a time.
+  const [clarification, setClarification] = useState<{
+    response: N8nWorkflowNeedsClarificationResponse;
+    currentIndex: number;
+    busy: boolean;
+    error?: string;
+  } | null>(null);
   const [workflowBusyId, setWorkflowBusyId] = useState<string | null>(null);
   const [workflowOpsBusy, setWorkflowOpsBusy] = useState(false);
   const [activeWorkflowConversation, setActiveWorkflowConversation] =
@@ -4727,6 +4922,7 @@ function AutomationsLayout() {
       setWorkflowOpsBusy(true);
       setPageNotice(null);
       setMissingCredentials(null);
+      setClarification(null);
       try {
         const result = await client.generateN8nWorkflow({
           prompt,
@@ -4739,9 +4935,11 @@ function AutomationsLayout() {
           return null;
         }
         if (isNeedsClarificationResponse(result)) {
-          setPageNotice(
-            "Workflow needs more details before it can deploy. Continue in the chat to clarify.",
-          );
+          setClarification({
+            response: result,
+            currentIndex: 0,
+            busy: false,
+          });
           return null;
         }
         if (conversation) {
@@ -4760,6 +4958,54 @@ function AutomationsLayout() {
     },
     [bindConversationToWorkflow, ctx, selectWorkflowById],
   );
+
+  // Resolve one clarification by posting the picked value to
+  // /resolve-clarification. The route either returns the next pending
+  // clarification (chained pickers) or a fully-deployed workflow.
+  const resolveClarificationChoice = useCallback(
+    async (paramPath: string, value: string): Promise<void> => {
+      setClarification((prev) =>
+        prev ? { ...prev, busy: true, error: undefined } : prev,
+      );
+      try {
+        const draftRecord = clarification?.response.draft as
+          | (Record<string, unknown> & { id?: string; name?: string })
+          | undefined;
+        if (!draftRecord) return;
+        const result = await client.resolveN8nClarification({
+          draft: draftRecord,
+          resolutions: [{ paramPath, value }],
+        });
+        if (isMissingCredentialsResponse(result)) {
+          setClarification(null);
+          setMissingCredentials(result.missingCredentials);
+          return;
+        }
+        if (isNeedsClarificationResponse(result)) {
+          setClarification({
+            response: result,
+            currentIndex: 0,
+            busy: false,
+          });
+          return;
+        }
+        // Successful deploy — refresh, select, and clear the panel.
+        setClarification(null);
+        await ctx.refreshAutomations();
+        selectWorkflowById(result.id);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setClarification((prev) =>
+          prev ? { ...prev, busy: false, error: message } : prev,
+        );
+      }
+    },
+    [clarification, ctx, selectWorkflowById],
+  );
+
+  const dismissClarification = useCallback(() => {
+    setClarification(null);
+  }, []);
 
   const createWorkflowDraft = useCallback(
     async (options?: { initialPrompt?: string; title?: string }) => {
@@ -5453,6 +5699,14 @@ function AutomationsLayout() {
             </div>
           </PagePanel>
         )}
+
+        {clarification ? (
+          <ClarificationPanel
+            state={clarification}
+            onChoose={resolveClarificationChoice}
+            onDismiss={dismissClarification}
+          />
+        ) : null}
 
         {(pageNotice || combinedError) && (
           <PagePanel

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -981,12 +981,14 @@ function useAutomationsViewController() {
     }
   };
 
-  const onDeleteTrigger = async (triggerId?: string) => {
+  const onDeleteTrigger = async (triggerId?: string, displayName?: string) => {
     const targetId = triggerId ?? editingId;
     if (!targetId) return;
     const confirmed = await confirmDesktopAction({
       title: t("heartbeatsview.deleteTitle"),
-      message: t("heartbeatsview.deleteMessage", { name: form.displayName }),
+      message: t("heartbeatsview.deleteMessage", {
+        name: displayName ?? form.displayName,
+      }),
       confirmLabel: t("common.delete"),
       cancelLabel: t("common.cancel"),
       type: "warning",
@@ -3472,7 +3474,9 @@ function TriggerAutomationDetailPane({
             />
             <IconAction
               label={t("common.delete")}
-              onClick={() => void onDeleteTrigger(trigger.id)}
+              onClick={() =>
+                void onDeleteTrigger(trigger.id, trigger.displayName)
+              }
               icon={<Trash2 className="h-3.5 w-3.5" />}
               tone="danger"
             />

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -4997,10 +4997,23 @@ function AutomationsLayout() {
           });
           return;
         }
-        // Successful deploy — refresh, select, and clear the panel.
+        // Successful deploy — refresh, select, and clear the panel. Wrap
+        // the post-deploy refresh in its own try so that a refresh failure
+        // surfaces via pageNotice instead of being swallowed by the outer
+        // catch (which would no-op once clarification is null).
         setClarification(null);
-        await ctx.refreshAutomations();
-        selectWorkflowById(result.id);
+        try {
+          await ctx.refreshAutomations();
+          selectWorkflowById(result.id);
+        } catch (refreshErr) {
+          const message =
+            refreshErr instanceof Error
+              ? refreshErr.message
+              : String(refreshErr);
+          setPageNotice(
+            `Workflow deployed but the automations list could not refresh: ${message}`,
+          );
+        }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setClarification((prev) =>

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -1709,9 +1709,10 @@ function ClarificationPanel({
   if (!current) return null;
 
   const options = optionsForClarification(state.response.catalog, current);
-  // Stable id derived from the paramPath so React preserves selection state
-  // across renders and the ChoiceWidget's internal "locked after first
-  // click" semantics behave correctly.
+  // Used as React key so chained clarifications (e.g. target_server →
+  // target_channel) force a fresh ChoiceWidget instance instead of inheriting
+  // the previous pick's locked/disabled internal state. Also doubled as the
+  // widget's data id.
   const choiceId = `n8n-clarification-${current.paramPath || "free-text"}`;
 
   return (
@@ -1730,6 +1731,7 @@ function ClarificationPanel({
           ) : null}
           {options.length > 0 ? (
             <ChoiceWidget
+              key={choiceId}
               id={choiceId}
               scope="n8n-clarification"
               options={options}
@@ -1740,6 +1742,7 @@ function ClarificationPanel({
             />
           ) : (
             <ClarificationFreeTextInput
+              key={choiceId}
               busy={state.busy}
               onSubmit={(value) => onChoose(current.paramPath, value)}
               placeholderHint={current.platform}
@@ -4971,7 +4974,12 @@ function AutomationsLayout() {
         const draftRecord = clarification?.response.draft as
           | (Record<string, unknown> & { id?: string; name?: string })
           | undefined;
-        if (!draftRecord) return;
+        if (!draftRecord) {
+          setClarification((prev) =>
+            prev ? { ...prev, busy: false } : prev,
+          );
+          return;
+        }
         const result = await client.resolveN8nClarification({
           draft: draftRecord,
           resolutions: [{ paramPath, value }],


### PR DESCRIPTION
## Summary

Renders the `needs_clarification` response from `POST /api/n8n/workflows/generate` (added in #7316) as an inline panel in `AutomationsView`, just below the missing-credentials banner. The user picks from a row of buttons drawn from the `connector-target-catalog` snapshot (#7315), the host calls `POST /api/n8n/workflows/resolve-clarification` with `{paramPath, value}`, and either deploys (clearing the panel and refreshing the workflow list) or chains a follow-up picker (server then channel) by surfacing the next pending clarification.

This was the planned slice-2 P5 UI surface that #7316 / #7317 made the backend for. Shipping it now closes the loop: the route + UX restoration are already on develop, but the user-facing clarification picker was missing.

## Implementation

`ClarificationPanel` renders `ChoiceWidget` directly. `ChoiceWidget`'s existing `onChoose` callback contract was already a clean direct callback — the chat round-trip via `sendActionMessage` is layered on in `MessageContent.tsx`, not in the widget itself, so the widget did not need an `onChooseDirect` prop. The clarification flow simply instantiates `ChoiceWidget` with its own callback.

`optionsForClarification` narrows the catalog snapshot per clarification kind:
- `target_server` lists one button per group.
- `target_channel` narrows to `scope.guildId` when set, then lists each text channel; if no scope is set and multiple guilds returned, the label is prefixed with the guild name to disambiguate same-named channels.
- `recipient` lists each recipient target.
- `value` / `free_text` / unmatched-platform fall through to a free-text `Input` bubble (`ClarificationFreeTextInput`) so the user can still answer when no catalog backs the question.

Cancel dismisses the panel locally without touching the server. A busy spinner suppresses re-clicks while resolve is in flight; an error string surfaces failed resolves (bad paramPath, validation rejection) without dropping the panel.

`client-n8n.ts` gains `resolveN8nClarification(request)` calling `POST /api/n8n/workflows/resolve-clarification` with the same 120s timeout as `generateN8nWorkflow` (validateAndRepair + deploy can be slow).

## Stacking

**Depends on #7340** (`milady/fix-trigger-delete-name`) — that PR's P1 fix is the first commit in this branch. When #7340 merges, this PR's diff collapses to just the P5 commit.

## Test plan

- [x] `bun run typecheck` clean in `packages/app-core`
- [ ] Manual: type a Discord-targeting prompt like "send a Discord message to my announcements channel when a new GitHub issue is opened" → expect `target_server` clarification card → click an option → expect chained `target_channel` clarification → click a channel → expect deploy success and panel clears
- [ ] Manual: same flow with `kind: free_text` clarification → expect `ClarificationFreeTextInput` → typing + Apply submits the value
- [ ] Manual: Cancel dismisses the panel without server call

Backend coverage from #7316 (route + helper tests) covers the `resolve-clarification` endpoint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the clarification quick-pick UI (`ClarificationPanel`, `ClarificationFreeTextInput`, `optionsForClarification`) to `AutomationsView`, replacing the previous static page-notice with an inline picker that chains server → channel → recipient selections driven by the catalog snapshot. `client-n8n.ts` gains `resolveN8nClarification` with the same 120 s timeout as `generateN8nWorkflow`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-ups — no runtime blocking bugs; two P2 edge cases around key collisions and dead UI code.

All three previously-flagged P1s (React key, busy-state leak, stale free-text) are addressed in this version of the code. Remaining findings are P2: `choiceId` can collide for consecutive paramPath-less clarifications, and `currentIndex` is never incremented so the Step X of Y display is unreachable. Neither blocks the happy path.

packages/app-core/src/components/pages/AutomationsView.tsx — `choiceId` generation and `currentIndex` advancement logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/client-n8n.ts | Adds `resolveN8nClarification` method via declaration merging, mirroring `generateN8nWorkflow` with the same 120 s timeout; straightforward and consistent with existing patterns. |
| packages/app-core/src/components/pages/AutomationsView.tsx | Adds `ClarificationPanel`, `ClarificationFreeTextInput`, and `optionsForClarification`; wires `resolveClarificationChoice` into `AutomationsLayout`. Two P2s: `choiceId` can collide for consecutive free-text clarifications with absent `paramPath`, and `currentIndex` is never advanced so the "Step X of Y" UI is unreachable. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant AV as AutomationsView
    participant API as /api/n8n/workflows

    U->>AV: Submit automation prompt
    AV->>API: POST /generate
    API-->>AV: needs_clarification {clarifications, catalog, draft}
    AV->>AV: setClarification({response, currentIndex:0})
    AV->>U: Render ClarificationPanel (ChoiceWidget or FreeTextInput)

    U->>AV: Pick option / submit text
    AV->>API: POST /resolve-clarification {draft, resolutions}

    alt Another clarification needed
        API-->>AV: needs_clarification (chained)
        AV->>AV: setClarification({response, currentIndex:0})
        AV->>U: Render next ClarificationPanel
    else Missing credentials
        API-->>AV: missing_credentials
        AV->>AV: setMissingCredentials(...)
        AV->>U: Show credentials banner
    else Deploy success
        API-->>AV: deployed workflow {id}
        AV->>AV: setClarification(null), refreshAutomations()
        AV->>U: Select deployed workflow
    end
```

<sub>Reviews (3): Last reviewed commit: ["fix(automations): surface post-deploy re..."](https://github.com/elizaos/eliza/commit/ad3416cec19be4072196a1e05c5e32844f4a30a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30623960)</sub>

<!-- /greptile_comment -->