### PR TITLE
fix(cloud): preserve primary app domain on detach

### DIFF
--- a/cloud/apps/api/v1/apps/[id]/domains/route.ts
+++ b/cloud/apps/api/v1/apps/[id]/domains/route.ts
@@ -34,16 +34,18 @@ const app = new Hono<AppEnv>();
 async function loadOwnedApp(c: AppContext) {
   const user = await requireUserOrApiKeyWithOrg(c);
   const appId = c.req.param("id");
-  if (!appId) return null;
+  if (!appId) return { error: "missing path params", status: 400 as const };
   const appRow = await appsService.getById(appId);
-  if (!appRow || appRow.organization_id !== user.organization_id) return null;
+  if (!appRow || appRow.organization_id !== user.organization_id) {
+    return { error: "App not found", status: 404 as const };
+  }
   return { user, app: appRow, appId };
 }
 
 app.get("/", async (c) => {
   try {
     const ctx = await loadOwnedApp(c);
-    if (!ctx) return c.json({ success: false, error: "App not found" }, 404);
+    if ("error" in ctx) return c.json({ success: false, error: ctx.error }, ctx.status);
 
     const domains = await managedDomainsService.listForApp(ctx.user.organization_id, ctx.appId);
     return c.json({
@@ -68,7 +70,7 @@ app.get("/", async (c) => {
 app.post("/", async (c) => {
   try {
     const ctx = await loadOwnedApp(c);
-    if (!ctx) return c.json({ success: false, error: "App not found" }, 404);
+    if ("error" in ctx) return c.json({ success: false, error: ctx.error }, ctx.status);
 
     const parsed = DomainSchema.safeParse(await c.req.json());
     if (!parsed.success) {
@@ -142,7 +144,7 @@ app.post("/", async (c) => {
 app.delete("/", async (c) => {
   try {
     const ctx = await loadOwnedApp(c);
-    if (!ctx) return c.json({ success: false, error: "App not found" }, 404);
+    if ("error" in ctx) return c.json({ success: false, error: ctx.error }, ctx.status);
 
     const parsed = DomainSchema.safeParse(await c.req.json());
     if (!parsed.success) {
@@ -159,7 +161,30 @@ app.delete("/", async (c) => {
     }
 
     await managedDomainsService.unassignFromResource(md.id);
-    await appDomainsCompat.clearCustomDomain(ctx.appId);
+    try {
+      const remainingDomains = (
+        await managedDomainsService.listForApp(ctx.user.organization_id, ctx.appId)
+      ).filter((candidate) => candidate.id !== md.id);
+      const primaryDomain = remainingDomains.find(
+        (candidate) => candidate.verified && candidate.status === "active",
+      );
+      if (primaryDomain) {
+        await appDomainsCompat.setCustomDomain({
+          appId: ctx.appId,
+          domain: primaryDomain.domain,
+          verified: primaryDomain.verified,
+        });
+      } else {
+        await appDomainsCompat.clearCustomDomain(ctx.appId);
+      }
+    } catch (error) {
+      await appDomainsCompat.clearCustomDomain(ctx.appId);
+      logger.warn("[Domains DELETE] detached domain but failed to refresh compatibility domain", {
+        appId: ctx.appId,
+        domain,
+        error: extractErrorMessage(error),
+      });
+    }
     logger.info("[Domains DELETE] detached domain", {
       appId: ctx.appId,
       domain,

--- a/cloud/packages/tests/unit/domains/app-domains-route.test.ts
+++ b/cloud/packages/tests/unit/domains/app-domains-route.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+interface ManagedDomain {
+  id: string;
+  domain: string;
+  organizationId: string;
+  appId: string | null;
+  registrar: "cloudflare" | "external";
+  status: string;
+  verified: boolean;
+  sslStatus?: string | null;
+  expiresAt?: Date | null;
+  cloudflareZoneId?: string | null;
+  verificationToken?: string | null;
+}
+
+function installMocks(listForApp: () => Promise<ManagedDomain[]>) {
+  const setCustomDomain = mock(async () => undefined);
+  const clearCustomDomain = mock(async () => undefined);
+  const unassignFromResource = mock(async () => undefined);
+  const warn = mock(() => undefined);
+
+  mock.module("@/lib/auth/workers-hono-auth", () => ({
+    requireUserOrApiKeyWithOrg: async () => ({ organization_id: "org-1" }),
+  }));
+  mock.module("@/lib/services/apps", () => ({
+    appsService: {
+      getById: async () => ({ id: "app-1", organization_id: "org-1" }),
+    },
+  }));
+  mock.module("@/lib/services/managed-domains", () => ({
+    managedDomainsService: {
+      getDomainByName: async () => ({
+        id: "detached-domain",
+        domain: "old.example",
+        organizationId: "org-1",
+        appId: "app-1",
+        registrar: "cloudflare",
+        status: "active",
+        verified: true,
+      }),
+      unassignFromResource,
+      listForApp,
+    },
+  }));
+  mock.module("@/lib/services/app-domains-compat", () => ({
+    appDomainsCompat: { setCustomDomain, clearCustomDomain },
+  }));
+  mock.module("@/lib/utils/logger", () => ({
+    logger: { error: () => undefined, info: () => undefined, warn },
+  }));
+
+  return { clearCustomDomain, setCustomDomain, unassignFromResource, warn };
+}
+
+async function loadRoute(mountPath: string) {
+  const mod = await import(
+    new URL(
+      `../../../../apps/api/v1/apps/[id]/domains/route.ts?test=${Date.now()}-${Math.random()}`,
+      import.meta.url,
+    ).href
+  );
+  const parent = new Hono();
+  parent.route(mountPath, mod.default as Hono);
+  return parent;
+}
+
+describe("app domains route", () => {
+  beforeEach(() => {
+    mock.restore();
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns 400 when app id path param is missing", async () => {
+    installMocks(async () => []);
+    const route = await loadRoute("/api/v1/apps/domains");
+
+    const response = await route.request("https://api.test/api/v1/apps/domains", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain: "old.example" }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { success: false; error: string };
+    expect(body).toEqual({ success: false, error: "missing path params" });
+  });
+
+  test("detaching one domain keeps the next eligible custom domain primary", async () => {
+    const mocks = installMocks(async () => [
+      {
+        id: "detached-domain",
+        domain: "old.example",
+        organizationId: "org-1",
+        appId: "app-1",
+        registrar: "cloudflare",
+        status: "active",
+        verified: true,
+      },
+      {
+        id: "remaining-domain",
+        domain: "new.example",
+        organizationId: "org-1",
+        appId: "app-1",
+        registrar: "external",
+        status: "active",
+        verified: true,
+      },
+    ]);
+    const route = await loadRoute("/api/v1/apps/:id/domains");
+
+    const response = await route.request("https://api.test/api/v1/apps/app-1/domains", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain: "old.example" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.unassignFromResource).toHaveBeenCalledWith("detached-domain");
+    expect(mocks.setCustomDomain).toHaveBeenCalledWith({
+      appId: "app-1",
+      domain: "new.example",
+      verified: true,
+    });
+    expect(mocks.clearCustomDomain).not.toHaveBeenCalled();
+  });
+
+  test("detaching the last eligible domain clears the compatibility custom domain", async () => {
+    const mocks = installMocks(async () => []);
+    const route = await loadRoute("/api/v1/apps/:id/domains");
+
+    const response = await route.request("https://api.test/api/v1/apps/app-1/domains", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain: "old.example" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.unassignFromResource).toHaveBeenCalledWith("detached-domain");
+    expect(mocks.clearCustomDomain).toHaveBeenCalledWith("app-1");
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+  });
+
+  test("detaching returns success when the compatibility refresh cannot list remaining domains", async () => {
+    const mocks = installMocks(async () => {
+      throw new Error("database timeout");
+    });
+    const route = await loadRoute("/api/v1/apps/:id/domains");
+
+    const response = await route.request("https://api.test/api/v1/apps/app-1/domains", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain: "old.example" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mocks.unassignFromResource).toHaveBeenCalledWith("detached-domain");
+    expect(mocks.clearCustomDomain).toHaveBeenCalledWith("app-1");
+    expect(mocks.setCustomDomain).not.toHaveBeenCalled();
+    expect(mocks.warn).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Relates to

Supersedes #7386 after applying the Greptile follow-up fixes on the current restored `develop` branch.

# Risks

Low. This is scoped to app managed-domain detach behavior and the app-domain route unit coverage.

# Background

## What does this PR do?

- Keeps the next eligible verified/active managed domain as the app compatibility custom domain when detaching the current domain.
- Clears the compatibility custom domain when no eligible domain remains.
- Returns `400` for missing app route params while preserving opaque `404` responses for missing or cross-org apps.
- Isolates post-detach compatibility refresh errors so a committed detach still returns success, clears the compatibility pointer, and logs a warning.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`cloud/apps/api/v1/apps/[id]/domains/route.ts` and `cloud/packages/tests/unit/domains/app-domains-route.test.ts`.

## Detailed testing steps

- `SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test --preload ./packages/tests/load-env.ts packages/tests/unit/domains/app-domains-route.test.ts`
- `bun ./node_modules/typescript/lib/tsc.js --noEmit --project tsconfig.test.json`
- `bun run build:api`
- `bunx biome check cloud/apps/api/v1/apps/'[id]'/domains/route.ts cloud/packages/tests/unit/domains/app-domains-route.test.ts`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues in the app-domain detach flow: it returns `400` (instead of silently falling through) when the `:id` path param is missing, and it elects the next eligible verified/active domain as the primary compat domain after a detach rather than unconditionally clearing it. A new unit test file covers all four key scenarios.

- **P1 — `clearCustomDomain` in the catch block can escape to the outer handler**: if the fallback `clearCustomDomain` call inside the `catch` block throws, the error propagates to the outer `catch` and returns a 500 even though `unassignFromResource` was already committed. The client would see a failure for an operation that actually succeeded.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the P1 catch-block escape; all other changes are correct and well-tested.

One P1 finding (clearCustomDomain can throw inside the catch block, returning 500 for a committed detach) caps the score at 4. The rest of the logic is sound, test coverage is solid, and the scope is narrow.

cloud/apps/api/v1/apps/[id]/domains/route.ts — specifically the inner catch block around the compat-refresh logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/apps/api/v1/apps/[id]/domains/route.ts | Refactors loadOwnedApp to return typed error objects (400/404) and adds primary-domain election logic on detach with an isolation catch block. |
| cloud/packages/tests/unit/domains/app-domains-route.test.ts | New unit tests covering 400 on missing param, primary-domain election, last-domain clear, and compat-refresh error isolation; all four cases are covered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route as DELETE /domains
    participant loadOwnedApp
    participant MDS as managedDomainsService
    participant ADC as appDomainsCompat

    Client->>Route: DELETE {domain}
    Route->>loadOwnedApp: loadOwnedApp(c)
    alt missing :id param
        loadOwnedApp-->>Route: {error, status:400}
        Route-->>Client: 400 missing path params
    else app not found / wrong org
        loadOwnedApp-->>Route: {error, status:404}
        Route-->>Client: 404 App not found
    else app found
        loadOwnedApp-->>Route: {user, app, appId}
        Route->>MDS: getDomainByName(domain)
        Route->>MDS: unassignFromResource(md.id)
        Note over Route: detach committed
        Route->>MDS: listForApp(org, appId)
        alt listForApp succeeds
            Route->>Route: filter out detached id
            alt verified+active domain remains
                Route->>ADC: setCustomDomain(primaryDomain)
            else no eligible domain
                Route->>ADC: clearCustomDomain(appId)
            end
        else listForApp or set/clear throws
            Route->>ADC: clearCustomDomain(appId)
            Route->>Route: logger.warn(...)
        end
        Route-->>Client: 200 success
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): preserve primary app domain ..."](https://github.com/elizaos/eliza/commit/916e2aed95ac41271e8015b8232f9ad270d38e55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30785383)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->