### PR TITLE
fix(elizacloud): rate-limit hygiene in IMAGE_DESCRIPTION handler

### DIFF
--- a/plugins/plugin-elizacloud/models/image.ts
+++ b/plugins/plugin-elizacloud/models/image.ts
@@ -47,6 +47,29 @@ export async function handleImageDescription(
   runtime: IAgentRuntime,
   params: ImageDescriptionParams | string
 ): Promise<{ title: string; description: string }> {
+  // Honour `DISABLE_IMAGE_DESCRIPTION` (set by the runtime when
+  // `features.vision === false`). The runtime exposes it via getSetting; some
+  // hosts only set it in process.env. Check both before burning a quota slot.
+  // The docs (`docs/runtime/core.md`) already promise this behaviour, but
+  // historically only `plugin-discord` honoured it at the call site, leaving
+  // every other caller (agent-orchestrator's task validator, vision, lifeops,
+  // farcaster, telegram) free to spend the rate-limit budget.
+  const disableSetting = getSetting(runtime, "DISABLE_IMAGE_DESCRIPTION", "");
+  const disabled =
+    disableSetting === "true" ||
+    disableSetting === "1" ||
+    process.env.DISABLE_IMAGE_DESCRIPTION === "true" ||
+    process.env.DISABLE_IMAGE_DESCRIPTION === "1";
+  if (disabled) {
+    logger.debug(
+      "[ELIZAOS_CLOUD] IMAGE_DESCRIPTION skipped — DISABLE_IMAGE_DESCRIPTION is set"
+    );
+    return {
+      title: "Image description disabled",
+      description: "Image description is disabled by configuration.",
+    };
+  }
+
   let imageUrl: string;
   let promptText: string | undefined;
   const modelName = getImageDescriptionModel(runtime);

--- a/plugins/plugin-elizacloud/models/image.ts
+++ b/plugins/plugin-elizacloud/models/image.ts
@@ -107,21 +107,48 @@ export async function handleImageDescription(
       max_tokens: maxTokens,
     };
 
-    // Retry with exponential backoff for transient errors (429 rate limit)
+    // On 429, honour the upstream's `retryAfter` instead of retrying on a
+    // hardcoded backoff. Hardcoded retries inside the rate-limit window add
+    // wasted requests to the same bucket and make the problem worse — see
+    // #7374's billing render-loop fix and S33's dashboard 429-aware UX.
+    // Strategy: only retry once, only if the upstream signals a short wait
+    // (≤5s, i.e. transient burst). Anything longer, bail immediately and let
+    // the caller fail fast.
     let response: Response | null = null;
-    for (let attempt = 0; attempt < 3; attempt++) {
+    let attemptedRetry = false;
+    for (let attempt = 0; attempt < 2; attempt++) {
       response = await client.routes.postApiV1ChatCompletionsRaw({
         json: requestBody,
       });
+      if (response.status !== 429 || attemptedRetry) break;
 
-      if (response.status === 429 && attempt < 2) {
-        const wait = (attempt + 1) * 2000; // 2s, 4s
+      const headerRetryAfter = Number(response.headers.get("retry-after"));
+      let bodyRetryAfter: number | undefined;
+      try {
+        const peek = (await response.clone().json()) as {
+          retryAfter?: unknown;
+        };
+        bodyRetryAfter =
+          typeof peek?.retryAfter === "number" ? peek.retryAfter : undefined;
+      } catch {
+        // Body wasn't JSON — fall through to header value.
+      }
+      const retryAfter = Number.isFinite(headerRetryAfter)
+        ? headerRetryAfter
+        : (bodyRetryAfter ?? 0);
+
+      if (retryAfter > 0 && retryAfter <= 5) {
         logger.warn(
-          `[ELIZAOS_CLOUD] Image analysis rate-limited (429), retrying in ${wait / 1000}s...`
+          `[ELIZAOS_CLOUD] Image analysis rate-limited (429), retrying once after ${retryAfter}s...`
         );
-        await new Promise((r) => setTimeout(r, wait));
+        await new Promise((r) => setTimeout(r, retryAfter * 1000));
+        attemptedRetry = true;
         continue;
       }
+      // Long rate-limit window: don't burn another bucket slot retrying inside it.
+      logger.warn(
+        `[ELIZAOS_CLOUD] Image analysis rate-limited (429); upstream retryAfter=${retryAfter || "unknown"}s — failing fast`
+      );
       break;
     }
 
@@ -130,6 +157,11 @@ export async function handleImageDescription(
       if (status === 402) {
         throw new Error(
           "Eliza Cloud credits exhausted — top up at https://www.elizacloud.ai/dashboard/settings?tab=billing"
+        );
+      }
+      if (status === 429) {
+        throw new Error(
+          "Eliza Cloud rate limit exceeded for image description — try again in a minute"
         );
       }
       throw new Error(`ElizaOS Cloud API error: ${status}`);

--- a/plugins/plugin-elizacloud/models/image.ts
+++ b/plugins/plugin-elizacloud/models/image.ts
@@ -122,20 +122,28 @@ export async function handleImageDescription(
       });
       if (response.status !== 429 || attemptedRetry) break;
 
-      const headerRetryAfter = Number(response.headers.get("retry-after"));
+      // `Number(null) === 0`, so guard against a missing header before
+      // calling `Number(...)` — otherwise the header path always wins with a
+      // bogus `0` and the body fallback becomes unreachable.
+      const headerValue = response.headers.get("retry-after");
+      const headerRetryAfter =
+        headerValue !== null && Number.isFinite(Number(headerValue))
+          ? Number(headerValue)
+          : undefined;
       let bodyRetryAfter: number | undefined;
       try {
         const peek = (await response.clone().json()) as {
           retryAfter?: unknown;
         };
         bodyRetryAfter =
-          typeof peek?.retryAfter === "number" ? peek.retryAfter : undefined;
+          typeof peek?.retryAfter === "number" &&
+          Number.isFinite(peek.retryAfter)
+            ? peek.retryAfter
+            : undefined;
       } catch {
         // Body wasn't JSON — fall through to header value.
       }
-      const retryAfter = Number.isFinite(headerRetryAfter)
-        ? headerRetryAfter
-        : (bodyRetryAfter ?? 0);
+      const retryAfter = headerRetryAfter ?? bodyRetryAfter ?? 0;
 
       if (retryAfter > 0 && retryAfter <= 5) {
         logger.warn(


### PR DESCRIPTION
@
## Summary
Two related fixes to `plugins/plugin-elizacloud/models/image.ts`:

1. **Honour `DISABLE_IMAGE_DESCRIPTION` at the handler.** `docs/runtime/core.md` documents this flag (set when `features.vision === false`) as a global short-circuit, but only `plugin-discord/attachments.ts` actually honoured it. Other callers (agent-orchestrators task validator, vision, lifeops, farcaster, telegram) all spent rate-limit budget regardless of the users vision toggle.
2. **Bail fast on long retry-after instead of amplifying 429s.** The previous retry loop fired up to 3 attempts with hardcoded 2s/4s waits. Elizaclouds redis rate-limiter counts 429-rejected requests, so each retry inside a 60s window consumed another bucket slot — one user-intent call became 3 wasted slots. Now: only retry once when upstream signals a short transient burst (≤5s); fail fast on long windows. Mirrors the pattern already used in `models/embeddings.ts`.

## Test plan
- [x] `tsc --noEmit -p plugins/plugin-elizacloud/tsconfig.json` clean
- [x] Verified at runtime: with `features.vision: false`, repeated boots show no IMAGE_DESCRIPTION calls vs the previous 5+ per boot.
- [x] Verified at runtime: a 60-second rate-limit window now logs `failing fast` and skips the second/third retry.
@

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two rate-limit hygiene issues in the `IMAGE_DESCRIPTION` handler: it now honours the `DISABLE_IMAGE_DESCRIPTION` flag before making any API call, and replaces a hardcoded 3-attempt backoff with a single header-aware retry that only fires for short (≤5 s) windows.

- **Early-exit for disabled vision**: reads the flag from both `getSetting` and `process.env`, returns a placeholder immediately, and prevents any quota spend when `features.vision === false`.
- **Smarter 429 handling**: parses `retry-after` from the response header (with a correct null-guard so `Number(null)` cannot produce a false-positive `0`) and falls back to the body JSON field; retries exactly once if the window is ≤5 s, otherwise logs \"failing fast\" and throws a descriptive error.

<h3>Confidence Score: 5/5</h3>

The change is well-scoped to a single handler with no new dependencies; both logic paths are straightforward and correctly guarded.

The DISABLE_IMAGE_DESCRIPTION early-exit is a clean short-circuit with no side effects. The retry refactor correctly handles the null-header sentinel, caps retries at one, and surfaces a descriptive error on rate-limit exhaustion. No existing behaviour for non-429 or non-402 responses is changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-elizacloud/models/image.ts | Adds DISABLE_IMAGE_DESCRIPTION early-exit and replaces hardcoded 3-attempt backoff with a single honour-retryAfter retry, correctly guarding against missing/null headers. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[handleImageDescription called] --> B{DISABLE_IMAGE_DESCRIPTION set?}
    B -- Yes --> C[Return placeholder immediately\nno API call]
    B -- No --> D[Build request body]
    D --> E[POST /api/v1/chat/completions\nattempt 0]
    E --> F{response.status?}
    F -- 200 OK --> G[Parse & return result]
    F -- 402 --> H[Throw: credits exhausted]
    F -- 429 --> I{attemptedRetry?}
    I -- Yes --> J[Break loop]
    I -- No --> K[Read retry-after\nheader + body JSON]
    K --> L{0 < retryAfter <= 5?}
    L -- Yes --> M[Sleep retryAfter s\nset attemptedRetry=true\nretry once]
    M --> E
    L -- No --> N[Log failing fast\nbreak loop]
    N --> O{response.ok?}
    J --> O
    O -- No, 429 --> P[Throw: rate limit exceeded]
    O -- No, other --> Q[Throw: API error]
    O -- Yes --> G
```

<sub>Reviews (2): Last reviewed commit: ["fix(elizacloud): guard against null Retr..."](https://github.com/elizaos/eliza/commit/6148a8d99c6d86f1d803cb6a67f33a12acbcc5be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30863500)</sub>

<!-- /greptile_comment -->