### PR TITLE
fix(cloud/frontend): apiFetch for /api/auth/steward-session

### DIFF
--- a/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
+++ b/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { resolveBrowserStewardApiUrl } from "@/lib/steward-url";
+import { apiFetch } from "../../lib/api-client";
 import { resolveLoginReturnTo } from "./login-return-to";
 import { buildStewardOAuthAuthorizeUrl, type StewardOAuthProvider } from "./steward-oauth-url";
 import { StewardWalletProviders } from "./steward-wallet-providers";
@@ -103,15 +104,22 @@ export default function StewardLoginSection() {
   const hasOAuthProviders = Boolean(providers.google || providers.discord || providers.github);
 
   const setSessionCookie = useCallback(async (token: string, refreshToken?: string | null) => {
-    const response = await fetch("/api/auth/steward-session", {
+    // Use apiFetch instead of raw fetch so the request resolves to the
+    // direct Workers origin (https://api.elizacloud.ai) on production.
+    // Routing through the same-origin Pages Functions proxy would set
+    // Set-Cookie on www.elizacloud.ai, but every subsequent apiFetch call
+    // (e.g. /api/auth/cli-session/<id>/complete) goes cross-origin to
+    // api.elizacloud.ai and the host-only www cookie does not flow with
+    // it, which deadlocks the CLI login spinner at "Generating API Key".
+    const response = await apiFetch("/api/auth/steward-session", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+      skipAuth: true,
+      json: {
         token,
         refreshToken:
           refreshToken ??
           (typeof window !== "undefined" ? localStorage.getItem("steward_refresh_token") : null),
-      }),
+      },
     });
     if (!response.ok) {
       const body = (await response.json().catch(() => null)) as { error?: string } | null;


### PR DESCRIPTION
## Bug

Follow-up to #7358. `setSessionCookie` (in `steward-login-section.tsx`) was still calling raw `fetch("/api/auth/steward-session")`, which goes same-origin to `www.elizacloud.ai`. The Worker sets `steward-token` + `steward-authed` cookies on the host the Set-Cookie response came from, so they end up host-only on `www.elizacloud.ai`.

After #7358 every other `apiFetch` call goes cross-origin to `api.elizacloud.ai`. The host-only `www` cookie does not flow on that cross-origin request, so `/api/auth/cli-session/<id>/complete` 401s, and the CLI login screen deadlocks at "Generating API Key" until the 30s client timeout fires.

## Symptom

After signing in with passkey on `/login`, the CLI bridge popup gets stuck on:

> 🔑 Generating API Key
> Creating your credentials for CLI access...
> ● ● ●

Forever, until the 30s client-side timeout converts it to a generic error.

## Fix

Switch `setSessionCookie` to `apiFetch` so the cookie-setting POST also goes to `api.elizacloud.ai`. The Set-Cookie response is now scoped to the same host that every subsequent `/api/*` call hits.

```diff
- const response = await fetch("/api/auth/steward-session", {
-   method: "POST",
-   headers: { "Content-Type": "application/json" },
-   body: JSON.stringify({ token, refreshToken: ... }),
- });
+ const response = await apiFetch("/api/auth/steward-session", {
+   method: "POST",
+   skipAuth: true,
+   json: { token, refreshToken: ... },
+ });
```

`apiFetch` already injects `credentials: "include"` and resolves to `api.elizacloud.ai` for elizacloud.ai hosts via `getApiBaseUrl`, exactly matching what every other authenticated apiFetch call does.

## Verification

Production deploy of this change: `/api/auth/cli-session/<id>/complete` returns 200 with the cookie attached, login flow unblocks past "Generating API Key", users land on the destination route.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a cookie-scoping bug in the CLI login flow: `setSessionCookie` was using raw `fetch` (same-origin, `www.elizacloud.ai`) while every downstream call used `apiFetch` (cross-origin, `api.elizacloud.ai`), so the `steward-token` cookie never reached the downstream origin and `/api/auth/cli-session/<id>/complete` 401'd. Switching to `apiFetch` with `skipAuth: true` and the `json` shorthand routes the cookie-setting POST to the same origin as all other authenticated calls, unblocking the CLI login flow.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core fix is correct and production-verified; only minor style/dead-code issues remain.

No P0/P1 issues found. The bug fix is well-reasoned and matches the pattern used everywhere else in the codebase. Two P2 findings (dead response.ok guard and relative import path) do not affect runtime behaviour.

No files require special attention beyond the minor cleanup noted in inline comments.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/apps/frontend/src/pages/login/steward-login-section.tsx | Switches setSessionCookie from raw fetch (same-origin) to apiFetch (cross-origin to api.elizacloud.ai); fix is correct but leaves a now-unreachable response.ok guard and uses a relative import where an alias is used elsewhere. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as "Browser (www.elizacloud.ai)"
    participant API as "Workers API (api.elizacloud.ai)"

    Note over Browser,API: Before fix (broken)
    Browser->>Browser: "POST /api/auth/steward-session (raw fetch, same-origin)"
    Browser-->>Browser: "Set-Cookie scoped to www.elizacloud.ai"
    Browser->>API: "GET /api/auth/cli-session/id/complete (cross-origin)"
    Note right of API: "www-scoped cookie NOT sent, 401"

    Note over Browser,API: After fix (this PR)
    Browser->>API: "POST /api/auth/steward-session (apiFetch, credentials include)"
    API-->>Browser: "Set-Cookie scoped to api.elizacloud.ai"
    Browser->>API: "GET /api/auth/cli-session/id/complete (same origin, cookie flows)"
    API-->>Browser: "200 - login unblocked"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/apps/frontend/src/pages/login/steward-login-section.tsx`, line 124-127 ([link](https://github.com/elizaos/eliza/blob/3e634ddf570ded5177de8eabffeabc15df968225/cloud/apps/frontend/src/pages/login/steward-login-section.tsx#L124-L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead code — `response.ok` branch is unreachable**

   `apiFetch` already throws an `ApiError` for any non-2xx response (see `api-client.ts` lines 151-154), so the `if (!response.ok)` branch can never be entered. The existing error propagation through `catch` still works correctly because `ApiError` extends `Error`, but the guarded block is misleading dead code. Consider removing it or replacing the `apiFetch` call with the lower-level `fetch` if the manual error shaping is intentional.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(cloud/frontend): use apiFetch for /a..."](https://github.com/elizaos/eliza/commit/3e634ddf570ded5177de8eabffeabc15df968225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30667709)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->