### PR TITLE
fix(cloud): repair steward login session flow

### DIFF
--- a/cloud/apps/frontend/src/entry-server.tsx
+++ b/cloud/apps/frontend/src/entry-server.tsx
@@ -31,7 +31,7 @@ if (typeof globalThis !== "undefined" && !("Buffer" in globalThis)) {
 import { renderToString } from "react-dom/server";
 import { HelmetProvider, type HelmetServerState } from "react-helmet-async";
 // react-router-dom v7 exposes StaticRouter from the main entry.
-import { StaticRouter } from "react-router-dom";
+import { StaticRouter } from "react-router-dom/server";
 import { Toaster } from "sonner";
 import LandingPageRoute from "./pages/page";
 import "./globals.css";

--- a/cloud/apps/frontend/src/lib/api-client.ts
+++ b/cloud/apps/frontend/src/lib/api-client.ts
@@ -31,13 +31,10 @@ function getApiBaseUrl(): string {
   const fromEnv = import.meta.env.VITE_API_URL ?? import.meta.env.NEXT_PUBLIC_API_URL;
   if (typeof fromEnv === "string" && fromEnv.length > 0) return fromEnv.replace(/\/+$/, "");
 
-  if (typeof window !== "undefined") {
-    const host = window.location.hostname.toLowerCase();
-    if (host === "elizacloud.ai" || host === "www.elizacloud.ai") {
-      return "https://api.elizacloud.ai";
-    }
-  }
-
+  // Browser calls default to same-origin so Cloudflare Pages Functions can
+  // proxy /api/* to the Worker while preserving frontend-scoped auth marker
+  // cookies. Deployments without a same-origin proxy can opt into a separate
+  // API origin with VITE_API_URL / NEXT_PUBLIC_API_URL.
   return "";
 }
 

--- a/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
+++ b/cloud/apps/frontend/src/pages/login/steward-login-section.tsx
@@ -104,13 +104,6 @@ export default function StewardLoginSection() {
   const hasOAuthProviders = Boolean(providers.google || providers.discord || providers.github);
 
   const setSessionCookie = useCallback(async (token: string, refreshToken?: string | null) => {
-    // Use apiFetch instead of raw fetch so the request resolves to the
-    // direct Workers origin (https://api.elizacloud.ai) on production.
-    // Routing through the same-origin Pages Functions proxy would set
-    // Set-Cookie on www.elizacloud.ai, but every subsequent apiFetch call
-    // (e.g. /api/auth/cli-session/<id>/complete) goes cross-origin to
-    // api.elizacloud.ai and the host-only www cookie does not flow with
-    // it, which deadlocks the CLI login spinner at "Generating API Key".
     const response = await apiFetch("/api/auth/steward-session", {
       method: "POST",
       skipAuth: true,

--- a/cloud/packages/lib/auth/workers-hono-auth.ts
+++ b/cloud/packages/lib/auth/workers-hono-auth.ts
@@ -48,7 +48,12 @@ function nonEmptySecret(value: string | undefined): string | null {
 }
 
 function getStewardSecret(env: Bindings): Uint8Array | null {
-  const raw = nonEmptySecret(env.STEWARD_SESSION_SECRET) ?? nonEmptySecret(env.STEWARD_JWT_SECRET);
+  // Mirror @stwd/auth getJwtSecret() and the shared Steward verifier:
+  // STEWARD_JWT_SECRET is canonical; STEWARD_SESSION_SECRET is the legacy
+  // fallback. If both are configured, choosing SESSION first makes routes that
+  // authenticate via workers-hono-auth (notably CLI login completion) reject
+  // valid Steward JWTs even though /api/auth/steward-session accepts them.
+  const raw = nonEmptySecret(env.STEWARD_JWT_SECRET) ?? nonEmptySecret(env.STEWARD_SESSION_SECRET);
   if (!raw) return null;
   if (_stewardSecret && _stewardSecret.raw === raw) return _stewardSecret.key;
   _stewardSecret = { raw, key: new TextEncoder().encode(raw) };

--- a/cloud/packages/lib/providers/StewardProvider.tsx
+++ b/cloud/packages/lib/providers/StewardProvider.tsx
@@ -5,29 +5,6 @@ import { StewardAuth, StewardClient } from "@stwd/sdk";
 import { createContext, useEffect, useMemo, useRef } from "react";
 import { resolveBrowserStewardApiUrl } from "@/lib/steward-url";
 
-// Resolve the absolute origin to use for /api/* calls in the browser. On
-// known elizacloud.ai hosts, bypass the same-origin Pages Functions proxy
-// and hit the Workers API directly so the steward-session cookie is set on
-// the same host that subsequent apiFetch / cli-login calls hit. Without
-// this, the cookie is set on www.elizacloud.ai while later requests go
-// cross-origin to api.elizacloud.ai and the host-only cookie does not
-// flow, deadlocking the CLI login spinner at "Generating API Key".
-const ELIZA_CLOUD_PROXIED_HOSTS = new Set([
-  "elizacloud.ai",
-  "www.elizacloud.ai",
-  "dev.elizacloud.ai",
-]);
-const ELIZA_CLOUD_DIRECT_API = "https://api.elizacloud.ai";
-
-function stewardSessionUrl(): string {
-  if (typeof window === "undefined") return "/api/auth/steward-session";
-  const host = window.location.hostname.toLowerCase();
-  if (ELIZA_CLOUD_PROXIED_HOSTS.has(host)) {
-    return `${ELIZA_CLOUD_DIRECT_API}/api/auth/steward-session`;
-  }
-  return "/api/auth/steward-session";
-}
-
 /**
  * Steward authentication provider for Eliza Cloud.
  *
@@ -53,8 +30,16 @@ type ImportMetaEnvLike = {
   env?: Record<string, string | undefined>;
 };
 
-function getViteEnvFlag(name: string): string | undefined {
+function getViteEnvValue(name: string): string | undefined {
   return (import.meta as unknown as ImportMetaEnvLike).env?.[name];
+}
+
+function getViteEnvFlag(name: string): string | undefined {
+  return getViteEnvValue(name);
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
 }
 
 function isPlaywrightTestAuthEnabled(): boolean {
@@ -70,10 +55,40 @@ function isPlaywrightTestAuthEnabled(): boolean {
  */
 const STEWARD_TOKEN_KEY = "steward_session_token";
 const STEWARD_REFRESH_TOKEN_KEY = "steward_refresh_token";
+const STEWARD_SESSION_ENDPOINT = "/api/auth/steward-session";
+const ELIZA_CLOUD_COOKIE_HOSTS = new Set(["elizacloud.ai", "www.elizacloud.ai"]);
+const ELIZA_CLOUD_DIRECT_SESSION_ENDPOINT = "https://api.elizacloud.ai/api/auth/steward-session";
 
 export const LocalStewardAuthContext = createContext<ReturnType<typeof useStewardAuth> | null>(
   null,
 );
+
+function configuredSessionEndpoint(): string {
+  const apiBase =
+    getViteEnvValue("VITE_API_URL") ||
+    getViteEnvValue("NEXT_PUBLIC_API_URL") ||
+    process.env.NEXT_PUBLIC_API_URL;
+  if (apiBase && !isPlaceholderValue(apiBase)) {
+    return `${trimTrailingSlash(apiBase)}${STEWARD_SESSION_ENDPOINT}`;
+  }
+  return STEWARD_SESSION_ENDPOINT;
+}
+
+function stewardSessionClearUrls(): string[] {
+  if (typeof window === "undefined") return [configuredSessionEndpoint()];
+  const urls = new Set([STEWARD_SESSION_ENDPOINT, configuredSessionEndpoint()]);
+  const host = window.location.hostname.toLowerCase();
+  if (ELIZA_CLOUD_COOKIE_HOSTS.has(host)) {
+    urls.add(ELIZA_CLOUD_DIRECT_SESSION_ENDPOINT);
+  }
+  return [...urls];
+}
+
+function clearServerStewardSessionCookies(): void {
+  for (const url of stewardSessionClearUrls()) {
+    fetch(url, { method: "DELETE", credentials: "include" }).catch(() => {});
+  }
+}
 
 function readStoredToken(): string | null {
   if (typeof window === "undefined") return null;
@@ -157,7 +172,7 @@ export function clearStaleStewardSession(): void {
     // ignore
   }
   // Server-side cookies (HttpOnly — JS can't touch them directly).
-  fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(() => {});
+  clearServerStewardSessionCookies();
   // Notify any in-tab listeners; the "storage" event covers cross-tab.
   try {
     window.dispatchEvent(new CustomEvent("steward-token-sync"));
@@ -198,7 +213,7 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
           lastSyncedToken.current = null;
           lastSyncedRefreshToken.current = null;
           wasAuthenticated.current = false;
-          fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(() => {});
+          clearServerStewardSessionCookies();
         }
         return;
       }
@@ -215,7 +230,7 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
       lastSyncedRefreshToken.current = refreshToken;
       wasAuthenticated.current = true;
 
-      fetch(stewardSessionUrl(), {
+      fetch(configuredSessionEndpoint(), {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
@@ -290,9 +305,7 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
             lastSyncedToken.current = null;
             lastSyncedRefreshToken.current = null;
             wasAuthenticated.current = false;
-            fetch(stewardSessionUrl(), { method: "DELETE", credentials: "include" }).catch(
-              () => {},
-            );
+            clearServerStewardSessionCookies();
           }
         }
       } catch (err) {

--- a/cloud/packages/tests/unit/workers-hono-auth.test.ts
+++ b/cloud/packages/tests/unit/workers-hono-auth.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, mock, test } from "bun:test";
+import { SignJWT } from "jose";
+
+const TEST_USER = {
+  id: "cloud-user-1",
+  email: "user@example.com",
+  organization_id: "org-1",
+  organization: {
+    id: "org-1",
+    name: "Test Org",
+    is_active: true,
+  },
+  is_active: true,
+  role: "admin",
+  steward_user_id: "stwd-user-1",
+  wallet_address: null,
+  is_anonymous: false,
+};
+
+mock.module("@/lib/services/users", () => ({
+  usersService: {
+    getByStewardId: async (stewardId: string) =>
+      stewardId === TEST_USER.steward_user_id ? TEST_USER : null,
+  },
+}));
+
+async function signStewardToken(secret: string) {
+  return new SignJWT({
+    email: TEST_USER.email,
+    tenantId: "elizacloud",
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(TEST_USER.steward_user_id)
+    .setIssuedAt()
+    .setExpirationTime("15m")
+    .sign(new TextEncoder().encode(secret));
+}
+
+function makeContext(token: string, env: Record<string, string | undefined>) {
+  const state = new Map<string, unknown>();
+  return {
+    env,
+    req: {
+      header(name: string) {
+        return name.toLowerCase() === "authorization" ? `Bearer ${token}` : undefined;
+      },
+    },
+    get(key: string) {
+      return state.get(key);
+    },
+    set(key: string, value: unknown) {
+      state.set(key, value);
+    },
+  };
+}
+
+describe("workers-hono-auth Steward JWT verification", () => {
+  test("prefers STEWARD_JWT_SECRET over legacy STEWARD_SESSION_SECRET when both are configured", async () => {
+    const { getCurrentUser } = await import("@/lib/auth/workers-hono-auth");
+    const token = await signStewardToken("canonical-jwt-secret");
+
+    const user = await getCurrentUser(
+      makeContext(token, {
+        STEWARD_JWT_SECRET: "canonical-jwt-secret",
+        STEWARD_SESSION_SECRET: "old-session-secret",
+        STEWARD_TENANT_ID: "elizacloud",
+      }) as never,
+    );
+
+    expect(user?.id).toBe(TEST_USER.id);
+    expect(user?.organization_id).toBe(TEST_USER.organization_id);
+  });
+
+  test("falls back to STEWARD_SESSION_SECRET when STEWARD_JWT_SECRET is absent", async () => {
+    const { getCurrentUser } = await import("@/lib/auth/workers-hono-auth");
+    const token = await signStewardToken("legacy-session-secret");
+
+    const user = await getCurrentUser(
+      makeContext(token, {
+        STEWARD_SESSION_SECRET: "legacy-session-secret",
+        STEWARD_TENANT_ID: "elizacloud",
+      }) as never,
+    );
+
+    expect(user?.id).toBe(TEST_USER.id);
+  });
+});


### PR DESCRIPTION
## Summary\n- prefer STEWARD_JWT_SECRET over legacy STEWARD_SESSION_SECRET in workers-hono-auth so CLI completion verifies the same Steward JWT accepted by steward-session\n- default browser API calls back to same-origin /api proxy so frontend-scoped auth marker cookies stay visible on elizacloud.ai\n- keep configured API origins supported via VITE_API_URL / NEXT_PUBLIC_API_URL and clear stale api.elizacloud.ai cookies left by the previous direct-cookie flow\n- add regression coverage for canonical JWT secret preference plus legacy fallback\n\n## Validation\n- SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test --preload ./packages/tests/load-env.ts packages/tests/unit/workers-hono-auth.test.ts\n- bunx biome check cloud/apps/frontend/src/lib/api-client.ts cloud/apps/frontend/src/entry-server.tsx cloud/apps/frontend/src/pages/login/steward-login-section.tsx cloud/packages/lib/providers/StewardProvider.tsx cloud/packages/lib/auth/workers-hono-auth.ts cloud/packages/tests/unit/workers-hono-auth.test.ts\n- codex exec review --uncommitted --dangerously-bypass-approvals-and-sandbox\n\n## Note\n- bun run --cwd apps/frontend typecheck is still blocked by pre-existing Redis scan typing in cloud/packages/lib/cache/client.ts, unrelated to this patch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CLI login deadlock on elizacloud.ai by making two coordinated changes: (1) flipping `workers-hono-auth` to prefer `STEWARD_JWT_SECRET` over the legacy `STEWARD_SESSION_SECRET` so the Worker's JWT verifier matches the Steward server, and (2) routing all browser session-cookie calls through the same-origin Cloudflare Pages proxy instead of directly to `api.elizacloud.ai` so the resulting cookie stays visible to all subsequent API calls.

- **P1 — stale cookie cleanup gap**: `ELIZA_CLOUD_COOKIE_HOSTS` omits `dev.elizacloud.ai`, which was covered by the old `ELIZA_CLOUD_PROXIED_HOSTS` set. Users on that host who have existing direct-API cookies will not have them cleared on logout because `clearServerStewardSessionCookies()` never fires the DELETE against `api.elizacloud.ai` for that origin.

<h3>Confidence Score: 3/5</h3>

Safe to merge for production elizacloud.ai, but dev.elizacloud.ai users cannot fully clear stale direct-API cookies on logout until the cleanup set is corrected.

The core fixes (secret priority swap, same-origin routing) are correct and well-tested. A P1 regression exists in the logout path for dev.elizacloud.ai: the stale-cookie cleanup set omits that host despite it being covered by the old flow, meaning HttpOnly cookies on api.elizacloud.ai will persist after logout for users on dev.elizacloud.ai. This pulls the score below the P1 ceiling of 4.

cloud/packages/lib/providers/StewardProvider.tsx — ELIZA_CLOUD_COOKIE_HOSTS needs dev.elizacloud.ai added to match the coverage of the removed ELIZA_CLOUD_PROXIED_HOSTS.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/lib/auth/workers-hono-auth.ts | Swaps JWT secret preference from STEWARD_SESSION_SECRET-first to STEWARD_JWT_SECRET-first, matching the canonical @stwd/auth verifier; the one-line change is well-commented and directly addresses the CLI login deadlock. |
| cloud/packages/lib/providers/StewardProvider.tsx | Replaces the direct-to-api.elizacloud.ai session cookie flow with a same-origin proxy approach; adds stale-cookie cleanup for old direct-API cookies, but dev.elizacloud.ai is omitted from the cleanup set despite being covered by the old proxied-hosts list. |
| cloud/apps/frontend/src/lib/api-client.ts | Removes elizacloud.ai hostname hard-coding from getApiBaseUrl(), adds a CROSS_ORIGIN_API_URL guard that throws when an absolute cross-origin URL is passed to apiFetch() in browser context; safe for all relative-path callers. |
| cloud/apps/frontend/src/pages/login/steward-login-section.tsx | Removes the cross-origin routing comment from setSessionCookie; the underlying apiFetch call is unchanged and now correctly routes through the same-origin proxy; pre-existing unreachable response.ok guard remains. |
| cloud/apps/frontend/src/entry-server.tsx | Corrects StaticRouter import to react-router-dom/server for proper React Router v7 SSR; a stale contradictory comment remains above the import. |
| cloud/packages/tests/unit/workers-hono-auth.test.ts | New unit tests cover canonical JWT secret preference and legacy fallback using bun:test and jose; well-structured and directly exercise the changed getStewardSecret logic. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant PagesProxy as CF Pages Proxy (/api/*)
    participant Worker as Cloud Worker

    Note over Browser,Worker: New same-origin session flow (post-PR)

    Browser->>PagesProxy: POST /api/auth/steward-session
    PagesProxy->>Worker: forward request
    Worker->>Worker: getStewardSecret()
    Note right of Worker: STEWARD_JWT_SECRET ?? STEWARD_SESSION_SECRET
    Worker->>Worker: jwtVerify(token, secret)
    Worker-->>PagesProxy: Set-Cookie: steward-token (same origin)
    PagesProxy-->>Browser: 200 OK + cookie scoped to Pages domain

    Browser->>PagesProxy: GET /api/auth/cli-session/{id}/complete
    PagesProxy->>Worker: forward + cookie included
    Worker->>Worker: getCurrentUser() reads steward-token
    Worker-->>Browser: CLI session complete

    Note over Browser,Worker: Stale cookie cleanup on logout
    Browser->>PagesProxy: DELETE /api/auth/steward-session
    Browser->>Worker: DELETE https://api.elizacloud.ai/api/auth/steward-session
    Note right of Browser: Only for elizacloud.ai / www — clears old direct cookies
    Note right of Browser: dev.elizacloud.ai NOT covered — stale cookies persist
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): repair steward login session..."](https://github.com/elizaos/eliza/commit/bf218ff8026e7ba08136c9058d64a9ffd886e1c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30674277)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->