### PR TITLE
feat(slack): migrate plugin-slack into the monorepo

### DIFF
--- a/plugins/plugin-slack/LICENSE
+++ b/plugins/plugin-slack/LICENSE
@@ -1,0 +1,1 @@
+{"message":"Not Found","documentation_url":"https://docs.github.com/rest/repos/contents#get-repository-content","status":"404"}

--- a/plugins/plugin-slack/README.md
+++ b/plugins/plugin-slack/README.md
@@ -1,0 +1,207 @@
+# @elizaos/plugin-slack
+
+Slack integration plugin for ElizaOS agents with Socket Mode support.
+
+## Features
+
+- **Socket Mode**: Real-time event handling via Slack Socket Mode
+- **Message Operations**: Send, edit, delete, read messages
+- **Reactions**: Add and remove emoji reactions
+- **Pins**: Pin and unpin messages, list pinned items
+- **Channels**: List channels, read channel history
+- **User Info**: Get user profile information
+- **Threads**: Full thread support with reply tracking
+- **Media**: Handle file uploads and attachments
+- **Custom Emoji**: List workspace custom emoji
+
+## Installation
+
+```bash
+npm install @elizaos/plugin-slack
+# or
+bun add @elizaos/plugin-slack
+```
+
+## Configuration
+
+### Required Environment Variables
+
+```env
+# Bot Token (starts with xoxb-)
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+
+# App Token for Socket Mode (starts with xapp-)
+SLACK_APP_TOKEN=xapp-your-app-token
+```
+
+### Optional Environment Variables
+
+```env
+# Signing Secret for request verification
+SLACK_SIGNING_SECRET=your-signing-secret
+
+# User Token for enhanced permissions (starts with xoxp-)
+SLACK_USER_TOKEN=xoxp-your-user-token
+
+# Comma-separated list of channel IDs to restrict bot to
+SLACK_CHANNEL_IDS=C123456789,C987654321
+
+# Ignore messages from other bots
+SLACK_SHOULD_IGNORE_BOT_MESSAGES=false
+
+# Only respond when mentioned
+SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS=false
+```
+
+## Slack App Setup
+
+1. Create a new Slack App at https://api.slack.com/apps
+2. Enable Socket Mode in your app settings
+3. Generate an App-Level Token with `connections:write` scope
+4. Add the following Bot Token Scopes:
+   - `channels:history` - Read messages in public channels
+   - `channels:read` - View basic channel information
+   - `chat:write` - Send messages
+   - `emoji:read` - View custom emoji
+   - `files:read` - View files
+   - `groups:history` - Read messages in private channels
+   - `groups:read` - View basic private channel information
+   - `im:history` - Read direct messages
+   - `im:read` - View basic direct message information
+   - `mpim:history` - Read group direct messages
+   - `mpim:read` - View basic group direct message information
+   - `pins:read` - View pinned items
+   - `pins:write` - Add and remove pinned items
+   - `reactions:read` - View reactions
+   - `reactions:write` - Add and remove reactions
+   - `team:read` - View workspace information
+   - `users:read` - View basic user information
+   - `users:read.email` - View user email addresses
+
+5. Enable Events and subscribe to:
+   - `message.channels` - Messages in public channels
+   - `message.groups` - Messages in private channels
+   - `message.im` - Direct messages
+   - `message.mpim` - Group direct messages
+   - `app_mention` - When the app is mentioned
+   - `member_joined_channel` - When a user joins a channel
+   - `member_left_channel` - When a user leaves a channel
+   - `reaction_added` - When a reaction is added
+   - `reaction_removed` - When a reaction is removed
+
+6. Install the app to your workspace
+
+## Usage
+
+### Add to your agent configuration
+
+```typescript
+import slackPlugin from "@elizaos/plugin-slack";
+
+const agent = {
+  // ... other configuration
+  plugins: [slackPlugin],
+};
+```
+
+### Character file configuration
+
+```json
+{
+  "name": "MyAgent",
+  "clients": ["slack"],
+  "settings": {
+    "slack": {
+      "shouldIgnoreBotMessages": true,
+      "shouldRespondOnlyToMentions": false
+    }
+  }
+}
+```
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| `SLACK_SEND_MESSAGE` | Send a message to a channel or thread |
+| `SLACK_REACT_TO_MESSAGE` | Add or remove emoji reactions |
+| `SLACK_READ_CHANNEL` | Read message history from a channel |
+| `SLACK_EDIT_MESSAGE` | Edit an existing message |
+| `SLACK_DELETE_MESSAGE` | Delete a message |
+| `SLACK_PIN_MESSAGE` | Pin a message to a channel |
+| `SLACK_UNPIN_MESSAGE` | Unpin a message from a channel |
+| `SLACK_LIST_PINS` | List pinned messages in a channel |
+| `SLACK_LIST_CHANNELS` | List available channels |
+| `SLACK_GET_USER_INFO` | Get information about a user |
+| `SLACK_EMOJI_LIST` | List custom emoji in the workspace |
+
+## Providers
+
+| Provider | Description |
+|----------|-------------|
+| `slackChannelState` | Current channel context and metadata |
+| `slackWorkspaceInfo` | Workspace-level information |
+| `slackMemberList` | Members in the current channel |
+
+## Events
+
+The plugin emits the following events:
+
+- `SLACK_MESSAGE_RECEIVED` - When a message is received
+- `SLACK_MESSAGE_SENT` - When a message is sent
+- `SLACK_REACTION_ADDED` - When a reaction is added
+- `SLACK_REACTION_REMOVED` - When a reaction is removed
+- `SLACK_APP_MENTION` - When the bot is mentioned
+- `SLACK_MEMBER_JOINED_CHANNEL` - When a member joins a channel
+- `SLACK_MEMBER_LEFT_CHANNEL` - When a member leaves a channel
+- `SLACK_FILE_SHARED` - When a file is shared
+
+## API Reference
+
+### SlackService
+
+The main service class providing direct access to Slack functionality:
+
+```typescript
+import { SlackService, SLACK_SERVICE_NAME } from "@elizaos/plugin-slack";
+
+// Get service from runtime
+const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+// Send a message
+await slackService.sendMessage(channelId, "Hello!", { threadTs: "..." });
+
+// Add a reaction
+await slackService.sendReaction(channelId, messageTs, "thumbsup");
+
+// Get user info
+const user = await slackService.getUser(userId);
+
+// List channels
+const channels = await slackService.listChannels();
+```
+
+## Troubleshooting
+
+### Bot not responding to messages
+
+1. Verify your `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are correct
+2. Check that Socket Mode is enabled in your Slack app
+3. Ensure the bot has been invited to the channel
+4. Check if `SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS` is enabled
+
+### Permission errors
+
+1. Verify the bot has all required OAuth scopes
+2. Reinstall the app to your workspace after adding new scopes
+3. Check if the channel is private and the bot is a member
+
+### Socket Mode connection issues
+
+1. Verify your `SLACK_APP_TOKEN` starts with `xapp-`
+2. Check that the app-level token has `connections:write` scope
+3. Ensure only one instance of the bot is running per token
+
+## License
+
+MIT

--- a/plugins/plugin-slack/__tests__/accounts.test.ts
+++ b/plugins/plugin-slack/__tests__/accounts.test.ts
@@ -1,0 +1,400 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_ACCOUNT_ID,
+  getMultiAccountConfig,
+  isMultiAccountEnabled,
+  listEnabledSlackAccounts,
+  listSlackAccountIds,
+  normalizeAccountId,
+  resolveSlackAccount,
+  resolveSlackAppToken,
+  resolveSlackBotToken,
+  resolveSlackUserToken,
+} from "../src/accounts";
+
+/**
+ * Tests for Slack multi-account management
+ */
+describe("Slack Accounts", () => {
+  describe("normalizeAccountId", () => {
+    it("should return default for null input", () => {
+      expect(normalizeAccountId(null)).toBe(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should return default for undefined input", () => {
+      expect(normalizeAccountId(undefined)).toBe(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should return default for empty string", () => {
+      expect(normalizeAccountId("")).toBe(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should return default for whitespace-only string", () => {
+      expect(normalizeAccountId("   ")).toBe(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should normalize to lowercase", () => {
+      expect(normalizeAccountId("MyAccount")).toBe("myaccount");
+    });
+
+    it("should trim whitespace", () => {
+      expect(normalizeAccountId("  account  ")).toBe("account");
+    });
+
+    it("should handle non-string input", () => {
+      expect(normalizeAccountId(123 as unknown as string)).toBe(
+        DEFAULT_ACCOUNT_ID,
+      );
+    });
+  });
+
+  describe("Token Resolution", () => {
+    describe("resolveSlackBotToken", () => {
+      it("should return undefined for null input", () => {
+        expect(resolveSlackBotToken(null)).toBeUndefined();
+      });
+
+      it("should return undefined for empty string", () => {
+        expect(resolveSlackBotToken("")).toBeUndefined();
+      });
+
+      it("should return undefined for whitespace-only string", () => {
+        expect(resolveSlackBotToken("   ")).toBeUndefined();
+      });
+
+      it("should return undefined for non-xoxb token", () => {
+        expect(resolveSlackBotToken("xoxp-invalid")).toBeUndefined();
+      });
+
+      it("should return undefined for xoxb without dash", () => {
+        expect(resolveSlackBotToken("xoxbinvalid")).toBeUndefined();
+      });
+
+      it("should return valid xoxb token", () => {
+        const token = "xoxb-123-456-abc";
+        expect(resolveSlackBotToken(token)).toBe(token);
+      });
+
+      it("should trim valid token", () => {
+        expect(resolveSlackBotToken("  xoxb-123-456-abc  ")).toBe(
+          "xoxb-123-456-abc",
+        );
+      });
+    });
+
+    describe("resolveSlackAppToken", () => {
+      it("should return undefined for null input", () => {
+        expect(resolveSlackAppToken(null)).toBeUndefined();
+      });
+
+      it("should return undefined for non-xapp token", () => {
+        expect(resolveSlackAppToken("xoxb-invalid")).toBeUndefined();
+      });
+
+      it("should return valid xapp token", () => {
+        const token = "xapp-1-ABC-123-xyz";
+        expect(resolveSlackAppToken(token)).toBe(token);
+      });
+    });
+
+    describe("resolveSlackUserToken", () => {
+      it("should return undefined for null input", () => {
+        expect(resolveSlackUserToken(null)).toBeUndefined();
+      });
+
+      it("should return undefined for non-xoxp token", () => {
+        expect(resolveSlackUserToken("xoxb-invalid")).toBeUndefined();
+      });
+
+      it("should return valid xoxp token", () => {
+        const token = "xoxp-123-456-789-abc";
+        expect(resolveSlackUserToken(token)).toBe(token);
+      });
+    });
+  });
+
+  describe("getMultiAccountConfig", () => {
+    it("should return empty config when character settings are undefined", () => {
+      const mockRuntime = {
+        character: undefined,
+      } as unknown as IAgentRuntime;
+
+      const config = getMultiAccountConfig(mockRuntime);
+      expect(config.enabled).toBeUndefined();
+      expect(config.botToken).toBeUndefined();
+      expect(config.accounts).toBeUndefined();
+    });
+
+    it("should return config from character settings", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              enabled: true,
+              botToken: "xoxb-test-token",
+              appToken: "xapp-test-token",
+              accounts: {
+                workspace1: { botToken: "xoxb-ws1-token" },
+              },
+            },
+          },
+        },
+      } as unknown as IAgentRuntime;
+
+      const config = getMultiAccountConfig(mockRuntime);
+      expect(config.enabled).toBe(true);
+      expect(config.botToken).toBe("xoxb-test-token");
+      expect(config.appToken).toBe("xapp-test-token");
+      expect(config.accounts?.workspace1).toBeDefined();
+    });
+  });
+
+  describe("listSlackAccountIds", () => {
+    it("should return default account when no accounts configured", () => {
+      const mockRuntime = {
+        character: { settings: {} },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const ids = listSlackAccountIds(mockRuntime);
+      expect(ids).toEqual([DEFAULT_ACCOUNT_ID]);
+    });
+
+    it("should include default account when base config has token", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              botToken: "xoxb-base-token",
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const ids = listSlackAccountIds(mockRuntime);
+      expect(ids).toContain(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should include default account when env has token", () => {
+      const mockRuntime = {
+        character: { settings: {} },
+        getSetting: vi.fn((key: string) => {
+          if (key === "SLACK_BOT_TOKEN") return "xoxb-env-token";
+          return undefined;
+        }),
+      } as unknown as IAgentRuntime;
+
+      const ids = listSlackAccountIds(mockRuntime);
+      expect(ids).toContain(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should include named accounts", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              accounts: {
+                workspace1: { botToken: "xoxb-ws1" },
+                workspace2: { botToken: "xoxb-ws2" },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const ids = listSlackAccountIds(mockRuntime);
+      expect(ids).toContain("workspace1");
+      expect(ids).toContain("workspace2");
+    });
+
+    it("should return sorted account IDs", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              accounts: {
+                zebra: {},
+                alpha: {},
+                mango: {},
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const ids = listSlackAccountIds(mockRuntime);
+      expect(ids).toEqual(["alpha", "mango", "zebra"]);
+    });
+  });
+
+  describe("resolveSlackAccount", () => {
+    it("should resolve account with merged configuration", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              enabled: true,
+              dmPolicy: "allowlist",
+              accounts: {
+                workspace1: {
+                  name: "My Workspace",
+                  botToken: "xoxb-ws1-token",
+                  dmPolicy: "open",
+                },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, "workspace1");
+      expect(account.accountId).toBe("workspace1");
+      expect(account.enabled).toBe(true);
+      expect(account.name).toBe("My Workspace");
+      expect(account.botToken).toBe("xoxb-ws1-token");
+      // Account is considered configured when it has a botToken
+      expect(account.botToken).toBeDefined();
+    });
+
+    it("should normalize account ID", () => {
+      const mockRuntime = {
+        character: { settings: {} },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, "  MyWorkspace  ");
+      expect(account.accountId).toBe("myworkspace");
+    });
+
+    it("should use default account ID for null input", () => {
+      const mockRuntime = {
+        character: { settings: {} },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, null);
+      expect(account.accountId).toBe(DEFAULT_ACCOUNT_ID);
+    });
+
+    it("should mark account as disabled when base disabled", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              enabled: false,
+              accounts: {
+                workspace1: { enabled: true },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, "workspace1");
+      expect(account.enabled).toBe(false);
+    });
+
+    it("should mark account as disabled when account disabled", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              enabled: true,
+              accounts: {
+                workspace1: { enabled: false },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, "workspace1");
+      expect(account.enabled).toBe(false);
+    });
+
+    it("should not have botToken when no token provided", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              accounts: {
+                workspace1: { name: "No Token" },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const account = resolveSlackAccount(mockRuntime, "workspace1");
+      // Account is considered configured when botToken exists
+      expect(account.botToken).toBeUndefined();
+      expect(account.botTokenSource).toBe("none");
+    });
+  });
+
+  describe("listEnabledSlackAccounts", () => {
+    it("should only return enabled and configured accounts", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              accounts: {
+                enabled1: { enabled: true, botToken: "xoxb-1" },
+                disabled: { enabled: false, botToken: "xoxb-2" },
+                unconfigured: { enabled: true },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      const accounts = listEnabledSlackAccounts(mockRuntime);
+      expect(accounts.length).toBe(1);
+      expect(accounts[0].accountId).toBe("enabled1");
+    });
+  });
+
+  describe("isMultiAccountEnabled", () => {
+    it("should return false for single account", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              botToken: "xoxb-single",
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      expect(isMultiAccountEnabled(mockRuntime)).toBe(false);
+    });
+
+    it("should return true for multiple accounts", () => {
+      const mockRuntime = {
+        character: {
+          settings: {
+            slack: {
+              accounts: {
+                workspace1: { enabled: true, botToken: "xoxb-ws1" },
+                workspace2: { enabled: true, botToken: "xoxb-ws2" },
+              },
+            },
+          },
+        },
+        getSetting: vi.fn().mockReturnValue(undefined),
+      } as unknown as IAgentRuntime;
+
+      expect(isMultiAccountEnabled(mockRuntime)).toBe(true);
+    });
+  });
+});

--- a/plugins/plugin-slack/__tests__/formatting.test.ts
+++ b/plugins/plugin-slack/__tests__/formatting.test.ts
@@ -1,0 +1,589 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSlackMessagePermalink,
+  chunkSlackText,
+  escapeSlackMrkdwn,
+  extractChannelIdFromMention,
+  extractUrlFromSlackLink,
+  extractUserIdFromMention,
+  formatSlackChannel,
+  formatSlackChannelMention,
+  formatSlackDate,
+  formatSlackLink,
+  formatSlackSpecialMention,
+  formatSlackUserDisplayName,
+  formatSlackUserGroupMention,
+  formatSlackUserMention,
+  getChannelTypeString,
+  isDirectMessage,
+  isGroupDm,
+  isPrivateChannel,
+  markdownToSlackMrkdwn,
+  markdownToSlackMrkdwnChunks,
+  parseSlackMessagePermalink,
+  resolveSlackSystemLocation,
+  stripSlackFormatting,
+  truncateText,
+} from "../src/formatting";
+import type { SlackChannel, SlackUser } from "../src/types";
+
+/**
+ * Tests for Slack formatting utilities
+ */
+describe("Slack Formatting", () => {
+  describe("escapeSlackMrkdwn", () => {
+    it("should return unchanged text when no special characters", () => {
+      expect(escapeSlackMrkdwn("Hello world")).toBe("Hello world");
+    });
+
+    it("should escape ampersands", () => {
+      expect(escapeSlackMrkdwn("A & B")).toBe("A &amp; B");
+    });
+
+    it("should escape less-than signs", () => {
+      expect(escapeSlackMrkdwn("a < b")).toBe("a &lt; b");
+    });
+
+    it("should escape greater-than signs", () => {
+      expect(escapeSlackMrkdwn("a > b")).toBe("a &gt; b");
+    });
+
+    it("should preserve valid Slack user mentions", () => {
+      expect(escapeSlackMrkdwn("Hello <@U123ABC>!")).toBe("Hello <@U123ABC>!");
+    });
+
+    it("should preserve valid Slack channel mentions", () => {
+      expect(escapeSlackMrkdwn("Check <#C123ABC>")).toBe("Check <#C123ABC>");
+    });
+
+    it("should preserve valid Slack links", () => {
+      expect(escapeSlackMrkdwn("Visit <https://example.com|Link>")).toBe(
+        "Visit <https://example.com|Link>",
+      );
+    });
+
+    it("should preserve valid Slack special mentions", () => {
+      expect(escapeSlackMrkdwn("Hey <!here>")).toBe("Hey <!here>");
+      expect(escapeSlackMrkdwn("Hey <!channel>")).toBe("Hey <!channel>");
+      expect(escapeSlackMrkdwn("Hey <!everyone>")).toBe("Hey <!everyone>");
+    });
+
+    it("should escape invalid angle brackets", () => {
+      expect(escapeSlackMrkdwn("<invalid>")).toBe("&lt;invalid&gt;");
+    });
+
+    it("should handle blockquotes specially", () => {
+      expect(escapeSlackMrkdwn("> Quote with & special")).toBe(
+        "> Quote with &amp; special",
+      );
+    });
+
+    it("should handle empty string", () => {
+      expect(escapeSlackMrkdwn("")).toBe("");
+    });
+
+    it("should handle multiple special characters", () => {
+      expect(escapeSlackMrkdwn("a & b < c > d")).toBe(
+        "a &amp; b &lt; c &gt; d",
+      );
+    });
+  });
+
+  describe("markdownToSlackMrkdwn", () => {
+    it("should return empty string for empty input", () => {
+      expect(markdownToSlackMrkdwn("")).toBe("");
+    });
+
+    it("should convert bold markdown to Slack bold", () => {
+      expect(markdownToSlackMrkdwn("This is **bold** text")).toBe(
+        "This is *bold* text",
+      );
+    });
+
+    it("should convert italic markdown to Slack italic", () => {
+      expect(markdownToSlackMrkdwn("This is *italic* text")).toBe(
+        "This is _italic_ text",
+      );
+    });
+
+    it("should convert strikethrough markdown to Slack strikethrough", () => {
+      expect(markdownToSlackMrkdwn("This is ~~strikethrough~~ text")).toBe(
+        "This is ~strikethrough~ text",
+      );
+    });
+
+    it("should convert markdown links to Slack links", () => {
+      expect(markdownToSlackMrkdwn("Click [here](https://example.com)")).toBe(
+        "Click <https://example.com|here>",
+      );
+    });
+
+    it("should simplify links where text matches URL", () => {
+      expect(
+        markdownToSlackMrkdwn("[https://example.com](https://example.com)"),
+      ).toBe("<https://example.com>");
+    });
+
+    it("should convert markdown headers to bold", () => {
+      expect(markdownToSlackMrkdwn("# Header 1")).toBe("*Header 1*");
+      expect(markdownToSlackMrkdwn("## Header 2")).toBe("*Header 2*");
+      expect(markdownToSlackMrkdwn("### Header 3")).toBe("*Header 3*");
+    });
+
+    it("should convert code blocks without language hint", () => {
+      expect(markdownToSlackMrkdwn("```javascript\ncode\n```")).toBe(
+        "```\ncode\n```",
+      );
+    });
+
+    it("should handle mixed formatting", () => {
+      const result = markdownToSlackMrkdwn(
+        "**Bold** and *italic* and ~~strike~~ and [link](https://x.com)",
+      );
+      expect(result).toBe(
+        "*Bold* and _italic_ and ~strike~ and <https://x.com|link>",
+      );
+    });
+  });
+
+  describe("chunkSlackText", () => {
+    it("should return empty array for empty text", () => {
+      expect(chunkSlackText("")).toEqual([]);
+    });
+
+    it("should return whitespace text as single chunk", () => {
+      expect(chunkSlackText("   ")).toEqual(["   "]);
+    });
+
+    it("should return single chunk for short text", () => {
+      expect(chunkSlackText("Hello world")).toEqual(["Hello world"]);
+    });
+
+    it("should return single chunk for text at max length", () => {
+      const text = "a".repeat(4000);
+      expect(chunkSlackText(text, 4000)).toEqual([text]);
+    });
+
+    it("should split long text into multiple chunks", () => {
+      const text = "a".repeat(5000);
+      const chunks = chunkSlackText(text, 2000);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.every((c) => c.length <= 2000)).toBe(true);
+    });
+
+    it("should prefer breaking at newlines", () => {
+      const text = "Line 1\n".repeat(100);
+      const chunks = chunkSlackText(text, 100);
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it("should handle code blocks when splitting", () => {
+      const codeBlock = `\`\`\`\n${"code line\n".repeat(500)}\`\`\``;
+      const chunks = chunkSlackText(codeBlock, 1000);
+      // Each chunk should be properly closed/opened
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe("markdownToSlackMrkdwnChunks", () => {
+    it("should convert and chunk markdown", () => {
+      const markdown = "**Bold** ".repeat(500);
+      const chunks = markdownToSlackMrkdwnChunks(markdown, 100);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.every((c) => c.includes("*"))).toBe(true);
+    });
+  });
+
+  describe("Mention Formatting", () => {
+    it("should format user mention correctly", () => {
+      expect(formatSlackUserMention("U123ABC")).toBe("<@U123ABC>");
+    });
+
+    it("should format channel mention correctly", () => {
+      expect(formatSlackChannelMention("C123ABC")).toBe("<#C123ABC>");
+    });
+
+    it("should format user group mention correctly", () => {
+      expect(formatSlackUserGroupMention("S123ABC")).toBe("<!subteam^S123ABC>");
+    });
+
+    it("should format special mentions correctly", () => {
+      expect(formatSlackSpecialMention("here")).toBe("<!here>");
+      expect(formatSlackSpecialMention("channel")).toBe("<!channel>");
+      expect(formatSlackSpecialMention("everyone")).toBe("<!everyone>");
+    });
+  });
+
+  describe("Link Formatting", () => {
+    it("should format simple link", () => {
+      expect(formatSlackLink("https://example.com")).toBe(
+        "<https://example.com>",
+      );
+    });
+
+    it("should format link with text", () => {
+      expect(formatSlackLink("https://example.com", "Example")).toBe(
+        "<https://example.com|Example>",
+      );
+    });
+
+    it("should not add text when it matches URL", () => {
+      expect(
+        formatSlackLink("https://example.com", "https://example.com"),
+      ).toBe("<https://example.com>");
+    });
+
+    it("should escape special characters in link", () => {
+      expect(formatSlackLink("https://example.com?a=1&b=2")).toBe(
+        "<https://example.com?a=1&amp;b=2>",
+      );
+    });
+  });
+
+  describe("Date Formatting", () => {
+    it("should format date with default format", () => {
+      const timestamp = 1704067200000; // Jan 1, 2024 00:00:00 UTC
+      const result = formatSlackDate(timestamp);
+      expect(result).toMatch(/<!date\^\d+\^/);
+    });
+
+    it("should format date with custom format", () => {
+      const timestamp = new Date("2024-01-01");
+      const result = formatSlackDate(timestamp, "{date_long}");
+      expect(result).toContain("{date_long}");
+    });
+
+    it("should include fallback text", () => {
+      const timestamp = 1704067200000;
+      const result = formatSlackDate(timestamp, "{date}", "Jan 1, 2024");
+      expect(result).toContain("|Jan 1, 2024>");
+    });
+  });
+
+  describe("Mention Extraction", () => {
+    describe("extractUserIdFromMention", () => {
+      it("should extract user ID from simple mention", () => {
+        expect(extractUserIdFromMention("<@U123ABC>")).toBe("U123ABC");
+      });
+
+      it("should extract user ID from mention with display name", () => {
+        expect(extractUserIdFromMention("<@U123ABC|john>")).toBe("U123ABC");
+      });
+
+      it("should extract W-prefixed user ID", () => {
+        expect(extractUserIdFromMention("<@W123ABC>")).toBe("W123ABC");
+      });
+
+      it("should return null for invalid mention", () => {
+        expect(extractUserIdFromMention("@U123ABC")).toBeNull();
+        expect(extractUserIdFromMention("<#C123ABC>")).toBeNull();
+        expect(extractUserIdFromMention("U123ABC")).toBeNull();
+      });
+    });
+
+    describe("extractChannelIdFromMention", () => {
+      it("should extract channel ID from mention", () => {
+        expect(extractChannelIdFromMention("<#C123ABC>")).toBe("C123ABC");
+      });
+
+      it("should extract channel ID with name", () => {
+        expect(extractChannelIdFromMention("<#C123ABC|general>")).toBe(
+          "C123ABC",
+        );
+      });
+
+      it("should extract G-prefixed channel ID", () => {
+        expect(extractChannelIdFromMention("<#G123ABC>")).toBe("G123ABC");
+      });
+
+      it("should extract D-prefixed DM ID", () => {
+        expect(extractChannelIdFromMention("<#D123ABC>")).toBe("D123ABC");
+      });
+
+      it("should return null for invalid mention", () => {
+        expect(extractChannelIdFromMention("#C123ABC")).toBeNull();
+        expect(extractChannelIdFromMention("<@U123ABC>")).toBeNull();
+      });
+    });
+
+    describe("extractUrlFromSlackLink", () => {
+      it("should extract URL from simple link", () => {
+        expect(extractUrlFromSlackLink("<https://example.com>")).toBe(
+          "https://example.com",
+        );
+      });
+
+      it("should extract URL from link with text", () => {
+        expect(
+          extractUrlFromSlackLink("<https://example.com|Click here>"),
+        ).toBe("https://example.com");
+      });
+
+      it("should return null for invalid link", () => {
+        expect(extractUrlFromSlackLink("https://example.com")).toBeNull();
+        expect(extractUrlFromSlackLink("<@U123>")).toBeNull();
+      });
+    });
+  });
+
+  describe("Channel Type Functions", () => {
+    const dmChannel: SlackChannel = {
+      id: "D123",
+      name: "",
+      isIm: true,
+      isMpim: false,
+      isPrivate: false,
+      isGroup: false,
+    };
+
+    const groupDmChannel: SlackChannel = {
+      id: "G123",
+      name: "mpdm-group",
+      isIm: false,
+      isMpim: true,
+      isPrivate: false,
+      isGroup: false,
+    };
+
+    const privateChannel: SlackChannel = {
+      id: "G456",
+      name: "private-channel",
+      isIm: false,
+      isMpim: false,
+      isPrivate: true,
+      isGroup: true,
+    };
+
+    const publicChannel: SlackChannel = {
+      id: "C123",
+      name: "general",
+      isIm: false,
+      isMpim: false,
+      isPrivate: false,
+      isGroup: false,
+    };
+
+    describe("isDirectMessage", () => {
+      it("should return true for DM", () => {
+        expect(isDirectMessage(dmChannel)).toBe(true);
+      });
+
+      it("should return false for non-DM", () => {
+        expect(isDirectMessage(publicChannel)).toBe(false);
+        expect(isDirectMessage(groupDmChannel)).toBe(false);
+      });
+    });
+
+    describe("isGroupDm", () => {
+      it("should return true for group DM", () => {
+        expect(isGroupDm(groupDmChannel)).toBe(true);
+      });
+
+      it("should return false for non-group DM", () => {
+        expect(isGroupDm(dmChannel)).toBe(false);
+        expect(isGroupDm(publicChannel)).toBe(false);
+      });
+    });
+
+    describe("isPrivateChannel", () => {
+      it("should return true for private channel", () => {
+        expect(isPrivateChannel(privateChannel)).toBe(true);
+      });
+
+      it("should return false for public channel", () => {
+        expect(isPrivateChannel(publicChannel)).toBe(false);
+      });
+    });
+
+    describe("getChannelTypeString", () => {
+      it("should return correct type strings", () => {
+        expect(getChannelTypeString(dmChannel)).toBe("DM");
+        expect(getChannelTypeString(groupDmChannel)).toBe("Group DM");
+        expect(getChannelTypeString(privateChannel)).toBe("Private Channel");
+        expect(getChannelTypeString(publicChannel)).toBe("Channel");
+      });
+    });
+
+    describe("formatSlackChannel", () => {
+      it("should format DM", () => {
+        expect(formatSlackChannel(dmChannel)).toBe("Direct Message");
+      });
+
+      it("should format group DM with name", () => {
+        expect(formatSlackChannel(groupDmChannel)).toBe("Group DM: mpdm-group");
+      });
+
+      it("should format channel with # prefix", () => {
+        expect(formatSlackChannel(publicChannel)).toBe("#general");
+      });
+    });
+  });
+
+  describe("User Display Name", () => {
+    it("should prefer display name", () => {
+      const user: SlackUser = {
+        id: "U123",
+        name: "john",
+        profile: {
+          displayName: "John Doe",
+          realName: "Jonathan Doe",
+        },
+      };
+      expect(formatSlackUserDisplayName(user)).toBe("John Doe");
+    });
+
+    it("should fall back to real name", () => {
+      const user: SlackUser = {
+        id: "U123",
+        name: "john",
+        profile: {
+          displayName: "",
+          realName: "Jonathan Doe",
+        },
+      };
+      expect(formatSlackUserDisplayName(user)).toBe("Jonathan Doe");
+    });
+
+    it("should fall back to username", () => {
+      const user: SlackUser = {
+        id: "U123",
+        name: "john",
+        profile: {
+          displayName: "",
+          realName: "",
+        },
+      };
+      expect(formatSlackUserDisplayName(user)).toBe("john");
+    });
+  });
+
+  describe("System Location", () => {
+    it("should include team name when provided", () => {
+      const channel: SlackChannel = {
+        id: "C123",
+        name: "general",
+        isIm: false,
+        isMpim: false,
+        isPrivate: false,
+        isGroup: false,
+      };
+      expect(resolveSlackSystemLocation(channel, "Acme Corp")).toBe(
+        "Acme Corp - Channel: #general",
+      );
+    });
+
+    it("should work without team name", () => {
+      const channel: SlackChannel = {
+        id: "C123",
+        name: "general",
+        isIm: false,
+        isMpim: false,
+        isPrivate: false,
+        isGroup: false,
+      };
+      expect(resolveSlackSystemLocation(channel)).toBe("Channel: #general");
+    });
+  });
+
+  describe("truncateText", () => {
+    it("should not truncate short text", () => {
+      expect(truncateText("Hello", 10)).toBe("Hello");
+    });
+
+    it("should truncate long text with ellipsis", () => {
+      expect(truncateText("Hello World", 8)).toBe("Hello W…");
+    });
+
+    it("should handle text exactly at max length", () => {
+      expect(truncateText("Hello", 5)).toBe("Hello");
+    });
+
+    it("should handle very short max length", () => {
+      expect(truncateText("Hello", 2)).toBe("H…");
+    });
+  });
+
+  describe("stripSlackFormatting", () => {
+    it("should remove bold formatting", () => {
+      expect(stripSlackFormatting("*bold*")).toBe("bold");
+    });
+
+    it("should remove italic formatting", () => {
+      expect(stripSlackFormatting("_italic_")).toBe("italic");
+    });
+
+    it("should remove strikethrough formatting", () => {
+      expect(stripSlackFormatting("~strike~")).toBe("strike");
+    });
+
+    it("should remove inline code", () => {
+      expect(stripSlackFormatting("`code`")).toBe("code");
+    });
+
+    it("should remove code blocks", () => {
+      expect(stripSlackFormatting("```code```")).toBe("");
+      expect(stripSlackFormatting("```\ncode\n```")).toBe("");
+    });
+
+    it("should remove user mentions", () => {
+      expect(stripSlackFormatting("<@U123>")).toBe("");
+      expect(stripSlackFormatting("<@U123|john>")).toBe("");
+    });
+
+    it("should remove channel mentions", () => {
+      expect(stripSlackFormatting("<#C123>")).toBe("");
+      expect(stripSlackFormatting("<#C123|general>")).toBe("");
+    });
+
+    it("should extract link text", () => {
+      expect(stripSlackFormatting("<https://example.com|Click here>")).toBe(
+        "Click here",
+      );
+    });
+
+    it("should unescape HTML entities", () => {
+      expect(stripSlackFormatting("&amp; &lt; &gt;")).toBe("& < >");
+    });
+  });
+
+  describe("Message Permalink", () => {
+    describe("buildSlackMessagePermalink", () => {
+      it("should build valid permalink", () => {
+        const permalink = buildSlackMessagePermalink(
+          "acme",
+          "C123ABC",
+          "1234567890.123456",
+        );
+        expect(permalink).toBe(
+          "https://acme.slack.com/archives/C123ABC/p1234567890123456",
+        );
+      });
+    });
+
+    describe("parseSlackMessagePermalink", () => {
+      it("should parse valid permalink", () => {
+        const result = parseSlackMessagePermalink(
+          "https://acme.slack.com/archives/C123ABC/p1234567890123456",
+        );
+        expect(result).toEqual({
+          workspaceDomain: "acme",
+          channelId: "C123ABC",
+          messageTs: "1234567890.123456",
+        });
+      });
+
+      it("should return null for invalid permalink", () => {
+        expect(parseSlackMessagePermalink("https://example.com")).toBeNull();
+        expect(parseSlackMessagePermalink("not a url")).toBeNull();
+      });
+
+      it("should handle http and https", () => {
+        expect(
+          parseSlackMessagePermalink(
+            "http://acme.slack.com/archives/C123/p1234567890123456",
+          ),
+        ).not.toBeNull();
+      });
+    });
+  });
+});

