### PR TITLE
feat(n8n-workflow): render Runtime Facts as fenced JSON block

### DIFF
--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -392,9 +392,9 @@ function buildRuntimeContextSections(ctx?: RuntimeContext): string {
   if (ctx.facts?.length) {
     lines.push('## Runtime Facts');
     lines.push('Use these real values verbatim instead of placeholders.');
-    for (const f of ctx.facts) {
-      lines.push(`- ${f}`);
-    }
+    lines.push('```json');
+    lines.push(JSON.stringify(ctx.facts, null, 2));
+    lines.push('```');
     lines.push('');
   }
   return lines.length ? `\n${lines.join('\n')}\n` : '';


### PR DESCRIPTION
## Summary

Mirror of [elizaos-plugins/plugin-n8n-workflow#26](https://github.com/elizaos-plugins/plugin-n8n-workflow/pull/26)'s nitpick fix into the monorepo. Plugin source of truth lives here now.

`buildRuntimeContextSections` previously rendered `## Runtime Facts` as plain bullets. Plain bullets are easy for the model to paraphrase, split, or fold into surrounding prose, which weakens the \"use verbatim\" guarantee the section is enforcing. A fenced JSON block is structurally harder to mutate and signals \"copy this exactly\" more reliably.

```diff
   if (ctx.facts?.length) {
     lines.push('## Runtime Facts');
     lines.push('Use these real values verbatim instead of placeholders.');
-    for (const f of ctx.facts) {
-      lines.push(`- ${f}`);
-    }
+    lines.push('```json');
+    lines.push(JSON.stringify(ctx.facts, null, 2));
+    lines.push('```');
     lines.push('');
   }
```

No behavior change for callers — the section content is the same, just emitted as JSON inside a fence rather than a markdown list.

## Test plan
- [x] \`tsc --noEmit -p plugins/plugin-n8n-workflow/tsconfig.json\` clean
- [x] No existing test asserts on the rendered Runtime Facts section, so no test updates needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changes `buildRuntimeContextSections` in the n8n-workflow plugin to emit the `## Runtime Facts` block as a fenced JSON array instead of a markdown bullet list, giving the LLM a stronger structural signal to copy values verbatim. The diff is minimal (3 lines replaced with 3 lines) and type-correct — `ctx.facts` is `string[]`, so `JSON.stringify(ctx.facts, null, 2)` produces a valid, properly-escaped JSON array that integrates cleanly with the surrounding `lines.join('
')` assembly.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 feedback present.

The change is logically correct, type-safe, and backward-compatible for callers. The single P2 finding (no unit test for the new rendering format) does not block merging but represents a gap worth closing.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/utils/generation.ts | Replaces per-item bullet loop with a single fenced JSON block for the Runtime Facts section; logic is correct and JSON.stringify handles escaping properly for the string[] type. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["buildRuntimeContextSections(ctx)"] --> B{ctx.facts?.length}
    B -- "no" --> C[skip section]
    B -- "yes" --> D["push '## Runtime Facts'"]
    D --> E["push 'Use these real values verbatim...'"]
    E --> F["push '```json'"]
    F --> G["push JSON.stringify(ctx.facts, null, 2)"]
    G --> H["push '```'"]
    H --> I["push '' (blank line)"]
    I --> J["lines.join('\n') → fenced JSON block in prompt"]
```

<sub>Reviews (1): Last reviewed commit: ["feat(n8n-workflow): render Runtime Facts..."](https://github.com/elizaos/eliza/commit/b643ecec8977d478d29a34d9074dafdf82c300f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30726146)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->