### PR TITLE
fix(cloud-frontend): cli-login completion effect deadlock

### DIFF
--- a/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx
+++ b/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx
@@ -133,6 +133,7 @@ function CliLoginContent() {
   const sessionId = searchParams.get("session");
   const [completion, setCompletion] = useState<CompletionState>({ status: "idle" });
   const lastSessionId = useRef(sessionId);
+  const completionFiredRef = useRef(false);
 
   useEffect(() => {
     if (lastSessionId.current === sessionId) {
@@ -140,17 +141,18 @@ function CliLoginContent() {
     }
 
     lastSessionId.current = sessionId;
+    completionFiredRef.current = false;
     setCompletion({ status: "idle" });
   }, [sessionId]);
 
-  // Do not list `completion.status` in the dependency array. When this effect
-  // sets "completing", a re-render would tear the effect down while the POST
-  // is in flight; cleanup sets `active = false` and aborts, and the catch
-  // returns early — leaving the UI stuck in "completing" forever.
   useEffect(() => {
     if (!sessionId || !ready || !authenticated) {
       return;
     }
+    if (completionFiredRef.current) {
+      return;
+    }
+    completionFiredRef.current = true;
 
     let active = true;
 

--- a/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx
+++ b/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx
@@ -143,8 +143,12 @@ function CliLoginContent() {
     setCompletion({ status: "idle" });
   }, [sessionId]);
 
+  // Do not list `completion.status` in the dependency array. When this effect
+  // sets "completing", a re-render would tear the effect down while the POST
+  // is in flight; cleanup sets `active = false` and aborts, and the catch
+  // returns early — leaving the UI stuck in "completing" forever.
   useEffect(() => {
-    if (!sessionId || !ready || !authenticated || completion.status !== "idle") {
+    if (!sessionId || !ready || !authenticated) {
       return;
     }
 
@@ -199,7 +203,7 @@ function CliLoginContent() {
       clearTimeout(timeout);
       abort.abort();
     };
-  }, [authenticated, completion.status, ready, sessionId]);
+  }, [authenticated, ready, sessionId]);
 
   const pageState = getPageState({ authenticated, completion, ready, sessionId });
   const returnToQuery = searchParams.toString();

--- a/cloud/packages/lib/services/cli-auth-sessions.ts
+++ b/cloud/packages/lib/services/cli-auth-sessions.ts
@@ -10,7 +10,6 @@ import { apiKeysService } from "./api-keys";
  * Session expiry time in minutes.
  */
 const SESSION_EXPIRY_MINUTES = 10; // Sessions expire after 10 minutes
-const CLI_LOGIN_KEY_NAME = "CLI Login";
 
 /**
  * Service for CLI authentication flow and session management.
@@ -78,13 +77,9 @@ export class CliAuthSessionsService {
       throw new Error("Session already authenticated or expired");
     }
 
-    // Keep only one active CLI-login key per user to prevent key sprawl when
-    // the login flow is retried repeatedly.
-    await apiKeysService.deactivateUserKeysByName(userId, CLI_LOGIN_KEY_NAME);
-
     // Generate API key for CLI usage
     const { apiKey, plainKey } = await apiKeysService.create({
-      name: CLI_LOGIN_KEY_NAME,
+      name: `CLI Login - ${new Date().toISOString()}`,
       description: "Generated via CLI login command",
       organization_id: organizationId,
       user_id: userId,

--- a/cloud/packages/lib/services/cli-auth-sessions.ts
+++ b/cloud/packages/lib/services/cli-auth-sessions.ts
@@ -79,20 +79,8 @@ export class CliAuthSessionsService {
     }
 
     // Keep only one active CLI-login key per user to prevent key sprawl when
-    // the login flow is retried repeatedly. Deactivate both the current
-    // canonical name and legacy timestamped names ("CLI Login - ...").
+    // the login flow is retried repeatedly.
     await apiKeysService.deactivateUserKeysByName(userId, CLI_LOGIN_KEY_NAME);
-    const orgKeys = await apiKeysRepository.listByOrganization(organizationId);
-    for (const key of orgKeys) {
-      if (
-        key.user_id === userId &&
-        key.is_active &&
-        typeof key.name === "string" &&
-        key.name.startsWith(`${CLI_LOGIN_KEY_NAME} - `)
-      ) {
-        await apiKeysService.update(key.id, { is_active: false });
-      }
-    }
 
     // Generate API key for CLI usage
     const { apiKey, plainKey } = await apiKeysService.create({

--- a/cloud/packages/lib/services/cli-auth-sessions.ts
+++ b/cloud/packages/lib/services/cli-auth-sessions.ts
@@ -79,8 +79,20 @@ export class CliAuthSessionsService {
     }
 
     // Keep only one active CLI-login key per user to prevent key sprawl when
-    // the login flow is retried repeatedly.
+    // the login flow is retried repeatedly. Deactivate both the current
+    // canonical name and legacy timestamped names ("CLI Login - ...").
     await apiKeysService.deactivateUserKeysByName(userId, CLI_LOGIN_KEY_NAME);
+    const orgKeys = await apiKeysRepository.listByOrganization(organizationId);
+    for (const key of orgKeys) {
+      if (
+        key.user_id === userId &&
+        key.is_active &&
+        typeof key.name === "string" &&
+        key.name.startsWith(`${CLI_LOGIN_KEY_NAME} - `)
+      ) {
+        await apiKeysService.update(key.id, { is_active: false });
+      }
+    }
 
     // Generate API key for CLI usage
     const { apiKey, plainKey } = await apiKeysService.create({

--- a/cloud/packages/lib/services/cli-auth-sessions.ts
+++ b/cloud/packages/lib/services/cli-auth-sessions.ts
@@ -10,6 +10,7 @@ import { apiKeysService } from "./api-keys";
  * Session expiry time in minutes.
  */
 const SESSION_EXPIRY_MINUTES = 10; // Sessions expire after 10 minutes
+const CLI_LOGIN_KEY_NAME = "CLI Login";
 
 /**
  * Service for CLI authentication flow and session management.
@@ -77,9 +78,13 @@ export class CliAuthSessionsService {
       throw new Error("Session already authenticated or expired");
     }
 
+    // Keep only one active CLI-login key per user to prevent key sprawl when
+    // the login flow is retried repeatedly.
+    await apiKeysService.deactivateUserKeysByName(userId, CLI_LOGIN_KEY_NAME);
+
     // Generate API key for CLI usage
     const { apiKey, plainKey } = await apiKeysService.create({
-      name: `CLI Login - ${new Date().toISOString()}`,
+      name: CLI_LOGIN_KEY_NAME,
       description: "Generated via CLI login command",
       organization_id: organizationId,
       user_id: userId,


### PR DESCRIPTION
## Summary

The `/auth/cli-login` page could get stuck on "Generating API Key" because the `useEffect` that POSTs `/api/auth/cli-session/:id/complete` listed `completion.status` in its dependency array. Setting status to `completing` re-ran the effect cleanup, aborted the in-flight request, and the `catch` path returned early when `!active` — leaving completion stuck in `completing` forever.

Milady (and any app using the hosted cli-login flow + server-side poll) never saw the session complete.

## Change

- Remove `completion.status` from the effect dependency array and drop the redundant `idle` guard that forced the same coupling.

## Testing

- `bun run lint` in `cloud/apps/frontend` (Biome): pass locally.
- CI: Cloud Tests workflow (`cloud/**`) should run `bun run verify` and the rest of the cloud matrix.

## Note

RuntimeGate / app-core onboarding hardening is separate; this PR is cloud frontend only for production elizacloud.ai.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `cli-login` completion deadlock by removing `completion.status` from the `useEffect` dependency array and adding a `completionFiredRef` one-shot guard to prevent double-POSTing. The root-cause fix and the re-entrancy guard are both correct, but one gap remains: the cleanup function still unconditionally calls `abort.abort()`, which can cancel the already-committed in-flight POST if `authenticated` or `ready` toggles mid-fetch, permanently freezing the UI on "Generating API Key".

<h3>Confidence Score: 4/5</h3>

Safe to merge for the common case, but the unconditional abort in cleanup leaves a narrow window where auth-state jitter during the POST permanently freezes the UI.

One P1 finding: the cleanup's unconditional abort.abort() can permanently freeze the 'Generating API Key' state if authenticated or ready toggles while the fetch is in flight. The deadlock fix itself is correct.

cloud/apps/frontend/src/pages/auth/cli-login/page.tsx — cleanup function at lines 203–207

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/apps/frontend/src/pages/auth/cli-login/page.tsx | Fixes the `completion.status` dep-array deadlock with a `completionFiredRef` one-shot guard, but the cleanup still unconditionally aborts the in-flight POST, which can permanently freeze the UI if `authenticated`/`ready` toggles mid-fetch. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant React as React Effect
    participant Ref as completionFiredRef
    participant Fetch as fetch /complete
    participant State as UI State

    React->>Ref: completionFiredRef.current = true
    React->>Fetch: POST /api/auth/cli-session/:id/complete
    Note over Fetch: In-flight...

    alt auth/ready briefly toggles (problematic path)
        React->>React: cleanup runs
        React->>State: active = false
        React->>Fetch: abort.abort() cancels in-flight POST
        Fetch-->>React: catch(AbortError)
        React->>State: !active → return early (stuck on completing)
        React->>React: effect re-runs
        React->>Ref: completionFiredRef.current is true → return early
        Note over State: UI permanently stuck on Generating API Key
    else normal path
        Fetch-->>React: 200 OK
        React->>State: setCompletion(success)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cloud/apps/frontend/src/pages/auth/cli-login/page.tsx`, line 203-207 ([link](https://github.com/elizaos/eliza/blob/f492088f629bc43fc1b236b13066f73ee2fe67c2/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx#L203-L207)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **In-flight POST aborted by effect cleanup**

   `completionFiredRef` correctly blocks a *second* POST from starting, but it doesn't protect the *first* POST from being aborted. If `authenticated` or `ready` changes while the fetch is in flight (e.g. a session refresh briefly toggles `authenticated` to `false`), React runs the cleanup from the first run — setting `active = false` and calling `abort.abort()` — then re-runs the effect body, which returns early because `completionFiredRef.current` is already `true`. The `catch` path at line 185 sees `!active` and returns without updating state, so the UI is permanently stuck on "Generating API Key".

   The simplest fix is to not abort the signal when completion has already been committed — move `abort.abort()` in the cleanup behind a `!completionFiredRef.current` guard:

   ```tsx
   return () => {
     active = false;
     clearTimeout(timeout);
     if (!completionFiredRef.current) {
       abort.abort();
     }
   };
   ```

2. `cloud/apps/frontend/src/pages/auth/cli-login/page.tsx`, line 203-207 ([link](https://github.com/elizaos/eliza/blob/7ffc4b8ec3644dbc52b21c43ed04ee578bf61a1b/cloud/apps/frontend/src/pages/auth/cli-login/page.tsx#L203-L207)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Cleanup unconditionally aborts the committed in-flight POST**

   `completionFiredRef` blocks a second POST from starting, but the cleanup still calls `abort.abort()` on every re-run. If `authenticated` or `ready` briefly toggles while the fetch is in flight, React runs this cleanup (`active = false`, `abort.abort()`), then re-runs the effect body — which returns early because `completionFiredRef.current` is already `true`. The `catch` at line 185 sees `!active` and exits silently, leaving the UI permanently stuck on "Generating API Key" with no recovery path.

   Guard the abort so it only cancels a request that hasn't been committed:

   ```tsx
       return () => {
         active = false;
         clearTimeout(timeout);
         if (!completionFiredRef.current) {
           abort.abort();
         }
       };
   ```

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Revert &quot;fix(cloud-auth): rotate single a..."](https://github.com/elizaos/eliza/commit/7ffc4b8ec3644dbc52b21c43ed04ee578bf61a1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30715703)</sub>

<!-- /greptile_comment -->