### PR TITLE
fix(automations): support free-form clarifications in resolve flow

### DIFF
--- a/packages/app-core/src/api/n8n-clarification.test.ts
+++ b/packages/app-core/src/api/n8n-clarification.test.ts
@@ -161,10 +161,43 @@ describe("applyResolutions", () => {
     });
   });
 
-  it("rejects a missing paramPath", () => {
+  it("treats empty paramPath as a free-form note under _meta.userNotes", () => {
+    const draft: Record<string, unknown> = {};
+    const result = applyResolutions(draft, [
+      { paramPath: "", value: "user-supplied context" },
+    ]);
+    expect(result).toEqual({ ok: true });
+    expect(draft).toEqual({
+      _meta: { userNotes: ["user-supplied context"] },
+    });
+  });
+
+  it("appends free-form notes when _meta.userNotes already exists as array", () => {
+    const draft: Record<string, unknown> = {
+      _meta: { userNotes: ["earlier note"] },
+    };
+    applyResolutions(draft, [{ paramPath: "", value: "next note" }]);
+    expect(draft).toEqual({
+      _meta: { userNotes: ["earlier note", "next note"] },
+    });
+  });
+
+  it("preserves non-array prior userNotes by coercing to a single-element array", () => {
+    const draft: Record<string, unknown> = {
+      _meta: { userNotes: "legacy string" },
+    };
+    applyResolutions(draft, [{ paramPath: "", value: "fresh note" }]);
+    expect(draft).toEqual({
+      _meta: { userNotes: ["legacy string", "fresh note"] },
+    });
+  });
+
+  it("rejects a non-string paramPath", () => {
     const draft: Record<string, unknown> = {};
     expect(
-      applyResolutions(draft, [{ paramPath: "", value: "x" } as never]),
+      applyResolutions(draft, [
+        { paramPath: undefined as unknown as string, value: "x" },
+      ]),
     ).toEqual({ ok: false, error: "resolution missing paramPath" });
   });
 

--- a/packages/app-core/src/api/n8n-clarification.ts
+++ b/packages/app-core/src/api/n8n-clarification.ts
@@ -202,7 +202,7 @@ export function applyResolutions(
   resolutions: ReadonlyArray<N8nClarificationResolution>,
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
-    if (!r || typeof r.paramPath !== "string" || r.paramPath.length === 0) {
+    if (!r || typeof r.paramPath !== "string") {
       return { ok: false, error: "resolution missing paramPath" };
     }
     if (typeof r.value !== "string") {
@@ -211,6 +211,20 @@ export function applyResolutions(
         error: "resolution value must be a string",
         paramPath: r.paramPath,
       };
+    }
+    if (r.paramPath.length === 0) {
+      // Free-form clarification with no field to wire into. Record the user's
+      // answer under draft._meta.userNotes so subsequent LLM iterations can
+      // consume the context, but don't mutate the workflow itself.
+      const meta = ((draft as Record<string, unknown>)._meta ??= {}) as Record<
+        string,
+        unknown
+      >;
+      const notes = Array.isArray(meta.userNotes)
+        ? (meta.userNotes as string[])
+        : ((meta.userNotes = []) as string[]);
+      notes.push(r.value);
+      continue;
     }
     try {
       setByDotPath(draft, r.paramPath, r.value);
@@ -228,20 +242,42 @@ export function applyResolutions(
 /**
  * Drop the resolved clarifications from the draft's `_meta` so the next
  * read of the draft does not re-prompt the user for the same parameter.
+ *
+ * Two pruning paths:
+ *  1. Object-form clarifications with paramPath → prune by paramPath match.
+ *  2. String-form clarifications (LLM emits free-form questions without a
+ *     paramPath) and object-form clarifications with empty paramPath →
+ *     prune positionally by `freeFormCount` (UI presents them in order, so
+ *     each free-form resolution consumes the next one).
  */
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
+  freeFormCount = 0,
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
   if (!meta || typeof meta !== "object") return;
   const list = meta.requiresClarification;
   if (!Array.isArray(list)) return;
+  let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
-    if (typeof item === "string") return true;
+    if (typeof item === "string") {
+      if (toDropFreeForm > 0) {
+        toDropFreeForm -= 1;
+        return false;
+      }
+      return true;
+    }
     if (item && typeof item === "object") {
       const path = (item as { paramPath?: unknown }).paramPath;
-      if (typeof path === "string" && resolved.has(path)) return false;
+      if (typeof path === "string" && path.length > 0 && resolved.has(path)) {
+        return false;
+      }
+      // Empty-paramPath object-form: also positional.
+      if ((typeof path !== "string" || path.length === 0) && toDropFreeForm > 0) {
+        toDropFreeForm -= 1;
+        return false;
+      }
     }
     return true;
   });

--- a/packages/app-core/src/api/n8n-clarification.ts
+++ b/packages/app-core/src/api/n8n-clarification.ts
@@ -222,7 +222,8 @@ export function applyResolutions(
       >;
       const notes = Array.isArray(meta.userNotes)
         ? (meta.userNotes as string[])
-        : ((meta.userNotes = []) as string[]);
+        : ((meta.userNotes =
+            meta.userNotes != null ? [String(meta.userNotes)] : []) as string[]);
       notes.push(r.value);
       continue;
     }
@@ -249,6 +250,13 @@ export function applyResolutions(
  *     paramPath) and object-form clarifications with empty paramPath →
  *     prune positionally by `freeFormCount` (UI presents them in order, so
  *     each free-form resolution consumes the next one).
+ *
+ * Positional-pruning contract: free-form items are dropped from the head of
+ * the stored list in order. The UI must therefore submit answers in the
+ * order they were presented, with no skipped or out-of-order items in a
+ * single batch — otherwise the wrong question gets pruned. If we ever need
+ * to support partial/interleaved submissions, switch the resolution payload
+ * to send the answered question text and match by value here instead.
  */
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,

--- a/packages/app-core/src/api/n8n-routes.ts
+++ b/packages/app-core/src/api/n8n-routes.ts
@@ -1451,14 +1451,15 @@ async function handleResolveClarification(
     return true;
   }
 
-  pruneResolvedClarifications(
-    draft,
-    new Set(
-      resolutions
-        .map((r) => r.paramPath)
-        .filter((p): p is string => typeof p === "string" && p.length > 0),
-    ),
+  const resolvedPaths = new Set(
+    resolutions
+      .map((r) => r.paramPath)
+      .filter((p): p is string => typeof p === "string" && p.length > 0),
   );
+  const freeFormCount = resolutions.filter(
+    (r) => typeof r.paramPath !== "string" || r.paramPath.length === 0,
+  ).length;
+  pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
   if (name?.trim()) {
     draft.name = name.trim();


### PR DESCRIPTION
## Summary

The clarification round-trip assumed every clarification has a non-empty `paramPath` that maps a user-supplied value into a workflow field. In practice the n8n workflow LLM also emits free-form clarifications without a paramPath (e.g. _\"Which Discord channel should the alerts go to?\"_ as a plain string in `_meta.requiresClarification`). Two contract gaps then break the UI flow:

1. **\`applyResolutions\` rejects empty \`paramPath\`** — returns \`{ ok: false, error: 'resolution missing paramPath' }\` → 400 Bad Request. The Apply button on a free-form clarification flashes red and never advances.
2. **\`pruneResolvedClarifications\` doesn't prune string-form items.** It only drops object-form clarifications by paramPath match. String-form items are always kept, so even if resolution had succeeded the next round-trip returns the same clarifications and the UI loops forever on Step 1.

This PR closes both gaps without inventing a new wire shape:

- **\`applyResolutions\`** — when \`paramPath\` is an empty string, record the user's answer under \`draft._meta.userNotes\` so subsequent LLM iterations have the context, but do not mutate the workflow.
- **\`pruneResolvedClarifications\`** — accept an explicit \`freeFormCount\` of empty-paramPath resolutions in the current request, then prune the first N string-form (or empty-paramPath object-form) items positionally — matching the order the UI presents them.
- **Caller in \`n8n-routes.ts\`** computes \`freeFormCount\` from the resolution shape and passes it through.

The behaviour is additive: existing object-form-with-paramPath flows are unchanged.

> **Note:** Real LLM output should ideally use structured \`kind: 'choice'\` clarifications backed by the connector catalog. That's a separate prompt-engineering / validator-rules problem in plugin-n8n-workflow. Until that lands, the free-form path needs to terminate cleanly so the UI machinery can be exercised.

## Repro before this PR

1. POST a prompt to \`/api/n8n/workflows/generate\` that triggers free-form clarifications (any reasonably ambiguous workflow request will do — the LLM frequently emits string-form questions).
2. The route returns \`status: 'needs_clarification'\` with \`clarifications[].paramPath === ''\`.
3. UI submits to \`/api/n8n/workflows/resolve-clarification\` with the user's answer. Either:
   - Pre-PR: 400 with \`resolution missing paramPath\`, or
   - With \`applyResolutions\` patched: 200 but the same clarification re-renders forever.

## Test plan

- [ ] Confirmed locally: free-form clarification round-trip advances the step counter and eventually deploys.
- [ ] Object-form clarifications with non-empty paramPath continue to mutate the workflow as before.
- [ ] User answers are preserved in \`draft._meta.userNotes\` for downstream LLM consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two contract gaps in the clarification resolve flow: `applyResolutions` now accepts empty-`paramPath` resolutions (storing the user's answer in `draft._meta.userNotes` instead of returning a 400), and `pruneResolvedClarifications` gains a `freeFormCount` parameter to positionally drop string-form and empty-`paramPath` object-form clarifications so the UI doesn't loop. Existing structured-clarification flows are unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the only finding is missing test coverage for the new pruning path, which does not affect correctness.

Only P2 findings (missing tests for the new `freeFormCount` pruning path). The logic itself is correct, well-commented with its ordering contract, and the existing structured-clarification path is unchanged.

`n8n-clarification.test.ts` — the `pruneResolvedClarifications` suite needs tests for `freeFormCount > 0`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/n8n-clarification.ts | Adds free-form clarification support: empty-paramPath resolutions are stored in `_meta.userNotes`, and `pruneResolvedClarifications` gains a positional `freeFormCount` pruning path. Both changes are well-commented with their ordering contract. The `userNotes` non-array coercion case is handled correctly. |
| packages/app-core/src/api/n8n-clarification.test.ts | Adds three new tests for `applyResolutions` covering the new empty-paramPath and non-array userNotes coercion paths. However, the `pruneResolvedClarifications` test suite has no new tests for `freeFormCount`, leaving the positional-pruning logic entirely without coverage. |
| packages/app-core/src/api/n8n-routes.ts | Caller correctly computes `freeFormCount` from the resolution batch and passes it to `pruneResolvedClarifications`. The existing `resolvedPaths` set continues to handle structured resolutions unchanged. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI
    participant Route as n8n-routes.ts
    participant Apply as applyResolutions
    participant Prune as pruneResolvedClarifications
    participant Draft as draft (_meta)

    UI->>Route: POST /resolve-clarification
    Route->>Apply: applyResolutions(draft, resolutions)
    Note over Apply: paramPath="" → store in _meta.userNotes
    Note over Apply: paramPath="x.y" → setByDotPath(draft, "x.y", "v")
    Apply-->>Route: {ok: true}
    Route->>Route: compute resolvedPaths, freeFormCount
    Route->>Prune: pruneResolvedClarifications(draft, resolvedPaths, freeFormCount)
    Note over Prune: string/empty-paramPath items → drop first N positionally
    Note over Prune: object items with paramPath → drop by Set match
    Prune->>Draft: meta.requiresClarification = remaining[]
    Route-->>UI: 200 {status: needs_clarification | complete}
```

<sub>Reviews (2): Last reviewed commit: ["fix(automations): preserve non-array use..."](https://github.com/elizaos/eliza/commit/0168cccffdc38037d77bd3fecd998dc95eec43f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30718050)</sub>

<!-- /greptile_comment -->