### PR TITLE
fix(n8n-workflow): tolerate prose-trailed JSON in parseWorkflowResponse

### DIFF
--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -304,11 +304,21 @@ Return the COMPLETE corrected workflow JSON. Preserve every field that was not p
 
 /**
  * Walk a string starting at every `{` opener, extract the first slice that
- * yields a valid JSON object, and return that slice. Tolerates leading and
- * trailing prose around the workflow JSON (which the LLM occasionally emits
- * in spite of `responseFormat: { type: 'json_object' }`).
+ * yields a valid JSON object, and return that parsed value. Tolerates leading
+ * and trailing prose around the workflow JSON (which the LLM occasionally
+ * emits in spite of `responseFormat: { type: 'json_object' }`).
+ *
+ * Returns the parsed value rather than the source string so callers don't pay
+ * for a second `JSON.parse` on the same bytes.
+ *
+ * Caveat: returns the *first* slice that round-trips through `JSON.parse`. If
+ * the LLM ever prefixes the workflow with a small standalone JSON fragment
+ * (e.g. `{"ok":true}\n{…full workflow…}`), the small fragment wins and the
+ * downstream `nodes`/`connections` validation throws "missing nodes array".
+ * That's an obvious failure mode rather than a silent corruption, so we don't
+ * try to second-guess which candidate is the workflow here.
  */
