### PR TITLE
fix(cloud): stop billing-fetch render-loop in CloudDashboard

### DIFF
--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -332,11 +332,19 @@ export function CloudDashboard() {
     };
   }, []);
 
+  // Refetch billing only when the cloud-connected flag flips. We deliberately
+  // exclude `fetchBillingData` from the dep array: its identity tracks `t`
+  // (i18n) and changes on every render, which would re-fire this effect every
+  // render and hammer `/api/cloud/billing/{summary,settings}` until Eliza
+  // Cloud rate-limits the keypair with 429s. The "fire once on connect" is
+  // the only intended behaviour; manual refresh + post-mutation refresh both
+  // call `fetchBillingData` directly elsewhere.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment above
   useEffect(() => {
     if (elizaCloudConnected) {
       void fetchBillingData();
     }
-  }, [elizaCloudConnected, fetchBillingData]);
+  }, [elizaCloudConnected]);
 
   // Drop cached billing on disconnect so we never show a stale balance.
   useEffect(() => {


### PR DESCRIPTION
## Summary

The \"fire on connect\" \`useEffect\` in \`CloudDashboard\` that calls \`fetchBillingData()\` listed \`fetchBillingData\` itself in its dep array. \`fetchBillingData\` is a \`useCallback\` whose deps include \`t\` (\`useTranslation\`), and \`t\` changes identity on every render in this codebase — so the callback is re-created every render, the dep array detects \"changed\", and the effect re-fires.

Each fire hammers \`/api/cloud/billing/summary\` and \`/api/cloud/billing/settings\`, which Eliza Cloud rate-limits per-API-key. Result: a flood of \`429 Too Many Requests\` responses that cascade through the dashboard on every keystroke or unrelated re-render. Observable in DevTools as dozens of duplicate billing requests within seconds, plus visible 429s in the network panel.

This PR drops \`fetchBillingData\` from the dep array. The only intended trigger is the \`elizaCloudConnected\` flip — and manual refresh + post-mutation refresh both call \`fetchBillingData()\` directly elsewhere in the component, so the change has no UX impact.

The \`// biome-ignore lint/correctness/useExhaustiveDependencies\` line is paired with an inline comment explaining why, so a future reader doesn't \"fix\" the lint warning without realizing it would re-introduce the loop.

## Repro before this PR

1. Connect Eliza Cloud in settings.
2. Open the cloud dashboard panel.
3. Open DevTools → Network → filter by \`billing\`.
4. Trigger any unrelated re-render (resize, focus toggle, theme tick) — every render fires fresh \`/billing/summary\` + \`/billing/settings\` requests. Within seconds the cloud returns \`429 Too Many Requests\`.

## Test plan

- [ ] Confirmed locally: opening the cloud dashboard fires \`/billing/{summary,settings}\` exactly once per connect.
- [ ] Manual \"Refresh\" button still works.
- [ ] Saving billing settings still triggers the post-mutation refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a render-loop bug in `CloudDashboard` where a `useEffect` for billing data fetching listed `fetchBillingData` in its dependency array. Because `fetchBillingData` is a `useCallback` that depends on `t` (from `useTranslation`, which changes identity on every render), the effect was re-firing on every render and flooding `/api/cloud/billing/summary` and `/api/cloud/billing/settings` until the API returned `429 Too Many Requests`.

The fix removes `fetchBillingData` from the dep array (guarded by a `biome-ignore` comment with inline explanation), relying solely on `elizaCloudConnected` as the trigger. Manual refresh and post-mutation refresh paths call `fetchBillingData` directly, so there is no UX regression.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no UX regression and a clear inline explanation.

Single-file change that removes an unintended dependency from a useEffect dep array, directly fixing a confirmed render-loop and API flood. Manual refresh, post-mutation refresh, and checkout-close paths all call fetchBillingData directly and are unaffected. The biome-ignore comment is paired with a thorough explanation, reducing future regression risk. No logic, auth, or data-handling changes are introduced.

No files require special attention. The broader root cause — `t` from `useTranslation` changing identity on every render — exists elsewhere in the component but does not produce the same looping side-effect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/ElizaCloudDashboard.tsx | Removes `fetchBillingData` from the `useEffect` dep array to stop a render-loop that was causing repeated API calls and 429 rate-limit errors; adds a clear biome-ignore comment explaining the intentional omission. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as React Render
    participant E as useEffect
    participant CB as fetchBillingData (useCallback)
    participant API as /api/cloud/billing/*

    Note over R,API: BEFORE (broken)
    R->>CB: t() changes identity → new fetchBillingData ref
    CB-->>E: dep changed → effect re-fires
    E->>API: GET /billing/summary + /billing/settings
    API-->>E: 429 Too Many Requests (within seconds)
    Note over R,E: Loops on every render

    Note over R,API: AFTER (fixed)
    R->>E: dep = [elizaCloudConnected] only
    Note over E: Effect fires only when connection flag flips
    E->>API: GET /billing/summary + /billing/settings
    API-->>E: 200 OK (once per connect)
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): stop billing-fetch render-lo..."](https://github.com/elizaos/eliza/commit/489485b2cafee3e948eb782c0685a51eabd12a59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30738276)</sub>

<!-- /greptile_comment -->