### PR TITLE
fix(plugin-video): revert typescript downgrade that hangs bun resolver

### DIFF
--- a/plugins/plugin-video/package.json
+++ b/plugins/plugin-video/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/node": "22.19.17",
     "tsup": "^8.5.1",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.0",
     "vitest": "^4.0.17"
   },
   "scripts": {


### PR DESCRIPTION
PR #7335 (renovate) downgraded plugin-video's typescript devDep from ^6.0.0 to ^5.7.3. Every other plugin in the workspace pins typescript ^6.0.x, so the introduced version split puts bun's resolver into a pathological loop — Build Agent Image hung at 'Resolving dependencies' for 40+ minutes (vs. 12s normal) and timed out twice.

Restore plugin-video to typescript ^6.0.0 to align with the rest of the workspace.

<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts a single-line change to `plugins/plugin-video/package.json`, restoring the `typescript` devDependency from `^5.7.3` (introduced by renovate PR #7335) back to `^6.0.0`, matching every other package in the monorepo workspace. The version split was causing bun's dependency resolver to enter a pathological loop during CI image builds.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a one-line revert that restores workspace-wide TypeScript version consistency.

Single-line change to a devDependency, confirmed correct by grepping all workspace packages — every other package already uses `^6.0.0` or `^6.0.3`. No logic, API, or runtime behavior is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-video/package.json | Reverts `typescript` devDependency from `^5.7.3` back to `^6.0.0`, aligning with every other plugin/package in the workspace and resolving bun resolver hangs. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["renovate PR #7335\ndowngraded plugin-video\ntypescript ^6.0.0 → ^5.7.3"] --> B["Workspace version split\nAll other plugins: ^6.0.x\nplugin-video: ^5.7.3"]
    B --> C["bun resolver enters\npathological loop\n(40+ min, 2× timeout)"]
    D["This PR\nRestores ^6.0.0"] --> E["Workspace alignment\nAll plugins: ^6.0.x"]
    E --> F["bun resolver\nnormal ~12s build"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-video): revert typescript dow..."](https://github.com/elizaos/eliza/commit/21e1d4c93affb80d0460106a2f20304d8fe5cab5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30640703)</sub>

<!-- /greptile_comment -->