--- a/plugins/plugin-slack/build.ts
+++ b/plugins/plugin-slack/build.ts
@@ -1,0 +1,26 @@
+import { build } from "bun";
+
+await build({
+  entrypoints: ["./src/index.ts"],
+  outdir: "./dist",
+  target: "node",
+  format: "esm",
+  splitting: false,
+  sourcemap: "external",
+  minify: false,
+  external: ["@elizaos/core", "@slack/bolt", "@slack/web-api", "zod"],
+});
+
+// Generate type declarations
+const proc = Bun.spawn(
+  ["bunx", "tsc", "--emitDeclarationOnly", "--declaration", "--declarationMap"],
+  {
+    cwd: import.meta.dir,
+    stdout: "inherit",
+    stderr: "inherit",
+  },
+);
+
+await proc.exited;
+
+console.log("Build complete!");

--- a/plugins/plugin-slack/package.json
+++ b/plugins/plugin-slack/package.json
@@ -1,0 +1,111 @@
+{
+	"name": "@elizaos/plugin-slack",
+	"version": "2.0.0-alpha.537",
+	"description": "Slack integration plugin for elizaOS agents with Socket Mode support",
+	"type": "module",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"sideEffects": false,
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/elizaos-plugins/plugin-slack.git"
+	},
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"keywords": [
+		"elizaos",
+		"plugin",
+		"slack",
+		"chat",
+		"messaging"
+	],
+	"author": "elizaOS",
+	"license": "MIT",
+	"scripts": {
+		"build": "bun run build.ts",
+		"build:ts": "bun run build.ts",
+		"dev": "bun --hot build.ts",
+		"clean": "rm -rf dist .turbo node_modules",
+		"test": "vitest run --passWithNoTests",
+		"typecheck": "tsc --noEmit",
+		"lint": "../../node_modules/.bin/biome check --write --unsafe .",
+		"lint:check": "../../node_modules/.bin/biome check .",
+		"format": "../../node_modules/.bin/biome format --write .",
+		"format:check": "../../node_modules/.bin/biome format ."
+	},
+	"dependencies": {
+		"@elizaos/core": "workspace:*",
+		"@slack/bolt": "^4.1.0",
+		"@slack/web-api": "^7.7.0",
+		"zod": "^4.4.2"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.14",
+		"@types/node": "^25.0.3",
+		"typescript": "^6.0.0",
+		"vitest": "^4.1.4"
+	},
+	"peerDependencies": {
+		"@elizaos/core": "workspace:*"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"agentConfig": {
+		"pluginType": "elizaos:plugin:1.0.0",
+		"pluginParameters": {
+			"SLACK_BOT_TOKEN": {
+				"type": "string",
+				"description": "Slack Bot Token (xoxb-...) for API authentication",
+				"required": true,
+				"sensitive": true
+			},
+			"SLACK_APP_TOKEN": {
+				"type": "string",
+				"description": "Slack App Token (xapp-...) for Socket Mode connections",
+				"required": true,
+				"sensitive": true
+			},
+			"SLACK_SIGNING_SECRET": {
+				"type": "string",
+				"description": "Slack Signing Secret for verifying requests",
+				"required": false,
+				"sensitive": true
+			},
+			"SLACK_USER_TOKEN": {
+				"type": "string",
+				"description": "Optional User Token (xoxp-...) for enhanced permissions",
+				"required": false,
+				"sensitive": true
+			},
+			"SLACK_CHANNEL_IDS": {
+				"type": "string",
+				"description": "Comma-separated list of channel IDs to restrict the bot to",
+				"required": false,
+				"sensitive": false
+			},
+			"SLACK_SHOULD_IGNORE_BOT_MESSAGES": {
+				"type": "boolean",
+				"description": "If true, the bot will ignore messages from other bots",
+				"required": false,
+				"sensitive": false
+			},
+			"SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS": {
+				"type": "boolean",
+				"description": "If true, the bot will only respond when mentioned",
+				"required": false,
+				"sensitive": false
+			}
+		}
+	}
+}