-function extractFirstBalancedJsonObject(text: string): string | null {
+function extractFirstBalancedJsonObject(text: string): unknown | null {
   for (let start = 0; start < text.length; start++) {
     if (text[start] !== '{') continue;
     let depth = 0;
@@ -335,8 +345,7 @@ function extractFirstBalancedJsonObject(text: string): string | null {
         if (depth === 0) {
           const candidate = text.slice(start, i + 1);
           try {
-            JSON.parse(candidate);
-            return candidate;
+            return JSON.parse(candidate);
           } catch {
             break;
           }
@@ -362,13 +371,13 @@ function parseWorkflowResponse(response: string): N8nWorkflow {
     // prose despite responseFormat: { type: 'json_object' }. Walk the cleaned
     // text and extract the first balanced JSON object that parses.
     const extracted = extractFirstBalancedJsonObject(cleaned);
-    if (!extracted) {
+    if (extracted == null) {
       throw new Error(
         `Failed to parse workflow JSON: ${initialError instanceof Error ? initialError.message : String(initialError)}\n\nRaw response: ${response}`,
         { cause: initialError }
       );
     }
-    workflow = JSON.parse(extracted) as N8nWorkflow;
+    workflow = extracted as N8nWorkflow;
   }
 
   if (!workflow.nodes || !Array.isArray(workflow.nodes)) {

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -302,6 +302,51 @@ Return the COMPLETE corrected workflow JSON. Preserve every field that was not p
   }
 }
 
+/**
+ * Walk a string starting at every `{` opener, extract the first slice that
+ * yields a valid JSON object, and return that slice. Tolerates leading and
+ * trailing prose around the workflow JSON (which the LLM occasionally emits
+ * in spite of `responseFormat: { type: 'json_object' }`).
+ */
+function extractFirstBalancedJsonObject(text: string): string | null {
+  for (let start = 0; start < text.length; start++) {
+    if (text[start] !== '{') continue;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+      } else if (ch === '{') {
+        depth++;
+      } else if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          const candidate = text.slice(start, i + 1);
+          try {
+            JSON.parse(candidate);
+            return candidate;
+          } catch {
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
 function parseWorkflowResponse(response: string): N8nWorkflow {
   // Strip markdown code fences (handles ```json, ```, with any whitespace/newlines)
   const cleaned = response
@@ -312,11 +357,18 @@ function parseWorkflowResponse(response: string): N8nWorkflow {
   let workflow: N8nWorkflow;
   try {
     workflow = JSON.parse(cleaned) as N8nWorkflow;
-  } catch (error) {
-    throw new Error(
-      `Failed to parse workflow JSON: ${error instanceof Error ? error.message : String(error)}\n\nRaw response: ${response}`,
-      { cause: error }
-    );
+  } catch (initialError) {
+    // Fence-strip + JSON.parse failed. The LLM may have wrapped the JSON in
+    // prose despite responseFormat: { type: 'json_object' }. Walk the cleaned
+    // text and extract the first balanced JSON object that parses.
+    const extracted = extractFirstBalancedJsonObject(cleaned);
+    if (!extracted) {
+      throw new Error(
+        `Failed to parse workflow JSON: ${initialError instanceof Error ? initialError.message : String(initialError)}\n\nRaw response: ${response}`,
+        { cause: initialError }
+      );
+    }
+    workflow = JSON.parse(extracted) as N8nWorkflow;
   }
 
   if (!workflow.nodes || !Array.isArray(workflow.nodes)) {


### PR DESCRIPTION
## Summary

Even with `responseFormat: { type: 'json_object' }` set on the `TEXT_LARGE` call, the LLM occasionally appends conversational prose **after** the workflow JSON (real example from a session today: `{...} What's good big man? meow, bitch.`). The current `parseWorkflowResponse` only strips markdown fences, so any non-fenced trailing text causes `JSON.parse` to throw and `/api/n8n/workflows/generate` returns 500.

This PR adds a balanced-JSON-object walker as a fallback. If the cleaned text fails to parse, it walks every `{` opener, finds the first slice that yields a valid JSON object, and parses that. The fast path (parse-after-strip) is preserved for well-behaved responses.

The mechanic mirrors the `extractFirstBalancedJsonValue` helper that [elizaos-plugins/plugin-elizacloud#18](https://github.com/elizaos-plugins/plugin-elizacloud/pull/18) adds to `models/object.ts` for the `OBJECT_*` model handlers — but it's needed independently in plugin-n8n-workflow because workflow generation routes through `TEXT_LARGE` (not `OBJECT_LARGE`), and the text-handler path doesn't run the elizacloud walker.

## Repro before this PR

1. Configure Eliza Cloud + connect at least one connector.
2. POST `/api/n8n/workflows/generate` with a prompt that triggers a non-trivial workflow.
3. If the LLM emits prose after the JSON (intermittent), the call 500s with `Failed to parse workflow JSON: JSON Parse error: Unable to parse JSON string`.

## Test plan

- [ ] Confirmed locally: prose-trailed responses now parse cleanly via the walker fallback.
- [ ] Well-formed responses still hit the fast path (no behaviour change).
- [ ] No regression in the existing fence-strip cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `extractFirstBalancedJsonObject` as a fallback in `parseWorkflowResponse` when fence-stripping + `JSON.parse` fails due to trailing LLM prose. The walker correctly handles string escaping, nested braces, and array structures, and the JSDoc clearly documents the first-wins caveat.

The implementation is correct for the stated repro. The double-parse concern and first-wins limitation from prior threads are addressed: the helper now returns the already-parsed value and the caveat is documented in the JSDoc.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fallback with no changes to the fast path and correct brace-walker logic

Only one file changed, the fast path is untouched, the walker correctly handles all JSON string-escape and nesting cases, and the known limitations are documented. No P0 or P1 findings.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/utils/generation.ts | Adds `extractFirstBalancedJsonObject` walker helper and wires it as a fallback in `parseWorkflowResponse`; logic, string-escape handling, and depth tracking are all correct |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[parseWorkflowResponse] --> B[Strip markdown fences]
    B --> C[JSON.parse cleaned]
    C -->|success| D[Validate nodes & connections]
    C -->|throws| E[extractFirstBalancedJsonObject]
    E --> F{Found balanced\nJSON object?}
    F -->|null| G[Throw error with\noriginal message + raw response]
    F -->|parsed value| D
    D -->|valid| H[Return N8nWorkflow]
    D -->|invalid| I[Throw validation error]
```

<sub>Reviews (2): Last reviewed commit: ["fix(n8n-workflow): return parsed value f..."](https://github.com/elizaos/eliza/commit/0e8be779ee513a4141f21c735e46daa48dcb1700) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30717925)</sub>

<!-- /greptile_comment -->