### PR TITLE
fix(agent): skip vault sentinels in applyConfigEnvToProcessEnv

### DIFF
--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -9,6 +9,7 @@ import {
 import JSON5 from "json5";
 import { readConfigEnvSync } from "../api/config-env.js";
 import { syncSolanaPublicKeyEnv } from "../api/wallet-env-sync.js";
+import { isVaultRef } from "../runtime/operations/vault-bridge.js";
 import { collectConfigEnvVars, collectConnectorEnvVars } from "./env-vars.js";
 import { resolveConfigIncludes } from "./includes.js";
 import { normalizeModelMetadataInConfig } from "./model-metadata.js";
@@ -35,7 +36,7 @@ function applyConfigEnvToProcessEnv(entries: Record<string, string>): void {
     // sentinel literal `vault://KEY` would overwrite the real plaintext on
     // every such call, and downstream `runtime.getSetting()` would hand the
     // sentinel to consumers like plugin-elizacloud, producing 401s.
-    if (typeof value === "string" && value.startsWith("vault://")) continue;
+    if (isVaultRef(value)) continue;
     process.env[key] = value;
   }
 }

--- a/packages/agent/src/config/config.ts
+++ b/packages/agent/src/config/config.ts
@@ -28,6 +28,14 @@ function resolveConfigWritePath(env: NodeJS.ProcessEnv = process.env): string {
 
 function applyConfigEnvToProcessEnv(entries: Record<string, string>): void {
   for (const [key, value] of Object.entries(entries)) {
+    // Skip unresolved vault sentinels. The boot-time vault hydration
+    // (resolveConfigEnvForProcess + applyCloudConfigToEnv) writes the resolved
+    // plaintext to process.env once at startup. Many services call
+    // loadElizaConfig() again later for unrelated reads; without this guard the
+    // sentinel literal `vault://KEY` would overwrite the real plaintext on
+    // every such call, and downstream `runtime.getSetting()` would hand the
+    // sentinel to consumers like plugin-elizacloud, producing 401s.
+    if (typeof value === "string" && value.startsWith("vault://")) continue;
     process.env[key] = value;
   }
 }


### PR DESCRIPTION
## Summary

`loadElizaConfig()` is invoked by ~30 services post-boot (registry-client, escalation, owner-name, custom-actions, plugin-routes, onboarding-routes, api/server, runtime/eliza, …). Every call walks `config.env` and unconditionally writes every value into `process.env` via the helper `applyConfigEnvToProcessEnv`.

When a key holds a `vault://KEY` sentinel — which is the on-disk representation after the secret has been migrated to the OS keychain — the literal sentinel string overwrites whatever resolved plaintext `applyCloudConfigToEnv` had set at step 2b of `startEliza`. Downstream `runtime.getSetting("KEY")` then hands the sentinel to consumers, producing things like `Authorization: Bearer vault://ELIZAOS_CLOUD_API_KEY` on outbound cloud calls — and a 401 from elizaOS Cloud even though the underlying credential in the vault is fine.

The fix is a single guard in `applyConfigEnvToProcessEnv`: if the value is a `vault://…` sentinel, skip the write. The resolved plaintext written earlier by `applyCloudConfigToEnv` (or by `resolveConfigEnvForProcess` for non-cloud keys) survives subsequent `loadElizaConfig()` calls. Real plaintext values still propagate normally — only the unresolved sentinel placeholder is filtered.

## Repro before this PR

1. Configure elizaOS Cloud with a real API key (any namespace).
2. Let the boot-time vault hydration migrate the key from `~/.<ns>/<ns>.json` env to the OS keychain (the on-disk env now has `"ELIZAOS_CLOUD_API_KEY": "vault://ELIZAOS_CLOUD_API_KEY"`).
3. Start the runtime. Any cloud LLM call eventually 401s with `elizaOS Cloud error 401`, even though direct `curl` with the same key returns 200. The literal `vault://ELIZAOS_CLOUD_API_KEY` is being sent as the bearer token.

## Test plan

- [ ] Confirmed locally: cloud LLM calls succeed after this fix where they previously 401'd.
- [ ] Inspected `process.env.ELIZAOS_CLOUD_API_KEY` mid-request — now retains the resolved real key across `loadElizaConfig()` invocations from other services.
- [ ] Existing `vault-bootstrap.test.ts` and `config.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where repeated `loadElizaConfig()` calls from post-boot services would overwrite resolved plaintext values in `process.env` with raw `vault://KEY` sentinel strings, causing downstream consumers to send literal sentinels as credentials and receive 401 errors. The fix adds a single `isVaultRef` guard in `applyConfigEnvToProcessEnv` to skip sentinel values, reusing the canonical utility already exported from `vault-bridge.ts`.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the change is minimal, targeted, and uses the established `isVaultRef` utility correctly.

Single-line guard with a clear rationale, backed by the existing `isVaultRef` type-guard from `vault-bridge.ts`. No new logic paths are introduced and the fix aligns with how the rest of the codebase handles vault sentinels. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/config/config.ts | Adds a vault-sentinel guard in `applyConfigEnvToProcessEnv` using the canonical `isVaultRef` utility, correctly preventing repeated `loadElizaConfig()` calls from overwriting resolved plaintext in `process.env` with literal sentinel strings. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Boot as startEliza boot
    participant VB as vault-bridge
    participant PE as process.env
    participant LEC as loadElizaConfig called 30x
    participant ACEP as applyConfigEnvToProcessEnv
    participant C as Consumers

    Boot->>VB: resolve vault sentinel to plaintext
    VB->>PE: write plaintext value at startup

    Note over LEC,ACEP: Post-boot services call loadElizaConfig
    LEC->>ACEP: entries contain vault sentinel
    ACEP->>ACEP: isVaultRef check returns true, skip write
    PE-->>PE: plaintext value preserved

    C->>PE: runtime.getSetting lookup
    PE-->>C: plaintext value returned correctly
```

<sub>Reviews (2): Last reviewed commit: ["fix(agent): use isVaultRef helper instea..."](https://github.com/elizaos/eliza/commit/28dfe6e56ad27a21ebe4a448fb9a0952d9e5ea7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30717819)</sub>

<!-- /greptile_comment -->