### PR TITLE
fix(app-core): unblock and surface cloud agent hosting failures in RuntimeGate

### DIFF
--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -33,6 +33,7 @@ const {
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
+    getCloudCompatAgentStatus: vi.fn(),
     getRestAuthToken: vi.fn(() => null),
     switchProvider: vi.fn(),
     setBaseUrl: vi.fn(),
@@ -325,6 +326,15 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
         completed_on: "2026-01-01T00:00:02.000Z",
       },
     });
+    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
+      success: true,
+      data: {
+        status: "running",
+        bridgeUrl: "https://agent-1.elizacloud.ai",
+        webUiUrl: null,
+        suspendedReason: null,
+      },
+    });
     clientMock.switchProvider.mockResolvedValue({
       success: true,
       provider: "elizacloud",
@@ -443,5 +453,127 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
     expect(clientMock.getCloudCompatJobStatus).toHaveBeenCalledTimes(3);
     expect(clientMock.setBaseUrl).not.toHaveBeenCalled();
     expect(completeOnboardingMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces 'hosting unavailable' when create returns nodeId=null and skips provision", async () => {
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    clientMock.createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", nodeId: null, status: "queued" },
+    });
+
+    render(<RuntimeGate />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Select Cloud"));
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "Cloud agent hosting isn't available on this instance. Try a local or remote agent.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(clientMock.provisionCloudCompatAgent).not.toHaveBeenCalled();
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+  });
+
+  it("times out async provisioning that stays queued past PROVISION_JOB_DEADLINE_MS", async () => {
+    vi.useFakeTimers();
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    clientMock.createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { agentId: "agent-1", nodeId: "node-1", status: "queued" },
+    });
+    clientMock.provisionCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "job-1", agentId: "agent-1", status: "queued" },
+    });
+    clientMock.getCloudCompatJobStatus.mockResolvedValue({
+      success: true,
+      data: {
+        id: "job-1",
+        jobId: "job-1",
+        type: "agent_provision",
+        status: "queued",
+        data: {},
+        result: null,
+        error: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        startedAt: null,
+        completedAt: null,
+        retryCount: 0,
+        name: "agent_provision",
+        state: "queued",
+        created_on: "2026-01-01T00:00:00.000Z",
+        completed_on: null,
+      },
+    });
+
+    render(<RuntimeGate />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Select Cloud"));
+    });
+
+    await vi.waitFor(() =>
+      expect(clientMock.provisionCloudCompatAgent).toHaveBeenCalledWith(
+        "agent-1",
+      ),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(125_000);
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        screen.getByText(
+          "Cloud agent provisioning is taking too long. The hosting service may be unavailable.",
+        ),
+      ).toBeTruthy(),
+    );
+    expect(clientMock.setBaseUrl).not.toHaveBeenCalled();
+    expect(completeOnboardingMock).not.toHaveBeenCalled();
+  });
+
+  it("re-provisions an existing agent whose /api/health probe fails", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("Network unreachable");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [RUNNING_AGENT],
+    });
+    clientMock.provisionCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { jobId: "", agentId: "agent-1", status: "running" },
+    });
+
+    render(<RuntimeGate />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Select Cloud"));
+    });
+
+    await vi.waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://agent-1.elizacloud.ai/api/health",
+        expect.objectContaining({ method: "GET" }),
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(clientMock.provisionCloudCompatAgent).toHaveBeenCalledWith(
+        "agent-1",
+      ),
+    );
+
+    vi.unstubAllGlobals();
   });
 });

--- a/packages/app-core/src/components/shell/RuntimeGate.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.tsx
@@ -56,6 +56,7 @@ import {
   type UiTheme,
   useApp,
 } from "../../state";
+import { fetchWithTimeout } from "../../utils/api-request";
 import { preOpenWindow, resolveAppAssetUrl } from "../../utils";
 import { LanguageDropdown } from "../shared/LanguageDropdown";
 import { ThemeToggle } from "../shared/ThemeToggle";
@@ -63,6 +64,8 @@ import { ThemeToggle } from "../shared/ThemeToggle";
 const MONO_FONT = "'Courier New', 'Courier', 'Monaco', monospace";
 
 const DEFAULT_AUTO_AGENT_NAME = "My Agent";
+
+const CLOUD_AGENT_PROBE_TIMEOUT_MS = 4_000;
 
 const LOCAL_AGENT_API_BASE = "http://127.0.0.1:31337";
 
