### PR TITLE
fix(cloud/frontend): StewardProvider syncs steward-session cookie to api.elizacloud.ai

### DIFF
--- a/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
+++ b/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { resolveBrowserStewardApiUrl } from "@/lib/steward-url";
+import { apiFetch } from "../../lib/api-client";
 import { resolveLoginReturnTo } from "./login-return-to";
 import { buildStewardOAuthAuthorizeUrl, type StewardOAuthProvider } from "./steward-oauth-url";
 import { StewardWalletProviders } from "./steward-wallet-providers";
@@ -103,15 +104,22 @@ export default function StewardLoginSection() {
   const hasOAuthProviders = Boolean(providers.google || providers.discord || providers.github);
 
   const setSessionCookie = useCallback(async (token: string, refreshToken?: string | null) => {
-    const response = await fetch("/api/auth/steward-session", {
+    // Use apiFetch instead of raw fetch so the request resolves to the
+    // direct Workers origin (https://api.elizacloud.ai) on production.
+    // Routing through the same-origin Pages Functions proxy would set
+    // Set-Cookie on www.elizacloud.ai, but every subsequent apiFetch call
+    // (e.g. /api/auth/cli-session/<id>/complete) goes cross-origin to
+    // api.elizacloud.ai and the host-only www cookie does not flow with
+    // it, which deadlocks the CLI login spinner at "Generating API Key".
+    const response = await apiFetch("/api/auth/steward-session", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
+      skipAuth: true,
+      json: {
         token,
         refreshToken:
           refreshToken ??
           (typeof window !== "undefined" ? localStorage.getItem("steward_refresh_token") : null),
-      }),
+      },
     });
     if (!response.ok) {
       const body = (await response.json().catch(() => null)) as { error?: string } | null;

--- a/cloud/packages/lib/providers/StewardProvider.tsx
+++ b/cloud/packages/lib/providers/StewardProvider.tsx
@@ -5,6 +5,29 @@ import { StewardAuth, StewardClient } from "@stwd/sdk";
 import { createContext, useEffect, useMemo, useRef } from "react";
 import { resolveBrowserStewardApiUrl } from "@/lib/steward-url";
 
+// Resolve the absolute origin to use for /api/* calls in the browser. On
+// known elizacloud.ai hosts, bypass the same-origin Pages Functions proxy
+// and hit the Workers API directly so the steward-session cookie is set on
+// the same host that subsequent apiFetch / cli-login calls hit. Without
+// this, the cookie is set on www.elizacloud.ai while later requests go
+// cross-origin to api.elizacloud.ai and the host-only cookie does not
+// flow, deadlocking the CLI login spinner at "Generating API Key".
+const ELIZA_CLOUD_PROXIED_HOSTS = new Set([
+  "elizacloud.ai",
+  "www.elizacloud.ai",
+  "dev.elizacloud.ai",
+]);
+const ELIZA_CLOUD_DIRECT_API = "https://api.elizacloud.ai";
+
+function stewardSessionUrl(): string {
+  if (typeof window === "undefined") return "/api/auth/steward-session";
+  const host = window.location.hostname.toLowerCase();
+  if (ELIZA_CLOUD_PROXIED_HOSTS.has(host)) {
+    return `${ELIZA_CLOUD_DIRECT_API}/api/auth/steward-session`;
+  }
+  return "/api/auth/steward-session";
+}
+
 /**
  * Steward authentication provider for Eliza Cloud.
  *
@@ -134,7 +157,7 @@ export function clearStaleStewardSession(): void {
     // ignore
   }
   // Server-side cookies (HttpOnly — JS can't touch them directly).
-  fetch("/api/auth/steward-session", { method: "DELETE" }).catch(() => {});
+  fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(() => {});
   // Notify any in-tab listeners; the "storage" event covers cross-tab.
   try {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));
@@ -175,7 +198,7 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
           lastSyncedToken.current = null;
           lastSyncedRefreshToken.current = null;
           wasAuthenticated.current = false;
-          fetch("/api/auth/steward-session", { method: "DELETE" }).catch(() => {});
+          fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(() => {});
         }
         return;
       }
@@ -192,8 +215,9 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
       lastSyncedRefreshToken.current = refreshToken;
       wasAuthenticated.current = true;
 
-      fetch("/api/auth/steward-session", {
+      fetch(stewardSessionUrl(), {
         method: "POST",
+        credentials: "include",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token, refreshToken }),
       })
@@ -266,7 +290,9 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
             lastSyncedToken.current = null;
             lastSyncedRefreshToken.current = null;
             wasAuthenticated.current = false;
-            fetch("/api/auth/steward-session", { method: "DELETE" }).catch(() => {});
+            fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(
+              () => {},
+            );
           }
         }
       } catch (err) {


### PR DESCRIPTION
## Bug

Follow-up to #7359. The login form's `setSessionCookie` was switched to `apiFetch` in #7359, but `StewardProvider` (`cloud/packages/lib/providers/StewardProvider.tsx`) has its own auto-sync `useEffect` that POSTs the localStorage token to `/api/auth/steward-session` via **raw fetch**. That request still goes same-origin to `www.elizacloud.ai`, so the `Set-Cookie` response is scoped host-only to `www`.

When `/auth/cli-login`'s `completeCliLogin` then sends apiFetch to `api.elizacloud.ai` (per #7358's SPA-direct behaviour), the host-only `www` cookie does not flow on the cross-origin request. The CLI login spinner deadlocks at "Generating API Key" until the 30s client timeout fires. Same root cause as #7359, second seam.

## Fix

Add a `stewardSessionUrl` helper that returns the absolute Workers origin (`https://api.elizacloud.ai/api/auth/steward-session`) when the SPA is running on a known elizacloud.ai host. Falls back to the relative same-origin path everywhere else (dev, preview, ad-hoc hosts).

All four `steward-session` calls in `StewardProvider` now go through `stewardSessionUrl` with explicit `credentials: "include"`:

| Call | Method | What |
|---|---|---|
| Auto-sync | POST | sets the cookie on api.elizacloud.ai |
| `clearStaleStewardSession` | DELETE | wipes the cookie on api |
| Token-rejected handler | DELETE | wipes the cookie on api |
| Server-rejected handler | DELETE | wipes the cookie on api |

## Verification

Live on production deploy `60caf2a0`:

- `www.elizacloud.ai/api/health` -> 200 JSON
- `www.elizacloud.ai/steward/auth/providers` -> 200 JSON
- `/auth/cli-login` completes past "Generating API Key" instead of hanging

Bundle hash flipped (`index-CPxemQT5` -> `index-n_-He2tp`) and a grep for the old raw `fetch(\`/api/auth/steward-session\`,{method:\`POST\`...)` pattern returns 0 matches.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a second seam of the CLI login deadlock: `StewardProvider`'s auto-sync `useEffect` was still using raw `fetch` to same-origin `www.elizacloud.ai`, so the `steward-session` cookie was scoped to `www` and never flowed on cross-origin `apiFetch` calls to `api.elizacloud.ai`. All four raw `fetch` calls in `StewardProvider` are redirected to `stewardSessionUrl()` (which returns the direct Workers origin on known elizacloud.ai hosts) and `credentials: "include"` is added; the login section's `setSessionCookie` is also switched to `apiFetch`.

- **P1**: `dev.elizacloud.ai` is in `ELIZA_CLOUD_PROXIED_HOSTS` (StewardProvider) but not in `getApiBaseUrl()` (api-client.ts), so on that host the session cookie is set on `api.elizacloud.ai` while `apiFetch` calls go same-origin to `dev.elizacloud.ai` — the same deadlock the PR intends to fix.

<h3>Confidence Score: 3/5</h3>

Safe to merge for production elizacloud.ai/www.elizacloud.ai; the fix is incomplete for dev.elizacloud.ai due to a missing entry in api-client.ts.

One P1 finding: dev.elizacloud.ai is added to ELIZA_CLOUD_PROXIED_HOSTS in StewardProvider but the matching getApiBaseUrl() list in api-client.ts was not updated, leaving that host with the exact cookie-domain mismatch this PR fixes. A P1 caps confidence at 4, and the incomplete coverage of a newly introduced host pulls it to 3.

cloud/packages/lib/providers/StewardProvider.tsx and cloud/apps/frontend/src/lib/api-client.ts need to stay in sync on which hosts are routed to the direct Workers origin.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/lib/providers/StewardProvider.tsx | Adds `stewardSessionUrl()` helper and `credentials: "include"` to all four raw `fetch` calls; `dev.elizacloud.ai` is listed in `ELIZA_CLOUD_PROXIED_HOSTS` here but absent from the equivalent list in `api-client.ts`, leaving that host with the same cookie-domain mismatch the PR is fixing. |
| cloud/apps/frontend/src/pages/login/steward-login-section.tsx | Switches `setSessionCookie` from raw `fetch` to `apiFetch` so the cookie is set on `api.elizacloud.ai`; the `!response.ok` guard added after the call is dead code because `apiFetch` throws before returning a non-ok response. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser (www.elizacloud.ai)
    participant StewardProvider as StewardProvider (AuthTokenSync)
    participant LoginSection as steward-login-section
    participant ApiClient as apiFetch (api-client.ts)
    participant ApiWorker as api.elizacloud.ai (Workers)
    participant CliLogin as /auth/cli-login

    Note over StewardProvider: Auto-sync useEffect fires
    StewardProvider->>StewardProvider: stewardSessionUrl() → https://api.elizacloud.ai/...
    StewardProvider->>ApiWorker: POST /api/auth/steward-session credentials:include
    ApiWorker-->>Browser: Set-Cookie: steward-session (api.elizacloud.ai)

    Note over LoginSection: User logs in
    LoginSection->>ApiClient: apiFetch('/api/auth/steward-session', skipAuth+json)
    ApiClient->>ApiClient: getApiBaseUrl() → https://api.elizacloud.ai
    ApiClient->>ApiWorker: POST https://api.elizacloud.ai/api/auth/steward-session credentials:include
    ApiWorker-->>Browser: Set-Cookie: steward-session (api.elizacloud.ai)

    Note over CliLogin: CLI login completion
    CliLogin->>ApiClient: apiFetch('/api/auth/cli-session/id/complete')
    ApiClient->>ApiWorker: POST https://api.elizacloud.ai/... Cookie:steward-session flows
    ApiWorker-->>CliLogin: 200 OK — CLI login unblocked
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/apps/frontend/src/pages/login/steward-login-section.tsx`, line 124-127 ([link](https://github.com/elizaos/eliza/blob/2386f31f82836684913860ed91465ad37c7a5175/cloud/apps/frontend/src/pages/login/steward-login-section.tsx#L124-L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead `!response.ok` branch after `apiFetch`**

   `apiFetch` already throws an `ApiError` for any non-2xx response (see `api-client.ts` lines 151–155) before returning. The `if (!response.ok)` check and its custom error path (`body?.error || "Could not establish a local Steward session"`) are therefore unreachable dead code. Callers will always receive an `ApiError` (whose `.message` is already populated by `errorDetails`), not the hand-crafted message from this block. The error handling still works via the catch in the calling `useEffect`, but the specific message string here is silently dropped.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(cloud/frontend): StewardProvider syn..."](https://github.com/elizaos/eliza/commit/2386f31f82836684913860ed91465ad37c7a5175) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30668708)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->