### PR TITLE
fix(elizaos): include cloud-sdk workspace in fullstack-app template

### DIFF
--- a/packages/elizaos/templates/fullstack-app/package.json
+++ b/packages/elizaos/templates/fullstack-app/package.json
@@ -14,7 +14,8 @@
     "eliza/packages/app-core/platforms/electrobun",
     "eliza/apps/*",
     "eliza/plugins/*",
-    "eliza/packages/*"
+    "eliza/packages/*",
+    "eliza/cloud/packages/sdk"
   ],
   "scripts": {
     "build": "bun run --cwd apps/app build",

--- a/packages/templates/fullstack-app/package.json
+++ b/packages/templates/fullstack-app/package.json
@@ -14,7 +14,8 @@
     "eliza/packages/app-core/platforms/electrobun",
     "eliza/apps/*",
     "eliza/plugins/*",
-    "eliza/packages/*"
+    "eliza/packages/*",
+    "eliza/cloud/packages/sdk"
   ],
   "scripts": {
     "build": "bun run --cwd apps/app build",


### PR DESCRIPTION
## Summary

- The fullstack-app template's `requiredSubmodules` clones `plugins/plugin-elizacloud`, which has a `workspace:*` dependency on `@elizaos/cloud-sdk` (at `cloud/packages/sdk`).
- The generated project's `workspaces` array did not include that path, so `bun install` failed on a freshly scaffolded project with `incorrect peer dependency` warnings and an unresolvable `@elizaos/cloud-sdk` reference.
- Adds `eliza/cloud/packages/sdk` to both copies of the template (`packages/elizaos/templates/fullstack-app/package.json` and the `packages/templates/fullstack-app/package.json` fallback) so fresh `elizaos create` projects install cleanly.

## Test plan

- [ ] `elizaos create` a new fullstack-app project from the patched templates
- [ ] Run `bun install` in the generated project — should resolve `@elizaos/cloud-sdk` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken `bun install` on freshly scaffolded `fullstack-app` projects by adding `eliza/cloud/packages/sdk` to the workspace array in both template copies. The root cause is that `plugin-elizacloud` (a `requiredSubmodule`) carries a `"@elizaos/cloud-sdk": "workspace:*"` dependency, but the SDK lives at `cloud/packages/sdk` in the eliza repo — a path not matched by the existing `eliza/packages/*` glob — so bun couldn't resolve it locally.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted, minimal change that fixes a real install-time breakage in the scaffold template

The fix is correct: `cloud/packages/sdk` is part of the main eliza repo and maps to `eliza/cloud/packages/sdk` in generated projects, which is not covered by the existing `eliza/packages/*` glob. Both template copies are updated identically. No logic changes, no security implications.

No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/elizaos/templates/fullstack-app/package.json | Adds `eliza/cloud/packages/sdk` workspace entry so bun can resolve `@elizaos/cloud-sdk` (used via `workspace:*` by `plugin-elizacloud`) after scaffolding |
| packages/templates/fullstack-app/package.json | Identical fix applied to the fallback template copy — adds `eliza/cloud/packages/sdk` to workspaces |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["elizaos create fullstack-app"] --> B["Clone eliza repo as git submodule\nat eliza/"]
    B --> C["Init requiredSubmodules\n(plugins/plugin-elizacloud, etc.)"]
    C --> D["plugin-elizacloud\ndeps: @elizaos/cloud-sdk workspace:*"]
    D --> E{bun install}
    E -- "Before fix\neliza/packages/* doesn't\nmatch eliza/cloud/packages/sdk" --> F["❌ Unresolvable @elizaos/cloud-sdk"]
    E -- "After fix\neliza/cloud/packages/sdk\nadded to workspaces" --> G["✅ bun resolves @elizaos/cloud-sdk\nfrom eliza/cloud/packages/sdk"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(elizaos): include cloud-sdk workspac..."](https://github.com/elizaos/eliza/commit/ea54c74aa5712c083c605de935c929c073a674bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30643999)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to include additional package paths in the project structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->