### PR TITLE
feat(app-core): rate-limit-aware ApiError + dashboard countdown UX

### DIFF
--- a/packages/agent/src/api/cloud-billing-routes.ts
+++ b/packages/agent/src/api/cloud-billing-routes.ts
@@ -18,17 +18,34 @@ const MAX_REDIRECTS = 4;
  * crypto/status changes rarely (it advertises whether crypto top-ups are
  * enabled and which networks). Caching it amortises the second upstream call
  * `forwardSummary` makes per dashboard refresh against the per-key rate limit.
+ *
+ * Keyed by `(baseUrl, Authorization header)` so multi-account hosts (or hosts
+ * that switch keys via re-login) never serve one account's cached status to
+ * another. The Authorization header is already present in process memory at
+ * the time of caching, so this introduces no new exposure.
  */
 const CRYPTO_STATUS_CACHE_MS = 60_000;
-let cachedCryptoStatus: { value: unknown; expiresAt: number } | null = null;
+const cryptoStatusCache = new Map<
+  string,
+  { value: unknown; expiresAt: number }
+>();
+
+function cryptoStatusCacheKey(
+  baseUrl: string,
+  headers: Record<string, string>,
+): string {
+  return `${baseUrl}|${headers.Authorization ?? ""}`;
+}
 
 async function fetchCryptoStatusCached(
   baseUrl: string,
   headers: Record<string, string>,
 ): Promise<unknown> {
   const now = Date.now();
-  if (cachedCryptoStatus && cachedCryptoStatus.expiresAt > now) {
-    return cachedCryptoStatus.value;
+  const cacheKey = cryptoStatusCacheKey(baseUrl, headers);
+  const cached = cryptoStatusCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
   }
   const response = await fetchUpstream(
     `${baseUrl}/api/crypto/status`,
@@ -37,10 +54,13 @@ async function fetchCryptoStatusCached(
     undefined,
   ).catch(() => null);
   if (!response || !response.ok) {
-    return cachedCryptoStatus?.value ?? null;
+    return cached?.value ?? null;
   }
   const value = await readJsonResponse(response).catch(() => ({}));
-  cachedCryptoStatus = { value, expiresAt: now + CRYPTO_STATUS_CACHE_MS };
+  cryptoStatusCache.set(cacheKey, {
+    value,
+    expiresAt: now + CRYPTO_STATUS_CACHE_MS,
+  });
   return value;
 }
 

--- a/packages/agent/src/api/cloud-billing-routes.ts
+++ b/packages/agent/src/api/cloud-billing-routes.ts
@@ -14,6 +14,35 @@ export interface CloudBillingRouteState {
 const PROXY_TIMEOUT_MS = 15_000;
 const MAX_BODY_BYTES = 1_048_576;
 const MAX_REDIRECTS = 4;
+/**
+ * crypto/status changes rarely (it advertises whether crypto top-ups are
+ * enabled and which networks). Caching it amortises the second upstream call
+ * `forwardSummary` makes per dashboard refresh against the per-key rate limit.
+ */
+const CRYPTO_STATUS_CACHE_MS = 60_000;
+let cachedCryptoStatus: { value: unknown; expiresAt: number } | null = null;
+
+async function fetchCryptoStatusCached(
+  baseUrl: string,
+  headers: Record<string, string>,
+): Promise<unknown> {
+  const now = Date.now();
+  if (cachedCryptoStatus && cachedCryptoStatus.expiresAt > now) {
+    return cachedCryptoStatus.value;
+  }
+  const response = await fetchUpstream(
+    `${baseUrl}/api/crypto/status`,
+    "GET",
+    headers,
+    undefined,
+  ).catch(() => null);
+  if (!response || !response.ok) {
+    return cachedCryptoStatus?.value ?? null;
+  }
+  const value = await readJsonResponse(response).catch(() => ({}));
+  cachedCryptoStatus = { value, expiresAt: now + CRYPTO_STATUS_CACHE_MS };
+  return value;
+}
 
 interface CloudAuthApiKeyService {
   isAuthenticated: () => boolean;
@@ -339,34 +368,45 @@ async function forwardSummary(
   baseUrl: string,
   headers: Record<string, string>,
 ): Promise<{ status: number; payload: Record<string, unknown> | unknown }> {
-  const [summaryResponse, cryptoStatusResponse] = await Promise.all([
-    fetchUpstream(
-      `${baseUrl}/api/v1/credits/summary`,
-      "GET",
-      headers,
-      undefined,
-    ),
-    fetchUpstream(
-      `${baseUrl}/api/crypto/status`,
-      "GET",
-      headers,
-      undefined,
-    ).catch(() => null),
-  ]);
-
+  const summaryResponse = await fetchUpstream(
+    `${baseUrl}/api/v1/credits/summary`,
+    "GET",
+    headers,
+    undefined,
+  );
   const summaryPayload = await readJsonResponse(summaryResponse);
   if (!summaryResponse.ok) {
     return { status: summaryResponse.status, payload: summaryPayload };
   }
 
-  const cryptoPayload = cryptoStatusResponse
-    ? await readJsonResponse(cryptoStatusResponse).catch(() => ({}))
-    : {};
+  // Fetch crypto/status only when summary succeeded; cache it across requests
+  // so we don't burn a per-key rate-limit slot every time the dashboard
+  // refreshes (it changes rarely).
+  const cryptoPayload = (await fetchCryptoStatusCached(baseUrl, headers)) ?? {};
 
   return {
     status: summaryResponse.status,
     payload: mapBillingSummary(summaryPayload, baseUrl, cryptoPayload),
   };
+}
+
+/**
+ * Wraps `sendJson` to also set the HTTP `Retry-After` header when the upstream
+ * payload describes a rate-limit (status 429 + `retryAfter` in the body).
+ * The body's `retryAfter` field is preserved for clients that read JSON.
+ */
+function sendJsonWithRetry(
+  res: http.ServerResponse,
+  payload: unknown,
+  status: number,
+): void {
+  if (status === 429 && isRecord(payload)) {
+    const retryAfter = readNumber(payload.retryAfter);
+    if (retryAfter && retryAfter > 0) {
+      res.setHeader("Retry-After", String(Math.ceil(retryAfter)));
+    }
+  }
+  sendJson(res, payload, status);
 }
 
 export async function handleCloudBillingRoute(
@@ -401,7 +441,7 @@ export async function handleCloudBillingRoute(
 
   if (pathname === "/api/cloud/billing/summary" && method === "GET") {
     const { status, payload } = await forwardSummary(baseUrl, headers);
-    sendJson(res, payload, status);
+    sendJsonWithRetry(res, payload, status);
     return true;
   }
 
@@ -413,7 +453,7 @@ export async function handleCloudBillingRoute(
       undefined,
     );
     const summaryPayload = await readJsonResponse(summaryResponse);
-    sendJson(
+    sendJsonWithRetry(
       res,
       summaryResponse.ok ? mapPaymentMethods(summaryPayload) : summaryPayload,
       summaryResponse.status,
@@ -430,7 +470,7 @@ export async function handleCloudBillingRoute(
       undefined,
     );
     const historyPayload = await readJsonResponse(historyResponse);
-    sendJson(
+    sendJsonWithRetry(
       res,
       historyResponse.ok ? mapBillingHistory(historyPayload) : historyPayload,
       historyResponse.status,
@@ -467,7 +507,7 @@ export async function handleCloudBillingRoute(
       upstreamBody,
     );
     const checkoutPayload = await readJsonResponse(checkoutResponse);
-    sendJson(
+    sendJsonWithRetry(
       res,
       checkoutResponse.ok
         ? mapCheckoutResponse(checkoutPayload)
@@ -503,7 +543,7 @@ export async function handleCloudBillingRoute(
       upstreamBody,
     );
     const cryptoPayload = await readJsonResponse(cryptoResponse);
-    sendJson(
+    sendJsonWithRetry(
       res,
       cryptoResponse.ok
         ? mapCryptoQuoteResponse(cryptoPayload, amountUsd, payCurrency, network)
@@ -530,7 +570,7 @@ export async function handleCloudBillingRoute(
       body,
     );
     const responseData = await readJsonResponse(upstreamResponse);
-    sendJson(res, responseData, upstreamResponse.status);
+    sendJsonWithRetry(res, responseData, upstreamResponse.status);
     return true;
   }
 
@@ -554,7 +594,7 @@ export async function handleCloudBillingRoute(
       body,
     );
     const responseData = await readJsonResponse(upstreamResponse);
-    sendJson(res, responseData, upstreamResponse.status);
+    sendJsonWithRetry(res, responseData, upstreamResponse.status);
     return true;
   }
 
@@ -571,6 +611,6 @@ export async function handleCloudBillingRoute(
     body,
   );
   const responseData = await readJsonResponse(upstreamResponse);
-  sendJson(res, responseData, upstreamResponse.status);
+  sendJsonWithRetry(res, responseData, upstreamResponse.status);
   return true;
 }

--- a/packages/app-core/src/api/client-base.ts
+++ b/packages/app-core/src/api/client-base.ts
@@ -393,13 +393,22 @@ export class ElizaClient {
             ? body.message
             : `HTTP ${res.status}`;
       const code = typeof body?.code === "string" ? body.code : undefined;
-      const headerRetryAfter = Number(res.headers.get("Retry-After"));
-      const bodyRetryAfter = Number(body?.retryAfter);
-      const retryAfter = Number.isFinite(bodyRetryAfter)
-        ? bodyRetryAfter
-        : Number.isFinite(headerRetryAfter)
-          ? headerRetryAfter
+      // `Number(null) === 0` and `Number(undefined) === NaN`, so we must guard
+      // each source before coercing — otherwise an absent `Retry-After` header
+      // produces a spurious `retryAfter = 0` on every non-rate-limit error
+      // path, polluting the shared `ApiError` surface for unrelated callers.
+      const headerValue = res.headers.get("Retry-After");
+      const headerRetryAfter =
+        headerValue !== null && Number.isFinite(Number(headerValue))
+          ? Number(headerValue)
           : undefined;
+      const rawBodyRetryAfter = body?.retryAfter;
+      const bodyRetryAfter =
+        typeof rawBodyRetryAfter === "number" &&
+        Number.isFinite(rawBodyRetryAfter)
+          ? rawBodyRetryAfter
+          : undefined;
+      const retryAfter = bodyRetryAfter ?? headerRetryAfter;
       throw new ApiError({
         kind: "http",
         path,

--- a/packages/app-core/src/api/client-base.ts
+++ b/packages/app-core/src/api/client-base.ts
@@ -384,13 +384,29 @@ export class ElizaClient {
         .json()
         .catch(() => ({ error: res.statusText }))) as Record<
         string,
-        string
+        unknown
       > | null;
+      const message =
+        typeof body?.error === "string"
+          ? body.error
+          : typeof body?.message === "string"
+            ? body.message
+            : `HTTP ${res.status}`;
+      const code = typeof body?.code === "string" ? body.code : undefined;
+      const headerRetryAfter = Number(res.headers.get("Retry-After"));
+      const bodyRetryAfter = Number(body?.retryAfter);
+      const retryAfter = Number.isFinite(bodyRetryAfter)
+        ? bodyRetryAfter
+        : Number.isFinite(headerRetryAfter)
+          ? headerRetryAfter
+          : undefined;
       throw new ApiError({
         kind: "http",
         path,
         status: res.status,
-        message: body?.error ?? `HTTP ${res.status}`,
+        message,
+        code,
+        retryAfter,
       });
     }
     return res;

--- a/packages/app-core/src/api/client-types-core.ts
+++ b/packages/app-core/src/api/client-types-core.ts
@@ -213,12 +213,18 @@ export class ApiError extends Error {
   readonly kind: ApiErrorKind;
   readonly status?: number;
   readonly path: string;
+  /** Application error code from the JSON body (e.g. "rate_limit_exceeded"). */
+  readonly code?: string;
+  /** Seconds until the caller should retry, from the JSON body or Retry-After header. */
+  readonly retryAfter?: number;
 
   constructor(options: {
     kind: ApiErrorKind;
     path: string;
     message: string;
     status?: number;
+    code?: string;
+    retryAfter?: number;
     cause?: unknown;
   }) {
     super(options.message);
@@ -226,6 +232,8 @@ export class ApiError extends Error {
     this.kind = options.kind;
     this.path = options.path;
     this.status = options.status;
+    this.code = options.code;
+    this.retryAfter = options.retryAfter;
     if (options.cause !== undefined) {
       (
         this as Error & {
@@ -238,6 +246,13 @@ export class ApiError extends Error {
 
 export function isApiError(value: unknown): value is ApiError {
   return value instanceof ApiError;
+}
+
+export function isRateLimitedError(value: unknown): value is ApiError {
+  return (
+    value instanceof ApiError &&
+    (value.status === 429 || value.code === "rate_limit_exceeded")
+  );
 }
 
 export interface RuntimeOrderItem {

--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -120,8 +120,11 @@ export function CloudDashboard() {
 
         if (!mountedRef.current) return;
 
-        // Detect rate-limit on either response before either side throws so
-        // we can render a single countdown banner and skip the error toast.
+        // Detect rate-limit independently on each half. We have to handle
+        // them separately so that a settings-only rate-limit doesn't discard
+        // a successfully-fetched summary (and vice-versa) — for a first-time
+        // visitor with no cached state that would mean a blank balance for
+        // the full countdown window even though the data was just fetched.
         const summaryRateLimited =
           isRecord(summaryResponse) && "__error" in summaryResponse
             ? isRateLimitedError(summaryResponse.__error)
@@ -129,22 +132,25 @@ export function CloudDashboard() {
               : null
             : null;
         const settingsRateLimited =
-          !summaryRateLimited &&
-          isRecord(settingsResponse) &&
-          "__error" in settingsResponse &&
-          isRateLimitedError(settingsResponse.__error)
-            ? settingsResponse.__error
+          isRecord(settingsResponse) && "__error" in settingsResponse
+            ? isRateLimitedError(settingsResponse.__error)
+              ? settingsResponse.__error
+              : null
             : null;
         const rateLimitedErr = summaryRateLimited ?? settingsRateLimited;
-        if (rateLimitedErr) {
-          const retryAfterSec =
-            typeof rateLimitedErr.retryAfter === "number" &&
+        const rateLimitDeadlineMs = rateLimitedErr
+          ? Date.now() +
+            (typeof rateLimitedErr.retryAfter === "number" &&
             rateLimitedErr.retryAfter > 0
               ? Math.ceil(rateLimitedErr.retryAfter)
-              : 60;
-          setRateLimitedUntilMs(Date.now() + retryAfterSec * 1000);
-          // Preserve last-known balance/settings on rate-limit so the user
-          // doesn't see a flicker of "—" — just a banner explaining the wait.
+              : 60) *
+              1000
+          : null;
+
+        if (summaryRateLimited) {
+          // Summary itself was throttled — preserve last-known summary AND
+          // last-known settings. Showing a countdown is the most we can do.
+          setRateLimitedUntilMs(rateLimitDeadlineMs);
           return;
         }
 
@@ -160,8 +166,18 @@ export function CloudDashboard() {
               );
         }
 
-        setRateLimitedUntilMs(null);
+        // Summary succeeded — apply the fresh balance immediately, even if
+        // settings is rate-limited or otherwise failed.
         setBillingSummary(normalizeBillingSummary(summaryResponse));
+
+        if (settingsRateLimited) {
+          // Settings was throttled but summary was fine. Keep last-known
+          // settings (don't null them out) and show the countdown banner.
+          setRateLimitedUntilMs(rateLimitDeadlineMs);
+          return;
+        }
+
+        setRateLimitedUntilMs(null);
 
         if (isRecord(settingsResponse) && !("__error" in settingsResponse)) {
           setBillingSettings(normalizeBillingSettings(settingsResponse));

--- a/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/app-core/src/components/pages/ElizaCloudDashboard.tsx
@@ -21,6 +21,7 @@ import {
   type CloudBillingSettings,
   type CloudBillingSummary,
   client,
+  isRateLimitedError,
 } from "../../api";
 import { useApp } from "../../state";
 import { openExternalUrl, preOpenWindow } from "../../utils";
@@ -71,6 +72,14 @@ export function CloudDashboard() {
     useState<CloudBillingSummary | null>(null);
   const [billingSettings, setBillingSettings] =
     useState<CloudBillingSettings | null>(null);
+  // When non-null, Eliza Cloud is rate-limiting us; render a countdown until
+  // the wall-clock passes this timestamp instead of "Too many requests".
+  const [rateLimitedUntilMs, setRateLimitedUntilMs] = useState<number | null>(
+    null,
+  );
+  const [, setCountdownTick] = useState(0);
+  const fetchInFlightRef = useRef<Promise<void> | null>(null);
+  const rateLimitRetryScheduledRef = useRef(false);
   const [billingAmount, setBillingAmount] = useState("25");
   const [autoTopUpForm, dispatchAutoTopUpForm] = useReducer(
     autoTopUpFormReducer,
@@ -99,47 +108,86 @@ export function CloudDashboard() {
   );
 
   const fetchBillingData = useCallback(async () => {
-    setBillingLoading(true);
-    setBillingError(null);
-    try {
-      const [summaryResponse, settingsResponse] = await Promise.all([
-        client.getCloudBillingSummary().catch((err) => ({ __error: err })),
-        client.getCloudBillingSettings().catch((err) => ({ __error: err })),
-      ]);
+    if (fetchInFlightRef.current) return fetchInFlightRef.current;
+    const run = (async () => {
+      setBillingLoading(true);
+      setBillingError(null);
+      try {
+        const [summaryResponse, settingsResponse] = await Promise.all([
+          client.getCloudBillingSummary().catch((err) => ({ __error: err })),
+          client.getCloudBillingSettings().catch((err) => ({ __error: err })),
+        ]);
 
-      if (!mountedRef.current) return;
+        if (!mountedRef.current) return;
 
-      if (isRecord(summaryResponse) && "__error" in summaryResponse) {
-        const err = summaryResponse.__error;
-        throw err instanceof Error
-          ? err
-          : new Error(
-              t("elizaclouddashboard.BillingSummaryUnavailable", {
-                defaultValue: "Billing summary unavailable.",
-              }),
-            );
-      }
+        // Detect rate-limit on either response before either side throws so
+        // we can render a single countdown banner and skip the error toast.
+        const summaryRateLimited =
+          isRecord(summaryResponse) && "__error" in summaryResponse
+            ? isRateLimitedError(summaryResponse.__error)
+              ? summaryResponse.__error
+              : null
+            : null;
+        const settingsRateLimited =
+          !summaryRateLimited &&
+          isRecord(settingsResponse) &&
+          "__error" in settingsResponse &&
+          isRateLimitedError(settingsResponse.__error)
+            ? settingsResponse.__error
+            : null;
+        const rateLimitedErr = summaryRateLimited ?? settingsRateLimited;
+        if (rateLimitedErr) {
+          const retryAfterSec =
+            typeof rateLimitedErr.retryAfter === "number" &&
+            rateLimitedErr.retryAfter > 0
+              ? Math.ceil(rateLimitedErr.retryAfter)
+              : 60;
+          setRateLimitedUntilMs(Date.now() + retryAfterSec * 1000);
+          // Preserve last-known balance/settings on rate-limit so the user
+          // doesn't see a flicker of "—" — just a banner explaining the wait.
+          return;
+        }
 
-      setBillingSummary(normalizeBillingSummary(summaryResponse));
+        if (isRecord(summaryResponse) && "__error" in summaryResponse) {
+          const err = summaryResponse.__error;
+          setRateLimitedUntilMs(null);
+          throw err instanceof Error
+            ? err
+            : new Error(
+                t("elizaclouddashboard.BillingSummaryUnavailable", {
+                  defaultValue: "Billing summary unavailable.",
+                }),
+              );
+        }
 
-      if (isRecord(settingsResponse) && !("__error" in settingsResponse)) {
-        setBillingSettings(normalizeBillingSettings(settingsResponse));
-      } else {
+        setRateLimitedUntilMs(null);
+        setBillingSummary(normalizeBillingSummary(summaryResponse));
+
+        if (isRecord(settingsResponse) && !("__error" in settingsResponse)) {
+          setBillingSettings(normalizeBillingSettings(settingsResponse));
+        } else {
+          setBillingSettings(null);
+        }
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setBillingSummary(null);
         setBillingSettings(null);
+        setBillingError(
+          err instanceof Error
+            ? err.message
+            : t("elizaclouddashboard.FailedToLoadBillingData", {
+                defaultValue: "Failed to load billing data.",
+              }),
+        );
+      } finally {
+        if (mountedRef.current) setBillingLoading(false);
       }
-    } catch (err) {
-      if (!mountedRef.current) return;
-      setBillingSummary(null);
-      setBillingSettings(null);
-      setBillingError(
-        err instanceof Error
-          ? err.message
-          : t("elizaclouddashboard.FailedToLoadBillingData", {
-              defaultValue: "Failed to load billing data.",
-            }),
-      );
+    })();
+    fetchInFlightRef.current = run;
+    try {
+      await run;
     } finally {
-      if (mountedRef.current) setBillingLoading(false);
+      fetchInFlightRef.current = null;
     }
   }, [t]);
 
@@ -332,6 +380,31 @@ export function CloudDashboard() {
     };
   }, []);
 
+  // Tick once per second while rate-limited so the countdown re-renders, then
+  // fire one auto-retry when the window expires. We schedule the retry once
+  // per rate-limit window (gated by rateLimitRetryScheduledRef) so we never
+  // turn this into a tight retry loop against an upstream that's still refusing.
+  useEffect(() => {
+    if (rateLimitedUntilMs === null) {
+      rateLimitRetryScheduledRef.current = false;
+      return;
+    }
+    const interval = window.setInterval(() => {
+      if (!mountedRef.current) return;
+      const remaining = rateLimitedUntilMs - Date.now();
+      if (remaining > 0) {
+        setCountdownTick((n) => n + 1);
+        return;
+      }
+      window.clearInterval(interval);
+      if (rateLimitRetryScheduledRef.current) return;
+      rateLimitRetryScheduledRef.current = true;
+      setRateLimitedUntilMs(null);
+      void fetchBillingData();
+    }, 1_000);
+    return () => window.clearInterval(interval);
+  }, [rateLimitedUntilMs, fetchBillingData]);
+
   // Refetch billing only when the cloud-connected flag flips. We deliberately
   // exclude `fetchBillingData` from the dep array: its identity tracks `t`
   // (i18n) and changes on every render, which would re-fire this effect every
@@ -491,6 +564,18 @@ export function CloudDashboard() {
   const formattedBalance =
     cloudBalanceNumber !== null ? cloudBalanceNumber.toFixed(2) : null;
   const currencyPrefix = cloudCurrency === "USD" ? "$" : `${cloudCurrency} `;
+  const rateLimitRemainingSec =
+    rateLimitedUntilMs !== null
+      ? Math.max(0, Math.ceil((rateLimitedUntilMs - Date.now()) / 1000))
+      : 0;
+  const isRateLimited = rateLimitRemainingSec > 0;
+  const rateLimitMessage = isRateLimited
+    ? t("elizaclouddashboard.RateLimitedRetryIn", {
+        defaultValue:
+          "Eliza Cloud is rate-limiting this account; retrying in {{seconds}}s.",
+        seconds: rateLimitRemainingSec,
+      })
+    : null;
 
   if (!elizaCloudConnected) {
     return (
@@ -561,9 +646,13 @@ export function CloudDashboard() {
             size="icon"
             className="h-8 w-8 rounded-lg"
             onClick={handleRefresh}
-            disabled={refreshing || billingLoading}
+            disabled={refreshing || billingLoading || isRateLimited}
             aria-label={t("common.refresh")}
-            title={t("common.refresh")}
+            title={
+              isRateLimited
+                ? (rateLimitMessage ?? t("common.refresh"))
+                : t("common.refresh")
+            }
           >
             <RefreshCw
               className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`}
@@ -593,7 +682,16 @@ export function CloudDashboard() {
         </div>
       )}
 
-      {billingError && (
+      {rateLimitMessage && (
+        <div
+          role="status"
+          className="mt-2 rounded-lg border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn"
+        >
+          {rateLimitMessage}
+        </div>
+      )}
+
+      {!rateLimitMessage && billingError && (
         <div
           role="alert"
           className="mt-2 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger"
@@ -659,7 +757,16 @@ export function CloudDashboard() {
         </span>
       </div>
 
-      {billingError && (
+      {rateLimitMessage && (
+        <div
+          role="status"
+          className="mb-4 rounded-lg border border-warn/30 bg-warn/10 px-3 py-2 text-sm text-warn"
+        >
+          {rateLimitMessage}
+        </div>
+      )}
+
+      {!rateLimitMessage && billingError && (
         <div
           role="alert"
           className="mb-4 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-sm text-danger"


### PR DESCRIPTION
@
## Summary
Makes the runtime cloud client and the dashboard rate-limit-aware end to end.

- **`ApiError`** now carries `code` (e.g. `"rate_limit_exceeded"`) and `retryAfter` (seconds), parsed from both the JSON body and the standard `Retry-After` HTTP header. Adds `isRateLimitedError()` type guard.
- **`cloud-billing-routes.ts`** caches `crypto/status` for 60s (it changes rarely), cutting summary upstream calls roughly in half. When forwarding an upstream 429, also sets the HTTP `Retry-After` header so any client tooling can honour it.
- **`CloudDashboard`** detects rate-limits specifically and renders a friendly countdown banner ("Eliza Cloud is rate-limiting this account; retrying in Ns") instead of raw "Too many requests". Disables the refresh button while the countdown is running, auto-retries once on expiry, preserves last-known balance during the wait, and de-dupes in-flight `fetchBillingData` calls.

Pairs naturally with #7397 (image-handler fixes) but stands alone — they touch disjoint files.

## Test plan
- [x] `bun run --filter @elizaos/app-core typecheck` and `bun run --filter @elizaos/agent typecheck` clean.
- [x] Verified at runtime: dashboard renders countdown when 429 is returned, refresh button disables, banner clears on successful retry.
@

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires rate-limit awareness end-to-end: `ApiError` gains `code` and `retryAfter` fields parsed from both the JSON body and the `Retry-After` HTTP header, the proxy layer forwards the header and gains a keyed crypto/status cache, and the dashboard replaces the raw "Too many requests" message with a live countdown banner and a single auto-retry on expiry.

- **`client-types-core.ts` / `client-base.ts`**: `ApiError` extended with `code` and `retryAfter`; parsing correctly guards against `Number(null) === 0`; `isRateLimitedError` type guard added.
- **`cloud-billing-routes.ts`**: `sendJsonWithRetry` sets `Retry-After` on proxied 429 responses; `fetchCryptoStatusCached` reduces upstream calls with a per-`(baseUrl, authHeader)` 60 s TTL cache.
- **`ElizaCloudDashboard.tsx`**: countdown banner, in-flight deduplication via `fetchInFlightRef`, and single-shot auto-retry on expiry with `rateLimitRetryScheduledRef` guard; summary data is now applied before the settings rate-limit early-return so a fresh balance is never discarded.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are well-scoped and the core error-parsing and countdown logic handle the primary paths correctly.

The `ApiError` extension and proxy header forwarding are straightforward and well-guarded. The dashboard countdown and dedup logic cover the main scenarios correctly. Two minor edge cases exist — unbounded cache entries in `cryptoStatusCache` for never-re-read keys, and a `rateLimitRetryScheduledRef` not being reset if the `useEffect` re-runs due to a `fetchBillingData` identity change (e.g., locale switch mid-countdown) — but neither affects typical usage paths.

No files require special attention for merging; the cache eviction gap in `cloud-billing-routes.ts` and the ref reset edge case in `ElizaCloudDashboard.tsx` are both low-frequency concerns.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/client-types-core.ts | Adds `code` and `retryAfter` optional fields to `ApiError`, extends constructor, and exports `isRateLimitedError` type guard checking status 429 or code "rate_limit_exceeded". |
| packages/app-core/src/api/client-base.ts | Extends the HTTP error path to parse `code` and `retryAfter` from the JSON body and `Retry-After` header with proper null/NaN guards; correctly avoids the `Number(null) === 0` pitfall. |
| packages/agent/src/api/cloud-billing-routes.ts | Adds per-key crypto/status cache and `sendJsonWithRetry` helper; cache Map has no eviction of expired entries for keys that are never re-read, accumulating stale entries in long-lived processes. |
| packages/app-core/src/components/pages/ElizaCloudDashboard.tsx | Adds rate-limit countdown banner, in-flight fetch deduplication, and auto-retry on expiry; `rateLimitRetryScheduledRef` is not reset on effect re-runs caused by dependency identity changes, which can leave the countdown stuck at 0s after a locale switch. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant D as CloudDashboard
    participant P as cloud-billing-routes (proxy)
    participant U as Eliza Cloud API

    D->>P: GET /api/cloud/billing/summary
    P->>U: GET /api/v1/credits/summary
    U-->>P: 200 OK (summary payload)
    P->>P: fetchCryptoStatusCached (60s TTL per key)
    alt cache hit
        P->>P: return cached value
    else cache miss
        P->>U: GET /api/crypto/status
        U-->>P: 200 OK (crypto payload)
        P->>P: store in cryptoStatusCache
    end
    P-->>D: 200 OK (merged payload)

    D->>P: GET /api/cloud/billing/summary (rate limited)
    P->>U: GET /api/v1/credits/summary
    U-->>P: 429 {retryAfter: 60}
    P->>P: sendJsonWithRetry → set Retry-After header
    P-->>D: 429 {retryAfter: 60}, Retry-After: 60

    Note over D: ApiError parsed with code + retryAfter
    Note over D: isRateLimitedError → show countdown banner
    Note over D: setInterval ticks every 1s
    Note over D: on expiry → setRateLimitedUntilMs(null) + fetchBillingData()
```

<sub>Reviews (3): Last reviewed commit: ["fix(cloud-dashboard): apply summary on s..."](https://github.com/elizaos/eliza/commit/27c35451aab26ac21697d94d123adc7635115ca1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30863552)</sub>

<!-- /greptile_comment -->