### PR TITLE
fix(orchestrator): use supported codex fast default

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-agent-frameworks.test.ts
@@ -173,7 +173,7 @@ describe("task-agent model preferences", () => {
     });
     expect(getTaskAgentModelPrefs(createRuntime(), "codex")).toEqual({
       powerful: "gpt-5.5",
-      fast: "gpt-5.5-mini",
+      fast: "gpt-5.4-mini",
     });
   });
 
@@ -203,7 +203,7 @@ describe("task-agent model preferences", () => {
 
     expect(getTaskAgentModelPrefs(createRuntime(), "codex")).toEqual({
       powerful: "gpt-config-power",
-      fast: "gpt-5.5-mini",
+      fast: "gpt-5.4-mini",
     });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -275,7 +275,7 @@ export const TASK_AGENT_DEFAULT_MODEL_PREFS: Record<
   TaskAgentModelPrefs
 > = {
   claude: { powerful: "claude-opus-4-7" },
-  codex: { powerful: "gpt-5.5", fast: "gpt-5.5-mini" },
+  codex: { powerful: "gpt-5.5", fast: "gpt-5.4-mini" },
   gemini: {},
   aider: {},
   opencode: {},


### PR DESCRIPTION
## Summary

Updates the Codex task-agent fast default from `gpt-5.5-mini` to `gpt-5.4-mini`.

`gpt-5.5-mini` is not available on the current Codex subscription path, while `gpt-5.4-mini` is supported and was verified in the live Nubilio runtime as the faster parent/small-model option. The powerful Codex task-agent default remains `gpt-5.5`.

## Validation

- `biome format` on the touched orchestrator files
- `vitest run src/__tests__/task-agent-frameworks.test.ts` (`18` tests)
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Codex task-agent fast model default from `gpt-5.5-mini` to `gpt-5.4-mini` in the orchestrator plugin, with matching test updates. The change is internally consistent within the plugin.

- **`task-agent-frameworks.ts`**: `TASK_AGENT_DEFAULT_MODEL_PREFS.codex.fast` updated to `gpt-5.4-mini`; both affected test assertions updated accordingly.
- **Other packages not updated**: `packages/agent/src/api/provider-switch-config.ts`, `model-provider-helpers.ts`, and `conversation-utils.ts` still reference `gpt-5.5-mini` — if the model is genuinely unavailable, those paths will also fail silently for users on the same subscription.

<h3>Confidence Score: 3/5</h3>

Safe within the orchestrator plugin, but leaves the same unsupported model ID active in three other packages that users on the same subscription tier will hit.

The orchestrator fix is correct and the tests are consistent, but `gpt-5.5-mini` remains the OpenAI small-model default in `provider-switch-config.ts` and is still registered in the model helpers and pricing tables. Any user whose agent auto-selects the OpenAI provider through those paths will receive the unsupported model ID that motivated this PR.

packages/agent/src/api/provider-switch-config.ts (openai.smallVal), packages/agent/src/api/model-provider-helpers.ts (model registry entry), and packages/app-core/src/components/conversations/conversation-utils.ts (pricing table)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts | Single-line change swapping the Codex fast default from `gpt-5.5-mini` to `gpt-5.4-mini` in `TASK_AGENT_DEFAULT_MODEL_PREFS`; change is correct and consistent. |
| plugins/plugin-agent-orchestrator/src/__tests__/task-agent-frameworks.test.ts | Two test assertions updated to expect `gpt-5.4-mini` instead of `gpt-5.5-mini`, matching the source change in both the baseline defaults test and the config-override test. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller requests Codex fast model] --> B{Runtime setting override?}
    B -- yes --> C[Use PARALLAX_CODEX_MODEL_FAST from runtime/config]
    B -- no --> D{Spawn metadata prefs?}
    D -- yes --> E[Use spawnPrefs.fast]
    D -- no --> F[TASK_AGENT_DEFAULT_MODEL_PREFS.codex.fast]
    F --> G["gpt-5.4-mini (updated)"]
    C --> H[Return merged prefs]
    E --> H
    G --> H

    subgraph "Unchanged paths (still gpt-5.5-mini)"
        I[provider-switch-config.ts — OpenAI smallVal]
        J[model-provider-helpers.ts — model registry]
        K[conversation-utils.ts — pricing table]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/agent/src/api/provider-switch-config.ts`, line 412 ([link](https://github.com/elizaos/eliza/blob/8ec2726e7aedf1608f10b5136616ba7a6e94c1ca/packages/agent/src/api/provider-switch-config.ts#L412)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Stale `gpt-5.5-mini` default outside the orchestrator**

   `provider-switch-config.ts` still uses `gpt-5.5-mini` as the OpenAI small-model default (`smallVal`). If this model ID is unavailable on the current subscription path (as the PR states), any agent that auto-selects the OpenAI provider via this config will silently serve users an unsupported model. The same stale string also appears in `packages/agent/src/api/model-provider-helpers.ts` (line 82) and `packages/app-core/src/components/conversations/conversation-utils.ts` (line 121).

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): use supported codex f..."](https://github.com/elizaos/eliza/commit/8ec2726e7aedf1608f10b5136616ba7a6e94c1ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30821774)</sub>

<!-- /greptile_comment -->