@@ -174,6 +177,22 @@ function resolveCloudAgentApiBase(agent: CloudCompatAgent): string | undefined {
     .filter((value): value is string => Boolean(value));
 
   return candidates.find((value) => !isCloudControlPlaneUrl(value));
+}
+
+async function probeCloudAgentReachable(
+  apiBase: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  try {
+    const res = await fetchWithTimeout(
+      `${apiBase.replace(/\/$/, "")}/api/status`,
+      { method: "GET" },
+      timeoutMs,
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
 }
 
 // TODO: replace with real onboarding artwork per runtime choice
@@ -724,6 +743,7 @@ export function RuntimeGate() {
       }
 
       let consecutivePollFailures = 0;
+      const provisionDeadline = Date.now() + AGENT_URL_WAIT_DEADLINE_MS;
       const stopPollingWithError = (message: string) => {
         if (pollTimerRef.current) clearInterval(pollTimerRef.current);
         pollTimerRef.current = null;
@@ -731,6 +751,15 @@ export function RuntimeGate() {
         setCloudStage("agent-list");
       };
       const pollProvisionJob = async () => {
+        if (Date.now() > provisionDeadline) {
+          stopPollingWithError(
+            t("runtimegate.provisioningTimeout", {
+              defaultValue:
+                "Cloud agent provisioning is taking too long. The hosting service may be unavailable.",
+            }),
+          );
+          return;
+        }
         let jobRes: Awaited<ReturnType<typeof client.getCloudCompatJobStatus>>;
         try {
           jobRes = await client.getCloudCompatJobStatus(jobId);
@@ -862,10 +891,17 @@ export function RuntimeGate() {
             setCloudStage("agent-list");
             return;
           }
-          if (
-            primary.status !== "running" ||
-            !resolveCloudAgentApiBase(primary)
-          ) {
+          const primaryApiBase = resolveCloudAgentApiBase(primary);
+          if (primary.status !== "running" || !primaryApiBase) {
+            await provisionAndConnect(primary.agent_id);
+            return;
+          }
+          const reachable = await probeCloudAgentReachable(
+            primaryApiBase,
+            CLOUD_AGENT_PROBE_TIMEOUT_MS,
+          );
+          if (cancelled) return;
+          if (!reachable) {
             await provisionAndConnect(primary.agent_id);
             return;
           }
@@ -875,7 +911,6 @@ export function RuntimeGate() {
       }
 
       // No agents yet — auto-create "My Agent" and provision.
-      setCloudStage("auto-creating");
       setError(null);
       const createRes = await client.createCloudCompatAgent({
         agentName: DEFAULT_AUTO_AGENT_NAME,
@@ -890,6 +925,17 @@ export function RuntimeGate() {
         setCloudStage("agent-list");
         return;
       }
+      if (createRes.data.nodeId == null) {
+        setError(
+          t("runtimegate.cloudHostingUnavailable", {
+            defaultValue:
+              "Cloud agent hosting isn't available on this instance. Try a local or remote agent.",
+          }),
+        );
+        setCloudStage("agent-list");
+        return;
+      }
+      setCloudStage("auto-creating");
 
       await provisionAndConnect(createRes.data.agentId);
     })().catch((err) => {

--- a/packages/app-core/src/components/shell/RuntimeGate.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.tsx
@@ -67,6 +67,8 @@ const DEFAULT_AUTO_AGENT_NAME = "My Agent";
 
 const CLOUD_AGENT_PROBE_TIMEOUT_MS = 4_000;
 
+const PROVISION_JOB_DEADLINE_MS = 120_000;
+
 const LOCAL_AGENT_API_BASE = "http://127.0.0.1:31337";
 
 /**
@@ -790,7 +792,7 @@ export function RuntimeGate() {
       }
 
       let consecutivePollFailures = 0;
-      const provisionDeadline = Date.now() + AGENT_URL_WAIT_DEADLINE_MS;
+      const provisionDeadline = Date.now() + PROVISION_JOB_DEADLINE_MS;
       const stopPollingWithError = (message: string) => {
         if (pollTimerRef.current) clearInterval(pollTimerRef.current);
         pollTimerRef.current = null;

--- a/packages/app-core/src/components/shell/RuntimeGate.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.tsx
@@ -185,7 +185,7 @@ async function probeCloudAgentReachable(
 ): Promise<boolean> {
   try {
     const res = await fetchWithTimeout(
-      `${apiBase.replace(/\/$/, "")}/api/status`,
+      `${apiBase.replace(/\/$/, "")}/api/health`,
       { method: "GET" },
       timeoutMs,
     );
@@ -982,6 +982,10 @@ export function RuntimeGate() {
         setCloudStage("agent-list");
         return;
       }
+      // MUST stay below the createCloudCompatAgent await — setting cloudStage
+      // earlier fires this effect's cleanup (cloudStage is in deps), flips
+      // cancelled=true, and the post-await guard then bails before
+      // provisionAndConnect runs.
       setCloudStage("auto-creating");
 
       await provisionAndConnect(createRes.data.agentId);


### PR DESCRIPTION
## Summary

Onboarding could get stuck silently in three different ways when cloud agent hosting was unhealthy. This PR makes the flow either complete or surface a clear, accurate error in each case.

## The four fixes

### 1. Cleanup race blocked provisioning entirely (the original repro)

The auto-create \`useEffect\` set \`cloudStage=\"auto-creating\"\` before awaiting \`createCloudCompatAgent\`. Because \`cloudStage\` is in the dep array, the state change fired the cleanup, flipping \`cancelled=true\`. The post-await \`if (cancelled) return\` then bailed out before \`provisionAndConnect\` ran, leaving the new agent at \`status=\"queued\" / nodeId=null\` and the UI stuck on \"Setting up your first agent…\".

**Fix:** move \`setCloudStage(\"auto-creating\")\` past the create await.

### 2. Hosting-unavailable response was silently treated as in-progress

When cloud provisioning capacity is missing, \`POST /agents\` returns \`status=\"queued\" / nodeId=null\`. Then \`provisionAndConnect\` polled a never-completing job.

**Fix:** detect \`nodeId == null\` on the create response and short-circuit with \"Cloud agent hosting isn't available on this instance\".

### 3. Provision-job polling had no deadline

\`pollProvisionJob\` looped forever on \`queued\`/\`in-progress\` with only network-failure exits. Defensive coverage for the case where \`nodeId\` is set but the worker dies later.

**Fix:** cap with the existing \`AGENT_URL_WAIT_DEADLINE_MS\`. On expiry, surface \"Cloud agent provisioning is taking too long. The hosting service may be unavailable.\"

### 4. Auto-pick trusted stale \"running\" records

The first existing agent was handed to \`finishAsCloud\` as soon as its DB \`status\` was \`running\` with a URL set. When the underlying container had died (common post-Vercel→CF cutover — the agent record persists but the host fleet may not), the downstream \`/api/status\` call timed out into the **local** agent's \"embedding model GGUF download\" startup hint, which is meaningless for cloud users.

**Fix:** probe \`\${apiBase}/api/status\` with a 4s timeout before \`finishAsCloud\`. On failure, fall through to \`provisionAndConnect\`, which now surfaces a cloud-specific error via (2) or (3).

## Repro

Verified live via Playwright MCP against \`https://www.elizacloud.ai\`:

- Before: POST \`/api/cloud/compat/agents\` → 201 \`{status: \"queued\", nodeId: null}\`, **no subsequent calls**, UI stuck on \"Setting up your first agent…\" forever.
- After: same POST → \"Cloud agent hosting isn't available on this instance\" displayed immediately on \`agent-list\` view.

## Reuse

\`probeCloudAgentReachable\` uses \`fetchWithTimeout\` from \`utils/api-request\` to avoid duplicating the AbortController + timer plumbing. The polling deadline reuses the existing \`AGENT_URL_WAIT_DEADLINE_MS\` constant.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses four silent hang scenarios in the cloud onboarding flow (`RuntimeGate`): a cleanup-race that cancelled provisioning before it started, a missing `nodeId == null` guard that let hosts without capacity spin forever, an unbounded polling loop that had no deadline, and stale DB "running" records that pointed to dead containers.

- **Fix 1–2**: `setCloudStage("auto-creating")` is moved below the `createCloudCompatAgent` await, and a `nodeId == null` short-circuit immediately surfaces "Cloud agent hosting isn't available on this instance" instead of entering an infinite poll.
- **Fix 3**: `pollProvisionJob` gains a 120-second `PROVISION_JOB_DEADLINE_MS` deadline; expiry surfaces a clear timeout message.
- **Fix 4**: Before handing a DB-"running" agent to `finishAsCloud`, the code now probes `${apiBase}/api/health` with a 4-second timeout via the existing `fetchWithTimeout` utility; on failure it falls through to `provisionAndConnect`.

<h3>Confidence Score: 4/5</h3>

The four onboarding fixes are well-targeted; the one remaining gap is the existing cancelled-flag/error-swallow path on throws from provisionAndConnect, noted in a prior review thread.

After setCloudStage("auto-creating") fires at line 991, the effect cleanup runs and sets cancelled=true. Any exception thrown inside provisionAndConnect is then caught by the outer .catch which returns early because cancelled is true, silently dropping the error and leaving the user on the spinner — structurally the same hang the PR set out to fix, just on the throw path.

RuntimeGate.tsx lines 991–995: the setCloudStage("auto-creating") → cancelled=true → provisionAndConnect throw → .catch swallows error sequence.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/shell/RuntimeGate.tsx | Four targeted fixes for silent cloud onboarding hangs: deadline added to provision polling, nodeId==null guard on create response, /api/health probe before trusting stale DB records, and setCloudStage ordering fix. The cancelled-flag/error-swallow risk on the throw path inside provisionAndConnect (already in review thread) is the remaining concern. |
| packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx | Three new tests added for the new scenarios; getCloudCompatAgentStatus mock moved into beforeEach. The "re-provisions" test leaves the URL-polling loop running after assertions complete without waiting for or asserting the final settled state. |

</details>

<sub>Reviews (4): Last reviewed commit: ["test(app-core): cover RuntimeGate hostin..."](https://github.com/elizaos/eliza/commit/66063b86cfb69b206309c2f2bb9f704f53cefbaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30904641)</sub>

<!-- /greptile_comment -->