--- a/plugins/plugin-slack/src/accounts.ts
+++ b/plugins/plugin-slack/src/accounts.ts
@@ -1,0 +1,421 @@
+import type { IAgentRuntime } from "@elizaos/core";
+
+/**
+ * Default account identifier used when no specific account is configured
+ */
+export const DEFAULT_ACCOUNT_ID = "default";
+
+/**
+ * Source of the Slack token
+ */
+export type SlackTokenSource = "env" | "config" | "character" | "none";
+
+/**
+ * DM-specific configuration
+ */
+export interface SlackDmConfig {
+  /** If false, ignore all incoming Slack DMs */
+  enabled?: boolean;
+  /** Direct message access policy */
+  policy?: "open" | "disabled" | "allowlist";
+  /** Allowlist for DM senders (ids or names) */
+  allowFrom?: Array<string | number>;
+  /** Reply-to mode for DMs */
+  replyToMode?: "off" | "first" | "all";
+}
+
+/**
+ * Channel-specific configuration
+ */
+export interface SlackChannelConfig {
+  /** If false, ignore this channel */
+  enabled?: boolean;
+  /** Require bot mention to respond */
+  requireMention?: boolean;
+  /** User allowlist for this channel */
+  users?: Array<string | number>;
+  /** Reply-to mode for this channel */
+  replyToMode?: "off" | "first" | "all";
+}
+
+/**
+ * Reaction notification mode
+ */
+export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+
+/**
+ * Slash command configuration
+ */
+export interface SlackSlashCommandConfig {
+  /** Enable slash commands */
+  enabled?: boolean;
+  /** Slash command name (without leading /) */
+  command?: string;
+}
+
+/**
+ * Action toggles for Slack features
+ */
+export interface SlackActionConfig {
+  /** Enable reactions */
+  reactions?: boolean;
+  /** Enable pins */
+  pins?: boolean;
+  /** Enable file uploads */
+  files?: boolean;
+  /** Enable message editing */
+  edit?: boolean;
+  /** Enable message deletion */
+  delete?: boolean;
+  /** Enable emoji list */
+  emojiList?: boolean;
+  /** Enable member info */
+  memberInfo?: boolean;
+}
+
+/**
+ * Configuration for a single Slack account
+ */
+export interface SlackAccountConfig {
+  /** Optional display name for this account */
+  name?: string;
+  /** If false, do not start this Slack account */
+  enabled?: boolean;
+  /** Slack bot token (xoxb-...) */
+  botToken?: string;
+  /** Slack app-level token (xapp-...) */
+  appToken?: string;
+  /** Slack signing secret */
+  signingSecret?: string;
+  /** Slack user token (xoxp-...) for user actions */
+  userToken?: string;
+  /** Controls how channel messages are handled */
+  groupPolicy?: "open" | "disabled" | "allowlist";
+  /** Outbound text chunk size (chars) */
+  textChunkLimit?: number;
+  /** Max media size in MB */
+  mediaMaxMb?: number;
+  /** Reaction notification mode */
+  reactionNotifications?: SlackReactionNotificationMode;
+  /** Reaction allowlist when mode is 'allowlist' */
+  reactionAllowlist?: Array<string | number>;
+  /** Reply-to mode */
+  replyToMode?: "off" | "first" | "all";
+  /** Reply-to mode by chat type */
+  replyToModeByChatType?: Record<string, "off" | "first" | "all">;
+  /** Per-action toggles */
+  actions?: SlackActionConfig;
+  /** Slash command configuration */
+  slashCommand?: SlackSlashCommandConfig;
+  /** DM configuration */
+  dm?: SlackDmConfig;
+  /** Per-channel configuration keyed by channel ID */
+  channels?: Record<string, SlackChannelConfig>;
+  /** Allowed channel IDs */
+  allowedChannelIds?: string[];
+  /** Whether to ignore bot messages */
+  shouldIgnoreBotMessages?: boolean;
+  /** Whether to respond only to mentions */
+  shouldRespondOnlyToMentions?: boolean;
+}
+
+/**
+ * Multi-account Slack configuration structure
+ */
+export interface SlackMultiAccountConfig {
+  /** Default/base configuration applied to all accounts */
+  enabled?: boolean;
+  botToken?: string;
+  appToken?: string;
+  /** Per-account configuration overrides */
+  accounts?: Record<string, SlackAccountConfig>;
+}
+
+/**
+ * Resolved Slack account with all configuration merged
+ */
+export interface ResolvedSlackAccount {
+  accountId: string;
+  enabled: boolean;
+  name?: string;
+  botToken?: string;
+  appToken?: string;
+  signingSecret?: string;
+  userToken?: string;
+  botTokenSource: SlackTokenSource;
+  appTokenSource: SlackTokenSource;
+  config: SlackAccountConfig;
+}
+
+/**
+ * Normalizes an account ID, returning the default if not provided
+ */
+export function normalizeAccountId(accountId?: string | null): string {
+  if (!accountId || typeof accountId !== "string") {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  const trimmed = accountId.trim().toLowerCase();
+  return trimmed || DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Validates and normalizes a Slack token with the expected prefix
+ */
+function normalizeSlackToken(
+  raw: string | null | undefined,
+  prefix: string,
+): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed?.startsWith(prefix) ? trimmed : undefined;
+}
+
+/**
+ * Validates and normalizes a Slack bot token (xoxb-)
+ */
+export function resolveSlackBotToken(raw?: string | null): string | undefined {
+  return normalizeSlackToken(raw, "xoxb-");
+}
+
+/**
+ * Validates and normalizes a Slack app token (xapp-)
+ */
+export function resolveSlackAppToken(raw?: string | null): string | undefined {
+  return normalizeSlackToken(raw, "xapp-");
+}
+
+/**
+ * Validates and normalizes a Slack user token (xoxp-)
+ */
+export function resolveSlackUserToken(raw?: string | null): string | undefined {
+  return normalizeSlackToken(raw, "xoxp-");
+}
+
+/**
+ * Gets the multi-account configuration from runtime settings
+ */
+export function getMultiAccountConfig(
+  runtime: IAgentRuntime,
+): SlackMultiAccountConfig {
+  const characterSlack = runtime.character?.settings?.slack as
+    | SlackMultiAccountConfig
+    | undefined;
+
+  return {
+    enabled: characterSlack?.enabled,
+    botToken: characterSlack?.botToken,
+    appToken: characterSlack?.appToken,
+    accounts: characterSlack?.accounts,
+  };
+}
+
+/**
+ * Lists all configured account IDs
+ */
+export function listSlackAccountIds(runtime: IAgentRuntime): string[] {
+  const config = getMultiAccountConfig(runtime);
+  const accounts = config.accounts;
+
+  if (!accounts || typeof accounts !== "object") {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+
+  const ids = Object.keys(accounts).filter(Boolean);
+  if (ids.length === 0) {
+    return [DEFAULT_ACCOUNT_ID];
+  }
+
+  return ids.slice().sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Resolves the default account ID to use
+ */
+export function resolveDefaultSlackAccountId(runtime: IAgentRuntime): string {
+  const ids = listSlackAccountIds(runtime);
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+}
+
+/**
+ * Gets the account-specific configuration
+ */
+function getAccountConfig(
+  runtime: IAgentRuntime,
+  accountId: string,
+): SlackAccountConfig | undefined {
+  const config = getMultiAccountConfig(runtime);
+  const accounts = config.accounts;
+
+  if (!accounts || typeof accounts !== "object") {
+    return undefined;
+  }
+
+  return accounts[accountId];
+}
+
+/**
+ * Merges base configuration with account-specific overrides
+ */
+/**
+ * Removes undefined values from an object to prevent them from overwriting during spread
+ */
+function filterDefined<T extends object>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as Partial<T>;
+}
+
+function mergeSlackAccountConfig(
+  runtime: IAgentRuntime,
+  accountId: string,
+): SlackAccountConfig {
+  const multiConfig = getMultiAccountConfig(runtime);
+  const { accounts: _ignored, ...baseConfig } = multiConfig;
+  const accountConfig = getAccountConfig(runtime, accountId) ?? {};
+
+  // Get environment/runtime settings for the base config
+  const envChannelIds = runtime.getSetting("SLACK_CHANNEL_IDS") as
+    | string
+    | undefined;
+
+  const envConfig: SlackAccountConfig = {
+    shouldIgnoreBotMessages:
+      (
+        runtime.getSetting("SLACK_SHOULD_IGNORE_BOT_MESSAGES") as string
+      )?.toLowerCase() === "true",
+    shouldRespondOnlyToMentions:
+      (
+        runtime.getSetting("SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS") as string
+      )?.toLowerCase() === "true",
+    allowedChannelIds: envChannelIds
+      ? envChannelIds
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined,
+  };
+
+  // Merge order: env defaults < base config < account config
+  // Filter undefined values to prevent them from overwriting defined values
+  return {
+    ...filterDefined(envConfig),
+    ...filterDefined(baseConfig),
+    ...filterDefined(accountConfig),
+  };
+}
+
+/**
+ * Resolves a complete Slack account configuration
+ */
+export function resolveSlackAccount(
+  runtime: IAgentRuntime,
+  accountId?: string | null,
+): ResolvedSlackAccount {
+  const normalizedAccountId = normalizeAccountId(accountId);
+  const multiConfig = getMultiAccountConfig(runtime);
+
+  const baseEnabled = multiConfig.enabled !== false;
+  const merged = mergeSlackAccountConfig(runtime, normalizedAccountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+
+  const allowEnv = normalizedAccountId === DEFAULT_ACCOUNT_ID;
+
+  // Resolve bot token
+  const envBotToken = allowEnv
+    ? resolveSlackBotToken(runtime.getSetting("SLACK_BOT_TOKEN") as string)
+    : undefined;
+  const configBotToken = resolveSlackBotToken(merged.botToken);
+  const botToken = configBotToken ?? envBotToken;
+  const botTokenSource: SlackTokenSource = configBotToken
+    ? "config"
+    : envBotToken
+      ? "env"
+      : "none";
+
+  // Resolve app token
+  const envAppToken = allowEnv
+    ? resolveSlackAppToken(runtime.getSetting("SLACK_APP_TOKEN") as string)
+    : undefined;
+  const configAppToken = resolveSlackAppToken(merged.appToken);
+  const appToken = configAppToken ?? envAppToken;
+  const appTokenSource: SlackTokenSource = configAppToken
+    ? "config"
+    : envAppToken
+      ? "env"
+      : "none";
+
+  // Resolve signing secret
+  const signingSecret =
+    merged.signingSecret ??
+    (runtime.getSetting("SLACK_SIGNING_SECRET") as string);
+
+  // Resolve user token
+  const envUserToken = allowEnv
+    ? resolveSlackUserToken(runtime.getSetting("SLACK_USER_TOKEN") as string)
+    : undefined;
+  const configUserToken = resolveSlackUserToken(merged.userToken);
+  const userToken = configUserToken ?? envUserToken;
+
+  return {
+    accountId: normalizedAccountId,
+    enabled,
+    name: merged.name?.trim() || undefined,
+    botToken,
+    appToken,
+    signingSecret,
+    userToken,
+    botTokenSource,
+    appTokenSource,
+    config: merged,
+  };
+}
+
+/**
+ * Lists all enabled Slack accounts
+ */
+export function listEnabledSlackAccounts(
+  runtime: IAgentRuntime,
+): ResolvedSlackAccount[] {
+  return listSlackAccountIds(runtime)
+    .map((accountId) => resolveSlackAccount(runtime, accountId))
+    .filter((account) => account.enabled && account.botToken);
+}
+
+/**
+ * Checks if multi-account mode is enabled
+ */
+export function isMultiAccountEnabled(runtime: IAgentRuntime): boolean {
+  const accounts = listEnabledSlackAccounts(runtime);
+  return accounts.length > 1;
+}
+
+/**
+ * Resolves the reply-to mode for a specific chat type
+ */
+export function resolveSlackReplyToMode(
+  account: ResolvedSlackAccount,
+  chatType?: string | null,
+): "off" | "first" | "all" {
+  const normalized = chatType?.toLowerCase().trim();
+
+  // Check chat type specific override
+  if (
+    normalized &&
+    account.config.replyToModeByChatType?.[normalized] !== undefined
+  ) {
+    return account.config.replyToModeByChatType[normalized] ?? "off";
+  }
+
+  // Check DM-specific setting
+  if (normalized === "direct" || normalized === "im") {
+    if (account.config.dm?.replyToMode !== undefined) {
+      return account.config.dm.replyToMode;
+    }
+  }
+
+  // Fall back to global setting
+  return account.config.replyToMode ?? "off";
+}

--- a/plugins/plugin-slack/src/actions/deleteMessage.ts
+++ b/plugins/plugin-slack/src/actions/deleteMessage.ts
@@ -1,0 +1,199 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { isValidMessageTs, SLACK_SERVICE_NAME } from "../types";
+
+const deleteMessageTemplate = `You are helping to extract delete message parameters for Slack.
+
+The user wants to delete a Slack message.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. messageTs: The message timestamp to delete (format: 1234567890.123456)
+2. channelId: The channel ID (optional, defaults to current channel)
+
+Respond with a JSON object like:
+{
+  "messageTs": "1234567890.123456",
+  "channelId": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const deleteMessage: Action = {
+  name: "SLACK_DELETE_MESSAGE",
+  similes: ["REMOVE_SLACK_MESSAGE", "DELETE_MESSAGE", "SLACK_REMOVE"],
+  description: "Delete a Slack message",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'delete', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|delete|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: deleteMessageTemplate,
+    });
+
+    let deleteInfo: {
+      messageTs: string;
+      channelId?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.messageTs) {
+        deleteInfo = {
+          messageTs: String(parsedResponse.messageTs),
+          channelId: parsedResponse.channelId
+            ? String(parsedResponse.channelId)
+            : null,
+        };
+        break;
+      }
+    }
+
+    if (!deleteInfo || !deleteInfo.messageTs) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:delete-message" },
+        "[SLACK_DELETE_MESSAGE] Could not extract delete info",
+      );
+      await callback?.({
+        text: "I couldn't understand which message to delete. Please specify the message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract delete parameters" };
+    }
+
+    if (!isValidMessageTs(deleteInfo.messageTs)) {
+      await callback?.({
+        text: "The message timestamp format is invalid. Please provide a valid Slack message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid message timestamp" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+    const channelId = deleteInfo.channelId || room?.channelId;
+
+    if (!channelId) {
+      await callback?.({
+        text: "I couldn't determine the channel for the message deletion.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    await slackService.deleteMessage(channelId, deleteInfo.messageTs);
+
+    const response: Content = {
+      text: "Message deleted successfully.",
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:delete-message",
+        messageTs: deleteInfo.messageTs,
+        channelId,
+      },
+      "[SLACK_DELETE_MESSAGE] Message deleted",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        messageTs: deleteInfo.messageTs,
+        channelId,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Delete that last message I sent",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll delete that message for you.",
+          actions: ["SLACK_DELETE_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default deleteMessage;

--- a/plugins/plugin-slack/src/actions/editMessage.ts
+++ b/plugins/plugin-slack/src/actions/editMessage.ts
@@ -1,0 +1,213 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { isValidMessageTs, SLACK_SERVICE_NAME } from "../types";
+
+const editMessageTemplate = `You are helping to extract edit message parameters for Slack.
+
+The user wants to edit an existing Slack message.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. messageTs: The message timestamp to edit (format: 1234567890.123456)
+2. newText: The new text content for the message
+3. channelId: The channel ID (optional, defaults to current channel)
+
+Respond with a JSON object like:
+{
+  "messageTs": "1234567890.123456",
+  "newText": "The updated message content",
+  "channelId": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const editMessage: Action = {
+  name: "SLACK_EDIT_MESSAGE",
+  similes: [
+    "UPDATE_SLACK_MESSAGE",
+    "MODIFY_MESSAGE",
+    "CHANGE_MESSAGE",
+    "SLACK_UPDATE",
+  ],
+  description: "Edit an existing Slack message",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'edit', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|edit|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: editMessageTemplate,
+    });
+
+    let editInfo: {
+      messageTs: string;
+      newText: string;
+      channelId?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.messageTs && parsedResponse?.newText) {
+        editInfo = {
+          messageTs: String(parsedResponse.messageTs),
+          newText: String(parsedResponse.newText),
+          channelId: parsedResponse.channelId
+            ? String(parsedResponse.channelId)
+            : null,
+        };
+        break;
+      }
+    }
+
+    if (!editInfo || !editInfo.messageTs || !editInfo.newText) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:edit-message" },
+        "[SLACK_EDIT_MESSAGE] Could not extract edit info",
+      );
+      await callback?.({
+        text: "I couldn't understand the edit request. Please specify the message timestamp and new content.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract edit parameters" };
+    }
+
+    if (!isValidMessageTs(editInfo.messageTs)) {
+      await callback?.({
+        text: "The message timestamp format is invalid. Please provide a valid Slack message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid message timestamp" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+    const channelId = editInfo.channelId || room?.channelId;
+
+    if (!channelId) {
+      await callback?.({
+        text: "I couldn't determine the channel for the message edit.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    await slackService.editMessage(
+      channelId,
+      editInfo.messageTs,
+      editInfo.newText,
+    );
+
+    const response: Content = {
+      text: "Message edited successfully.",
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:edit-message",
+        messageTs: editInfo.messageTs,
+        channelId,
+      },
+      "[SLACK_EDIT_MESSAGE] Message edited",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        messageTs: editInfo.messageTs,
+        channelId,
+        newText: editInfo.newText,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Edit that message to say 'Meeting at 3pm' instead",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll update that message for you.",
+          actions: ["SLACK_EDIT_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default editMessage;

--- a/plugins/plugin-slack/src/actions/emojiList.ts
+++ b/plugins/plugin-slack/src/actions/emojiList.ts
@@ -1,0 +1,186 @@
+import type {
+  Action,
+  ActionExample,
+  ActionResult,
+  Content,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { SLACK_SERVICE_NAME } from "../types";
+
+export const emojiList: Action = {
+  name: "SLACK_EMOJI_LIST",
+  similes: [
+    "LIST_SLACK_EMOJI",
+    "SHOW_EMOJI",
+    "GET_CUSTOM_EMOJI",
+    "CUSTOM_EMOJI",
+    "WORKSPACE_EMOJI",
+  ],
+  description: "List custom emoji available in the Slack workspace",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'emoji', 'list'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|emoji|list)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const emoji = await slackService.getEmojiList();
+    const emojiNames = Object.keys(emoji).sort();
+
+    if (emojiNames.length === 0) {
+      const response: Content = {
+        text: "There are no custom emoji in this workspace.",
+        source: message.content.source,
+      };
+      await callback?.(response);
+
+      return {
+        success: true,
+        data: {
+          emojiCount: 0,
+          emoji: {},
+        },
+      };
+    }
+
+    // Group emoji into chunks for display
+    const _chunkSize = 20;
+    const displayCount = Math.min(emojiNames.length, 100);
+    const displayEmoji = emojiNames.slice(0, displayCount);
+
+    // Detect aliases (emoji that reference other emoji with "alias:")
+    const aliases: string[] = [];
+    const custom: string[] = [];
+
+    for (const name of displayEmoji) {
+      const value = emoji[name];
+      if (value.startsWith("alias:")) {
+        aliases.push(name);
+      } else {
+        custom.push(name);
+      }
+    }
+
+    const emojiDisplay = custom.map((name) => `:${name}:`).join(" ");
+    const aliasDisplay =
+      aliases.length > 0
+        ? `\n\nAliases: ${aliases.map((name) => `:${name}:`).join(" ")}`
+        : "";
+
+    const truncationNote =
+      emojiNames.length > displayCount
+        ? `\n\n(Showing ${displayCount} of ${emojiNames.length} total custom emoji)`
+        : "";
+
+    const response: Content = {
+      text: `Custom emoji in this workspace (${emojiNames.length} total):\n\n${emojiDisplay}${aliasDisplay}${truncationNote}`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:emoji-list",
+        emojiCount: emojiNames.length,
+      },
+      "[SLACK_EMOJI_LIST] Emoji listed",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        emojiCount: emojiNames.length,
+        emoji: Object.fromEntries(
+          displayEmoji.map((name) => [name, emoji[name]]),
+        ),
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Show me the custom emoji in this workspace",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll list the custom emoji available.",
+          actions: ["SLACK_EMOJI_LIST"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "What emoji can I use here?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Let me show you the custom emoji in this workspace.",
+          actions: ["SLACK_EMOJI_LIST"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default emojiList;

--- a/plugins/plugin-slack/src/actions/getUserInfo.ts
+++ b/plugins/plugin-slack/src/actions/getUserInfo.ts
@@ -1,0 +1,248 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import {
+  getSlackUserDisplayName,
+  isValidUserId,
+  SLACK_SERVICE_NAME,
+} from "../types";
+
+const getUserInfoTemplate = `You are helping to extract user info parameters for Slack.
+
+The user wants to get information about a Slack user.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. userId: The Slack user ID to look up (format: U followed by alphanumeric characters, e.g., U0123456789)
+
+Respond with a JSON object like:
+{
+  "userId": "U0123456789"
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const getUserInfo: Action = {
+  name: "SLACK_GET_USER_INFO",
+  similes: [
+    "GET_SLACK_USER",
+    "USER_INFO",
+    "SLACK_USER",
+    "MEMBER_INFO",
+    "WHO_IS",
+  ],
+  description: "Get information about a Slack user",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'get', 'user', 'info'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|get|user|info)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: getUserInfoTemplate,
+    });
+
+    let userInfo: { userId: string } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.userId) {
+        userInfo = {
+          userId: String(parsedResponse.userId),
+        };
+        break;
+      }
+    }
+
+    if (!userInfo || !userInfo.userId) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:get-user-info" },
+        "[SLACK_GET_USER_INFO] Could not extract user info",
+      );
+      await callback?.({
+        text: "I couldn't determine which user to look up. Please specify a user ID.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract user ID" };
+    }
+
+    if (!isValidUserId(userInfo.userId)) {
+      await callback?.({
+        text: "The user ID format is invalid. Slack user IDs start with U followed by alphanumeric characters.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid user ID format" };
+    }
+
+    const user = await slackService.getUser(userInfo.userId);
+
+    if (!user) {
+      await callback?.({
+        text: `I couldn't find a user with ID ${userInfo.userId}.`,
+        source: "slack",
+      });
+      return { success: false, error: "User not found" };
+    }
+
+    const displayName = getSlackUserDisplayName(user);
+    const roles: string[] = [];
+    if (user.isAdmin) roles.push("Admin");
+    if (user.isOwner) roles.push("Owner");
+    if (user.isPrimaryOwner) roles.push("Primary Owner");
+    if (user.isBot) roles.push("Bot");
+    if (user.isRestricted) roles.push("Guest");
+
+    const userDetails = [
+      `**Name:** ${displayName}`,
+      user.profile.realName && user.profile.realName !== displayName
+        ? `**Real Name:** ${user.profile.realName}`
+        : null,
+      `**Username:** @${user.name}`,
+      user.profile.title ? `**Title:** ${user.profile.title}` : null,
+      user.profile.email ? `**Email:** ${user.profile.email}` : null,
+      user.tz ? `**Timezone:** ${user.tzLabel || user.tz}` : null,
+      user.profile.statusText
+        ? `**Status:** ${user.profile.statusEmoji || ""} ${user.profile.statusText}`
+        : null,
+      roles.length > 0 ? `**Roles:** ${roles.join(", ")}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const response: Content = {
+      text: `User information for ${displayName}:\n\n${userDetails}`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:get-user-info",
+        userId: userInfo.userId,
+        displayName,
+      },
+      "[SLACK_GET_USER_INFO] User info retrieved",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        userId: user.id,
+        name: user.name,
+        displayName,
+        realName: user.profile.realName,
+        title: user.profile.title,
+        email: user.profile.email,
+        timezone: user.tz,
+        isAdmin: user.isAdmin,
+        isOwner: user.isOwner,
+        isBot: user.isBot,
+        statusText: user.profile.statusText,
+        statusEmoji: user.profile.statusEmoji,
+        avatar: user.profile.image192 || user.profile.image72,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Who is U0123456789?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Let me look up that user for you.",
+          actions: ["SLACK_GET_USER_INFO"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Get information about the user who sent the last message",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll fetch their profile information.",
+          actions: ["SLACK_GET_USER_INFO"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default getUserInfo;

--- a/plugins/plugin-slack/src/actions/listChannels.ts
+++ b/plugins/plugin-slack/src/actions/listChannels.ts
@@ -1,0 +1,163 @@
+import type {
+  Action,
+  ActionExample,
+  ActionResult,
+  Content,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { SLACK_SERVICE_NAME } from "../types";
+
+export const listChannels: Action = {
+  name: "SLACK_LIST_CHANNELS",
+  similes: [
+    "LIST_SLACK_CHANNELS",
+    "SHOW_CHANNELS",
+    "GET_CHANNELS",
+    "CHANNELS_LIST",
+  ],
+  description: "List available Slack channels in the workspace",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'list', 'channels'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|list|channels)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const channels = await slackService.listChannels({
+      types: "public_channel,private_channel",
+      limit: 100,
+    });
+
+    // Sort channels by name
+    const sortedChannels = channels
+      .filter((ch) => !ch.isArchived)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    // Format channel list
+    const channelList = sortedChannels.map((ch) => {
+      const memberCount =
+        ch.numMembers !== undefined ? ` (${ch.numMembers} members)` : "";
+      const privateIndicator = ch.isPrivate ? " 🔒" : "";
+      const topic = ch.topic?.value
+        ? ` - ${ch.topic.value.slice(0, 50)}${ch.topic.value.length > 50 ? "..." : ""}`
+        : "";
+      return `• #${ch.name}${privateIndicator}${memberCount}${topic}`;
+    });
+
+    const response: Content = {
+      text: `Found ${sortedChannels.length} channels:\n\n${channelList.join("\n")}`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:list-channels",
+        channelCount: sortedChannels.length,
+      },
+      "[SLACK_LIST_CHANNELS] Channels listed",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        channelCount: sortedChannels.length,
+        channels: sortedChannels.map((ch) => ({
+          id: ch.id,
+          name: ch.name,
+          isPrivate: ch.isPrivate,
+          numMembers: ch.numMembers,
+          topic: ch.topic?.value,
+          purpose: ch.purpose?.value,
+        })),
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Show me all the channels in this workspace",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll list all the available channels.",
+          actions: ["SLACK_LIST_CHANNELS"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "What channels can I join?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Let me show you the available channels.",
+          actions: ["SLACK_LIST_CHANNELS"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default listChannels;

--- a/plugins/plugin-slack/src/actions/listPins.ts
+++ b/plugins/plugin-slack/src/actions/listPins.ts
@@ -1,0 +1,253 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { SLACK_SERVICE_NAME } from "../types";
+
+const listPinsTemplate = `You are helping to extract list pins parameters for Slack.
+
+The user wants to see pinned messages in a Slack channel.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. channelRef: The channel to list pins from (default: "current" for the current channel, or a channel name/ID)
+
+Respond with a JSON object like:
+{
+  "channelRef": "current"
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const listPins: Action = {
+  name: "SLACK_LIST_PINS",
+  similes: [
+    "LIST_SLACK_PINS",
+    "SHOW_PINS",
+    "GET_PINNED_MESSAGES",
+    "PINNED_MESSAGES",
+  ],
+  description: "List pinned messages in a Slack channel",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'list', 'pins'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|list|pins)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: listPinsTemplate,
+    });
+
+    let listInfo: { channelRef?: string } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse) {
+        listInfo = {
+          channelRef: parsedResponse.channelRef
+            ? String(parsedResponse.channelRef)
+            : "current",
+        };
+        break;
+      }
+    }
+
+    if (!listInfo) {
+      listInfo = { channelRef: "current" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+
+    if (!room || !room.channelId) {
+      await callback?.({
+        text: "I couldn't determine the current channel.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    let targetChannelId = room.channelId;
+
+    // If a specific channel was referenced (not "current"), try to find it
+    if (listInfo.channelRef && listInfo.channelRef !== "current") {
+      const channels = await slackService.listChannels();
+      const targetChannel = channels.find((ch) => {
+        const channelName = ch.name?.toLowerCase() || "";
+        const searchTerm = listInfo?.channelRef?.toLowerCase() || "";
+        return (
+          channelName === searchTerm ||
+          channelName === searchTerm.replace(/^#/, "") ||
+          ch.id === listInfo?.channelRef
+        );
+      });
+      if (targetChannel) {
+        targetChannelId = targetChannel.id;
+      }
+    }
+
+    const pins = await slackService.listPins(targetChannelId);
+
+    if (pins.length === 0) {
+      const channelInfo = await slackService.getChannel(targetChannelId);
+      const channelName = channelInfo?.name || targetChannelId;
+
+      const response: Content = {
+        text: `There are no pinned messages in #${channelName}.`,
+        source: message.content.source,
+      };
+      await callback?.(response);
+
+      return {
+        success: true,
+        data: {
+          channelId: targetChannelId,
+          pinCount: 0,
+          pins: [],
+        },
+      };
+    }
+
+    // Format pinned messages
+    const formattedPins = pins.map((pin, index) => {
+      const timestamp = new Date(parseFloat(pin.ts) * 1000).toISOString();
+      const user = pin.user || "unknown";
+      const text = pin.text?.slice(0, 100) || "[no text]";
+      const truncated = pin.text && pin.text.length > 100 ? "..." : "";
+      return `${index + 1}. [${timestamp}] ${user}: ${text}${truncated}`;
+    });
+
+    const channelInfo = await slackService.getChannel(targetChannelId);
+    const channelName = channelInfo?.name || targetChannelId;
+
+    const response: Content = {
+      text: `Pinned messages in #${channelName} (${pins.length}):\n\n${formattedPins.join("\n\n")}`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:list-pins",
+        channelId: targetChannelId,
+        pinCount: pins.length,
+      },
+      "[SLACK_LIST_PINS] Pins listed",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        channelId: targetChannelId,
+        channelName,
+        pinCount: pins.length,
+        pins: pins.map((p) => ({
+          ts: p.ts,
+          user: p.user,
+          text: p.text,
+        })),
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Show me the pinned messages in this channel",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll list the pinned messages.",
+          actions: ["SLACK_LIST_PINS"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "What's pinned in #announcements?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Let me check the pins in #announcements.",
+          actions: ["SLACK_LIST_PINS"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default listPins;

--- a/plugins/plugin-slack/src/actions/pinMessage.ts
+++ b/plugins/plugin-slack/src/actions/pinMessage.ts
@@ -1,0 +1,199 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { isValidMessageTs, SLACK_SERVICE_NAME } from "../types";
+
+const pinMessageTemplate = `You are helping to extract pin message parameters for Slack.
+
+The user wants to pin a message in a Slack channel.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. messageTs: The message timestamp to pin (format: 1234567890.123456)
+2. channelId: The channel ID (optional, defaults to current channel)
+
+Respond with a JSON object like:
+{
+  "messageTs": "1234567890.123456",
+  "channelId": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const pinMessage: Action = {
+  name: "SLACK_PIN_MESSAGE",
+  similes: ["PIN_SLACK_MESSAGE", "PIN_MESSAGE", "SLACK_PIN", "SAVE_MESSAGE"],
+  description: "Pin a message in a Slack channel",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'pin', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|pin|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: pinMessageTemplate,
+    });
+
+    let pinInfo: {
+      messageTs: string;
+      channelId?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.messageTs) {
+        pinInfo = {
+          messageTs: String(parsedResponse.messageTs),
+          channelId: parsedResponse.channelId
+            ? String(parsedResponse.channelId)
+            : null,
+        };
+        break;
+      }
+    }
+
+    if (!pinInfo || !pinInfo.messageTs) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:pin-message" },
+        "[SLACK_PIN_MESSAGE] Could not extract pin info",
+      );
+      await callback?.({
+        text: "I couldn't understand which message to pin. Please specify the message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract pin parameters" };
+    }
+
+    if (!isValidMessageTs(pinInfo.messageTs)) {
+      await callback?.({
+        text: "The message timestamp format is invalid. Please provide a valid Slack message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid message timestamp" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+    const channelId = pinInfo.channelId || room?.channelId;
+
+    if (!channelId) {
+      await callback?.({
+        text: "I couldn't determine the channel for pinning the message.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    await slackService.pinMessage(channelId, pinInfo.messageTs);
+
+    const response: Content = {
+      text: "Message pinned successfully.",
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:pin-message",
+        messageTs: pinInfo.messageTs,
+        channelId,
+      },
+      "[SLACK_PIN_MESSAGE] Message pinned",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        messageTs: pinInfo.messageTs,
+        channelId,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Pin that important announcement",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll pin that message to the channel.",
+          actions: ["SLACK_PIN_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default pinMessage;

--- a/plugins/plugin-slack/src/actions/reactToMessage.ts
+++ b/plugins/plugin-slack/src/actions/reactToMessage.ts
@@ -1,0 +1,245 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { isValidMessageTs, SLACK_SERVICE_NAME } from "../types";
+
+const reactToMessageTemplate = `You are helping to extract reaction parameters for Slack.
+
+The user wants to add a reaction (emoji) to a Slack message.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. emoji: The emoji name to react with (without colons, e.g., "thumbsup" not ":thumbsup:")
+2. messageTs: The message timestamp to react to (format: 1234567890.123456)
+3. channelId: The channel ID (optional, defaults to current channel)
+4. remove: Whether to remove the reaction instead of adding it (default: false)
+
+Respond with a JSON object like:
+{
+  "emoji": "thumbsup",
+  "messageTs": "1234567890.123456",
+  "channelId": null,
+  "remove": false
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const reactToMessage: Action = {
+  name: "SLACK_REACT_TO_MESSAGE",
+  similes: [
+    "ADD_SLACK_REACTION",
+    "REACT_SLACK",
+    "SLACK_EMOJI",
+    "ADD_EMOJI",
+    "REMOVE_REACTION",
+  ],
+  description: "Add or remove an emoji reaction to a Slack message",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'react', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|react|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: reactToMessageTemplate,
+    });
+
+    let reactionInfo: {
+      emoji: string;
+      messageTs: string;
+      channelId?: string | null;
+      remove?: boolean;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.emoji && parsedResponse?.messageTs) {
+        reactionInfo = {
+          emoji: String(parsedResponse.emoji),
+          messageTs: String(parsedResponse.messageTs),
+          channelId: parsedResponse.channelId
+            ? String(parsedResponse.channelId)
+            : null,
+          remove: Boolean(parsedResponse.remove),
+        };
+        break;
+      }
+    }
+
+    if (!reactionInfo || !reactionInfo.emoji || !reactionInfo.messageTs) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:react-to-message" },
+        "[SLACK_REACT_TO_MESSAGE] Could not extract reaction info",
+      );
+      await callback?.({
+        text: "I couldn't understand the reaction request. Please specify the emoji and message to react to.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract reaction parameters" };
+    }
+
+    if (!isValidMessageTs(reactionInfo.messageTs)) {
+      await callback?.({
+        text: "The message timestamp format is invalid. Please provide a valid Slack message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid message timestamp" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+    const channelId = reactionInfo.channelId || room?.channelId;
+
+    if (!channelId) {
+      await callback?.({
+        text: "I couldn't determine the channel for the reaction.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    if (reactionInfo.remove) {
+      await slackService.removeReaction(
+        channelId,
+        reactionInfo.messageTs,
+        reactionInfo.emoji,
+      );
+    } else {
+      await slackService.sendReaction(
+        channelId,
+        reactionInfo.messageTs,
+        reactionInfo.emoji,
+      );
+    }
+
+    const actionWord = reactionInfo.remove ? "removed" : "added";
+    const response: Content = {
+      text: `Reaction :${reactionInfo.emoji}: ${actionWord} successfully.`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:react-to-message",
+        emoji: reactionInfo.emoji,
+        messageTs: reactionInfo.messageTs,
+        channelId,
+        remove: reactionInfo.remove,
+      },
+      `[SLACK_REACT_TO_MESSAGE] Reaction ${actionWord}`,
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        emoji: reactionInfo.emoji,
+        messageTs: reactionInfo.messageTs,
+        channelId,
+        action: reactionInfo.remove ? "removed" : "added",
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "React to the last message with a thumbs up",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll add a thumbs up reaction to that message.",
+          actions: ["SLACK_REACT_TO_MESSAGE"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Add a :tada: emoji to that announcement",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Adding the tada emoji reaction now.",
+          actions: ["SLACK_REACT_TO_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default reactToMessage;

--- a/plugins/plugin-slack/src/actions/readChannel.ts
+++ b/plugins/plugin-slack/src/actions/readChannel.ts
@@ -1,0 +1,258 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { SLACK_SERVICE_NAME } from "../types";
+
+const readChannelTemplate = `You are helping to extract read channel parameters for Slack.
+
+The user wants to read message history from a Slack channel.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. channelRef: The channel to read from (default: "current" for the current channel, or a channel name/ID)
+2. limit: Number of messages to retrieve (default: 10, max: 100)
+3. before: Optional message timestamp to fetch messages before
+4. after: Optional message timestamp to fetch messages after
+
+Respond with a JSON object like:
+{
+  "channelRef": "current",
+  "limit": 10,
+  "before": null,
+  "after": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const readChannel: Action = {
+  name: "SLACK_READ_CHANNEL",
+  similes: [
+    "READ_SLACK_MESSAGES",
+    "GET_CHANNEL_HISTORY",
+    "SLACK_HISTORY",
+    "FETCH_MESSAGES",
+    "LIST_MESSAGES",
+  ],
+  description: "Read message history from a Slack channel",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'read', 'channel'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|read|channel)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: readChannelTemplate,
+    });
+
+    let readInfo: {
+      channelRef?: string;
+      limit?: number;
+      before?: string | null;
+      after?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse) {
+        readInfo = {
+          channelRef: parsedResponse.channelRef
+            ? String(parsedResponse.channelRef)
+            : "current",
+          limit: parsedResponse.limit
+            ? Math.min(Number(parsedResponse.limit), 100)
+            : 10,
+          before: parsedResponse.before
+            ? String(parsedResponse.before)
+            : undefined,
+          after: parsedResponse.after
+            ? String(parsedResponse.after)
+            : undefined,
+        };
+        break;
+      }
+    }
+
+    if (!readInfo) {
+      readInfo = { channelRef: "current", limit: 10 };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+
+    if (!room || !room.channelId) {
+      await callback?.({
+        text: "I couldn't determine the current channel.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    let targetChannelId = room.channelId;
+
+    // If a specific channel was referenced (not "current"), try to find it
+    if (readInfo.channelRef && readInfo.channelRef !== "current") {
+      const channels = await slackService.listChannels();
+      const targetChannel = channels.find((ch) => {
+        const channelName = ch.name?.toLowerCase() || "";
+        const searchTerm = readInfo?.channelRef?.toLowerCase() || "";
+        return (
+          channelName === searchTerm ||
+          channelName === searchTerm.replace(/^#/, "") ||
+          ch.id === readInfo?.channelRef
+        );
+      });
+      if (targetChannel) {
+        targetChannelId = targetChannel.id;
+      }
+    }
+
+    const messages = await slackService.readHistory(targetChannelId, {
+      limit: readInfo.limit,
+      before: readInfo.before || undefined,
+      after: readInfo.after || undefined,
+    });
+
+    // Format messages for display
+    const formattedMessages = messages.map((msg) => {
+      const timestamp = new Date(parseFloat(msg.ts) * 1000).toISOString();
+      const user = msg.user || "unknown";
+      const text = msg.text || "[no text]";
+      return `[${timestamp}] ${user}: ${text}`;
+    });
+
+    const channelInfo = await slackService.getChannel(targetChannelId);
+    const channelName = channelInfo?.name || targetChannelId;
+
+    const response: Content = {
+      text: `Here are the last ${messages.length} messages from #${channelName}:\n\n${formattedMessages.join("\n")}`,
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:read-channel",
+        channelId: targetChannelId,
+        messageCount: messages.length,
+      },
+      "[SLACK_READ_CHANNEL] Channel history retrieved",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        channelId: targetChannelId,
+        channelName,
+        messageCount: messages.length,
+        messages: messages.map((m) => ({
+          ts: m.ts,
+          user: m.user,
+          text: m.text,
+          threadTs: m.threadTs,
+        })),
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Show me the last 5 messages in this channel",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll fetch the recent messages for you.",
+          actions: ["SLACK_READ_CHANNEL"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "What's been happening in #announcements?",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Let me check the recent messages in #announcements.",
+          actions: ["SLACK_READ_CHANNEL"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default readChannel;

--- a/plugins/plugin-slack/src/actions/sendMessage.ts
+++ b/plugins/plugin-slack/src/actions/sendMessage.ts
@@ -1,0 +1,248 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { SLACK_SERVICE_NAME } from "../types";
+
+const sendMessageTemplate = `You are helping to extract send message parameters for Slack.
+
+The user wants to send a message to a Slack channel.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. text: The message text to send
+2. channelRef: The channel to send to (default: "current" for the current channel, or a channel name/ID)
+3. threadTs: Optional thread timestamp to reply in a thread (default: null)
+
+Respond with a JSON object like:
+{
+  "text": "The message to send",
+  "channelRef": "current",
+  "threadTs": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const sendMessage: Action = {
+  name: "SLACK_SEND_MESSAGE",
+  similes: [
+    "SEND_SLACK_MESSAGE",
+    "POST_TO_SLACK",
+    "MESSAGE_SLACK",
+    "SLACK_POST",
+    "SEND_TO_CHANNEL",
+  ],
+  description: "Send a message to a Slack channel or thread",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'send', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|send|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: sendMessageTemplate,
+    });
+
+    let messageInfo: {
+      text: string;
+      channelRef?: string;
+      threadTs?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.text) {
+        messageInfo = {
+          text: String(parsedResponse.text),
+          channelRef: parsedResponse.channelRef
+            ? String(parsedResponse.channelRef)
+            : "current",
+          threadTs: parsedResponse.threadTs
+            ? String(parsedResponse.threadTs)
+            : undefined,
+        };
+        break;
+      }
+    }
+
+    if (!messageInfo || !messageInfo.text) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:send-message" },
+        "[SLACK_SEND_MESSAGE] Could not extract message info",
+      );
+      await callback?.({
+        text: "I couldn't understand what message you want me to send. Please try again with a clearer request.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract message parameters" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+
+    if (!room || !room.channelId) {
+      await callback?.({
+        text: "I couldn't determine the current channel.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    let targetChannelId = room.channelId;
+
+    // If a specific channel was referenced (not "current"), try to find it
+    if (messageInfo.channelRef && messageInfo.channelRef !== "current") {
+      const channels = await slackService.listChannels();
+      const targetChannel = channels.find((ch) => {
+        const channelName = ch.name?.toLowerCase() || "";
+        const searchTerm = messageInfo?.channelRef?.toLowerCase() || "";
+        return (
+          channelName === searchTerm ||
+          channelName === searchTerm.replace(/^#/, "") ||
+          ch.id === messageInfo?.channelRef
+        );
+      });
+      if (targetChannel) {
+        targetChannelId = targetChannel.id;
+      }
+    }
+
+    const result = await slackService.sendMessage(
+      targetChannelId,
+      messageInfo.text,
+      {
+        threadTs: messageInfo.threadTs || undefined,
+        replyBroadcast: undefined,
+        unfurlLinks: undefined,
+        unfurlMedia: undefined,
+        mrkdwn: undefined,
+        attachments: undefined,
+        blocks: undefined,
+      },
+    );
+
+    const response: Content = {
+      text: "Message sent successfully.",
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:send-message",
+        messageTs: result.ts,
+        channelId: targetChannelId,
+      },
+      "[SLACK_SEND_MESSAGE] Message sent successfully",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        messageTs: result.ts,
+        channelId: targetChannelId,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Send a message to #general saying 'Hello everyone!'",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll send that message to #general for you.",
+          actions: ["SLACK_SEND_MESSAGE"],
+        },
+      },
+    ],
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Post 'Meeting starts in 5 minutes' to this channel",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll post that announcement here.",
+          actions: ["SLACK_SEND_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default sendMessage;

--- a/plugins/plugin-slack/src/actions/unpinMessage.ts
+++ b/plugins/plugin-slack/src/actions/unpinMessage.ts
@@ -1,0 +1,204 @@
+import {
+  type Action,
+  type ActionExample,
+  type ActionResult,
+  type Content,
+  composePromptFromState,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  parseJSONObjectFromText,
+  type State,
+} from "@elizaos/core";
+import type { SlackService } from "../service";
+import { isValidMessageTs, SLACK_SERVICE_NAME } from "../types";
+
+const unpinMessageTemplate = `You are helping to extract unpin message parameters for Slack.
+
+The user wants to unpin a message from a Slack channel.
+
+Recent conversation:
+{{recentMessages}}
+
+Extract the following:
+1. messageTs: The message timestamp to unpin (format: 1234567890.123456)
+2. channelId: The channel ID (optional, defaults to current channel)
+
+Respond with a JSON object like:
+{
+  "messageTs": "1234567890.123456",
+  "channelId": null
+}
+
+Only respond with the JSON object, no other text.`;
+
+export const unpinMessage: Action = {
+  name: "SLACK_UNPIN_MESSAGE",
+  similes: [
+    "UNPIN_SLACK_MESSAGE",
+    "UNPIN_MESSAGE",
+    "SLACK_UNPIN",
+    "REMOVE_PIN",
+  ],
+  description: "Unpin a message from a Slack channel",
+        validate: async (runtime: any, message: any, state?: any, options?: any): Promise<boolean> => {
+    	const __avTextRaw = typeof message?.content?.text === 'string' ? message.content.text : '';
+    	const __avText = __avTextRaw.toLowerCase();
+    	const __avKeywords = ['slack', 'unpin', 'message'];
+    	const __avKeywordOk =
+    		__avKeywords.length > 0 &&
+    		__avKeywords.some((kw) => kw.length > 0 && __avText.includes(kw));
+    	const __avRegex = new RegExp('\\b(?:slack|unpin|message)\\b', 'i');
+    	const __avRegexOk = __avRegex.test(__avText);
+    	const __avSource = String(message?.content?.source ?? message?.source ?? '');
+    	const __avExpectedSource = 'slack';
+    	const __avSourceOk = __avExpectedSource
+    		? __avSource === __avExpectedSource
+    		: Boolean(__avSource || state || runtime?.agentId || runtime?.getService);
+    	const __avOptions = options && typeof options === 'object' ? options : {};
+    	const __avInputOk =
+    		__avText.trim().length > 0 ||
+    		Object.keys(__avOptions as Record<string, unknown>).length > 0 ||
+    		Boolean(message?.content && typeof message.content === 'object');
+
+    	if (!(__avKeywordOk && __avRegexOk && __avSourceOk && __avInputOk)) {
+    		return false;
+    	}
+
+    	const __avLegacyValidate = async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+  ): Promise<boolean> => {
+    return message.content.source === "slack";
+  };
+    	try {
+    		return Boolean(await (__avLegacyValidate as any)(runtime, message, state, options));
+    	} catch {
+    		return false;
+    	}
+    },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult | undefined> => {
+    const slackService = runtime.getService(SLACK_SERVICE_NAME) as SlackService;
+
+    if (!slackService || !slackService.client) {
+      await callback?.({
+        text: "Slack service is not available.",
+        source: "slack",
+      });
+      return { success: false, error: "Slack service not available" };
+    }
+
+    const prompt = composePromptFromState({
+      state,
+      template: unpinMessageTemplate,
+    });
+
+    let unpinInfo: {
+      messageTs: string;
+      channelId?: string | null;
+    } | null = null;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+        prompt,
+      });
+
+      const parsedResponse = parseJSONObjectFromText(response);
+      if (parsedResponse?.messageTs) {
+        unpinInfo = {
+          messageTs: String(parsedResponse.messageTs),
+          channelId: parsedResponse.channelId
+            ? String(parsedResponse.channelId)
+            : null,
+        };
+        break;
+      }
+    }
+
+    if (!unpinInfo || !unpinInfo.messageTs) {
+      runtime.logger.debug(
+        { src: "plugin:slack:action:unpin-message" },
+        "[SLACK_UNPIN_MESSAGE] Could not extract unpin info",
+      );
+      await callback?.({
+        text: "I couldn't understand which message to unpin. Please specify the message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not extract unpin parameters" };
+    }
+
+    if (!isValidMessageTs(unpinInfo.messageTs)) {
+      await callback?.({
+        text: "The message timestamp format is invalid. Please provide a valid Slack message timestamp.",
+        source: "slack",
+      });
+      return { success: false, error: "Invalid message timestamp" };
+    }
+
+    const stateData = state?.data;
+    const room = stateData?.room || (await runtime.getRoom(message.roomId));
+    const channelId = unpinInfo.channelId || room?.channelId;
+
+    if (!channelId) {
+      await callback?.({
+        text: "I couldn't determine the channel for unpinning the message.",
+        source: "slack",
+      });
+      return { success: false, error: "Could not determine channel" };
+    }
+
+    await slackService.unpinMessage(channelId, unpinInfo.messageTs);
+
+    const response: Content = {
+      text: "Message unpinned successfully.",
+      source: message.content.source,
+    };
+
+    runtime.logger.debug(
+      {
+        src: "plugin:slack:action:unpin-message",
+        messageTs: unpinInfo.messageTs,
+        channelId,
+      },
+      "[SLACK_UNPIN_MESSAGE] Message unpinned",
+    );
+
+    await callback?.(response);
+
+    return {
+      success: true,
+      data: {
+        messageTs: unpinInfo.messageTs,
+        channelId,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{user1}}",
+        content: {
+          text: "Unpin that old announcement",
+        },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "I'll remove the pin from that message.",
+          actions: ["SLACK_UNPIN_MESSAGE"],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default unpinMessage;

--- a/plugins/plugin-slack/src/config.ts
+++ b/plugins/plugin-slack/src/config.ts
@@ -1,0 +1,191 @@
+/**
+ * Slack plugin configuration types.
+ *
+ * These types define the configuration schema for the Slack plugin.
+ * Shared base types are imported from @elizaos/core.
+ */
+
+import type {
+  BlockStreamingCoalesceConfig,
+  ChannelHeartbeatVisibilityConfig,
+  DmConfig,
+  DmPolicy,
+  GroupPolicy,
+  GroupToolPolicyBySenderConfig,
+  GroupToolPolicyConfig,
+  MarkdownConfig,
+  ProviderCommandsConfig,
+  ReplyToMode,
+} from "@elizaos/core";
+
+// ============================================================
+// DM Configuration
+// ============================================================
+
+export type SlackDmConfig = {
+  /** If false, ignore all incoming Slack DMs. Default: true. */
+  enabled?: boolean;
+  /** Direct message access policy (default: pairing). */
+  policy?: DmPolicy;
+  /** Allowlist for DM senders (ids). */
+  allowFrom?: Array<string | number>;
+  /** If true, allow group DMs (default: false). */
+  groupEnabled?: boolean;
+  /** Optional allowlist for group DM channels (ids or slugs). */
+  groupChannels?: Array<string | number>;
+};
+
+// ============================================================
+// Channel Configuration
+// ============================================================
+
+export type SlackChannelConfig = {
+  /** If false, disable the bot in this channel. (Alias for allow: false.) */
+  enabled?: boolean;
+  /** Legacy channel allow toggle; prefer enabled. */
+  allow?: boolean;
+  /** Require mentioning the bot to trigger replies. */
+  requireMention?: boolean;
+  /** Optional tool policy overrides for this channel. */
+  tools?: GroupToolPolicyConfig;
+  toolsBySender?: GroupToolPolicyBySenderConfig;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
+  /** Allowlist of users that can invoke the bot in this channel. */
+  users?: Array<string | number>;
+  /** Optional skill filter for this channel. */
+  skills?: string[];
+  /** Optional system prompt for this channel. */
+  systemPrompt?: string;
+};
+
+// ============================================================
+// Reaction Configuration
+// ============================================================
+
+export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";
+
+// ============================================================
+// Action Configuration
+// ============================================================
+
+export type SlackActionConfig = {
+  reactions?: boolean;
+  messages?: boolean;
+  pins?: boolean;
+  search?: boolean;
+  permissions?: boolean;
+  memberInfo?: boolean;
+  channelInfo?: boolean;
+  emojiList?: boolean;
+};
+
+// ============================================================
+// Slash Command Configuration
+// ============================================================
+
+export type SlackSlashCommandConfig = {
+  /** Enable handling for the configured slash command (default: false). */
+  enabled?: boolean;
+  /** Slash command name (default: "otto"). */
+  name?: string;
+  /** Session key prefix for slash commands (default: "slack:slash"). */
+  sessionPrefix?: string;
+  /** Reply ephemerally (default: true). */
+  ephemeral?: boolean;
+};
+
+// ============================================================
+// Thread Configuration
+// ============================================================
+
+export type SlackThreadConfig = {
+  /** Scope for thread history context (thread|channel). Default: thread. */
+  historyScope?: "thread" | "channel";
+  /** If true, thread sessions inherit the parent channel transcript. Default: false. */
+  inheritParent?: boolean;
+};
+
+// ============================================================
+// Account Configuration
+// ============================================================
+
+export type SlackAccountConfig = {
+  /** Optional display name for this account (used in CLI/UI lists). */
+  name?: string;
+  /** Slack connection mode (socket|http). Default: socket. */
+  mode?: "socket" | "http";
+  /** Slack signing secret (required for HTTP mode). */
+  signingSecret?: string;
+  /** Slack Events API webhook path (default: /slack/events). */
+  webhookPath?: string;
+  /** Optional provider capability tags used for agent/runtime guidance. */
+  capabilities?: string[];
+  /** Markdown formatting overrides (tables). */
+  markdown?: MarkdownConfig;
+  /** Override native command registration for Slack (bool or "auto"). */
+  commands?: ProviderCommandsConfig;
+  /** Allow channel-initiated config writes (default: true). */
+  configWrites?: boolean;
+  /** If false, do not start this Slack account. Default: true. */
+  enabled?: boolean;
+  botToken?: string;
+  appToken?: string;
+  userToken?: string;
+  /** If true, restrict user token to read operations only. Default: true. */
+  userTokenReadOnly?: boolean;
+  /** Allow bot-authored messages to trigger replies (default: false). */
+  allowBots?: boolean;
+  /** Default mention requirement for channel messages (default: true). */
+  requireMention?: boolean;
+  /**
+   * Controls how channel messages are handled:
+   * - "open": channels bypass allowlists; mention-gating applies
+   * - "disabled": block all channel messages
+   * - "allowlist": only allow channels present in channels.slack.channels
+   */
+  groupPolicy?: GroupPolicy;
+  /** Max channel messages to keep as history context (0 disables). */
+  historyLimit?: number;
+  /** Max DM turns to keep as history context. */
+  dmHistoryLimit?: number;
+  /** Per-DM config overrides keyed by user ID. */
+  dms?: Record<string, DmConfig>;
+  textChunkLimit?: number;
+  /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
+  chunkMode?: "length" | "newline";
+  blockStreaming?: boolean;
+  /** Merge streamed block replies before sending. */
+  blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  mediaMaxMb?: number;
+  /** Reaction notification mode (off|own|all|allowlist). Default: own. */
+  reactionNotifications?: SlackReactionNotificationMode;
+  /** Allowlist for reaction notifications when mode is allowlist. */
+  reactionAllowlist?: Array<string | number>;
+  /** Control reply threading when reply tags are present (off|first|all). */
+  replyToMode?: ReplyToMode;
+  /**
+   * Optional per-chat-type reply threading overrides.
+   * Example: { direct: "all", group: "first", channel: "off" }.
+   */
+  replyToModeByChatType?: Partial<
+    Record<"direct" | "group" | "channel", ReplyToMode>
+  >;
+  /** Thread session behavior. */
+  thread?: SlackThreadConfig;
+  actions?: SlackActionConfig;
+  slashCommand?: SlackSlashCommandConfig;
+  dm?: SlackDmConfig;
+  channels?: Record<string, SlackChannelConfig>;
+  /** Heartbeat visibility settings for this channel. */
+  heartbeat?: ChannelHeartbeatVisibilityConfig;
+};
+
+// ============================================================
+// Main Slack Configuration
+// ============================================================
+
+export type SlackConfig = {
+  /** Optional per-account Slack configuration (multi-account). */
+  accounts?: Record<string, SlackAccountConfig>;
+} & SlackAccountConfig;

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -1,0 +1,483 @@
+import type { SlackChannel, SlackUser } from "./types";
+
+/**
+ * Escape special characters for Slack mrkdwn format
+ * Preserves Slack's angle-bracket tokens so mentions and links stay intact
+ */
+function escapeSlackMrkdwnSegment(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
+
+/**
+ * Checks if an angle-bracket token is an allowed Slack format
+ */
+function isAllowedSlackAngleToken(token: string): boolean {
+  if (!token.startsWith("<") || !token.endsWith(">")) {
+    return false;
+  }
+  const inner = token.slice(1, -1);
+  return (
+    inner.startsWith("@") ||
+    inner.startsWith("#") ||
+    inner.startsWith("!") ||
+    inner.startsWith("mailto:") ||
+    inner.startsWith("tel:") ||
+    inner.startsWith("http://") ||
+    inner.startsWith("https://") ||
+    inner.startsWith("slack://")
+  );
+}
+
+/**
+ * Escapes Slack mrkdwn content while preserving valid Slack tokens
+ */
+function escapeSlackMrkdwnContent(text: string): string {
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+    return text;
+  }
+
+  SLACK_ANGLE_TOKEN_RE.lastIndex = 0;
+  const out: string[] = [];
+  let lastIndex = 0;
+
+  for (
+    let match = SLACK_ANGLE_TOKEN_RE.exec(text);
+    match;
+    match = SLACK_ANGLE_TOKEN_RE.exec(text)
+  ) {
+    const matchIndex = match.index ?? 0;
+    out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex, matchIndex)));
+    const token = match[0] ?? "";
+    out.push(
+      isAllowedSlackAngleToken(token) ? token : escapeSlackMrkdwnSegment(token),
+    );
+    lastIndex = matchIndex + token.length;
+  }
+
+  out.push(escapeSlackMrkdwnSegment(text.slice(lastIndex)));
+  return out.join("");
+}
+
+/**
+ * Escapes Slack mrkdwn text, handling blockquotes specially
+ */
+export function escapeSlackMrkdwn(text: string): string {
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+    return text;
+  }
+
+  return text
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("> ")) {
+        return `> ${escapeSlackMrkdwnContent(line.slice(2))}`;
+      }
+      return escapeSlackMrkdwnContent(line);
+    })
+    .join("\n");
+}
+
+// Placeholder used during conversion to prevent bold from being matched as italic
+const BOLD_PLACEHOLDER = "\u0000BOLD\u0000";
+
+/**
+ * Converts markdown bold to Slack mrkdwn
+ * Uses placeholder to prevent bold from being matched by italic converter
+ */
+function convertBold(text: string): string {
+  return text.replace(
+    /\*\*(.+?)\*\*/g,
+    `${BOLD_PLACEHOLDER}$1${BOLD_PLACEHOLDER}`,
+  );
+}
+
+/**
+ * Converts markdown italic to Slack mrkdwn
+ */
+function convertItalic(text: string): string {
+  // Markdown uses single * for italic, Slack uses _
+  // Then restore bold placeholders to actual asterisks
+  const converted = text.replace(
+    /(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g,
+    "_$1_",
+  );
+  return converted.replace(new RegExp(BOLD_PLACEHOLDER, "g"), "*");
+}
+
+/**
+ * Converts markdown strikethrough to Slack mrkdwn
+ */
+function convertStrikethrough(text: string): string {
+  return text.replace(/~~(.+?)~~/g, "~$1~");
+}
+
+/**
+ * Converts markdown code blocks to Slack mrkdwn
+ */
+function convertCodeBlocks(text: string): string {
+  // Slack code blocks don't support language hints in the same way
+  return text.replace(/```(\w*)\n?([\s\S]*?)```/g, "```\n$2```");
+}
+
+/**
+ * Converts markdown links to Slack mrkdwn links
+ */
+function convertLinks(text: string): string {
+  return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, linkText, url) => {
+    const trimmedUrl = url.trim();
+    const trimmedText = linkText.trim();
+    // If link text matches URL, just use URL
+    if (
+      trimmedText === trimmedUrl ||
+      trimmedText === trimmedUrl.replace(/^mailto:/, "")
+    ) {
+      return `<${escapeSlackMrkdwnSegment(trimmedUrl)}>`;
+    }
+    return `<${escapeSlackMrkdwnSegment(trimmedUrl)}|${escapeSlackMrkdwnSegment(trimmedText)}>`;
+  });
+}
+
+/**
+ * Converts markdown headings to Slack mrkdwn (bold text)
+ * Uses placeholder to prevent headings from being matched by italic converter
+ */
+function convertHeadings(text: string): string {
+  return text.replace(
+    /^#{1,6}\s+(.+)$/gm,
+    `${BOLD_PLACEHOLDER}$1${BOLD_PLACEHOLDER}`,
+  );
+}
+
+/**
+ * Converts markdown to Slack mrkdwn format
+ */
+export function markdownToSlackMrkdwn(markdown: string): string {
+  if (!markdown) {
+    return "";
+  }
+
+  // Process in order: code blocks -> links -> headings -> text styles -> escape
+  let result = convertCodeBlocks(markdown);
+  result = convertLinks(result);
+  result = convertHeadings(result);
+  result = convertBold(result);
+  result = convertItalic(result);
+  result = convertStrikethrough(result);
+  result = escapeSlackMrkdwn(result);
+
+  return result;
+}
+
+/**
+ * Options for chunking Slack text
+ */
+export interface ChunkSlackTextOpts {
+  /** Max characters per message. Default: 4000 */
+  maxChars?: number;
+}
+
+const DEFAULT_MAX_CHARS = 4000;
+
+/**
+ * Chunks Slack text while preserving code blocks
+ */
+export function chunkSlackText(
+  text: string,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): string[] {
+  if (!text) {
+    return [];
+  }
+
+  if (text.length <= maxChars) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+  let inCodeBlock = false;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxChars) {
+      chunks.push(remaining);
+      break;
+    }
+
+    // Find a good break point
+    let breakPoint = maxChars;
+
+    // Check if we're in a code block
+    const codeBlockCount = (remaining.slice(0, maxChars).match(/```/g) || [])
+      .length;
+    inCodeBlock = codeBlockCount % 2 !== 0;
+
+    // Try to break at a newline
+    const newlineIndex = remaining.lastIndexOf("\n", maxChars);
+    if (newlineIndex > maxChars * 0.5) {
+      breakPoint = newlineIndex + 1;
+    } else {
+      // Try to break at a space
+      const spaceIndex = remaining.lastIndexOf(" ", maxChars);
+      if (spaceIndex > maxChars * 0.5) {
+        breakPoint = spaceIndex + 1;
+      }
+    }
+
+    let chunk = remaining.slice(0, breakPoint);
+
+    // If we're breaking inside a code block, close it
+    if (inCodeBlock) {
+      chunk += "\n```";
+    }
+
+    chunks.push(chunk);
+
+    remaining = remaining.slice(breakPoint);
+
+    // If we were in a code block, reopen it
+    if (inCodeBlock) {
+      remaining = `\`\`\`\n${remaining}`;
+    }
+  }
+
+  return chunks;
+}
+
+/**
+ * Converts markdown to Slack mrkdwn and splits into chunks
+ */
+export function markdownToSlackMrkdwnChunks(
+  markdown: string,
+  limit: number,
+): string[] {
+  return chunkSlackText(markdownToSlackMrkdwn(markdown), limit);
+}
+
+/**
+ * Formats a Slack user mention
+ */
+export function formatSlackUserMention(userId: string): string {
+  return `<@${userId}>`;
+}
+
+/**
+ * Formats a Slack channel mention
+ */
+export function formatSlackChannelMention(channelId: string): string {
+  return `<#${channelId}>`;
+}
+
+/**
+ * Formats a Slack user group mention
+ */
+export function formatSlackUserGroupMention(groupId: string): string {
+  return `<!subteam^${groupId}>`;
+}
+
+/**
+ * Formats a Slack special mention (@here, @channel, @everyone)
+ */
+export function formatSlackSpecialMention(
+  type: "here" | "channel" | "everyone",
+): string {
+  return `<!${type}>`;
+}
+
+/**
+ * Formats a Slack link
+ */
+export function formatSlackLink(url: string, text?: string): string {
+  const safeUrl = escapeSlackMrkdwnSegment(url);
+  if (text && text !== url) {
+    return `<${safeUrl}|${escapeSlackMrkdwnSegment(text)}>`;
+  }
+  return `<${safeUrl}>`;
+}
+
+/**
+ * Formats a Slack date
+ */
+export function formatSlackDate(
+  timestamp: number | Date,
+  format: string = "{date_short_pretty} at {time}",
+  fallbackText?: string,
+): string {
+  const unix = Math.floor(
+    (typeof timestamp === "number" ? timestamp : timestamp.getTime()) / 1000,
+  );
+  const fallback = fallbackText || new Date(unix * 1000).toISOString();
+  return `<!date^${unix}^${format}|${fallback}>`;
+}
+
+/**
+ * Extracts user ID from a Slack mention
+ */
+export function extractUserIdFromMention(mention: string): string | null {
+  const match = mention.match(/^<@([UW][A-Z0-9]+)(?:\|[^>]*)?>$/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts channel ID from a Slack mention
+ */
+export function extractChannelIdFromMention(mention: string): string | null {
+  const match = mention.match(/^<#([CGD][A-Z0-9]+)(?:\|[^>]*)?>$/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extracts URL from a Slack link
+ */
+export function extractUrlFromSlackLink(link: string): string | null {
+  const match = link.match(/^<(https?:\/\/[^|>]+)(?:\|[^>]*)?>$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Formats a user's display name
+ */
+export function formatSlackUserDisplayName(user: SlackUser): string {
+  return user.profile.displayName || user.profile.realName || user.name;
+}
+
+/**
+ * Formats a channel for display
+ */
+export function formatSlackChannel(channel: SlackChannel): string {
+  if (channel.isIm) {
+    return "Direct Message";
+  }
+  if (channel.isMpim) {
+    return `Group DM: ${channel.name}`;
+  }
+  return `#${channel.name}`;
+}
+
+/**
+ * Gets the channel type as a human-readable string
+ */
+export function getChannelTypeString(channel: SlackChannel): string {
+  if (channel.isIm) {
+    return "DM";
+  }
+  if (channel.isMpim) {
+    return "Group DM";
+  }
+  if (channel.isPrivate || channel.isGroup) {
+    return "Private Channel";
+  }
+  return "Channel";
+}
+
+/**
+ * Resolves the system location string for logging/display
+ */
+export function resolveSlackSystemLocation(
+  channel: SlackChannel,
+  teamName?: string,
+): string {
+  const channelType = getChannelTypeString(channel);
+  const channelName = formatSlackChannel(channel);
+  if (teamName) {
+    return `${teamName} - ${channelType}: ${channelName}`;
+  }
+  return `${channelType}: ${channelName}`;
+}
+
+/**
+ * Checks if a channel is a direct message
+ */
+export function isDirectMessage(channel: SlackChannel): boolean {
+  return channel.isIm;
+}
+
+/**
+ * Checks if a channel is a group DM (multi-party IM)
+ */
+export function isGroupDm(channel: SlackChannel): boolean {
+  return channel.isMpim;
+}
+
+/**
+ * Checks if a channel is a private channel
+ */
+export function isPrivateChannel(channel: SlackChannel): boolean {
+  return channel.isPrivate || channel.isGroup;
+}
+
+/**
+ * Truncates text to a maximum length with an ellipsis
+ */
+export function truncateText(
+  text: string,
+  maxLength: number,
+  ellipsis = "…",
+): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength - ellipsis.length) + ellipsis;
+}
+
+/**
+ * Strips Slack mrkdwn formatting from text
+ */
+export function stripSlackFormatting(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, "") // Code blocks (must be before inline code)
+    .replace(/\*([^*]+)\*/g, "$1") // Bold
+    .replace(/_([^_]+)_/g, "$1") // Italic
+    .replace(/~([^~]+)~/g, "$1") // Strikethrough
+    .replace(/`([^`]+)`/g, "$1") // Inline code
+    .replace(/<@[UW][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User mentions
+    .replace(/<#[CGD][A-Z0-9]+(?:\|[^>]*)?>/gi, "") // Channel mentions
+    .replace(/<!subteam\^[A-Z0-9]+(?:\|[^>]*)?>/gi, "") // User group mentions
+    .replace(/<!(?:here|channel|everyone)(?:\|[^>]*)?>/gi, "") // Special mentions
+    .replace(/<(https?:\/\/[^|>]+)(?:\|([^>]*))?>/, "$2") // Links with text
+    .replace(/<(https?:\/\/[^>]+)>/, "$1") // Plain links
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .trim();
+}
+
+/**
+ * Builds a Slack message permalink
+ */
+export function buildSlackMessagePermalink(
+  workspaceDomain: string,
+  channelId: string,
+  messageTs: string,
+): string {
+  const formattedTs = `p${messageTs.replace(".", "")}`;
+  return `https://${workspaceDomain}.slack.com/archives/${channelId}/${formattedTs}`;
+}
+
+/**
+ * Parses a Slack message permalink
+ */
+export function parseSlackMessagePermalink(
+  link: string,
+): { workspaceDomain: string; channelId: string; messageTs: string } | null {
+  const match = link.match(
+    /^https?:\/\/([^.]+)\.slack\.com\/archives\/([CGD][A-Z0-9]+)\/p(\d+)/i,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const ts = match[3];
+  // Convert p1234567890123456 to 1234567890.123456
+  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+
+  return {
+    workspaceDomain: match[1],
+    channelId: match[2],
+    messageTs,
+  };
+}

--- a/plugins/plugin-slack/src/index.ts
+++ b/plugins/plugin-slack/src/index.ts
@@ -1,0 +1,244 @@
+import { type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
+import deleteMessage from "./actions/deleteMessage";
+import editMessage from "./actions/editMessage";
+import emojiList from "./actions/emojiList";
+import getUserInfo from "./actions/getUserInfo";
+import listChannels from "./actions/listChannels";
+import listPins from "./actions/listPins";
+import pinMessage from "./actions/pinMessage";
+import reactToMessage from "./actions/reactToMessage";
+import readChannel from "./actions/readChannel";
+// Actions
+import sendMessage from "./actions/sendMessage";
+import unpinMessage from "./actions/unpinMessage";
+
+// Providers
+import { channelStateProvider } from "./providers/channelState";
+import { memberListProvider } from "./providers/memberList";
+import { workspaceInfoProvider } from "./providers/workspaceInfo";
+
+// Service
+import { SlackService } from "./service";
+
+const slackPlugin: Plugin = {
+  name: "slack",
+  description: "Slack integration plugin for ElizaOS with Socket Mode support",
+  services: [SlackService],
+  actions: [
+    sendMessage,
+    reactToMessage,
+    readChannel,
+    editMessage,
+    deleteMessage,
+    pinMessage,
+    unpinMessage,
+    listChannels,
+    getUserInfo,
+    listPins,
+    emojiList,
+  ],
+  providers: [channelStateProvider, workspaceInfoProvider, memberListProvider],
+  init: async (_config: Record<string, string>, runtime: IAgentRuntime) => {
+    const botToken = runtime.getSetting("SLACK_BOT_TOKEN") as string;
+    const appToken = runtime.getSetting("SLACK_APP_TOKEN") as string;
+    const signingSecret = runtime.getSetting("SLACK_SIGNING_SECRET") as string;
+    const userToken = runtime.getSetting("SLACK_USER_TOKEN") as string;
+    const channelIds = runtime.getSetting("SLACK_CHANNEL_IDS") as string;
+    const ignoreBotMessages = runtime.getSetting(
+      "SLACK_SHOULD_IGNORE_BOT_MESSAGES",
+    ) as string;
+    const respondOnlyToMentions = runtime.getSetting(
+      "SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+    ) as string;
+
+    // Log configuration status
+    const maskToken = (token: string | undefined): string => {
+      if (!token || token.trim() === "") return "[not set]";
+      if (token.length <= 8) return "***";
+      return `${token.slice(0, 4)}...${token.slice(-4)}`;
+    };
+
+    logger.info(
+      {
+        src: "plugin:slack",
+        agentId: runtime.agentId,
+        settings: {
+          botToken: maskToken(botToken),
+          appToken: maskToken(appToken),
+          signingSecret: signingSecret ? "[set]" : "[not set]",
+          userToken: maskToken(userToken),
+          channelIds: channelIds || "[all channels]",
+          ignoreBotMessages: ignoreBotMessages || "false",
+          respondOnlyToMentions: respondOnlyToMentions || "false",
+        },
+      },
+      "Slack plugin initializing",
+    );
+
+    if (!botToken || botToken.trim() === "") {
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_BOT_TOKEN not provided - Slack plugin is loaded but will not be functional",
+      );
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "To enable Slack functionality, please provide SLACK_BOT_TOKEN in your .env file",
+      );
+      return;
+    }
+
+    if (!appToken || appToken.trim() === "") {
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_APP_TOKEN not provided - Socket Mode will not work",
+      );
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "To enable Socket Mode, please provide SLACK_APP_TOKEN in your .env file",
+      );
+      return;
+    }
+
+    // Validate token formats
+    if (!botToken.startsWith("xoxb-")) {
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_BOT_TOKEN should start with 'xoxb-'. Please verify your token.",
+      );
+    }
+
+    if (!appToken.startsWith("xapp-")) {
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_APP_TOKEN should start with 'xapp-'. Please verify your token.",
+      );
+    }
+
+    if (userToken && !userToken.startsWith("xoxp-")) {
+      logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_USER_TOKEN should start with 'xoxp-'. Please verify your token.",
+      );
+    }
+
+    logger.info(
+      { src: "plugin:slack", agentId: runtime.agentId },
+      "Slack plugin configuration validated successfully",
+    );
+  },
+};
+
+export default slackPlugin;
+
+// Account management exports
+export {
+  DEFAULT_ACCOUNT_ID,
+  isMultiAccountEnabled,
+  listEnabledSlackAccounts,
+  listSlackAccountIds,
+  normalizeAccountId,
+  type ResolvedSlackAccount,
+  resolveDefaultSlackAccountId,
+  resolveSlackAccount,
+  resolveSlackAppToken,
+  resolveSlackBotToken,
+  resolveSlackReplyToMode,
+  resolveSlackUserToken,
+  type SlackAccountConfig,
+  type SlackActionConfig,
+  type SlackChannelConfig,
+  type SlackDmConfig,
+  type SlackMultiAccountConfig,
+  type SlackReactionNotificationMode,
+  type SlackSlashCommandConfig,
+  type SlackTokenSource,
+} from "./accounts";
+export { deleteMessage } from "./actions/deleteMessage";
+export { editMessage } from "./actions/editMessage";
+export { emojiList } from "./actions/emojiList";
+export { getUserInfo } from "./actions/getUserInfo";
+export { listChannels } from "./actions/listChannels";
+export { listPins } from "./actions/listPins";
+export { pinMessage } from "./actions/pinMessage";
+export { reactToMessage } from "./actions/reactToMessage";
+export { readChannel } from "./actions/readChannel";
+// Export actions
+export { sendMessage } from "./actions/sendMessage";
+export { unpinMessage } from "./actions/unpinMessage";
+// Channel configuration types
+export type {
+  SlackConfig,
+  SlackThreadConfig,
+} from "./config";
+// Formatting exports
+export {
+  buildSlackMessagePermalink,
+  type ChunkSlackTextOpts,
+  chunkSlackText,
+  escapeSlackMrkdwn,
+  extractChannelIdFromMention,
+  extractUrlFromSlackLink,
+  extractUserIdFromMention,
+  formatSlackChannel,
+  formatSlackChannelMention,
+  formatSlackDate,
+  formatSlackLink,
+  formatSlackSpecialMention,
+  formatSlackUserDisplayName,
+  formatSlackUserGroupMention,
+  formatSlackUserMention,
+  getChannelTypeString,
+  isDirectMessage,
+  isGroupDm,
+  isPrivateChannel,
+  markdownToSlackMrkdwn,
+  markdownToSlackMrkdwnChunks,
+  parseSlackMessagePermalink,
+  resolveSlackSystemLocation,
+  stripSlackFormatting,
+  truncateText,
+} from "./formatting";
+// Export providers
+export { channelStateProvider } from "./providers/channelState";
+export { memberListProvider } from "./providers/memberList";
+export { workspaceInfoProvider } from "./providers/workspaceInfo";
+// Export service for direct access
+export { SlackService } from "./service";
+// Export types
+export type {
+  ISlackService,
+  SlackChannel,
+  SlackChannelType,
+  SlackEventPayloadMap,
+  SlackFile,
+  SlackMessage,
+  SlackMessageReceivedPayload,
+  SlackMessageSendOptions,
+  SlackMessageSentPayload,
+  SlackReaction,
+  SlackReactionPayload,
+  SlackSettings,
+  SlackTeam,
+  SlackUser,
+  SlackUserProfile,
+} from "./types";
+export {
+  formatMessageTsForLink,
+  getSlackChannelType,
+  getSlackUserDisplayName,
+  isValidChannelId,
+  isValidMessageTs,
+  isValidTeamId,
+  isValidUserId,
+  MAX_SLACK_BLOCKS,
+  MAX_SLACK_FILE_SIZE,
+  MAX_SLACK_MESSAGE_LENGTH,
+  parseSlackMessageLink,
+  SLACK_SERVICE_NAME,
+  SlackApiError,
+  SlackClientNotAvailableError,
+  SlackConfigurationError,
+  SlackEventTypes,
+  SlackPluginError,
+  SlackServiceNotInitializedError,
+} from "./types";

--- a/plugins/plugin-slack/src/providers/channelState.ts
+++ b/plugins/plugin-slack/src/providers/channelState.ts
@@ -1,0 +1,169 @@
+import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
+import type { SlackService } from "../service";
+import { getSlackChannelType, ServiceType } from "../types";
+import { validateActionKeywords, validateActionRegex } from "@elizaos/core";
+
+/**
+ * Provider for retrieving Slack channel state information.
+ */
+export const channelStateProvider: Provider = {
+  name: "slackChannelState",
+  description: "Provides information about the current Slack channel context",
+    dynamic: true,
+  relevanceKeywords: [
+    "slackchannelstate",
+    "channelstateprovider",
+    "plugin",
+    "slack",
+    "status",
+    "state",
+    "context",
+    "info",
+    "details",
+    "chat",
+    "conversation",
+    "agent",
+    "room",
+    "channel",
+  ],
+get: async (runtime: IAgentRuntime, message: Memory, state: State) => {  const __providerKeywords = ["slackchannelstate", "channelstateprovider", "plugin", "slack", "status", "state", "context", "info", "details", "chat", "conversation", "agent", "room", "channel"];
+  const __providerRegex = new RegExp(`\\b(${__providerKeywords.join("|")})\\b`, "i");
+  const __recentMessages = (state?.recentMessagesData as Memory[] | undefined) ?? [];
+  const __isRelevant =
+    validateActionKeywords(message, __recentMessages, __providerKeywords) ||
+    validateActionRegex(message, __recentMessages, __providerRegex);
+  if (!__isRelevant) {
+    return { text: "" };
+  }
+
+
+    const room = state.data?.room ?? (await runtime.getRoom(message.roomId));
+    if (!room) {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    // If message source is not slack, return empty
+    if (message.content.source !== "slack") {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const agentName = state?.agentName || "The agent";
+    const senderName = state?.senderName || "someone";
+
+    let responseText = "";
+    let channelType = "";
+    let workspaceName = "";
+    let channelName = "";
+    const channelId = room.channelId ?? "";
+    const threadTs = room.metadata?.threadTs as string | undefined;
+
+    const slackService = runtime.getService(ServiceType.SLACK) as SlackService;
+    if (!slackService || !slackService.client) {
+      runtime.logger.warn(
+        {
+          src: "plugin:slack:provider:channelState",
+          agentId: runtime.agentId,
+          channelId,
+        },
+        "No Slack client found",
+      );
+      return {
+        data: {
+          room,
+          channelType: "unknown",
+          channelId,
+        },
+        values: {
+          channelType: "unknown",
+          channelId,
+        },
+        text: "",
+      };
+    }
+
+    // Get channel info
+    const channel = channelId ? await slackService.getChannel(channelId) : null;
+    if (channel) {
+      channelName = channel.name;
+      const slackChannelType = getSlackChannelType(channel);
+
+      if (slackChannelType === "im") {
+        channelType = "DM";
+        responseText = `${agentName} is currently in a direct message conversation with ${senderName} on Slack. ${agentName} should engage in conversation, responding to messages that are addressed to them.`;
+      } else if (slackChannelType === "mpim") {
+        channelType = "GROUP_DM";
+        responseText = `${agentName} is currently in a group direct message on Slack. ${agentName} should be aware that multiple people can see this conversation.`;
+      } else {
+        channelType =
+          slackChannelType === "group" ? "PRIVATE_CHANNEL" : "PUBLIC_CHANNEL";
+
+        if (threadTs) {
+          responseText = `${agentName} is currently in a thread within the channel #${channelName} on Slack.`;
+          responseText += `\n${agentName} should keep responses focused on the thread topic and be mindful of thread etiquette.`;
+        } else {
+          responseText = `${agentName} is currently having a conversation in the Slack channel #${channelName}.`;
+          responseText += `\n${agentName} is in a channel with other users and should only participate when directly addressed or when the conversation is relevant to them.`;
+        }
+
+        if (channel.topic?.value) {
+          responseText += `\nChannel topic: ${channel.topic.value}`;
+        }
+        if (channel.purpose?.value) {
+          responseText += `\nChannel purpose: ${channel.purpose.value}`;
+        }
+      }
+    } else {
+      channelType = "unknown";
+      responseText = `${agentName} is in a Slack conversation but couldn't retrieve channel details.`;
+    }
+
+    // Add workspace context if available
+    const teamId = slackService.getTeamId();
+    if (teamId && room.worldId) {
+      const world = await runtime.getWorld(room.worldId);
+      if (world) {
+        workspaceName = world.name;
+        responseText += `\nWorkspace: ${workspaceName}`;
+      }
+    }
+
+    // Add thread context if applicable
+    if (threadTs) {
+      responseText += `\nThis is a threaded conversation (thread timestamp: ${threadTs}).`;
+    }
+
+    return {
+      data: {
+        room,
+        channelType,
+        workspaceName,
+        channelName,
+        channelId,
+        threadTs,
+        isThread: Boolean(threadTs),
+        topic: channel?.topic?.value,
+        purpose: channel?.purpose?.value,
+        isPrivate: channel?.isPrivate,
+        numMembers: channel?.numMembers,
+      },
+      values: {
+        channelType,
+        workspaceName,
+        channelName,
+        channelId,
+        isThread: Boolean(threadTs),
+      },
+      text: responseText,
+    };
+  },
+};
+
+export default channelStateProvider;

--- a/plugins/plugin-slack/src/providers/memberList.ts
+++ b/plugins/plugin-slack/src/providers/memberList.ts
@@ -1,0 +1,156 @@
+import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
+import type { SlackService } from "../service";
+import { getSlackUserDisplayName, ServiceType } from "../types";
+import { validateActionKeywords, validateActionRegex } from "@elizaos/core";
+
+/**
+ * Provider for retrieving Slack channel member information.
+ */
+export const memberListProvider: Provider = {
+  name: "slackMemberList",
+  description:
+    "Provides information about members in the current Slack channel",
+    dynamic: true,
+  relevanceKeywords: [
+    "slackmemberlist",
+    "memberlistprovider",
+    "plugin",
+    "slack",
+    "status",
+    "state",
+    "context",
+    "info",
+    "details",
+    "chat",
+    "conversation",
+    "agent",
+    "room",
+    "channel",
+  ],
+get: async (runtime: IAgentRuntime, message: Memory, state: State) => {  const __providerKeywords = ["slackmemberlist", "memberlistprovider", "plugin", "slack", "status", "state", "context", "info", "details", "chat", "conversation", "agent", "room", "channel"];
+  const __providerRegex = new RegExp(`\\b(${__providerKeywords.join("|")})\\b`, "i");
+  const __recentMessages = (state?.recentMessagesData as Memory[] | undefined) ?? [];
+  const __isRelevant =
+    validateActionKeywords(message, __recentMessages, __providerKeywords) ||
+    validateActionRegex(message, __recentMessages, __providerRegex);
+  if (!__isRelevant) {
+    return { text: "" };
+  }
+
+
+    // If message source is not slack, return empty
+    if (message.content.source !== "slack") {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const room = state.data?.room ?? (await runtime.getRoom(message.roomId));
+    if (!room || !room.channelId) {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const slackService = runtime.getService(ServiceType.SLACK) as SlackService;
+    if (!slackService || !slackService.client) {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const channelId = room.channelId;
+
+    // Get channel members
+    const membersResult = await slackService.client.conversations.members({
+      channel: channelId,
+      limit: 100,
+    });
+
+    const memberIds = membersResult.members || [];
+
+    if (memberIds.length === 0) {
+      return {
+        data: {
+          channelId,
+          memberCount: 0,
+          members: [],
+        },
+        values: {
+          memberCount: 0,
+        },
+        text: "No members found in this channel.",
+      };
+    }
+
+    // Get user info for each member (limited to first 20 for performance)
+    const memberLimit = 20;
+    const limitedMemberIds = memberIds.slice(0, memberLimit);
+    const members: Array<{
+      id: string;
+      name: string;
+      displayName: string;
+      isBot: boolean;
+      isAdmin: boolean;
+    }> = [];
+
+    for (const memberId of limitedMemberIds) {
+      const user = await slackService.getUser(memberId);
+      if (user) {
+        members.push({
+          id: user.id,
+          name: user.name,
+          displayName: getSlackUserDisplayName(user),
+          isBot: user.isBot,
+          isAdmin: user.isAdmin || user.isOwner,
+        });
+      }
+    }
+
+    // Get channel info for name
+    const channel = await slackService.getChannel(channelId);
+    const channelName = channel?.name || channelId;
+
+    // Format member list
+    const botUserId = slackService.getBotUserId();
+    const memberDescriptions = members.map((m) => {
+      const tags: string[] = [];
+      if (m.id === botUserId) tags.push("this bot");
+      if (m.isBot && m.id !== botUserId) tags.push("bot");
+      if (m.isAdmin) tags.push("admin");
+      const tagStr = tags.length > 0 ? ` (${tags.join(", ")})` : "";
+      return `- ${m.displayName} (@${m.name})${tagStr}`;
+    });
+
+    const truncationNote =
+      memberIds.length > memberLimit
+        ? `\n\n(Showing ${memberLimit} of ${memberIds.length} total members)`
+        : "";
+
+    const responseText = `Members in #${channelName}:\n${memberDescriptions.join("\n")}${truncationNote}`;
+
+    return {
+      data: {
+        channelId,
+        channelName,
+        memberCount: memberIds.length,
+        members,
+        hasMoreMembers: memberIds.length > memberLimit,
+      },
+      values: {
+        channelId,
+        channelName,
+        memberCount: memberIds.length,
+      },
+      text: responseText,
+    };
+  },
+};
+
+export default memberListProvider;

--- a/plugins/plugin-slack/src/providers/workspaceInfo.ts
+++ b/plugins/plugin-slack/src/providers/workspaceInfo.ts
@@ -1,0 +1,144 @@
+import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
+import type { SlackService } from "../service";
+import { ServiceType } from "../types";
+import { validateActionKeywords, validateActionRegex } from "@elizaos/core";
+
+/**
+ * Provider for retrieving Slack workspace information.
+ */
+export const workspaceInfoProvider: Provider = {
+  name: "slackWorkspaceInfo",
+  description: "Provides information about the Slack workspace",
+    dynamic: true,
+  relevanceKeywords: [
+    "slackworkspaceinfo",
+    "workspaceinfoprovider",
+    "plugin",
+    "slack",
+    "status",
+    "state",
+    "context",
+    "info",
+    "details",
+    "chat",
+    "conversation",
+    "agent",
+    "room",
+    "channel",
+  ],
+get: async (runtime: IAgentRuntime, message: Memory, state: State) => {  const __providerKeywords = ["slackworkspaceinfo", "workspaceinfoprovider", "plugin", "slack", "status", "state", "context", "info", "details", "chat", "conversation", "agent", "room", "channel"];
+  const __providerRegex = new RegExp(`\\b(${__providerKeywords.join("|")})\\b`, "i");
+  const __recentMessages = (state?.recentMessagesData as Memory[] | undefined) ?? [];
+  const __isRelevant =
+    validateActionKeywords(message, __recentMessages, __providerKeywords) ||
+    validateActionRegex(message, __recentMessages, __providerRegex);
+  if (!__isRelevant) {
+    return { text: "" };
+  }
+
+
+    // If message source is not slack, return empty
+    if (message.content.source !== "slack") {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const slackService = runtime.getService(ServiceType.SLACK) as SlackService;
+    if (!slackService || !slackService.client) {
+      return {
+        data: {},
+        values: {},
+        text: "",
+      };
+    }
+
+    const teamId = slackService.getTeamId();
+    const botUserId = slackService.getBotUserId();
+    const isConnected = slackService.isServiceConnected();
+
+    let workspaceName = "";
+    let domain = "";
+
+    // Get workspace info from world if available
+    const room = state.data?.room ?? (await runtime.getRoom(message.roomId));
+    if (room?.worldId) {
+      const world = await runtime.getWorld(room.worldId);
+      if (world) {
+        workspaceName = world.name;
+        const worldMetadata = world.metadata as
+          | Record<string, unknown>
+          | undefined;
+        domain = (worldMetadata?.domain as string) || "";
+      }
+    }
+
+    // Get channel statistics
+    const channels = await slackService.listChannels({
+      types: "public_channel,private_channel",
+    });
+    const publicChannels = channels.filter(
+      (ch) => !ch.isPrivate && !ch.isArchived,
+    );
+    const privateChannels = channels.filter(
+      (ch) => ch.isPrivate && !ch.isArchived,
+    );
+    const memberChannels = channels.filter(
+      (ch) => ch.isMember && !ch.isArchived,
+    );
+
+    // Get allowed channels
+    const allowedChannelIds = slackService.getAllowedChannelIds();
+    const hasChannelRestrictions = allowedChannelIds.length > 0;
+
+    const agentName = state?.agentName || "The agent";
+
+    let responseText = `${agentName} is connected to the Slack workspace`;
+    if (workspaceName) {
+      responseText += ` "${workspaceName}"`;
+    }
+    if (domain) {
+      responseText += ` (${domain}.slack.com)`;
+    }
+    responseText += ".";
+
+    responseText += `\n\nWorkspace statistics:`;
+    responseText += `\n- Public channels: ${publicChannels.length}`;
+    responseText += `\n- Private channels: ${privateChannels.length}`;
+    responseText += `\n- Channels the bot is a member of: ${memberChannels.length}`;
+
+    if (hasChannelRestrictions) {
+      responseText += `\n\nNote: The bot is restricted to ${allowedChannelIds.length} specific channel(s).`;
+    }
+
+    return {
+      data: {
+        teamId,
+        botUserId,
+        workspaceName,
+        domain,
+        isConnected,
+        publicChannelCount: publicChannels.length,
+        privateChannelCount: privateChannels.length,
+        memberChannelCount: memberChannels.length,
+        hasChannelRestrictions,
+        allowedChannelIds,
+      },
+      values: {
+        teamId: teamId || "",
+        botUserId: botUserId || "",
+        workspaceName,
+        domain,
+        isConnected,
+        publicChannelCount: publicChannels.length,
+        privateChannelCount: privateChannels.length,
+        memberChannelCount: memberChannels.length,
+      },
+      text: responseText,
+    };
+  },
+};
+
+export default workspaceInfoProvider;

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -1,0 +1,1272 @@
+import {
+  ChannelType,
+  type Character,
+  type Content,
+  createUniqueUuid,
+  type EventPayload,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type IMessageService,
+  type Media,
+  type Memory,
+  type Room,
+  Service,
+  stringToUuid,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { App, LogLevel } from "@slack/bolt";
+import type { WebAPICallResult, WebClient } from "@slack/web-api";
+
+// Define Slack event types inline to avoid import issues
+interface SlackMessageEventType {
+  type: "message";
+  channel: string;
+  channel_type?: string;
+  user?: string;
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  team?: string;
+  bot_id?: string;
+  files?: Array<Record<string, unknown>>;
+}
+
+interface SlackAppMentionEventType {
+  type: "app_mention";
+  channel: string;
+  user?: string;
+  text: string;
+  ts: string;
+  thread_ts?: string;
+  event_ts: string;
+}
+
+// Helper to get message service from runtime
+const getMessageService = (runtime: IAgentRuntime): IMessageService | null => {
+  if ("messageService" in runtime) {
+    const withMessageService = runtime as IAgentRuntime & {
+      messageService?: IMessageService | null;
+    };
+    return withMessageService.messageService ?? null;
+  }
+  return null;
+};
+
+import {
+  getSlackChannelType,
+  getSlackUserDisplayName,
+  type ISlackService,
+  isValidChannelId,
+  MAX_SLACK_MESSAGE_LENGTH,
+  SLACK_SERVICE_NAME,
+  type SlackAttachment,
+  type SlackBlock,
+  type SlackChannel,
+  SlackEventTypes,
+  type SlackFile,
+  type SlackMessage,
+  type SlackMessageSendOptions,
+  type SlackSettings,
+  type SlackUser,
+} from "./types";
+
+import { markdownToSlackMrkdwn } from "./formatting";
+
+/**
+ * SlackService class for interacting with Slack via Socket Mode
+ */
+export class SlackService extends Service implements ISlackService {
+  static serviceType: string = SLACK_SERVICE_NAME;
+  capabilityDescription =
+    "The agent is able to send and receive messages on Slack";
+
+  app: App | null = null;
+  client: WebClient | null = null;
+  character: Character;
+  botUserId: string | null = null;
+  teamId: string | null = null;
+
+  private settings: SlackSettings;
+  private botToken: string | null = null;
+  private appToken: string | null = null;
+  private signingSecret: string | null = null;
+  private userToken: string | undefined = undefined;
+  private allowedChannelIds: Set<string> = new Set();
+  private dynamicChannelIds: Set<string> = new Set();
+  private userCache: Map<string, SlackUser> = new Map();
+  private channelCache: Map<string, SlackChannel> = new Map();
+  private isStarting = false;
+  private isConnected = false;
+
+  constructor(runtime: IAgentRuntime) {
+    super(runtime);
+    this.character = runtime.character;
+    this.settings = this.loadSettings();
+
+    // Parse allowed channel IDs
+    const channelIdsRaw = runtime.getSetting("SLACK_CHANNEL_IDS") as
+      | string
+      | undefined;
+    if (channelIdsRaw?.trim()) {
+      channelIdsRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0 && isValidChannelId(s))
+        .forEach((id) => this.allowedChannelIds.add(id));
+
+      this.runtime.logger.debug(
+        {
+          src: "plugin:slack",
+          agentId: this.runtime.agentId,
+          allowedChannelIds: Array.from(this.allowedChannelIds),
+        },
+        "Channel restrictions enabled",
+      );
+    }
+  }
+
+  private loadSettings(): SlackSettings {
+    const ignoreBotMessages = this.runtime.getSetting(
+      "SLACK_SHOULD_IGNORE_BOT_MESSAGES",
+    );
+    const respondOnlyToMentions = this.runtime.getSetting(
+      "SLACK_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+    );
+
+    return {
+      allowedChannelIds: undefined,
+      shouldIgnoreBotMessages:
+        ignoreBotMessages === "true" || ignoreBotMessages === true,
+      shouldRespondOnlyToMentions:
+        respondOnlyToMentions === "true" || respondOnlyToMentions === true,
+    };
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<SlackService> {
+    const service = new SlackService(runtime);
+
+    const botToken = runtime.getSetting("SLACK_BOT_TOKEN") as string;
+    const appToken = runtime.getSetting("SLACK_APP_TOKEN") as string;
+    const signingSecret = runtime.getSetting("SLACK_SIGNING_SECRET") as
+      | string
+      | undefined;
+    const userToken = runtime.getSetting("SLACK_USER_TOKEN") as
+      | string
+      | undefined;
+
+    if (!botToken || !botToken.trim()) {
+      runtime.logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_BOT_TOKEN not provided, Slack service will not start",
+      );
+      return service;
+    }
+
+    if (!appToken || !appToken.trim()) {
+      runtime.logger.warn(
+        { src: "plugin:slack", agentId: runtime.agentId },
+        "SLACK_APP_TOKEN not provided, Socket Mode will not work",
+      );
+      return service;
+    }
+
+    service.botToken = botToken;
+    service.appToken = appToken;
+    service.signingSecret = signingSecret || undefined;
+    service.userToken = userToken || undefined;
+
+    await service.initialize();
+
+    return service;
+  }
+
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService(SLACK_SERVICE_NAME) as
+      | SlackService
+      | undefined;
+    if (service) {
+      await service.shutdown();
+    }
+  }
+
+  async stop(): Promise<void> {
+    await this.shutdown();
+  }
+
+  private async initialize(): Promise<void> {
+    if (this.isStarting || this.isConnected) {
+      return;
+    }
+
+    this.isStarting = true;
+
+    this.runtime.logger.info(
+      { src: "plugin:slack", agentId: this.runtime.agentId },
+      "Initializing Slack service with Socket Mode",
+    );
+
+    this.app = new App({
+      token: this.botToken!,
+      appToken: this.appToken!,
+      socketMode: true,
+      logLevel: LogLevel.INFO,
+      ...(this.signingSecret ? { signingSecret: this.signingSecret } : {}),
+    });
+
+    this.client = this.app.client;
+
+    // Get bot user info
+    const authResult = await this.client.auth.test();
+    this.botUserId = authResult.user_id as string;
+    this.teamId = authResult.team_id as string;
+
+    this.runtime.logger.info(
+      {
+        src: "plugin:slack",
+        agentId: this.runtime.agentId,
+        botUserId: this.botUserId,
+        teamId: this.teamId,
+      },
+      "Slack bot authenticated",
+    );
+
+    // Register event handlers
+    this.registerEventHandlers();
+
+    // Start the Socket Mode connection
+    await this.app.start();
+
+    this.isConnected = true;
+    this.isStarting = false;
+
+    this.runtime.logger.info(
+      { src: "plugin:slack", agentId: this.runtime.agentId },
+      "Slack service started successfully",
+    );
+
+    // Ensure all workspaces exist
+    await this.ensureWorkspaceExists();
+  }
+
+  private async shutdown(): Promise<void> {
+    if (this.app) {
+      await this.app.stop();
+      this.app = null;
+      this.client = null;
+      this.isConnected = false;
+
+      this.runtime.logger.info(
+        { src: "plugin:slack", agentId: this.runtime.agentId },
+        "Slack service stopped",
+      );
+    }
+  }
+
+  private registerEventHandlers(): void {
+    if (!this.app) return;
+
+    // Handle regular messages
+    this.app.message(async ({ message, client }) => {
+      await this.handleMessage(message as SlackMessageEventType, client);
+    });
+
+    // Handle app mentions
+    this.app.event("app_mention", async ({ event, client }) => {
+      await this.handleAppMention(event as SlackAppMentionEventType, client);
+    });
+
+    // Handle reactions
+    this.app.event("reaction_added", async ({ event }) => {
+      await this.handleReactionAdded(event);
+    });
+
+    this.app.event("reaction_removed", async ({ event }) => {
+      await this.handleReactionRemoved(event);
+    });
+
+    // Handle channel joins/leaves
+    this.app.event("member_joined_channel", async ({ event }) => {
+      await this.handleMemberJoinedChannel(event);
+    });
+
+    this.app.event("member_left_channel", async ({ event }) => {
+      await this.handleMemberLeftChannel(event);
+    });
+
+    // Handle file shares
+    this.app.event("file_shared", async ({ event }) => {
+      await this.handleFileShared(event);
+    });
+  }
+
+  private async handleMessage(
+    message: SlackMessageEventType,
+    _client: WebClient,
+  ): Promise<void> {
+    // Ignore bot messages if configured
+    if (this.settings.shouldIgnoreBotMessages && message.bot_id) {
+      return;
+    }
+
+    // Ignore messages from self
+    if (message.user === this.botUserId) {
+      return;
+    }
+
+    // Check channel restrictions
+    if (!this.isChannelAllowed(message.channel)) {
+      this.runtime.logger.debug(
+        {
+          src: "plugin:slack",
+          agentId: this.runtime.agentId,
+          channelId: message.channel,
+        },
+        "Message received in non-allowed channel, ignoring",
+      );
+      return;
+    }
+
+    // Check if we should only respond to mentions
+    const isMentioned = message.text?.includes(`<@${this.botUserId}>`);
+    // Skip @mentions in channels — handleAppMention handles those
+    if (isMentioned && message.channel_type !== 'im') {
+      return;
+    }
+    if (this.settings.shouldRespondOnlyToMentions && !isMentioned) {
+      return;
+    }
+
+    const _isThreadReply = Boolean(
+      message.thread_ts && message.thread_ts !== message.ts,
+    );
+
+    // Build memory from message
+    const memory = await this.buildMemoryFromMessage(message);
+    if (!memory) return;
+
+    // Get or create room
+    const room = await this.ensureRoomExists(
+      message.channel,
+      message.thread_ts,
+    );
+
+    const existingEntity = await this.runtime.getEntityById(memory.entityId);
+    if (!existingEntity) {
+      const user = await this.getUser(message.user);
+      const displayName = user ? getSlackUserDisplayName(user) : message.user;
+      await this.runtime.createEntity({
+        id: memory.entityId,
+        names: [displayName],
+        metadata: { slack: { id: message.user, name: displayName, userName: user?.name || message.user } },
+        agentId: this.runtime.agentId,
+      });
+    }
+
+    // Store the memory
+    await this.runtime.createMemory(memory, "messages");
+
+    // Emit event
+    await this.runtime.emitEvent(
+      SlackEventTypes.MESSAGE_RECEIVED as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+
+    // Process the message through the agent
+    await this.processAgentMessage(
+      memory,
+      room,
+      message.channel,
+      message.thread_ts || message.ts,
+    );
+  }
+
+  private async handleAppMention(
+    event: SlackAppMentionEventType,
+    _client: WebClient,
+  ): Promise<void> {
+    // Skip if no user (optional in AppMentionEvent)
+    if (!event.user) return;
+
+    // Build memory from mention
+    const memory = await this.buildMemoryFromMention({
+      user: event.user,
+      text: event.text,
+      channel: event.channel,
+      ts: event.ts,
+      thread_ts: event.thread_ts,
+    });
+    if (!memory) return;
+
+    // Get or create room
+    const room = await this.ensureRoomExists(event.channel, event.thread_ts);
+
+    const existingEntity = await this.runtime.getEntityById(memory.entityId);
+    if (!existingEntity) {
+      const user = await this.getUser(event.user);
+      const displayName = user ? getSlackUserDisplayName(user) : event.user;
+      await this.runtime.createEntity({
+        id: memory.entityId,
+        names: [displayName],
+        metadata: { slack: { id: event.user, name: displayName, userName: user?.name || event.user } },
+        agentId: this.runtime.agentId,
+      });
+    }
+
+    // Store the memory
+    await this.runtime.createMemory(memory, "messages");
+
+    // Emit event
+    await this.runtime.emitEvent(
+      SlackEventTypes.APP_MENTION as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+
+    // Process the message
+    await this.processAgentMessage(
+      memory,
+      room,
+      event.channel,
+      event.thread_ts || event.ts,
+    );
+  }
+
+  private async handleReactionAdded(_event: {
+    user: string;
+    reaction: string;
+    item: { type: string; channel: string; ts: string };
+    item_user?: string;
+  }): Promise<void> {
+    await this.runtime.emitEvent(
+      SlackEventTypes.REACTION_ADDED as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+  }
+
+  private async handleReactionRemoved(_event: {
+    user: string;
+    reaction: string;
+    item: { type: string; channel: string; ts: string };
+    item_user?: string;
+  }): Promise<void> {
+    await this.runtime.emitEvent(
+      SlackEventTypes.REACTION_REMOVED as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+  }
+
+  private async handleMemberJoinedChannel(event: {
+    user: string;
+    channel: string;
+    team?: string;
+  }): Promise<void> {
+    // If the bot joined, add to dynamic channels
+    if (event.user === this.botUserId) {
+      this.dynamicChannelIds.add(event.channel);
+      await this.ensureRoomExists(event.channel);
+    }
+
+    await this.runtime.emitEvent(
+      SlackEventTypes.MEMBER_JOINED_CHANNEL as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+  }
+
+  private async handleMemberLeftChannel(event: {
+    user: string;
+    channel: string;
+    team?: string;
+  }): Promise<void> {
+    // If the bot left, remove from dynamic channels
+    if (event.user === this.botUserId) {
+      this.dynamicChannelIds.delete(event.channel);
+    }
+
+    await this.runtime.emitEvent(
+      SlackEventTypes.MEMBER_LEFT_CHANNEL as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+  }
+
+  private async handleFileShared(_event: {
+    file_id: string;
+    user_id: string;
+    channel_id: string;
+  }): Promise<void> {
+    await this.runtime.emitEvent(
+      SlackEventTypes.FILE_SHARED as string,
+      {
+        runtime: this.runtime,
+        source: "slack",
+      } as EventPayload,
+    );
+  }
+
+  private isChannelAllowed(channelId: string): boolean {
+    // If no restrictions, all channels allowed
+    if (
+      this.allowedChannelIds.size === 0 &&
+      this.dynamicChannelIds.size === 0
+    ) {
+      return true;
+    }
+
+    // Check static and dynamic allowed lists
+    return (
+      this.allowedChannelIds.has(channelId) ||
+      this.dynamicChannelIds.has(channelId)
+    );
+  }
+
+  private async processAgentMessage(
+    memory: Memory,
+    room: Room,
+    channelId: string,
+    threadTs: string,
+  ): Promise<void> {
+    const callback: HandlerCallback = async (
+      response: Content,
+    ): Promise<Memory[]> => {
+      const responseText = response.text || "";
+      if (!responseText.trim()) {
+        this.runtime.logger.warn({ src: "plugin:slack", channelId, roomId: room.id }, "Empty response from model, skipping sendMessage");
+        return [];
+      }
+
+      await this.sendMessage(channelId, responseText, {
+        threadTs,
+        replyBroadcast: undefined,
+        unfurlLinks: undefined,
+        unfurlMedia: undefined,
+        mrkdwn: undefined,
+        attachments: undefined,
+        blocks: undefined,
+      });
+
+      // Create memory for the response
+      const responseMemory: Memory = {
+        id: createUniqueUuid(this.runtime, `slack-response-${Date.now()}`),
+        agentId: this.runtime.agentId,
+        roomId: room.id,
+        entityId: this.runtime.agentId,
+        content: {
+          text: response.text || "",
+          source: "slack",
+          inReplyTo: memory.id,
+        },
+        createdAt: Date.now(),
+      };
+
+      await this.runtime.createMemory(responseMemory, "messages");
+
+      await this.runtime.emitEvent(
+        SlackEventTypes.MESSAGE_SENT as string,
+        {
+          runtime: this.runtime,
+          source: "slack",
+        } as EventPayload,
+      );
+
+      return [responseMemory];
+    };
+
+    const messageService = getMessageService(this.runtime);
+    if (messageService) {
+      await messageService.handleMessage(this.runtime, memory, callback);
+    }
+  }
+
+  private async buildMemoryFromMessage(
+    message: SlackMessageEventType,
+  ): Promise<Memory | null> {
+    if (!message.user) return null;
+
+    const roomId = await this.getRoomId(message.channel, message.thread_ts);
+    const entityId = this.getEntityId(message.user);
+
+    // Get user info for display name
+    const user = await this.getUser(message.user);
+    const displayName = user ? getSlackUserDisplayName(user) : message.user;
+
+    // Extract media from files
+    const media: Media[] = [];
+    if ("files" in message && message.files) {
+      for (const file of message.files as unknown as SlackFile[]) {
+        media.push({
+          id: file.id,
+          url: file.urlPrivate,
+          title: file.title || file.name,
+          source: "slack",
+          description: file.name,
+        });
+      }
+    }
+
+    const memory: Memory = {
+      id: createUniqueUuid(this.runtime, `slack-${message.ts}`),
+      agentId: this.runtime.agentId,
+      roomId,
+      entityId,
+      content: {
+        text: message.text || "",
+        source: "slack",
+        name: displayName,
+        ...(media.length > 0 ? { attachments: media } : {}),
+      },
+      createdAt: this.parseSlackTimestamp(message.ts),
+    };
+
+    return memory;
+  }
+
+  private async buildMemoryFromMention(event: {
+    user: string;
+    text: string;
+    channel: string;
+    ts: string;
+    thread_ts?: string;
+  }): Promise<Memory | null> {
+    const roomId = await this.getRoomId(event.channel, event.thread_ts);
+    const entityId = this.getEntityId(event.user);
+
+    const user = await this.getUser(event.user);
+    const displayName = user ? getSlackUserDisplayName(user) : event.user;
+
+    // Remove the bot mention from the text
+    const cleanText = event.text.replace(`<@${this.botUserId}>`, "").trim();
+
+    const memory: Memory = {
+      id: createUniqueUuid(this.runtime, `slack-mention-${event.ts}`),
+      agentId: this.runtime.agentId,
+      roomId,
+      entityId,
+      content: {
+        text: cleanText,
+        source: "slack",
+        name: displayName,
+        mentionContext: { isMention: true, isReply: false, isThread: false },
+      },
+      createdAt: this.parseSlackTimestamp(event.ts),
+    };
+
+    return memory;
+  }
+
+  private async getRoomId(channelId: string, threadTs?: string): Promise<UUID> {
+    // Use thread_ts to create unique rooms for threads
+    const roomKey = threadTs ? `${channelId}-${threadTs}` : channelId;
+    return createUniqueUuid(this.runtime, `slack-room-${roomKey}`);
+  }
+
+  private getEntityId(userId: string): UUID {
+    return stringToUuid(`slack-user-${userId}`);
+  }
+
+  private parseSlackTimestamp(ts: string): number {
+    // Slack timestamps are in the format: 1234567890.123456
+    const [seconds] = ts.split(".");
+    return parseInt(seconds, 10) * 1000;
+  }
+
+  private async ensureWorkspaceExists(): Promise<void> {
+    if (!this.teamId || !this.client) return;
+
+    const worldId = createUniqueUuid(
+      this.runtime,
+      `slack-workspace-${this.teamId}`,
+    );
+
+    const existingWorld = await this.runtime.getWorld(worldId);
+    if (existingWorld) return;
+
+    // Get team info
+    const teamInfo = await this.client.team.info();
+    const team = teamInfo.team;
+
+    const world: World = {
+      id: worldId,
+      name:
+        (team as { name?: string })?.name || `Slack Workspace ${this.teamId}`,
+      agentId: this.runtime.agentId,
+      metadata: {
+        type: "slack",
+        extra: {
+          teamId: this.teamId,
+          domain: (team as { domain?: string })?.domain,
+        },
+      },
+    };
+
+    await this.runtime.createWorld(world);
+
+    this.runtime.logger.info(
+      {
+        src: "plugin:slack",
+        agentId: this.runtime.agentId,
+        worldId,
+        teamId: this.teamId,
+      },
+      "Created Slack workspace world",
+    );
+  }
+
+  private async ensureRoomExists(
+    channelId: string,
+    threadTs?: string,
+  ): Promise<Room> {
+    const roomId = await this.getRoomId(channelId, threadTs);
+
+    const existingRoom = await this.runtime.getRoom(roomId);
+    if (existingRoom) return existingRoom;
+
+    // Get channel info
+    const channel = await this.getChannel(channelId);
+    const channelType = channel ? getSlackChannelType(channel) : "channel";
+
+    const worldId = this.teamId
+      ? createUniqueUuid(this.runtime, `slack-workspace-${this.teamId}`)
+      : undefined;
+
+    const elizaChannelType =
+      channelType === "im"
+        ? ChannelType.DM
+        : channelType === "mpim"
+          ? ChannelType.GROUP
+          : ChannelType.GROUP;
+
+    const room: Room = {
+      id: roomId,
+      name: channel?.name || channelId,
+      agentId: this.runtime.agentId,
+      source: "slack",
+      type: elizaChannelType,
+      channelId,
+      worldId,
+      metadata: {
+        slackChannelType: channelType,
+        threadTs,
+        topic: channel?.topic?.value,
+        purpose: channel?.purpose?.value,
+        serverId: this.teamId,
+      },
+    };
+
+    await this.runtime.createRoom(room);
+
+    this.runtime.logger.debug(
+      {
+        src: "plugin:slack",
+        agentId: this.runtime.agentId,
+        roomId,
+        channelId,
+        threadTs,
+      },
+      "Created Slack room",
+    );
+
+    return room;
+  }
+
+  async getUser(userId: string): Promise<SlackUser | null> {
+    // Check cache first
+    if (this.userCache.has(userId)) {
+      return this.userCache.get(userId)!;
+    }
+
+    if (!this.client) return null;
+
+    const result = await this.client.users.info({ user: userId });
+    if (!result.user) return null;
+
+    const user: SlackUser = {
+      id: result.user.id!,
+      teamId: result.user.team_id,
+      name: result.user.name!,
+      deleted: result.user.deleted || false,
+      realName: result.user.real_name,
+      tz: result.user.tz,
+      tzLabel: result.user.tz_label,
+      tzOffset: result.user.tz_offset,
+      profile: {
+        title: result.user.profile?.title,
+        phone: result.user.profile?.phone,
+        skype: result.user.profile?.skype,
+        realName: result.user.profile?.real_name,
+        realNameNormalized: result.user.profile?.real_name_normalized,
+        displayName: result.user.profile?.display_name,
+        displayNameNormalized: result.user.profile?.display_name_normalized,
+        statusText: result.user.profile?.status_text,
+        statusEmoji: result.user.profile?.status_emoji,
+        statusExpiration: result.user.profile?.status_expiration,
+        avatarHash: result.user.profile?.avatar_hash,
+        email: result.user.profile?.email,
+        image24: result.user.profile?.image_24,
+        image32: result.user.profile?.image_32,
+        image48: result.user.profile?.image_48,
+        image72: result.user.profile?.image_72,
+        image192: result.user.profile?.image_192,
+        image512: result.user.profile?.image_512,
+        image1024: result.user.profile?.image_1024,
+        imageOriginal: result.user.profile?.image_original,
+        team: result.user.profile?.team,
+      },
+      isAdmin: result.user.is_admin || false,
+      isOwner: result.user.is_owner || false,
+      isPrimaryOwner: result.user.is_primary_owner || false,
+      isRestricted: result.user.is_restricted || false,
+      isUltraRestricted: result.user.is_ultra_restricted || false,
+      isBot: result.user.is_bot || false,
+      isAppUser: result.user.is_app_user || false,
+      updated: result.user.updated || 0,
+    };
+
+    this.userCache.set(userId, user);
+    return user;
+  }
+
+  async getChannel(channelId: string): Promise<SlackChannel | null> {
+    // Check cache first
+    if (this.channelCache.has(channelId)) {
+      return this.channelCache.get(channelId)!;
+    }
+
+    if (!this.client) return null;
+
+    const result = await this.client.conversations.info({ channel: channelId });
+    if (!result.channel) return null;
+
+    const channel: SlackChannel = {
+      id: (result.channel as { id: string }).id,
+      name: (result.channel as { name: string }).name || "",
+      isChannel:
+        (result.channel as { is_channel?: boolean }).is_channel || false,
+      isGroup: (result.channel as { is_group?: boolean }).is_group || false,
+      isIm: (result.channel as { is_im?: boolean }).is_im || false,
+      isMpim: (result.channel as { is_mpim?: boolean }).is_mpim || false,
+      isPrivate:
+        (result.channel as { is_private?: boolean }).is_private || false,
+      isArchived:
+        (result.channel as { is_archived?: boolean }).is_archived || false,
+      isGeneral:
+        (result.channel as { is_general?: boolean }).is_general || false,
+      isShared: (result.channel as { is_shared?: boolean }).is_shared || false,
+      isOrgShared:
+        (result.channel as { is_org_shared?: boolean }).is_org_shared || false,
+      isMember: (result.channel as { is_member?: boolean }).is_member || false,
+      topic: (
+        result.channel as {
+          topic?: { value: string; creator: string; last_set: number };
+        }
+      ).topic
+        ? {
+            value: (result.channel as { topic: { value: string } }).topic.value,
+            creator: (result.channel as { topic: { creator: string } }).topic
+              .creator,
+            lastSet: (result.channel as { topic: { last_set: number } }).topic
+              .last_set,
+          }
+        : undefined,
+      purpose: (
+        result.channel as {
+          purpose?: { value: string; creator: string; last_set: number };
+        }
+      ).purpose
+        ? {
+            value: (result.channel as { purpose: { value: string } }).purpose
+              .value,
+            creator: (result.channel as { purpose: { creator: string } })
+              .purpose.creator,
+            lastSet: (result.channel as { purpose: { last_set: number } })
+              .purpose.last_set,
+          }
+        : undefined,
+      numMembers: (result.channel as { num_members?: number }).num_members,
+      created: (result.channel as { created: number }).created,
+      creator: (result.channel as { creator: string }).creator,
+    };
+
+    this.channelCache.set(channelId, channel);
+    return channel;
+  }
+
+  async sendMessage(
+    channelId: string,
+    text: string,
+    options?: SlackMessageSendOptions,
+  ): Promise<{ ts: string; channelId: string }> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    // Split message if too long
+    const convertedText = markdownToSlackMrkdwn(text);
+    const messages = this.splitMessage(convertedText);
+    let lastTs = "";
+
+    for (const msg of messages) {
+      const result = await this.client.chat.postMessage({
+        channel: channelId,
+        text: msg,
+        thread_ts: options?.threadTs,
+        reply_broadcast: options?.replyBroadcast,
+        unfurl_links: options?.unfurlLinks,
+        unfurl_media: options?.unfurlMedia,
+        mrkdwn: options?.mrkdwn ?? true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        attachments: options?.attachments as unknown as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        blocks: options?.blocks as unknown as any,
+      });
+
+      lastTs = result.ts as string;
+    }
+
+    return { ts: lastTs, channelId };
+  }
+
+  async sendReaction(
+    channelId: string,
+    messageTs: string,
+    emoji: string,
+  ): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    // Remove colons if present
+    const cleanEmoji = emoji.replace(/^:/, "").replace(/:$/, "");
+
+    await this.client.reactions.add({
+      channel: channelId,
+      timestamp: messageTs,
+      name: cleanEmoji,
+    });
+  }
+
+  async removeReaction(
+    channelId: string,
+    messageTs: string,
+    emoji: string,
+  ): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const cleanEmoji = emoji.replace(/^:/, "").replace(/:$/, "");
+
+    await this.client.reactions.remove({
+      channel: channelId,
+      timestamp: messageTs,
+      name: cleanEmoji,
+    });
+  }
+
+  async editMessage(
+    channelId: string,
+    messageTs: string,
+    text: string,
+  ): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    await this.client.chat.update({
+      channel: channelId,
+      ts: messageTs,
+      text,
+    });
+  }
+
+  async deleteMessage(channelId: string, messageTs: string): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    await this.client.chat.delete({
+      channel: channelId,
+      ts: messageTs,
+    });
+  }
+
+  async pinMessage(channelId: string, messageTs: string): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    await this.client.pins.add({
+      channel: channelId,
+      timestamp: messageTs,
+    });
+  }
+
+  async unpinMessage(channelId: string, messageTs: string): Promise<void> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    await this.client.pins.remove({
+      channel: channelId,
+      timestamp: messageTs,
+    });
+  }
+
+  async listPins(channelId: string): Promise<SlackMessage[]> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const result = await this.client.pins.list({ channel: channelId });
+
+    return (result.items || [])
+      .filter(
+        (item): item is { type: "message"; message: Record<string, unknown> } =>
+          item.type === "message" && "message" in item && !!item.message,
+      )
+      .map((item) => ({
+        type: item.message.type as string,
+        subtype: item.message.subtype as string | undefined,
+        ts: item.message.ts as string,
+        user: item.message.user as string | undefined,
+        text: item.message.text as string,
+        threadTs: item.message.thread_ts as string | undefined,
+        replyCount: item.message.reply_count as number | undefined,
+        replyUsersCount: item.message.reply_users_count as number | undefined,
+        latestReply: item.message.latest_reply as string | undefined,
+        reactions: item.message.reactions as
+          | { name: string; count: number; users: string[] }[]
+          | undefined,
+        files: item.message.files as SlackFile[] | undefined,
+        attachments: item.message.attachments as SlackAttachment[] | undefined,
+        blocks: item.message.blocks as SlackBlock[] | undefined,
+      }));
+  }
+
+  async readHistory(
+    channelId: string,
+    options?: { limit?: number; before?: string; after?: string },
+  ): Promise<SlackMessage[]> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const result = await this.client.conversations.history({
+      channel: channelId,
+      limit: options?.limit || 100,
+      latest: options?.before,
+      oldest: options?.after,
+    });
+
+    return (result.messages || []).map((msg) => ({
+      type: msg.type as string,
+      subtype: msg.subtype as string | undefined,
+      ts: msg.ts as string,
+      user: msg.user as string | undefined,
+      text: msg.text as string,
+      threadTs: msg.thread_ts as string | undefined,
+      replyCount: msg.reply_count as number | undefined,
+      replyUsersCount: msg.reply_users_count as number | undefined,
+      latestReply: msg.latest_reply as string | undefined,
+      reactions: msg.reactions as
+        | { name: string; count: number; users: string[] }[]
+        | undefined,
+      files: msg.files as SlackFile[] | undefined,
+      attachments: msg.attachments as SlackAttachment[] | undefined,
+      blocks: msg.blocks as SlackBlock[] | undefined,
+    }));
+  }
+
+  async listChannels(options?: {
+    types?: string;
+    limit?: number;
+  }): Promise<SlackChannel[]> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const result = await this.client.conversations.list({
+      types: options?.types || "public_channel,private_channel",
+      limit: options?.limit || 1000,
+    });
+
+    return (result.channels || []).map((ch) => ({
+      id: ch.id!,
+      name: ch.name || "",
+      isChannel: ch.is_channel || false,
+      isGroup: ch.is_group || false,
+      isIm: ch.is_im || false,
+      isMpim: ch.is_mpim || false,
+      isPrivate: ch.is_private || false,
+      isArchived: ch.is_archived || false,
+      isGeneral: ch.is_general || false,
+      isShared: ch.is_shared || false,
+      isOrgShared: ch.is_org_shared || false,
+      isMember: ch.is_member || false,
+      topic: ch.topic
+        ? {
+            value: ch.topic.value!,
+            creator: ch.topic.creator!,
+            lastSet: ch.topic.last_set!,
+          }
+        : undefined,
+      purpose: ch.purpose
+        ? {
+            value: ch.purpose.value!,
+            creator: ch.purpose.creator!,
+            lastSet: ch.purpose.last_set!,
+          }
+        : undefined,
+      numMembers: ch.num_members,
+      created: ch.created || 0,
+      creator: ch.creator || "",
+    }));
+  }
+
+  async getEmojiList(): Promise<Record<string, string>> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const result = await this.client.emoji.list();
+    return (result.emoji || {}) as Record<string, string>;
+  }
+
+  async uploadFile(
+    channelId: string,
+    content: Buffer | string,
+    filename: string,
+    options?: { title?: string; initialComment?: string; threadTs?: string },
+  ): Promise<{ fileId: string; permalink: string }> {
+    if (!this.client) {
+      throw new Error("Slack client not initialized");
+    }
+
+    const result = await this.client.files.uploadV2({
+      channel_id: channelId,
+      content: typeof content === "string" ? content : undefined,
+      file: typeof content !== "string" ? content : undefined,
+      filename,
+      title: options?.title,
+      initial_comment: options?.initialComment,
+      thread_ts: options?.threadTs,
+    });
+
+    const resultWithFile = result as WebAPICallResult & {
+      file?: { id: string; permalink: string };
+    };
+    const file = resultWithFile.file;
+    return {
+      fileId: file?.id || "",
+      permalink: file?.permalink || "",
+    };
+  }
+
+  private splitMessage(text: string): string[] {
+    if (text.length <= MAX_SLACK_MESSAGE_LENGTH) {
+      return [text];
+    }
+
+    const messages: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+      if (remaining.length <= MAX_SLACK_MESSAGE_LENGTH) {
+        messages.push(remaining);
+        break;
+      }
+
+      // Find a good split point (prefer newlines, then spaces)
+      let splitIndex = MAX_SLACK_MESSAGE_LENGTH;
+
+      const lastNewline = remaining.lastIndexOf("\n", MAX_SLACK_MESSAGE_LENGTH);
+      if (lastNewline > MAX_SLACK_MESSAGE_LENGTH / 2) {
+        splitIndex = lastNewline + 1;
+      } else {
+        const lastSpace = remaining.lastIndexOf(" ", MAX_SLACK_MESSAGE_LENGTH);
+        if (lastSpace > MAX_SLACK_MESSAGE_LENGTH / 2) {
+          splitIndex = lastSpace + 1;
+        }
+      }
+
+      messages.push(remaining.slice(0, splitIndex));
+      remaining = remaining.slice(splitIndex);
+    }
+
+    return messages;
+  }
+
+  /**
+   * Add a channel to the dynamic allowed list
+   */
+  addAllowedChannel(channelId: string): void {
+    if (isValidChannelId(channelId)) {
+      this.dynamicChannelIds.add(channelId);
+    }
+  }
+
+  /**
+   * Remove a channel from the dynamic allowed list
+   */
+  removeAllowedChannel(channelId: string): void {
+    this.dynamicChannelIds.delete(channelId);
+  }
+
+  /**
+   * Get all currently allowed channel IDs
+   */
+  getAllowedChannelIds(): string[] {
+    return [...this.allowedChannelIds, ...this.dynamicChannelIds];
+  }
+
+  /**
+   * Check if the service is connected
+   */
+  isServiceConnected(): boolean {
+    return this.isConnected && this.app !== null;
+  }
+
+  /**
+   * Get the bot's user ID
+   */
+  getBotUserId(): string | null {
+    return this.botUserId;
+  }
+
+  /**
+   * Get the team/workspace ID
+   */
+  getTeamId(): string | null {
+    return this.teamId;
+  }
+
+  /**
+   * Clear the user cache
+   */
+  clearUserCache(): void {
+    this.userCache.clear();
+  }
+
+  /**
+   * Clear the channel cache
+   */
+  clearChannelCache(): void {
+    this.channelCache.clear();
+  }
+}

--- a/plugins/plugin-slack/src/types.ts
+++ b/plugins/plugin-slack/src/types.ts
@@ -1,0 +1,435 @@
+import type {
+  Character,
+  EntityPayload,
+  EventPayload,
+  MessagePayload,
+  WorldPayload,
+} from "@elizaos/core";
+import type { App as BoltApp } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
+
+/**
+ * Slack-specific event types
+ */
+export enum SlackEventTypes {
+  MESSAGE_RECEIVED = "SLACK_MESSAGE_RECEIVED",
+  MESSAGE_SENT = "SLACK_MESSAGE_SENT",
+  REACTION_ADDED = "SLACK_REACTION_ADDED",
+  REACTION_REMOVED = "SLACK_REACTION_REMOVED",
+  CHANNEL_JOINED = "SLACK_CHANNEL_JOINED",
+  CHANNEL_LEFT = "SLACK_CHANNEL_LEFT",
+  MEMBER_JOINED_CHANNEL = "SLACK_MEMBER_JOINED_CHANNEL",
+  MEMBER_LEFT_CHANNEL = "SLACK_MEMBER_LEFT_CHANNEL",
+  APP_MENTION = "SLACK_APP_MENTION",
+  SLASH_COMMAND = "SLACK_SLASH_COMMAND",
+  FILE_SHARED = "SLACK_FILE_SHARED",
+  THREAD_REPLY = "SLACK_THREAD_REPLY",
+}
+
+export interface SlackMessageReceivedPayload extends MessagePayload {
+  channelId: string;
+  threadTs: string | undefined;
+  userId: string;
+  teamId: string | undefined;
+  isThreadReply: boolean;
+  files: SlackFile[];
+}
+
+export interface SlackMessageSentPayload extends MessagePayload {
+  channelId: string;
+  threadTs: string | undefined;
+  messageTs: string;
+}
+
+export interface SlackReactionPayload extends EventPayload {
+  reaction: string;
+  userId: string;
+  channelId: string;
+  messageTs: string;
+  itemUser: string | undefined;
+}
+
+export interface SlackChannelPayload extends WorldPayload {
+  channelId: string;
+  channelName: string;
+  channelType: SlackChannelType;
+}
+
+export interface SlackMemberPayload extends EntityPayload {
+  userId: string;
+  channelId: string;
+}
+
+export interface SlackAppMentionPayload extends MessagePayload {
+  channelId: string;
+  userId: string;
+  threadTs: string | undefined;
+}
+
+export interface SlackSlashCommandPayload extends EventPayload {
+  command: string;
+  text: string;
+  userId: string;
+  channelId: string;
+  teamId: string;
+  responseUrl: string;
+  triggerId: string;
+}
+
+export interface SlackFile {
+  id: string;
+  name: string;
+  title: string;
+  mimetype: string;
+  filetype: string;
+  size: number;
+  urlPrivate: string;
+  urlPrivateDownload: string | undefined;
+  permalink: string;
+  thumb64: string | undefined;
+  thumb80: string | undefined;
+  thumb360: string | undefined;
+}
+
+export type SlackChannelType = "channel" | "group" | "im" | "mpim";
+
+export interface SlackEventPayloadMap {
+  [SlackEventTypes.MESSAGE_RECEIVED]: SlackMessageReceivedPayload;
+  [SlackEventTypes.MESSAGE_SENT]: SlackMessageSentPayload;
+  [SlackEventTypes.REACTION_ADDED]: SlackReactionPayload;
+  [SlackEventTypes.REACTION_REMOVED]: SlackReactionPayload;
+  [SlackEventTypes.CHANNEL_JOINED]: SlackChannelPayload;
+  [SlackEventTypes.CHANNEL_LEFT]: SlackChannelPayload;
+  [SlackEventTypes.MEMBER_JOINED_CHANNEL]: SlackMemberPayload;
+  [SlackEventTypes.MEMBER_LEFT_CHANNEL]: SlackMemberPayload;
+  [SlackEventTypes.APP_MENTION]: SlackAppMentionPayload;
+  [SlackEventTypes.SLASH_COMMAND]: SlackSlashCommandPayload;
+  [SlackEventTypes.FILE_SHARED]: SlackMessageReceivedPayload;
+  [SlackEventTypes.THREAD_REPLY]: SlackMessageReceivedPayload;
+}
+
+export interface SlackUser {
+  id: string;
+  teamId: string | undefined;
+  name: string;
+  deleted: boolean;
+  realName: string | undefined;
+  tz: string | undefined;
+  tzLabel: string | undefined;
+  tzOffset: number | undefined;
+  profile: SlackUserProfile;
+  isAdmin: boolean;
+  isOwner: boolean;
+  isPrimaryOwner: boolean;
+  isRestricted: boolean;
+  isUltraRestricted: boolean;
+  isBot: boolean;
+  isAppUser: boolean;
+  updated: number;
+}
+
+export interface SlackUserProfile {
+  title: string | undefined;
+  phone: string | undefined;
+  skype: string | undefined;
+  realName: string | undefined;
+  realNameNormalized: string | undefined;
+  displayName: string | undefined;
+  displayNameNormalized: string | undefined;
+  statusText: string | undefined;
+  statusEmoji: string | undefined;
+  statusExpiration: number | undefined;
+  avatarHash: string | undefined;
+  email: string | undefined;
+  image24: string | undefined;
+  image32: string | undefined;
+  image48: string | undefined;
+  image72: string | undefined;
+  image192: string | undefined;
+  image512: string | undefined;
+  image1024: string | undefined;
+  imageOriginal: string | undefined;
+  team: string | undefined;
+}
+
+export interface SlackChannel {
+  id: string;
+  name: string;
+  isChannel: boolean;
+  isGroup: boolean;
+  isIm: boolean;
+  isMpim: boolean;
+  isPrivate: boolean;
+  isArchived: boolean;
+  isGeneral: boolean;
+  isShared: boolean;
+  isOrgShared: boolean;
+  isMember: boolean;
+  topic: SlackChannelTopic | undefined;
+  purpose: SlackChannelPurpose | undefined;
+  numMembers: number | undefined;
+  created: number;
+  creator: string;
+}
+
+export interface SlackChannelTopic {
+  value: string;
+  creator: string;
+  lastSet: number;
+}
+
+export interface SlackChannelPurpose {
+  value: string;
+  creator: string;
+  lastSet: number;
+}
+
+export interface SlackMessage {
+  type: string;
+  subtype: string | undefined;
+  ts: string;
+  user: string | undefined;
+  text: string;
+  threadTs: string | undefined;
+  replyCount: number | undefined;
+  replyUsersCount: number | undefined;
+  latestReply: string | undefined;
+  reactions: SlackReaction[] | undefined;
+  files: SlackFile[] | undefined;
+  attachments: SlackAttachment[] | undefined;
+  blocks: SlackBlock[] | undefined;
+}
+
+export interface SlackReaction {
+  name: string;
+  count: number;
+  users: string[];
+}
+
+export interface SlackAttachment {
+  id: number;
+  fallback: string | undefined;
+  color: string | undefined;
+  pretext: string | undefined;
+  authorName: string | undefined;
+  authorLink: string | undefined;
+  authorIcon: string | undefined;
+  title: string | undefined;
+  titleLink: string | undefined;
+  text: string | undefined;
+  fields: SlackAttachmentField[] | undefined;
+  imageUrl: string | undefined;
+  thumbUrl: string | undefined;
+  footer: string | undefined;
+  footerIcon: string | undefined;
+  ts: string | undefined;
+}
+
+export interface SlackAttachmentField {
+  title: string;
+  value: string;
+  short: boolean;
+}
+
+export interface SlackBlock {
+  type: string;
+  blockId: string | undefined;
+  elements: SlackBlockElement[] | undefined;
+  text: SlackBlockText | undefined;
+}
+
+export interface SlackBlockElement {
+  type: string;
+  text: SlackBlockText | undefined;
+  actionId: string | undefined;
+  url: string | undefined;
+  value: string | undefined;
+  style: string | undefined;
+}
+
+export interface SlackBlockText {
+  type: string;
+  text: string;
+  emoji: boolean | undefined;
+  verbatim: boolean | undefined;
+}
+
+export interface SlackTeam {
+  id: string;
+  name: string;
+  domain: string;
+  emailDomain: string | undefined;
+  icon: SlackTeamIcon;
+}
+
+export interface SlackTeamIcon {
+  image34: string | undefined;
+  image44: string | undefined;
+  image68: string | undefined;
+  image88: string | undefined;
+  image102: string | undefined;
+  image132: string | undefined;
+  image230: string | undefined;
+  imageDefault: boolean;
+}
+
+export interface ISlackService {
+  app: BoltApp | null;
+  client: WebClient | null;
+  character: Character;
+  botUserId: string | null;
+  teamId: string | null;
+}
+
+export const SLACK_SERVICE_NAME = "slack";
+
+export const ServiceType = {
+  SLACK: "slack",
+} as const;
+
+export interface SlackSettings {
+  allowedChannelIds: string[] | undefined;
+  shouldIgnoreBotMessages: boolean;
+  shouldRespondOnlyToMentions: boolean;
+}
+
+export interface SlackMessageSendOptions {
+  threadTs: string | undefined;
+  replyBroadcast: boolean | undefined;
+  unfurlLinks: boolean | undefined;
+  unfurlMedia: boolean | undefined;
+  mrkdwn: boolean | undefined;
+  attachments: SlackAttachment[] | undefined;
+  blocks: SlackBlock[] | undefined;
+}
+
+export class SlackPluginError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = "SlackPluginError";
+  }
+}
+
+export class SlackServiceNotInitializedError extends SlackPluginError {
+  constructor() {
+    super("Slack service is not initialized", "SERVICE_NOT_INITIALIZED");
+    this.name = "SlackServiceNotInitializedError";
+  }
+}
+
+export class SlackClientNotAvailableError extends SlackPluginError {
+  constructor() {
+    super("Slack client is not available", "CLIENT_NOT_AVAILABLE");
+    this.name = "SlackClientNotAvailableError";
+  }
+}
+
+export class SlackConfigurationError extends SlackPluginError {
+  constructor(missingConfig: string) {
+    super(`Missing required configuration: ${missingConfig}`, "MISSING_CONFIG");
+    this.name = "SlackConfigurationError";
+  }
+}
+
+export class SlackApiError extends SlackPluginError {
+  constructor(
+    message: string,
+    public readonly apiErrorCode: string | undefined,
+  ) {
+    super(message, "API_ERROR");
+    this.name = "SlackApiError";
+  }
+}
+
+/**
+ * Validates a Slack channel ID format
+ */
+export function isValidChannelId(id: string): boolean {
+  // Slack channel IDs start with C (public), G (private/group), or D (DM)
+  return /^[CGD][A-Z0-9]{8,}$/i.test(id);
+}
+
+/**
+ * Validates a Slack user ID format
+ */
+export function isValidUserId(id: string): boolean {
+  // Slack user IDs start with U or W (enterprise grid)
+  return /^[UW][A-Z0-9]{8,}$/i.test(id);
+}
+
+/**
+ * Validates a Slack team ID format
+ */
+export function isValidTeamId(id: string): boolean {
+  // Slack team IDs start with T
+  return /^T[A-Z0-9]{8,}$/i.test(id);
+}
+
+/**
+ * Validates a Slack message timestamp format
+ */
+export function isValidMessageTs(ts: string): boolean {
+  // Slack timestamps are in the format: 1234567890.123456
+  return /^\d+\.\d{6}$/.test(ts);
+}
+
+/**
+ * Parses a Slack message link to extract channel and message IDs
+ */
+export function parseSlackMessageLink(
+  link: string,
+): { channelId: string; messageTs: string } | null {
+  // Format: https://workspace.slack.com/archives/C12345678/p1234567890123456
+  const match = link.match(/\/archives\/([CGD][A-Z0-9]+)\/p(\d+)/i);
+  if (!match) return null;
+
+  const channelId = match[1];
+  const ts = match[2];
+  // Convert the timestamp: p1234567890123456 -> 1234567890.123456
+  const messageTs = `${ts.slice(0, 10)}.${ts.slice(10)}`;
+
+  return { channelId, messageTs };
+}
+
+/**
+ * Formats a message timestamp for use in Slack links
+ */
+export function formatMessageTsForLink(ts: string): string {
+  // Convert: 1234567890.123456 -> p1234567890123456
+  return `p${ts.replace(".", "")}`;
+}
+
+/**
+ * Gets the display name for a Slack user
+ */
+export function getSlackUserDisplayName(user: SlackUser): string {
+  return user.profile.displayName || user.profile.realName || user.name;
+}
+
+/**
+ * Determines the channel type from a Slack channel object
+ */
+export function getSlackChannelType(channel: SlackChannel): SlackChannelType {
+  if (channel.isIm) return "im";
+  if (channel.isMpim) return "mpim";
+  if (channel.isGroup || channel.isPrivate) return "group";
+  return "channel";
+}
+
+/**
+ * Maximum message length for Slack messages
+ */
+export const MAX_SLACK_MESSAGE_LENGTH = 4000;
+
+/**
+ * Maximum number of blocks per message
+ */
+export const MAX_SLACK_BLOCKS = 50;
+
+/**
+ * Maximum file size for uploads (in bytes) - 1GB for paid, varies for free
+ */
+export const MAX_SLACK_FILE_SIZE = 1024 * 1024 * 1024;

--- a/plugins/plugin-slack/tsconfig.json
+++ b/plugins/plugin-slack/tsconfig.json
@@ -1,0 +1,34 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM"],
+		"strict": false,
+		"noEmit": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"allowImportingTsExtensions": true,
+		"declaration": true,
+		"declarationMap": true,
+		"noUnusedLocals": false,
+		"noUnusedParameters": false,
+		"noImplicitReturns": false,
+		"noImplicitAny": false,
+		"strictPropertyInitialization": false,
+		"useUnknownInCatchVariables": false,
+		"types": ["node", "bun-types"]
+	},
+	"include": ["./**/*.ts"],
+	"exclude": [
+		"node_modules",
+		"dist",
+		"test/**",
+		"**/__tests__/**",
+		"**/*.test.ts",
+		"build.ts"
+	]
+}


### PR DESCRIPTION
## Summary

Brings \`@elizaos/plugin-slack\` from [elizaos-plugins/plugin-slack](https://github.com/elizaos-plugins/plugin-slack) into the monorepo at \`plugins/plugin-slack/\` alongside the other connector plugins already living here (discord, telegram, signal, whatsapp, wechat, xmtp, instagram, matrix, line, feishu, google-chat, imessage, x, twitch, bluesky, bluebubbles, farcaster, nostr).

Slack was the last major-platform connector still living standalone. The standalone repo is at \`v2.0.0-alpha\` with the same \`typescript/python/rust\` layout as plugin-elizacloud and friends, so it was already migration-ready — just hadn't been picked up by the migration sweep.

The source matches the standalone repo's \`next\` branch tip plus the multi-message handling fix from [elizaos-plugins/plugin-slack#1](https://github.com/elizaos-plugins/plugin-slack/pull/1) (\`d50e802\`), which has been sitting on standalone with an APPROVED review since 2026-02-28. That PR will close as superseded by this one.

## What lands

- \`src/\` — service, accounts, formatting, config, index, types, plus:
  - \`actions/\` — sendMessage, editMessage, deleteMessage, listChannels, readChannel, pinMessage, unpinMessage, listPins, reactToMessage, emojiList, getUserInfo (11 actions)
  - \`providers/\` — channelState, memberList, workspaceInfo (3 providers)
- \`__tests__/\` — \`accounts.test.ts\` (98 tests), \`formatting.test.ts\` (22 tests)
- \`package.json\` — workspace-aware: \`@elizaos/core: workspace:*\`, version bumped to \`2.0.0-alpha.537\` to match sibling plugins, scripts aligned with monorepo conventions (biome from root \`node_modules\`)
- \`tsconfig.json\` (modeled on plugin-discord), \`build.ts\` (unchanged from standalone), \`README.md\`, \`LICENSE\`

## API drift fixes (alpha.3 → alpha.537)

The standalone \`peerDependencies\` pinned \`@elizaos/core: 2.0.0-alpha.3\`. The monorepo is at alpha.537, and the core API has moved in two specific ways the slack plugin needed updates for:

- **\`State.recentMessagesData\` typing.** Providers in \`channelState.ts\`, \`memberList.ts\`, \`workspaceInfo.ts\` read \`state?.recentMessagesData\`, which is now typed as the broader \`StateValue\` union (\`string | number | bigint | true | object\`) rather than \`Memory[]\` directly. Cast the field to \`Memory[] | undefined\` at the read site so \`validateActionKeywords\` / \`validateActionRegex\` get the expected shape. Behavior unchanged.
- **\`MentionContext\` shape.** \`service.ts\` was constructing \`{ isMention: true }\`; the type now requires \`isReply\` and \`isThread\` too. Filled with \`false\` for the mention-only path. Behavior unchanged for the existing mention handling.

## Verified

- ✅ \`tsc --noEmit -p plugins/plugin-slack/tsconfig.json\` clean
- ✅ 120/120 unit tests pass (\`bun test plugins/plugin-slack/__tests__/\`)
- ✅ \`bun run build.ts\` produces \`dist/index.js\` + \`.d.ts\` cleanly

## Follow-ups (not in this PR)

- Close [elizaos-plugins/plugin-slack#1](https://github.com/elizaos-plugins/plugin-slack/pull/1) as superseded once this lands.
- The standalone repo itself can be archived or kept as a thin re-export, mirroring how the other migrated plugin repos are handled.
- The CodeRabbit P2 nitpick on the multi-message handling fix (channel_type undefined edge case) is preserved as-is from the standalone PR — landing the existing fix verbatim, leaving any further hardening to a follow-up.

## Test plan
- [x] Typecheck clean
- [x] Unit tests green (120/120)
- [x] Build artifact produced
- [ ] Wire-up smoke test against a live Slack workspace — out of scope for this PR; happy to follow up if maintainers want it before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates `@elizaos/plugin-slack` from its standalone repository into the monorepo, adding 11 actions, 3 providers, a Socket Mode service, and 120 passing unit tests. The alpha API drift fixes (`State.recentMessagesData` cast and `MentionContext` shape) are correctly applied.

- **P1 – silent message drops**: `getUser()` in `handleMessage` and `handleAppMention` calls `client.users.info` without a try/catch. A Slack API error (rate-limit, deactivated user, network) will throw through the entire Bolt event handler, causing the message to be lost with no memory stored and no agent reply.
- **P2 – stale `repository.url`**: `package.json` still points to the old `elizaos-plugins/plugin-slack` standalone repo instead of the monorepo.
- **P2 – unused `zod` runtime dependency**: `zod` is declared in `dependencies` but never imported in any source file.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without fixing the missing try/catch around getUser() — incoming messages are silently dropped on any Slack API error during user lookup.

One P1 defect (unguarded getUser throws drop live messages) plus two P2 hygiene issues (stale repo URL, unused zod dependency). The P1 is on the critical incoming-message path so the score is pulled below the ceiling.

plugins/plugin-slack/src/service.ts (handleMessage and handleAppMention event handlers); plugins/plugin-slack/package.json

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-slack/src/service.ts | Core Slack service with Socket Mode integration — contains a P1 missing try/catch around `getUser()` in event handlers (messages silently dropped on API errors), and a P2 channel-type mapping where both MPIM and public channels collapse to `ChannelType.GROUP`. |
| plugins/plugin-slack/package.json | Package metadata has two P2 issues: `repository.url` still points to the old standalone repo and `zod` is declared as a runtime dependency but is never imported in source. |
| plugins/plugin-slack/src/index.ts | Plugin registration and re-exports; token validation and masked logging look correct. Imports/exports are well-organized. |
| plugins/plugin-slack/src/actions/sendMessage.ts | Action handler with LLM-extracted parameters; the generated `validate` wrapper is verbose but functionally correct; channel resolution and fallback logic are sound. |
| plugins/plugin-slack/src/providers/channelState.ts | Channel state provider with correct `Memory[] | undefined` cast for `recentMessagesData`; relevance-gating and fallback paths look correct. |
| plugins/plugin-slack/src/types.ts | Comprehensive Slack type definitions, error classes, and utility functions; looks correct and well-structured. |
| plugins/plugin-slack/src/accounts.ts | Multi-account resolution helpers with token validation logic; parallel type definitions to `config.ts` but scoped correctly to `accounts.ts` exports only. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Slack as Slack (Socket Mode)
    participant Bolt as @slack/bolt App
    participant SVC as SlackService
    participant RT as IAgentRuntime
    participant Agent as MessageService

    Slack->>Bolt: message / app_mention event
    Bolt->>SVC: handleMessage() / handleAppMention()
    SVC->>SVC: isChannelAllowed()
    SVC->>RT: getEntityById(entityId)
    SVC->>Slack: users.info (getUser) ⚠️ no try/catch
    SVC->>RT: createEntity()
    SVC->>RT: createMemory(memory, "messages")
    SVC->>RT: emitEvent(SLACK_MESSAGE_RECEIVED)
    SVC->>Agent: messageService.handleMessage(memory, callback)
    Agent-->>SVC: callback(response)
    SVC->>Slack: chat.postMessage (sendMessage)
    SVC->>RT: createMemory(responseMemory)
    SVC->>RT: emitEvent(SLACK_MESSAGE_SENT)
```

<sub>Reviews (1): Last reviewed commit: ["feat(slack): migrate plugin-slack into m..."](https://github.com/elizaos/eliza/commit/32b5ec0448c0943d5ccdbaa1ed00047fb7d94310) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30739102)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->