### PR TITLE
fix(cloud/frontend): SPA hits api.elizacloud.ai directly for /steward/*

### DIFF
--- a/cloud/apps/frontend/src/entry-server.tsx
+++ b/cloud/apps/frontend/src/entry-server.tsx
@@ -32,7 +32,7 @@ import { renderToString } from "react-dom/server";
 import { HelmetProvider, type HelmetServerState } from "react-helmet-async";
 // react-router-dom v7 unified the package: StaticRouter ships from the main
 // entry, not the legacy `react-router-dom/server` subpath (which v7 dropped).
-import { StaticRouter } from "react-router-dom";
+import { StaticRouter } from "react-router-dom/server";
 import { Toaster } from "sonner";
 import LandingPageRoute from "./pages/page";
 import "./globals.css";

--- a/cloud/packages/lib/steward-url.ts
+++ b/cloud/packages/lib/steward-url.ts
@@ -13,6 +13,26 @@ function getBrowserOrigin(): string | undefined {
   return typeof location?.origin === "string" ? location.origin : undefined;
 }
 
+function getBrowserHostname(): string | undefined {
+  const location = (globalThis as typeof globalThis & { location?: { hostname?: unknown } })
+    .location;
+  return typeof location?.hostname === "string" ? location.hostname.toLowerCase() : undefined;
+}
+
+/**
+ * Hostnames where the browser SPA is co-hosted with a Cloudflare Pages
+ * deployment that proxies `/steward/*` to the Workers API. We bypass the
+ * proxy and call `api.elizacloud.ai` directly so login keeps working
+ * even when the Pages Functions bundle is missing or broken (the SPA
+ * lives behind a CDN we do not always control).
+ */
+const ELIZA_CLOUD_PROXIED_HOSTS = new Set([
+  "elizacloud.ai",
+  "www.elizacloud.ai",
+  "dev.elizacloud.ai",
+]);
+const ELIZA_CLOUD_DIRECT_API = "https://api.elizacloud.ai";
+
 export type StewardUrlEnv = Record<string, unknown>;
 
 function envString(env: StewardUrlEnv, key: string): string | undefined {
@@ -23,6 +43,14 @@ function envString(env: StewardUrlEnv, key: string): string | undefined {
 export function resolveBrowserStewardApiUrl(origin?: string): string {
   if (isUsableUrl(process.env.NEXT_PUBLIC_STEWARD_API_URL)) {
     return trimTrailingSlash(process.env.NEXT_PUBLIC_STEWARD_API_URL);
+  }
+
+  // When the SPA is loaded from a known elizacloud.ai host, skip the
+  // same-origin Pages Functions proxy and hit the Workers API directly.
+  // The Workers API allowlists these origins for CORS + credentials.
+  const browserHost = getBrowserHostname();
+  if (browserHost && ELIZA_CLOUD_PROXIED_HOSTS.has(browserHost)) {
+    return `${ELIZA_CLOUD_DIRECT_API}${STEWARD_PREFIX}`;
   }
 
   const resolvedOrigin = origin || getBrowserOrigin();


### PR DESCRIPTION
## Bug

The Cloudflare Pages `functions/api/[[path]].ts` + `functions/steward/[[path]].ts` proxy keeps disappearing on manual local deploys. Each time it does, every `www.elizacloud.ai/api/*` and `/steward/*` request falls through to the SPA `index.html`, returning HTML instead of JSON.

Symptom: `/login` renders the empty skeleton because `StewardAuth.getProviders()` returns `<!doctype html>` and `setProviders` never fires. Same root cause kills milady.ai login flow (which proxies through `www.elizacloud.ai`).

In a single 50 minute window today the production deploy was reverted to a working state five times before this PR shipped.

## Fix

Two changes:

1. `cloud/packages/lib/steward-url.ts` — `resolveBrowserStewardApiUrl` now detects when the SPA is running on a known elizacloud.ai host and returns the direct Workers origin (`https://api.elizacloud.ai/steward`) instead of the same-origin path. The Workers CORS allowlist already includes `elizacloud.ai` + `www.elizacloud.ai`. Credentials flow cross-origin because the auth cookies are set on `api.elizacloud.ai` and the SDK uses `credentials: include`.

2. `cloud/apps/frontend/src/entry-server.tsx` — `react-router-dom` resolves to `v6.30` in the lockfile despite `^7.0.0` in `package.json`, and v6 ships `StaticRouter` at `react-router-dom/server`, not the top level. Without this fix, the SSR build crashes and `prerender.mjs` cannot run, so `dist/index.html` ends up with an empty `<div id="root"></div>`. That's the "black screen" people see when the SPA hydrates with a runtime error.

The `functions/_middleware.ts` proxy stays in place so dev / preview deploys keep working same-origin. This PR only changes the fallback for production hosts.

`api-client.ts` already had the same direct-origin logic for `/api/*` (`getApiBaseUrl()` returns `https://api.elizacloud.ai` for elizacloud.ai hosts). This PR brings the steward path in line.

## Verification

- `bunx @biomejs/biome check` clean
- `bun run build` succeeds (vite client + vite ssr + prerender wrote 24.5 KB index.html with full hero content)
- Production deploy `c53a445b` shipped manually with this build:
  - `www.elizacloud.ai/api/health` → 200 JSON
  - `www.elizacloud.ai/steward/auth/providers` → 200 JSON
  - `api.elizacloud.ai/steward/auth/providers` from `Origin: https://www.elizacloud.ai` → 200 JSON with `access-control-allow-origin: https://www.elizacloud.ai` (cross-origin CORS works)

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent production issues in the elizacloud.ai frontend: the SSR blank-screen caused by importing `StaticRouter` from the wrong module path (v6 vs v7 convention mismatch in the lockfile), and the `/steward/*` 404/HTML responses caused by a fragile Cloudflare Pages Functions proxy. The steward URL resolver now detects known elizacloud.ai hostnames and routes directly to `api.elizacloud.ai`, mirroring the existing `getApiBaseUrl()` pattern already used for `/api/*`.

- `dev.elizacloud.ai` is added to the bypass set but is not mentioned in the Workers CORS allowlist described in the PR — if it is not allowlisted, all requests from `dev.elizacloud.ai` will receive CORS errors instead of falling back to the same-origin proxy path.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the two verified production hosts; the unverified dev.elizacloud.ai CORS entry is a potential P1 that could break dev deployments if not confirmed in the Workers allowlist.

One P1 finding (unverified CORS origin for dev.elizacloud.ai) brings the ceiling to 4 and the unresolved nature of whether it affects active deployments pulls it to 3.

cloud/packages/lib/steward-url.ts — confirm dev.elizacloud.ai is in the Workers CORS allowlist before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/apps/frontend/src/entry-server.tsx | Corrects the StaticRouter import to react-router-dom/server (v6 path) to fix the blank SSR output; the in-file comment still describes the v7 import convention and now contradicts the code. |
| cloud/packages/lib/steward-url.ts | Adds hostname-based bypass to call api.elizacloud.ai directly on known elizacloud.ai hosts; dev.elizacloud.ai is included but not verified against the Workers CORS allowlist, which could break dev deployments with CORS errors. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant CF_Pages as Cloudflare Pages<br/>(www.elizacloud.ai)
    participant Workers as Workers API<br/>(api.elizacloud.ai)

    Note over Browser,Workers: Before fix — proxy missing → SPA fallback
    Browser->>CF_Pages: GET /steward/auth/providers
    CF_Pages-->>Browser: 200 text/html (index.html — SPA fallback)
    Browser-->>Browser: StewardAuth.getProviders() parses HTML → login broken

    Note over Browser,Workers: After fix — known elizacloud.ai host bypasses proxy
    Browser->>Browser: getBrowserHostname() → "www.elizacloud.ai"
    Browser->>Browser: ELIZA_CLOUD_PROXIED_HOSTS.has(host) → true
    Browser->>Workers: GET https://api.elizacloud.ai/steward/auth/providers<br/>(credentials: include, cross-origin)
    Workers-->>Browser: 200 JSON + access-control-allow-origin: https://www.elizacloud.ai

    Note over Browser,Workers: Dev/preview deploys (host not in set) — same-origin proxy unchanged
    Browser->>CF_Pages: GET /steward/auth/providers
    CF_Pages->>Workers: proxy via functions/_middleware.ts
    Workers-->>CF_Pages: 200 JSON
    CF_Pages-->>Browser: 200 JSON
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud/frontend): SPA hits api.elizac..."](https://github.com/elizaos/eliza/commit/0e16b9028d43903baaf6207490c0f996631bdbf0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30667018)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->