### PR TITLE
ci(training): add Training Stack workflow gating packages/training

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,10 +6,14 @@
 # labels we use:
 #   kvm — Linux x86_64 host with /dev/kvm available, used for Cuttlefish/AOSP
 #         builds (.github/workflows/elizaos-cuttlefish.yml).
+#   gpu-cuda-12.6 — Linux x86_64 host with an NVIDIA GPU + CUDA 12.6 driver
+#                   stack, used for the eliza-1 training stack QJL nvcc
+#                   build (.github/workflows/training-stack.yml).
 
 self-hosted-runner:
   labels:
     - kvm
+    - gpu-cuda-12.6
 
 paths:
   .github/workflows/*.yml:

--- a/.github/workflows/training-stack.yml
+++ b/.github/workflows/training-stack.yml
@@ -1,0 +1,166 @@
+name: Training Stack
+
+# Reproducibility gate for the eliza-1 training + quantization stack.
+#
+# Two lanes:
+#   - cpu-smoke:  GitHub-hosted ubuntu-22.04. Builds the CPU image, lints
+#                 packages/training/scripts/, runs the model_registry
+#                 import probe, and any pure-python tests that do not
+#                 require CUDA. Runs on every PR that touches
+#                 packages/training/**.
+#   - gpu-build:  Self-hosted runner with `gpu-cuda-12.6` label. Builds
+#                 the full GPU Dockerfile (which exercises QJL nvcc end
+#                 to end) and runs CUDA-dependent tests. The job parses
+#                 even if no runner with that label is online — GitHub
+#                 will simply queue the job until one appears, so we
+#                 keep the queue short with a short timeout.
+#
+# CUDA / torch alignment lives in packages/training/Dockerfile and
+# packages/training/pyproject.toml — keep the runner label and the
+# Dockerfile CUDA tag in lockstep when they change.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - "packages/training/**"
+      - ".github/workflows/training-stack.yml"
+  pull_request:
+    branches: [develop]
+    paths:
+      - "packages/training/**"
+      - ".github/workflows/training-stack.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: training-stack-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cpu-smoke:
+    name: CPU smoke (lint + import)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build CPU image
+        id: build_cpu
+        uses: docker/build-push-action@v6
+        with:
+          context: packages/training
+          file: packages/training/Dockerfile.cpu
+          tags: eliza-training-cpu:ci
+          load: true
+          cache-from: type=gha,scope=training-cpu
+          cache-to: type=gha,scope=training-cpu,mode=max
+
+      - name: Install ruff (host)
+        # ruff lint is fast on the host and gives a clean GitHub
+        # Annotations surface — no need to shell into the container.
+        run: pipx install ruff || pip install --user ruff
+
+      - name: Lint packages/training/scripts/
+        run: ruff check packages/training/scripts/
+
+      - name: Import probe — model_registry
+        # The whole point of this lane: catch import-time errors in the
+        # training package before they hit a real GPU run.
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/packages/training:/workspace" \
+            -e PYTHONPATH=/workspace/scripts \
+            eliza-training-cpu:ci \
+            -c "python -c 'from training.model_registry import REGISTRY; print(list(REGISTRY))'"
+
+      - name: Run pure-python tests (best effort)
+        # test_reward_fn.py is the DPOGRPOAgent's deliverable and may
+        # not exist yet; degrade gracefully so this lane stays green
+        # while that lane lands.
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}/packages/training:/workspace" \
+            -e PYTHONPATH=/workspace/scripts \
+            eliza-training-cpu:ci \
+            -c "set -e; \
+                if [ -f /workspace/scripts/test_reward_fn.py ]; then \
+                  echo '[cpu-smoke] running scripts/test_reward_fn.py'; \
+                  pytest -xvs /workspace/scripts/test_reward_fn.py; \
+                else \
+                  echo '[cpu-smoke] scripts/test_reward_fn.py absent — running model_registry probe instead'; \
+                  python -c 'from training.model_registry import REGISTRY; assert REGISTRY, \"empty registry\"; print(\"registry OK:\", list(REGISTRY))'; \
+                fi"
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpu-smoke-logs
+          path: |
+            packages/training/scripts/**/*.log
+            /tmp/*.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+  gpu-build:
+    name: GPU build (QJL nvcc + Triton JIT)
+    # Self-hosted GPU runner. If no runner with this label is online,
+    # GitHub queues the job until one appears or the workflow times out
+    # — it does not fail the run. That matches the operator note in
+    # packages/training/CI.md: "GPU jobs are skipped, not failed."
+    runs-on: [self-hosted, gpu-cuda-12.6]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Show GPU / CUDA host environment
+        run: |
+          nvidia-smi || echo "[gpu-build] nvidia-smi not available"
+          nvcc --version || echo "[gpu-build] nvcc not on host PATH (Docker image still has it)"
+          docker --version
+
+      - name: Build GPU image
+        # End-to-end validation of the QJL nvcc compile chain. If this
+        # step succeeds, every later run on this image is guaranteed
+        # to have working QJL .so files and a Triton-capable toolchain.
+        run: |
+          docker build \
+            --file packages/training/Dockerfile \
+            --tag eliza-training:ci \
+            packages/training
+
+      - name: Run QJL CUDA tests (skip cleanly if no GPU visible)
+        # test_qjl.py auto-skips its CUDA-dependent assertions when no
+        # GPU is visible inside the container. Mounting --gpus all gives
+        # it real CUDA devices when the runner has them.
+        run: |
+          docker run --rm --gpus all \
+            -v "${{ github.workspace }}/packages/training:/workspace_src:ro" \
+            eliza-training:ci \
+            -c "set -e; \
+                cd /workspace; \
+                python scripts/quantization/test_qjl.py || \
+                  { echo '[gpu-build] test_qjl.py exited non-zero (may be acceptable skip — see logs)'; exit 1; }"
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-build-logs
+          path: |
+            packages/training/scripts/**/*.log
+            /tmp/*.log
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds `.github/workflows/training-stack.yml` — the CI reproducibility gate for the eliza-1 training + quantization stack landed in `packages/training/` (commit c88a910757). Two lanes:

- **cpu-smoke**: GitHub-hosted ubuntu-22.04. Builds the CPU image, lints `packages/training/scripts/`, runs the model_registry import probe, and runs pure-python tests when present. No CUDA needed; runs on every PR touching `packages/training/**`.
- **gpu-build**: Self-hosted runner with the new `gpu-cuda-12.6` label. Builds the full GPU Dockerfile (which exercises the QJL nvcc compile chain end to end) and runs CUDA-dependent tests with `--gpus all`. If no runner with that label is online, GitHub queues the job rather than failing — see `packages/training/CI.md`.

Both lanes are paths-filtered to `packages/training/**` + this workflow file, so general PRs do not pay the cost.

Also updates `.github/actionlint.yaml` self-hosted-runner labels to include `gpu-cuda-12.6` so workflow lint accepts the new label without warnings.

## Test plan

- [ ] `actionlint` passes against the new workflow (run by the repo's existing workflow lint).
- [ ] cpu-smoke lane succeeds on a follow-up touch under `packages/training/scripts/` (or via `workflow_dispatch`).
- [ ] gpu-build lane is queued (not failed) on this PR, since no `gpu-cuda-12.6` runner is online yet — confirmed by checking the run UI.
- [ ] When a `gpu-cuda-12.6` runner comes online, gpu-build lane builds `packages/training/Dockerfile` and the QJL nvcc compile chain succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a two-lane CI workflow (`training-stack.yml`) gating `packages/training/`: a GitHub-hosted `cpu-smoke` lane for lint and import validation, and a self-hosted `gpu-build` lane for the full QJL nvcc compile chain. It also registers the `gpu-cuda-12.6` runner label in `actionlint.yaml`.

- The gpu-build test step mounts the workspace at `/workspace_src` but then `cd`s to `/workspace` — the volume is never read, and the path inconsistency will cause confusion or silent breakage if that mount is relied on in the future.
- All three `docker run` calls pass `-c \"...\"` without `--entrypoint sh`, implicitly relying on the Dockerfiles setting a shell as their entrypoint; this should be made explicit to guard against future Dockerfile changes.

<h3>Confidence Score: 3/5</h3>

The cpu-smoke lane is safe; the gpu-build lane has a dead volume mount that makes the -v flag a no-op and could mislead future maintainers.

The gpu-build test step mounts the PR workspace at /workspace_src but immediately does cd /workspace, so the mounted volume is never consulted. Because the GPU image was built from the current checkout immediately before, tests still run against the right code — but the inconsistency makes the mount's intent opaque and sets a trap for anyone who later expects /workspace_src to contain live sources. The implicit shell entrypoint assumption across all docker run calls is an additional fragility that is one Dockerfile change away from a confusing failure.

.github/workflows/training-stack.yml — the gpu-build test step's volume mount and all three docker run entrypoint assumptions warrant a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/training-stack.yml | New CI workflow with two lanes (cpu-smoke, gpu-build); contains a volume mount path mismatch and implicit entrypoint assumptions across all docker run commands. |
| .github/actionlint.yaml | Adds gpu-cuda-12.6 to the self-hosted runner label allowlist so actionlint accepts the new label without warnings; straightforward and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    trigger([push/PR to develop\nor workflow_dispatch]) --> paths{paths filter\npackages/training/**}
    paths -- no match --> skip([workflow skipped])
    paths -- match --> smoke & gpu

    subgraph cpu-smoke [cpu-smoke]
        smoke[Checkout] --> buildx[Setup Docker Buildx]
        buildx --> buildcpu[Build CPU image]
        buildcpu --> ruff[Install ruff on host]
        ruff --> lint[ruff check scripts/]
        lint --> probe[docker run: import probe]
        probe --> pytest[docker run: pytest best-effort]
    end

    subgraph gpu-build [gpu-build]
        gpu[Checkout] --> env[Show GPU/CUDA env]
        env --> buildgpu[docker build GPU image]
        buildgpu --> qjl[docker run --gpus all test_qjl.py]
    end
```

<sub>Reviews (1): Last reviewed commit: ["ci(training): add Training Stack workflo..."](https://github.com/elizaos/eliza/commit/a0e8da03ee433d87e76befcc3df25efc753b120e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30794626)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->