### PR TITLE
feat(orchestrator): support codex image descriptions

### DIFF
--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -33,7 +33,6 @@ const {
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
-    getCloudCompatAgentStatus: vi.fn(),
     getRestAuthToken: vi.fn(() => null),
     switchProvider: vi.fn(),
     setBaseUrl: vi.fn(),
@@ -324,14 +323,6 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
         state: "completed",
         created_on: "2026-01-01T00:00:00.000Z",
         completed_on: "2026-01-01T00:00:02.000Z",
-      },
-    });
-    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
-      success: true,
-      data: {
-        status: "running",
-        bridgeUrl: "https://agent-1.elizacloud.ai",
-        webUiUrl: null,
       },
     });
     clientMock.switchProvider.mockResolvedValue({

--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -33,6 +33,7 @@ const {
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
+    getCloudCompatAgentStatus: vi.fn(),
     getRestAuthToken: vi.fn(() => null),
     switchProvider: vi.fn(),
     setBaseUrl: vi.fn(),
@@ -323,6 +324,14 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
         state: "completed",
         created_on: "2026-01-01T00:00:00.000Z",
         completed_on: "2026-01-01T00:00:02.000Z",
+      },
+    });
+    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
+      success: true,
+      data: {
+        status: "running",
+        bridgeUrl: "https://agent-1.elizacloud.ai",
+        webUiUrl: null,
       },
     });
     clientMock.switchProvider.mockResolvedValue({

--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { fetchRemoteMedia } from "./fetch.ts";
+
+describe("fetchRemoteMedia", () => {
+	it("applies timeout signals to guarded fetches", async () => {
+		let sawAbortSignal = false;
+		const result = await fetchRemoteMedia({
+			url: "https://example.com/image.png",
+			timeoutMs: 30_000,
+			lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+			fetchImpl: async (_input, init) => {
+				sawAbortSignal = init?.signal instanceof AbortSignal;
+				return new Response(Buffer.from("png"), {
+					headers: { "content-type": "image/png" },
+				});
+			},
+		});
+
+		expect(sawAbortSignal).toBe(true);
+		expect(result.contentType).toBe("image/png");
+	});
+});

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -44,6 +44,7 @@ export type FetchMediaOptions = {
 	filePathHint?: string;
 	maxBytes?: number;
 	maxRedirects?: number;
+	timeoutMs?: number;
 	ssrfPolicy?: SsrfPolicy;
 	lookupFn?: LookupFn;
 };
@@ -122,6 +123,7 @@ export async function fetchRemoteMedia(
 		filePathHint,
 		maxBytes,
 		maxRedirects,
+		timeoutMs,
 		ssrfPolicy,
 		lookupFn,
 	} = options;
@@ -134,6 +136,7 @@ export async function fetchRemoteMedia(
 			url,
 			fetchImpl,
 			maxRedirects,
+			timeoutMs,
 			policy: ssrfPolicy,
 			lookupFn,
 		});

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -107,6 +107,120 @@ async function readErrorBodySnippet(
 	}
 }
 
+async function fetchGuardedMedia(options: FetchMediaOptions): Promise<{
+	response: Response;
+	finalUrl: string;
+	release: () => Promise<void>;
+}> {
+	try {
+		return await fetchWithSsrfGuard({
+			url: options.url,
+			fetchImpl: options.fetchImpl,
+			maxRedirects: options.maxRedirects,
+			timeoutMs: options.timeoutMs,
+			policy: options.ssrfPolicy,
+			lookupFn: options.lookupFn,
+		});
+	} catch (err) {
+		throw new MediaFetchError(
+			"fetch_failed",
+			`Failed to fetch media from ${options.url}: ${String(err)}`,
+		);
+	}
+}
+
+async function throwIfHttpError(
+	res: Response,
+	url: string,
+	finalUrl: string,
+): Promise<void> {
+	if (res.ok) {
+		return;
+	}
+
+	const statusText = res.statusText ? ` ${res.statusText}` : "";
+	const redirected = finalUrl !== url ? ` (redirected to ${finalUrl})` : "";
+	let detail = `HTTP ${res.status}${statusText}`;
+	if (!res.body) {
+		detail = `HTTP ${res.status}${statusText}; empty response body`;
+	} else {
+		const snippet = await readErrorBodySnippet(res);
+		if (snippet) {
+			detail += `; body: ${snippet}`;
+		}
+	}
+	throw new MediaFetchError(
+		"http_error",
+		`Failed to fetch media from ${url}${redirected}: ${detail}`,
+	);
+}
+
+function enforceContentLengthLimit(
+	res: Response,
+	url: string,
+	maxBytes?: number,
+): void {
+	const contentLength = res.headers.get("content-length");
+	if (!maxBytes || !contentLength) {
+		return;
+	}
+
+	const length = Number(contentLength);
+	if (Number.isFinite(length) && length > maxBytes) {
+		throw new MediaFetchError(
+			"max_bytes",
+			`Failed to fetch media from ${url}: content length ${length} exceeds maxBytes ${maxBytes}`,
+		);
+	}
+}
+
+function fileNameFromUrl(url: string): string | undefined {
+	try {
+		const parsed = new URL(url);
+		const base = getBasename(parsed.pathname);
+		return base || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function resolveMediaMetadata(params: {
+	res: Response;
+	buffer: Buffer;
+	finalUrl: string;
+	filePathHint?: string;
+}): Promise<Pick<FetchMediaResult, "contentType" | "fileName">> {
+	const { res, buffer, finalUrl, filePathHint } = params;
+	const headerFileName = parseContentDispositionFileName(
+		res.headers.get("content-disposition"),
+	);
+	let fileName =
+		headerFileName ||
+		fileNameFromUrl(finalUrl) ||
+		(filePathHint ? getBasename(filePathHint) : undefined);
+
+	const filePathForMime =
+		headerFileName && getExtname(headerFileName)
+			? headerFileName
+			: (filePathHint ?? finalUrl);
+	const contentType = await detectMime({
+		buffer,
+		headerMime: res.headers.get("content-type"),
+		filePath: filePathForMime,
+	});
+	if (fileName && !getExtname(fileName) && contentType) {
+		const ext = extensionForMime(contentType);
+		if (ext) {
+			fileName = `${fileName}${ext}`;
+		}
+	}
+
+	return {
+		contentType: contentType ?? undefined,
+		fileName,
+	};
+}
+
 /**
  * Fetch remote media with SSRF protection.
  *
@@ -117,114 +231,28 @@ async function readErrorBodySnippet(
 export async function fetchRemoteMedia(
 	options: FetchMediaOptions,
 ): Promise<FetchMediaResult> {
-	const {
-		url,
-		fetchImpl,
-		filePathHint,
-		maxBytes,
-		maxRedirects,
-		timeoutMs,
-		ssrfPolicy,
-		lookupFn,
-	} = options;
-
-	let res: Response;
-	let finalUrl = url;
-	let release: (() => Promise<void>) | null = null;
-	try {
-		const result = await fetchWithSsrfGuard({
-			url,
-			fetchImpl,
-			maxRedirects,
-			timeoutMs,
-			policy: ssrfPolicy,
-			lookupFn,
-		});
-		res = result.response;
-		finalUrl = result.finalUrl;
-		release = result.release;
-	} catch (err) {
-		throw new MediaFetchError(
-			"fetch_failed",
-			`Failed to fetch media from ${url}: ${String(err)}`,
-		);
-	}
+	const { response: res, finalUrl, release } = await fetchGuardedMedia(options);
 
 	try {
-		if (!res.ok) {
-			const statusText = res.statusText ? ` ${res.statusText}` : "";
-			const redirected = finalUrl !== url ? ` (redirected to ${finalUrl})` : "";
-			let detail = `HTTP ${res.status}${statusText}`;
-			if (!res.body) {
-				detail = `HTTP ${res.status}${statusText}; empty response body`;
-			} else {
-				const snippet = await readErrorBodySnippet(res);
-				if (snippet) {
-					detail += `; body: ${snippet}`;
-				}
-			}
-			throw new MediaFetchError(
-				"http_error",
-				`Failed to fetch media from ${url}${redirected}: ${detail}`,
-			);
-		}
+		await throwIfHttpError(res, options.url, finalUrl);
+		enforceContentLengthLimit(res, options.url, options.maxBytes);
 
-		const contentLength = res.headers.get("content-length");
-		if (maxBytes && contentLength) {
-			const length = Number(contentLength);
-			if (Number.isFinite(length) && length > maxBytes) {
-				throw new MediaFetchError(
-					"max_bytes",
-					`Failed to fetch media from ${url}: content length ${length} exceeds maxBytes ${maxBytes}`,
-				);
-			}
-		}
-
-		const buffer = maxBytes
-			? await readResponseWithLimit(res, maxBytes)
+		const buffer = options.maxBytes
+			? await readResponseWithLimit(res, options.maxBytes)
 			: Buffer.from(await res.arrayBuffer());
-		let fileNameFromUrl: string | undefined;
-		try {
-			const parsed = new URL(finalUrl);
-			const base = getBasename(parsed.pathname);
-			fileNameFromUrl = base || undefined;
-		} catch {
-			// ignore parse errors; leave undefined
-		}
-
-		const headerFileName = parseContentDispositionFileName(
-			res.headers.get("content-disposition"),
-		);
-		let fileName =
-			headerFileName ||
-			fileNameFromUrl ||
-			(filePathHint ? getBasename(filePathHint) : undefined);
-
-		const filePathForMime =
-			headerFileName && getExtname(headerFileName)
-				? headerFileName
-				: (filePathHint ?? finalUrl);
-		const contentType = await detectMime({
+		const metadata = await resolveMediaMetadata({
+			res,
 			buffer,
-			headerMime: res.headers.get("content-type"),
-			filePath: filePathForMime,
+			finalUrl,
+			filePathHint: options.filePathHint,
 		});
-		if (fileName && !getExtname(fileName) && contentType) {
-			const ext = extensionForMime(contentType);
-			if (ext) {
-				fileName = `${fileName}${ext}`;
-			}
-		}
 
 		return {
 			buffer,
-			contentType: contentType ?? undefined,
-			fileName,
+			...metadata,
 		};
 	} finally {
-		if (release) {
-			await release();
-		}
+		await release();
 	}
 }
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
@@ -1,13 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { ModelType, type IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { taskAgentPlugin } from "../index.js";
 import {
   buildCodexExecArgs,
   buildCodexImageDescriptionPrompt,
   buildCodexModelPrompt,
+  codexCliImageDescriptionModel,
+  isCodexModelProviderEnabled,
   parseCodexImageDescriptionResult,
   promptFromGenerateTextParams,
+  readCodexModelProviderPriority,
 } from "../services/codex-model-provider.js";
 
+function runtimeWithSettings(settings: Record<string, string>): IAgentRuntime {
+  return {
+    getSetting(key: string) {
+      return settings[key];
+    },
+  } as IAgentRuntime;
+}
+
 describe("codex model provider", () => {
+  const originalModels = taskAgentPlugin.models;
+  const originalPriority = taskAgentPlugin.priority;
+
+  afterEach(() => {
+    taskAgentPlugin.models = originalModels;
+    if (originalPriority === undefined) {
+      delete taskAgentPlugin.priority;
+    } else {
+      taskAgentPlugin.priority = originalPriority;
+    }
+  });
+
   it("uses codex exec in read-only non-interactive output-file mode", () => {
     const args = buildCodexExecArgs("/tmp/out.txt", {
       binary: "codex",
@@ -24,7 +49,6 @@ describe("codex model provider", () => {
       "-C",
       "/workspace",
       "--skip-git-repo-check",
-      "--ignore-rules",
       "--ephemeral",
       "--color",
       "never",
@@ -36,6 +60,34 @@ describe("codex model provider", () => {
       "gpt-5.5",
       "-",
     ]);
+  });
+
+  it("reads Codex provider enablement from runtime settings", () => {
+    const runtime = runtimeWithSettings({
+      PARALLAX_CODEX_MODEL_PROVIDER: "true",
+      PARALLAX_CODEX_MODEL_PRIORITY: "77",
+    });
+
+    expect(isCodexModelProviderEnabled(runtime)).toBe(true);
+    expect(readCodexModelProviderPriority(runtime)).toBe(77);
+  });
+
+  it("registers Codex models during plugin init", () => {
+    taskAgentPlugin.models = undefined;
+    delete taskAgentPlugin.priority;
+
+    taskAgentPlugin.init?.(
+      {},
+      runtimeWithSettings({
+        PARALLAX_CODEX_MODEL_PROVIDER: "true",
+        PARALLAX_CODEX_MODEL_PRIORITY: "77",
+      }),
+    );
+
+    expect(taskAgentPlugin.priority).toBe(77);
+    expect(taskAgentPlugin.models?.[ModelType.IMAGE_DESCRIPTION]).toBe(
+      codexCliImageDescriptionModel,
+    );
   });
 
   it("extracts a plain prompt before falling back to messages", () => {
@@ -104,5 +156,14 @@ describe("codex model provider", () => {
       title: "Red square",
       description: "A red square with the word RED.",
     });
+  });
+
+  it("blocks private image URLs before invoking codex", async () => {
+    await expect(
+      codexCliImageDescriptionModel(runtimeWithSettings({}), {
+        imageUrl: "http://127.0.0.1/image.png",
+        prompt: "describe this",
+      }),
+    ).rejects.toThrow(/private|internal|Blocked/i);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { ModelType, type IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { taskAgentPlugin } from "../index.js";
@@ -11,6 +14,7 @@ import {
   parseCodexImageDescriptionResult,
   promptFromGenerateTextParams,
   readCodexModelProviderPriority,
+  runCodexExec,
 } from "../services/codex-model-provider.js";
 
 function runtimeWithSettings(settings: Record<string, string>): IAgentRuntime {
@@ -159,5 +163,77 @@ describe("codex model provider", () => {
         prompt: "describe this",
       }),
     ).rejects.toThrow(/private|internal|Blocked/i);
+  });
+
+  it("passes percent-encoded data URL image bytes to codex without utf8 corruption", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "codex-provider-test-"));
+    try {
+      const fakeCodex = path.join(tempDir, "fake-codex");
+      await writeFile(
+        fakeCodex,
+        `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "exec" && args.includes("--help")) {
+  console.log("--output-last-message");
+  process.exit(0);
+}
+const outputFile = args[args.indexOf("--output-last-message") + 1];
+const imagePath = args[args.indexOf("--image") + 1];
+const description = fs.readFileSync(imagePath).subarray(0, 8).toString("hex");
+fs.writeFileSync(outputFile, JSON.stringify({ title: "image", description }));
+`,
+        { mode: 0o755 },
+      );
+
+      await expect(
+        codexCliImageDescriptionModel(
+          runtimeWithSettings({
+            PARALLAX_CODEX_BIN: fakeCodex,
+            PARALLAX_CODEX_MODEL_WORKDIR: tempDir,
+            PARALLAX_CODEX_MODEL_TIMEOUT_MS: "5000",
+          }),
+          {
+            imageUrl: "data:image/png,%89PNG%0D%0A%1A%0A",
+            prompt: "describe this",
+          },
+        ),
+      ).resolves.toEqual({
+        title: "image",
+        description: "89504e470d0a1a0a",
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects cleanly when codex exits before reading stdin", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "codex-provider-test-"));
+    try {
+      const fakeCodex = path.join(tempDir, "fake-codex");
+      await writeFile(
+        fakeCodex,
+        `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "exec" && args.includes("--help")) {
+  console.log("--output-last-message");
+  process.exit(0);
+}
+process.exit(23);
+`,
+        { mode: 0o755 },
+      );
+
+      await expect(
+        runCodexExec("x".repeat(2_000_000), {
+          binary: fakeCodex,
+          workdir: tempDir,
+          reasoningEffort: "low",
+          timeoutMs: 5000,
+        }),
+      ).rejects.toThrow(/code 23|empty model response/i);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCodexExecArgs,
+  buildCodexImageDescriptionPrompt,
+  buildCodexModelPrompt,
+  parseCodexImageDescriptionResult,
+  promptFromGenerateTextParams,
+} from "../services/codex-model-provider.js";
+
+describe("codex model provider", () => {
+  it("uses codex exec in read-only non-interactive output-file mode", () => {
+    const args = buildCodexExecArgs("/tmp/out.txt", {
+      binary: "codex",
+      workdir: "/workspace",
+      model: "gpt-5.5",
+      reasoningEffort: "low",
+      timeoutMs: 1000,
+    });
+
+    expect(args).toEqual([
+      "exec",
+      "-s",
+      "read-only",
+      "-C",
+      "/workspace",
+      "--skip-git-repo-check",
+      "--ignore-rules",
+      "--ephemeral",
+      "--color",
+      "never",
+      "-c",
+      "model_reasoning_effort=low",
+      "--output-last-message",
+      "/tmp/out.txt",
+      "--model",
+      "gpt-5.5",
+      "-",
+    ]);
+  });
+
+  it("extracts a plain prompt before falling back to messages", () => {
+    expect(promptFromGenerateTextParams({ prompt: "hello" })).toBe("hello");
+    expect(
+      promptFromGenerateTextParams({
+        prompt: "",
+        messages: [
+          { role: "system", content: "sys" },
+          { role: "user", content: "hi" },
+        ],
+      } as never),
+    ).toContain("user: hi");
+  });
+
+  it("passes image files to codex exec before the stdin prompt marker", () => {
+    const args = buildCodexExecArgs(
+      "/tmp/out.txt",
+      {
+        binary: "codex",
+        workdir: "/workspace",
+        model: "gpt-5.4-mini",
+        reasoningEffort: "low",
+        timeoutMs: 1000,
+      },
+      true,
+      { imagePaths: ["/tmp/a.png", "/tmp/b.webp"] },
+    );
+
+    expect(args.slice(-5)).toEqual([
+      "--image",
+      "/tmp/a.png",
+      "--image",
+      "/tmp/b.webp",
+      "-",
+    ]);
+  });
+
+  it("wraps eliza model calls with strict provider instructions", () => {
+    const prompt = buildCodexModelPrompt(
+      { prompt: "return <response><text>ok</text></response>" },
+      "ACTION_PLANNER",
+    );
+
+    expect(prompt).toContain("non-interactive elizaOS model provider");
+    expect(prompt).toContain("Model type: ACTION_PLANNER");
+    expect(prompt).toContain("<eliza_prompt>");
+    expect(prompt).toContain("return <response><text>ok</text></response>");
+  });
+
+  it("builds bounded image-description prompts and parses JSON results", () => {
+    const prompt = buildCodexImageDescriptionPrompt({
+      imageUrl: "https://example.test/image.png",
+      prompt: "describe briefly",
+    });
+
+    expect(prompt).toContain("IMAGE_DESCRIPTION");
+    expect(prompt).toContain("describe briefly");
+    expect(prompt).toContain("Return JSON only");
+
+    expect(
+      parseCodexImageDescriptionResult(
+        '{"title":"Red square","description":"A red square with the word RED."}',
+      ),
+    ).toEqual({
+      title: "Red square",
+      description: "A red square with the word RED.",
+    });
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts
@@ -1,11 +1,12 @@
 import { ModelType, type IAgentRuntime } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { taskAgentPlugin } from "../index.js";
 import {
   buildCodexExecArgs,
   buildCodexImageDescriptionPrompt,
   buildCodexModelPrompt,
   codexCliImageDescriptionModel,
+  codexCliTextModel,
   isCodexModelProviderEnabled,
   parseCodexImageDescriptionResult,
   promptFromGenerateTextParams,
@@ -17,22 +18,11 @@ function runtimeWithSettings(settings: Record<string, string>): IAgentRuntime {
     getSetting(key: string) {
       return settings[key];
     },
+    registerModel: vi.fn(),
   } as IAgentRuntime;
 }
 
 describe("codex model provider", () => {
-  const originalModels = taskAgentPlugin.models;
-  const originalPriority = taskAgentPlugin.priority;
-
-  afterEach(() => {
-    taskAgentPlugin.models = originalModels;
-    if (originalPriority === undefined) {
-      delete taskAgentPlugin.priority;
-    } else {
-      taskAgentPlugin.priority = originalPriority;
-    }
-  });
-
   it("uses codex exec in read-only non-interactive output-file mode", () => {
     const args = buildCodexExecArgs("/tmp/out.txt", {
       binary: "codex",
@@ -73,20 +63,24 @@ describe("codex model provider", () => {
   });
 
   it("registers Codex models during plugin init", () => {
-    taskAgentPlugin.models = undefined;
-    delete taskAgentPlugin.priority;
+    const runtime = runtimeWithSettings({
+      PARALLAX_CODEX_MODEL_PROVIDER: "true",
+      PARALLAX_CODEX_MODEL_PRIORITY: "77",
+    });
 
-    taskAgentPlugin.init?.(
-      {},
-      runtimeWithSettings({
-        PARALLAX_CODEX_MODEL_PROVIDER: "true",
-        PARALLAX_CODEX_MODEL_PRIORITY: "77",
-      }),
-    );
+    taskAgentPlugin.init?.({}, runtime);
 
-    expect(taskAgentPlugin.priority).toBe(77);
-    expect(taskAgentPlugin.models?.[ModelType.IMAGE_DESCRIPTION]).toBe(
+    expect(runtime.registerModel).toHaveBeenCalledWith(
+      ModelType.IMAGE_DESCRIPTION,
       codexCliImageDescriptionModel,
+      taskAgentPlugin.name,
+      77,
+    );
+    expect(runtime.registerModel).toHaveBeenCalledWith(
+      ModelType.TEXT_LARGE,
+      codexCliTextModel,
+      taskAgentPlugin.name,
+      77,
     );
   });
 

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -40,29 +40,6 @@ import {
   readCodexModelProviderPriority,
 } from "./services/codex-model-provider.js";
 
-const codexModelProviderModels = {
-  [ModelType.TEXT_NANO]: codexCliTextModel,
-  [ModelType.TEXT_SMALL]: codexCliTextModel,
-  [ModelType.TEXT_MEDIUM]: codexCliTextModel,
-  [ModelType.TEXT_LARGE]: codexCliTextModel,
-  [ModelType.TEXT_MEGA]: codexCliTextModel,
-  [ModelType.IMAGE_DESCRIPTION]: codexCliImageDescriptionModel,
-  [ModelType.RESPONSE_HANDLER]: codexCliTextModel,
-  [ModelType.ACTION_PLANNER]: codexCliTextModel,
-  [ModelType.TEXT_COMPLETION]: codexCliTextModel,
-} satisfies Plugin["models"];
-
-function configureCodexModelProvider(runtime: IAgentRuntime): void {
-  if (!isCodexModelProviderEnabled(runtime)) {
-    delete taskAgentPlugin.priority;
-    delete taskAgentPlugin.models;
-    return;
-  }
-
-  taskAgentPlugin.priority = readCodexModelProviderPriority(runtime);
-  taskAgentPlugin.models = codexModelProviderModels;
-}
-
 export const taskAgentPlugin: Plugin = {
   name: "@elizaos/plugin-agent-orchestrator",
   description:
@@ -70,7 +47,39 @@ export const taskAgentPlugin: Plugin = {
     "manage workspaces, track current task status, and keep background work moving while the main agent stays in conversation",
 
   init(_config, runtime) {
-    configureCodexModelProvider(runtime);
+    if (!isCodexModelProviderEnabled(runtime)) {
+      return;
+    }
+
+    const priority = readCodexModelProviderPriority(runtime);
+    const textHandler = codexCliTextModel as unknown as Parameters<
+      IAgentRuntime["registerModel"]
+    >[1];
+    for (const modelType of [
+      ModelType.TEXT_NANO,
+      ModelType.TEXT_SMALL,
+      ModelType.TEXT_MEDIUM,
+      ModelType.TEXT_LARGE,
+      ModelType.TEXT_MEGA,
+      ModelType.RESPONSE_HANDLER,
+      ModelType.ACTION_PLANNER,
+      ModelType.TEXT_COMPLETION,
+    ]) {
+      runtime.registerModel(
+        modelType,
+        textHandler,
+        taskAgentPlugin.name,
+        priority,
+      );
+    }
+    runtime.registerModel(
+      ModelType.IMAGE_DESCRIPTION,
+      codexCliImageDescriptionModel as unknown as Parameters<
+        IAgentRuntime["registerModel"]
+      >[1],
+      taskAgentPlugin.name,
+      priority,
+    );
   },
 
   // SwarmCoordinator and auth callback wiring is done in PTYService.start()

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -10,7 +10,7 @@
  * @module @elizaos/plugin-agent-orchestrator
  */
 
-import { ModelType, type Plugin } from "@elizaos/core";
+import { ModelType, type IAgentRuntime, type Plugin } from "@elizaos/core";
 // Side-effect: register coding-agent HTTP routes with the runtime route registry.
 import "./register-routes.js";
 import { finalizeWorkspaceAction } from "./actions/finalize-workspace.js";
@@ -40,18 +40,39 @@ import {
   readCodexModelProviderPriority,
 } from "./services/codex-model-provider.js";
 
-const codexModelProviderEnabled = isCodexModelProviderEnabled();
+const codexModelProviderModels = {
+  [ModelType.TEXT_NANO]: codexCliTextModel,
+  [ModelType.TEXT_SMALL]: codexCliTextModel,
+  [ModelType.TEXT_MEDIUM]: codexCliTextModel,
+  [ModelType.TEXT_LARGE]: codexCliTextModel,
+  [ModelType.TEXT_MEGA]: codexCliTextModel,
+  [ModelType.IMAGE_DESCRIPTION]: codexCliImageDescriptionModel,
+  [ModelType.RESPONSE_HANDLER]: codexCliTextModel,
+  [ModelType.ACTION_PLANNER]: codexCliTextModel,
+  [ModelType.TEXT_COMPLETION]: codexCliTextModel,
+} satisfies Plugin["models"];
+
+function configureCodexModelProvider(runtime: IAgentRuntime): void {
+  if (!isCodexModelProviderEnabled(runtime)) {
+    delete taskAgentPlugin.priority;
+    delete taskAgentPlugin.models;
+    return;
+  }
+
+  taskAgentPlugin.priority = readCodexModelProviderPriority(runtime);
+  taskAgentPlugin.models = codexModelProviderModels;
+}
 
 export const taskAgentPlugin: Plugin = {
   name: "@elizaos/plugin-agent-orchestrator",
   description:
     "Orchestrate open-ended task agents (Claude Code, Codex, Gemini CLI, Aider, Pi, etc.) via PTY sessions, " +
     "manage workspaces, track current task status, and keep background work moving while the main agent stays in conversation",
-  ...(codexModelProviderEnabled
-    ? { priority: readCodexModelProviderPriority() }
-    : {}),
 
-  // NOTE: init() is NOT reliably called by ElizaOS for workspace plugins.
+  init(_config, runtime) {
+    configureCodexModelProvider(runtime);
+  },
+
   // SwarmCoordinator and auth callback wiring is done in PTYService.start()
   // which ElizaOS calls reliably via the services lifecycle.
 
@@ -85,22 +106,6 @@ export const taskAgentPlugin: Plugin = {
     activeWorkspaceContextProvider, // Live workspace/session state
     codingAgentExamplesProvider, // Structured action call examples
   ],
-
-  ...(codexModelProviderEnabled
-    ? {
-        models: {
-          [ModelType.TEXT_NANO]: codexCliTextModel,
-          [ModelType.TEXT_SMALL]: codexCliTextModel,
-          [ModelType.TEXT_MEDIUM]: codexCliTextModel,
-          [ModelType.TEXT_LARGE]: codexCliTextModel,
-          [ModelType.TEXT_MEGA]: codexCliTextModel,
-          [ModelType.IMAGE_DESCRIPTION]: codexCliImageDescriptionModel,
-          [ModelType.RESPONSE_HANDLER]: codexCliTextModel,
-          [ModelType.ACTION_PLANNER]: codexCliTextModel,
-          [ModelType.TEXT_COMPLETION]: codexCliTextModel,
-        },
-      }
-    : {}),
 };
 
 export const codingAgentPlugin = taskAgentPlugin;

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -10,7 +10,7 @@
  * @module @elizaos/plugin-agent-orchestrator
  */
 
-import type { Plugin } from "@elizaos/core";
+import { ModelType, type Plugin } from "@elizaos/core";
 // Side-effect: register coding-agent HTTP routes with the runtime route registry.
 import "./register-routes.js";
 import { finalizeWorkspaceAction } from "./actions/finalize-workspace.js";
@@ -33,12 +33,23 @@ import { activeWorkspaceContextProvider } from "./providers/active-workspace-con
 // Services
 import { PTYService } from "./services/pty-service.js";
 import { CodingWorkspaceService } from "./services/workspace-service.js";
+import {
+  codexCliImageDescriptionModel,
+  codexCliTextModel,
+  isCodexModelProviderEnabled,
+  readCodexModelProviderPriority,
+} from "./services/codex-model-provider.js";
+
+const codexModelProviderEnabled = isCodexModelProviderEnabled();
 
 export const taskAgentPlugin: Plugin = {
   name: "@elizaos/plugin-agent-orchestrator",
   description:
     "Orchestrate open-ended task agents (Claude Code, Codex, Gemini CLI, Aider, Pi, etc.) via PTY sessions, " +
     "manage workspaces, track current task status, and keep background work moving while the main agent stays in conversation",
+  ...(codexModelProviderEnabled
+    ? { priority: readCodexModelProviderPriority() }
+    : {}),
 
   // NOTE: init() is NOT reliably called by ElizaOS for workspace plugins.
   // SwarmCoordinator and auth callback wiring is done in PTYService.start()
@@ -74,6 +85,22 @@ export const taskAgentPlugin: Plugin = {
     activeWorkspaceContextProvider, // Live workspace/session state
     codingAgentExamplesProvider, // Structured action call examples
   ],
+
+  ...(codexModelProviderEnabled
+    ? {
+        models: {
+          [ModelType.TEXT_NANO]: codexCliTextModel,
+          [ModelType.TEXT_SMALL]: codexCliTextModel,
+          [ModelType.TEXT_MEDIUM]: codexCliTextModel,
+          [ModelType.TEXT_LARGE]: codexCliTextModel,
+          [ModelType.TEXT_MEGA]: codexCliTextModel,
+          [ModelType.IMAGE_DESCRIPTION]: codexCliImageDescriptionModel,
+          [ModelType.RESPONSE_HANDLER]: codexCliTextModel,
+          [ModelType.ACTION_PLANNER]: codexCliTextModel,
+          [ModelType.TEXT_COMPLETION]: codexCliTextModel,
+        },
+      }
+    : {}),
 };
 
 export const codingAgentPlugin = taskAgentPlugin;

--- a/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
@@ -1,0 +1,518 @@
+import { randomUUID } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import {
+  type GenerateTextParams,
+  type IAgentRuntime,
+  type ImageDescriptionParams,
+  type ImageDescriptionResult,
+  logger,
+} from "@elizaos/core";
+import { readConfigEnvKey } from "./config-env.js";
+
+const TRUE_VALUE = /^(1|true|yes|on)$/i;
+const FALSE_VALUE = /^(0|false|no|off)$/i;
+const DEFAULT_TIMEOUT_MS = 105_000;
+const MAX_CAPTURE_CHARS = 16_000;
+const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
+const IMAGE_FETCH_TIMEOUT_MS = 30_000;
+const KILL_GRACE_MS = 5_000;
+const OUTPUT_LAST_MESSAGE_HELP_TIMEOUT_MS = 5_000;
+const outputLastMessageSupportCache = new Map<string, Promise<boolean>>();
+
+type CodexExecInput = {
+  imagePaths?: string[];
+};
+
+export type CodexExecOptions = {
+  binary: string;
+  workdir: string;
+  model?: string;
+  reasoningEffort: string;
+  timeoutMs: number;
+};
+
+function readSetting(
+  runtime: IAgentRuntime | undefined,
+  key: string,
+): string | undefined {
+  const runtimeValue = runtime?.getSetting(key);
+  if (typeof runtimeValue === "string" && runtimeValue.trim()) {
+    return runtimeValue.trim();
+  }
+  const configValue = readConfigEnvKey(key);
+  if (typeof configValue === "string" && configValue.trim()) {
+    return configValue.trim();
+  }
+  const envValue = process.env[key];
+  return typeof envValue === "string" && envValue.trim()
+    ? envValue.trim()
+    : undefined;
+}
+
+export function isCodexModelProviderEnabled(): boolean {
+  const raw =
+    readConfigEnvKey("PARALLAX_CODEX_MODEL_PROVIDER") ??
+    process.env.PARALLAX_CODEX_MODEL_PROVIDER;
+  if (!raw) return false;
+  if (TRUE_VALUE.test(raw)) return true;
+  if (FALSE_VALUE.test(raw)) return false;
+  return false;
+}
+
+export function readCodexModelProviderPriority(): number {
+  const raw =
+    readConfigEnvKey("PARALLAX_CODEX_MODEL_PRIORITY") ??
+    process.env.PARALLAX_CODEX_MODEL_PRIORITY;
+  const parsed = raw ? Number(raw) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : 50;
+}
+
+export function resolveCodexExecOptions(
+  runtime?: IAgentRuntime,
+): CodexExecOptions {
+  const timeoutRaw = readSetting(runtime, "PARALLAX_CODEX_MODEL_TIMEOUT_MS");
+  const timeoutMs = timeoutRaw ? Number(timeoutRaw) : DEFAULT_TIMEOUT_MS;
+  return {
+    binary: readSetting(runtime, "PARALLAX_CODEX_BIN") ?? "codex",
+    workdir:
+      readSetting(runtime, "PARALLAX_CODEX_MODEL_WORKDIR") ?? process.cwd(),
+    model:
+      readSetting(runtime, "PARALLAX_CODEX_MODEL") ??
+      readSetting(runtime, "PARALLAX_CODEX_EXEC_MODEL"),
+    reasoningEffort:
+      readSetting(runtime, "PARALLAX_CODEX_MODEL_REASONING_EFFORT") ?? "low",
+    timeoutMs:
+      Number.isFinite(timeoutMs) && timeoutMs > 0
+        ? Math.floor(timeoutMs)
+        : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+export function buildCodexExecArgs(
+  outputFile: string,
+  options: CodexExecOptions,
+  useOutputLastMessage = true,
+  input: CodexExecInput = {},
+): string[] {
+  const args = [
+    "exec",
+    "-s",
+    "read-only",
+    "-C",
+    options.workdir,
+    "--skip-git-repo-check",
+    "--ignore-rules",
+    "--ephemeral",
+    "--color",
+    "never",
+    "-c",
+    `model_reasoning_effort=${options.reasoningEffort}`,
+  ];
+  if (useOutputLastMessage) {
+    args.push("--output-last-message", outputFile);
+  }
+  if (options.model) {
+    args.push("--model", options.model);
+  }
+  for (const imagePath of input.imagePaths ?? []) {
+    args.push("--image", imagePath);
+  }
+  args.push("-");
+  return args;
+}
+
+export function promptFromGenerateTextParams(params: GenerateTextParams): string {
+  if (typeof params.prompt === "string" && params.prompt.length > 0) {
+    return params.prompt;
+  }
+  const maybeMessages = (params as unknown as { messages?: unknown }).messages;
+  if (Array.isArray(maybeMessages)) {
+    return maybeMessages
+      .map((message) => {
+        if (!message || typeof message !== "object") return String(message);
+        const record = message as Record<string, unknown>;
+        const role = typeof record.role === "string" ? record.role : "message";
+        const content =
+          typeof record.content === "string"
+            ? record.content
+            : JSON.stringify(record.content);
+        return `${role}: ${content}`;
+      })
+      .join("\n\n");
+  }
+  return JSON.stringify(params);
+}
+
+export function buildCodexModelPrompt(
+  params: GenerateTextParams,
+  modelType?: string,
+): string {
+  const responseFormat =
+    typeof params.responseFormat === "string"
+      ? params.responseFormat
+      : params.responseFormat?.type;
+  const formatHint = responseFormat
+    ? `The requested response format is ${responseFormat}.`
+    : "Use the response format requested by the prompt.";
+  return [
+    "You are running as a non-interactive elizaOS model provider.",
+    "Use the prompt below as the complete task. Do not inspect local files or run shell commands unless the prompt explicitly asks for local filesystem facts.",
+    "Return only the final model output. No labels, no status text, no markdown fences unless the prompt explicitly asks for markdown.",
+    modelType ? `Model type: ${modelType}.` : "",
+    formatHint,
+    "",
+    "<eliza_prompt>",
+    promptFromGenerateTextParams(params),
+    "</eliza_prompt>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function buildCodexImageDescriptionPrompt(
+  params: ImageDescriptionParams | string,
+): string {
+  const prompt =
+    typeof params === "string"
+      ? "Describe this image accurately."
+      : params.prompt?.trim() || "Describe this image accurately.";
+  return [
+    "You are running as a non-interactive elizaOS IMAGE_DESCRIPTION model provider.",
+    "Use only the attached image content and the user prompt below.",
+    "Do not run shell commands, inspect files, mention file paths, or include implementation details.",
+    'Return JSON only, with this shape: {"title":"short title","description":"natural language description"}.',
+    "",
+    "<user_prompt>",
+    prompt,
+    "</user_prompt>",
+  ].join("\n");
+}
+
+export function parseCodexImageDescriptionResult(
+  text: string,
+): ImageDescriptionResult {
+  const cleaned = text
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/\s*```$/i, "")
+    .trim();
+  try {
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+    const title = typeof parsed.title === "string" ? parsed.title.trim() : "";
+    const description =
+      typeof parsed.description === "string" ? parsed.description.trim() : "";
+    if (title || description) {
+      return {
+        title: title || "Image Analysis",
+        description: description || title,
+      };
+    }
+  } catch {
+    // Plain text is acceptable; older Codex CLI builds do not always honor JSON-only prompts.
+  }
+
+  const firstLine = cleaned.split(/\r?\n/).find((line) => line.trim())?.trim();
+  return {
+    title: firstLine?.slice(0, 80) || "Image Analysis",
+    description: cleaned || "Image description unavailable.",
+  };
+}
+
+function appendCapture(current: string, chunk: Buffer): string {
+  const next = current + chunk.toString("utf8");
+  if (next.length <= MAX_CAPTURE_CHARS) return next;
+  return next.slice(next.length - MAX_CAPTURE_CHARS);
+}
+
+function codexSupportsOutputLastMessage(binary: string): Promise<boolean> {
+  const cached = outputLastMessageSupportCache.get(binary);
+  if (cached) return cached;
+
+  const probe = new Promise<boolean>((resolve) => {
+    const child = spawn(binary, ["exec", "--help"], {
+      env: { ...process.env, NO_COLOR: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    let settled = false;
+    const finish = (supported: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(supported);
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(false);
+    }, OUTPUT_LAST_MESSAGE_HELP_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      output = appendCapture(output, chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      output = appendCapture(output, chunk);
+    });
+    child.on("error", () => finish(false));
+    child.on("close", () => finish(output.includes("--output-last-message")));
+  });
+
+  outputLastMessageSupportCache.set(binary, probe);
+  return probe;
+}
+
+export async function runCodexExec(
+  prompt: string,
+  options: CodexExecOptions,
+  input: CodexExecInput = {},
+): Promise<string> {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "eliza-codex-model-"));
+  const outputFile = path.join(tempDir, `${randomUUID()}.txt`);
+  const supportsOutputLastMessage = await codexSupportsOutputLastMessage(
+    options.binary,
+  );
+  const args = buildCodexExecArgs(
+    outputFile,
+    options,
+    supportsOutputLastMessage,
+    input,
+  );
+  let stdout = "";
+  let stderr = "";
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(options.binary, args, {
+        cwd: options.workdir,
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      let settled = false;
+      let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+      const cleanupTimers = () => {
+        clearTimeout(timer);
+        if (escalationTimer) {
+          clearTimeout(escalationTimer);
+          escalationTimer = undefined;
+        }
+      };
+      const settle = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanupTimers();
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        escalationTimer = setTimeout(() => {
+          child.kill("SIGKILL");
+        }, KILL_GRACE_MS);
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(
+          new Error(
+            `codex exec timed out after ${options.timeoutMs}ms for model provider call`,
+          ),
+        );
+      }, options.timeoutMs);
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdout = appendCapture(stdout, chunk);
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr = appendCapture(stderr, chunk);
+      });
+      child.on("error", (error) => {
+        cleanupTimers();
+        if (settled) return;
+        settle(() => reject(error));
+      });
+      child.on("close", (code, signal) => {
+        cleanupTimers();
+        if (settled) return;
+        if (code === 0) {
+          settle(resolve);
+          return;
+        }
+        settle(() =>
+          reject(
+            new Error(
+              `codex exec exited with code ${code ?? "null"} signal ${
+                signal ?? "null"
+              }. ${stderr || stdout}`.trim(),
+            ),
+          ),
+        );
+      });
+
+      child.stdin.end(prompt);
+    });
+
+    const finalMessage = supportsOutputLastMessage
+      ? await readFile(outputFile, "utf8")
+          .then((value) => value.trim())
+          .catch((error) => {
+            throw new Error(
+              `codex exec did not write --output-last-message output (${error instanceof Error ? error.message : String(error)}). ${stderr || stdout}`.trim(),
+            );
+          })
+      : stdout.trim();
+    if (!finalMessage) {
+      throw new Error(`codex exec produced an empty model response. ${stderr || stdout}`.trim());
+    }
+    return finalMessage;
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function imageUrlFromParams(params: ImageDescriptionParams | string): string {
+  if (typeof params === "string") return params.trim();
+  return params.imageUrl.trim();
+}
+
+function imageExtensionForMime(mime: string | undefined): string {
+  if (!mime) return "";
+  if (mime === "image/jpeg") return ".jpg";
+  if (mime === "image/png") return ".png";
+  if (mime === "image/webp") return ".webp";
+  if (mime === "image/gif") return ".gif";
+  return ".img";
+}
+
+function imageExtensionForUrl(url: URL): string {
+  const extension = path.extname(url.pathname).toLowerCase();
+  if ([".gif", ".jpg", ".jpeg", ".png", ".webp"].includes(extension)) {
+    return extension;
+  }
+  return "";
+}
+
+async function writeDataUrlImage(imageUrl: string, tempDir: string): Promise<string> {
+  const match = imageUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s);
+  if (!match) {
+    throw new Error("IMAGE_DESCRIPTION requires an http(s) URL or image data URL");
+  }
+  const mime = match[1]?.toLowerCase();
+  if (!mime?.startsWith("image/")) {
+    throw new Error(`IMAGE_DESCRIPTION data URL is not an image: ${mime ?? "unknown"}`);
+  }
+  const buffer = match[2]
+    ? Buffer.from(match[3] ?? "", "base64")
+    : Buffer.from(decodeURIComponent(match[3] ?? ""), "utf8");
+  if (buffer.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
+  }
+  const imagePath = path.join(
+    tempDir,
+    `${randomUUID()}${imageExtensionForMime(mime)}`,
+  );
+  await writeFile(imagePath, buffer);
+  return imagePath;
+}
+
+async function downloadImageUrl(imageUrl: string, tempDir: string): Promise<string> {
+  if (imageUrl.startsWith("data:")) {
+    return writeDataUrlImage(imageUrl, tempDir);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(imageUrl);
+  } catch {
+    throw new Error("IMAGE_DESCRIPTION requires an http(s) URL or image data URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`IMAGE_DESCRIPTION does not support ${parsed.protocol} URLs`);
+  }
+
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), IMAGE_FETCH_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(parsed, { signal: abort.signal });
+  } catch (error) {
+    throw new Error(
+      `IMAGE_DESCRIPTION image fetch failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!response.ok) {
+    throw new Error(
+      `IMAGE_DESCRIPTION image fetch failed: ${response.status} ${response.statusText}`,
+    );
+  }
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
+    throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
+  }
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";")[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType && !contentType.startsWith("image/")) {
+    throw new Error(`IMAGE_DESCRIPTION URL is not an image: ${contentType}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (buffer.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
+  }
+  const imagePath = path.join(
+    tempDir,
+    `${randomUUID()}${imageExtensionForMime(contentType) || imageExtensionForUrl(parsed)}`,
+  );
+  await writeFile(imagePath, buffer);
+  return imagePath;
+}
+
+export async function codexCliImageDescriptionModel(
+  runtime: IAgentRuntime,
+  params: ImageDescriptionParams | string,
+): Promise<ImageDescriptionResult> {
+  const imageUrl = imageUrlFromParams(params);
+  if (!imageUrl) {
+    throw new Error("IMAGE_DESCRIPTION requires a valid image URL");
+  }
+
+  const tempDir = await mkdtemp(path.join(tmpdir(), "eliza-codex-image-"));
+  try {
+    const imagePath = await downloadImageUrl(imageUrl, tempDir);
+    const options = resolveCodexExecOptions(runtime);
+    logger.info(
+      `[codex-model-provider] running codex exec for IMAGE_DESCRIPTION in ${options.workdir}`,
+    );
+    const text = await runCodexExec(buildCodexImageDescriptionPrompt(params), options, {
+      imagePaths: [imagePath],
+    });
+    return parseCodexImageDescriptionResult(text);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export async function codexCliTextModel(
+  runtime: IAgentRuntime,
+  params: GenerateTextParams,
+): Promise<string> {
+  const rawModelType = (params as unknown as { modelType?: unknown }).modelType;
+  const modelType = typeof rawModelType === "string" ? rawModelType : undefined;
+  const options = resolveCodexExecOptions(runtime);
+  const prompt = buildCodexModelPrompt(params, modelType);
+  logger.info(
+    `[codex-model-provider] running codex exec for ${modelType ?? "text"} in ${options.workdir}`,
+  );
+  return runCodexExec(prompt, options);
+}

--- a/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import {
-  fetchWithSsrfGuard,
+  fetchRemoteMedia,
   type GenerateTextParams,
   type IAgentRuntime,
   type ImageDescriptionParams,
@@ -463,16 +463,18 @@ async function downloadImageUrl(
     );
   }
 
-  let response: Response | undefined;
-  let release: (() => Promise<void>) | undefined;
+  let buffer: Buffer;
+  let contentType: string | undefined;
   try {
-    const result = await fetchWithSsrfGuard({
+    const result = await fetchRemoteMedia({
       url: parsed.toString(),
+      maxBytes: MAX_IMAGE_BYTES,
+      maxRedirects: 3,
       timeoutMs: IMAGE_FETCH_TIMEOUT_MS,
       lookupFn: nodeLookup,
     });
-    response = result.response;
-    release = result.release;
+    buffer = result.buffer;
+    contentType = result.contentType?.split(";")[0]?.trim().toLowerCase();
   } catch (error) {
     throw new Error(
       `IMAGE_DESCRIPTION image fetch failed: ${
@@ -481,42 +483,15 @@ async function downloadImageUrl(
     );
   }
 
-  try {
-    if (!response.ok) {
-      throw new Error(
-        `IMAGE_DESCRIPTION image fetch failed: ${response.status} ${response.statusText}`,
-      );
-    }
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
-      throw new Error(
-        `IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`,
-      );
-    }
-    const contentType = response.headers
-      .get("content-type")
-      ?.split(";")[0]
-      ?.trim()
-      .toLowerCase();
-    if (contentType && !contentType.startsWith("image/")) {
-      throw new Error(`IMAGE_DESCRIPTION URL is not an image: ${contentType}`);
-    }
-
-    const buffer = Buffer.from(await response.arrayBuffer());
-    if (buffer.byteLength > MAX_IMAGE_BYTES) {
-      throw new Error(
-        `IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`,
-      );
-    }
-    const imagePath = path.join(
-      tempDir,
-      `${randomUUID()}${imageExtensionForMime(contentType) || imageExtensionForUrl(parsed)}`,
-    );
-    await writeFile(imagePath, buffer);
-    return imagePath;
-  } finally {
-    await release?.();
+  if (contentType && !contentType.startsWith("image/")) {
+    throw new Error(`IMAGE_DESCRIPTION URL is not an image: ${contentType}`);
   }
+  const imagePath = path.join(
+    tempDir,
+    `${randomUUID()}${imageExtensionForMime(contentType) || imageExtensionForUrl(parsed)}`,
+  );
+  await writeFile(imagePath, buffer);
+  return imagePath;
 }
 
 export async function codexCliImageDescriptionModel(

--- a/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
@@ -232,6 +232,11 @@ function appendCapture(current: string, chunk: Buffer): string {
   return next.slice(next.length - MAX_CAPTURE_CHARS);
 }
 
+function errorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown })?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
 function codexSupportsOutputLastMessage(binary: string): Promise<boolean> {
   const cached = outputLastMessageSupportCache.get(binary);
   if (cached) return cached;
@@ -335,6 +340,14 @@ export async function runCodexExec(
       child.stderr.on("data", (chunk: Buffer) => {
         stderr = appendCapture(stderr, chunk);
       });
+      child.stdin.on("error", (error) => {
+        if (settled) return;
+        if (errorCode(error) === "EPIPE") {
+          stderr = appendCapture(stderr, Buffer.from(error.message));
+          return;
+        }
+        settle(() => reject(error));
+      });
       child.on("error", (error) => {
         cleanupTimers();
         if (settled) return;
@@ -411,25 +424,54 @@ const nodeLookup: LookupFn = async (hostname, options) => {
   }));
 };
 
+function decodePercentEncodedBytes(value: string): Buffer {
+  const bytes: number[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "%") {
+      const hex = value.slice(index + 1, index + 3);
+      if (!/^[0-9a-f]{2}$/i.test(hex)) {
+        throw new Error("IMAGE_DESCRIPTION data URL has invalid percent encoding");
+      }
+      bytes.push(Number.parseInt(hex, 16));
+      index += 2;
+      continue;
+    }
+    const code = char.charCodeAt(0);
+    if (code > 0x7f) {
+      throw new Error(
+        "IMAGE_DESCRIPTION non-base64 data URLs must use percent-encoded bytes",
+      );
+    }
+    bytes.push(code);
+  }
+  return Buffer.from(bytes);
+}
+
 async function writeDataUrlImage(
   imageUrl: string,
   tempDir: string,
 ): Promise<string> {
-  const match = imageUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s);
+  const match = imageUrl.match(/^data:([^,]*),(.*)$/s);
   if (!match) {
     throw new Error(
       "IMAGE_DESCRIPTION requires an http(s) URL or image data URL",
     );
   }
-  const mime = match[1]?.toLowerCase();
+  const metadata = (match[1] ?? "").split(";").filter(Boolean);
+  const mime = metadata[0]?.toLowerCase() || "text/plain";
+  const isBase64 = metadata
+    .slice(1)
+    .some((part) => part.toLowerCase() === "base64");
   if (!mime?.startsWith("image/")) {
     throw new Error(
       `IMAGE_DESCRIPTION data URL is not an image: ${mime ?? "unknown"}`,
     );
   }
-  const buffer = match[2]
-    ? Buffer.from(match[3] ?? "", "base64")
-    : Buffer.from(decodeURIComponent(match[3] ?? ""), "utf8");
+  const payload = match[2] ?? "";
+  const buffer = isBase64
+    ? Buffer.from(payload, "base64")
+    : decodePercentEncodedBytes(payload);
   if (buffer.byteLength > MAX_IMAGE_BYTES) {
     throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
   }

--- a/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts
@@ -1,13 +1,16 @@
 import { randomUUID } from "node:crypto";
+import { lookup as dnsLookup } from "node:dns/promises";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spawn } from "node:child_process";
 import {
+  fetchWithSsrfGuard,
   type GenerateTextParams,
   type IAgentRuntime,
   type ImageDescriptionParams,
   type ImageDescriptionResult,
+  type LookupFn,
   logger,
 } from "@elizaos/core";
 import { readConfigEnvKey } from "./config-env.js";
@@ -52,20 +55,18 @@ function readSetting(
     : undefined;
 }
 
-export function isCodexModelProviderEnabled(): boolean {
-  const raw =
-    readConfigEnvKey("PARALLAX_CODEX_MODEL_PROVIDER") ??
-    process.env.PARALLAX_CODEX_MODEL_PROVIDER;
+export function isCodexModelProviderEnabled(runtime?: IAgentRuntime): boolean {
+  const raw = readSetting(runtime, "PARALLAX_CODEX_MODEL_PROVIDER");
   if (!raw) return false;
   if (TRUE_VALUE.test(raw)) return true;
   if (FALSE_VALUE.test(raw)) return false;
   return false;
 }
 
-export function readCodexModelProviderPriority(): number {
-  const raw =
-    readConfigEnvKey("PARALLAX_CODEX_MODEL_PRIORITY") ??
-    process.env.PARALLAX_CODEX_MODEL_PRIORITY;
+export function readCodexModelProviderPriority(
+  runtime?: IAgentRuntime,
+): number {
+  const raw = readSetting(runtime, "PARALLAX_CODEX_MODEL_PRIORITY");
   const parsed = raw ? Number(raw) : Number.NaN;
   return Number.isFinite(parsed) ? parsed : 50;
 }
@@ -104,7 +105,6 @@ export function buildCodexExecArgs(
     "-C",
     options.workdir,
     "--skip-git-repo-check",
-    "--ignore-rules",
     "--ephemeral",
     "--color",
     "never",
@@ -124,7 +124,9 @@ export function buildCodexExecArgs(
   return args;
 }
 
-export function promptFromGenerateTextParams(params: GenerateTextParams): string {
+export function promptFromGenerateTextParams(
+  params: GenerateTextParams,
+): string {
   if (typeof params.prompt === "string" && params.prompt.length > 0) {
     return params.prompt;
   }
@@ -214,7 +216,10 @@ export function parseCodexImageDescriptionResult(
     // Plain text is acceptable; older Codex CLI builds do not always honor JSON-only prompts.
   }
 
-  const firstLine = cleaned.split(/\r?\n/).find((line) => line.trim())?.trim();
+  const firstLine = cleaned
+    .split(/\r?\n/)
+    .find((line) => line.trim())
+    ?.trim();
   return {
     title: firstLine?.slice(0, 80) || "Image Analysis",
     description: cleaned || "Image description unavailable.",
@@ -310,13 +315,13 @@ export async function runCodexExec(
       };
 
       const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
         child.kill("SIGTERM");
         escalationTimer = setTimeout(() => {
           child.kill("SIGKILL");
         }, KILL_GRACE_MS);
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
         reject(
           new Error(
             `codex exec timed out after ${options.timeoutMs}ms for model provider call`,
@@ -366,7 +371,9 @@ export async function runCodexExec(
           })
       : stdout.trim();
     if (!finalMessage) {
-      throw new Error(`codex exec produced an empty model response. ${stderr || stdout}`.trim());
+      throw new Error(
+        `codex exec produced an empty model response. ${stderr || stdout}`.trim(),
+      );
     }
     return finalMessage;
   } finally {
@@ -396,14 +403,29 @@ function imageExtensionForUrl(url: URL): string {
   return "";
 }
 
-async function writeDataUrlImage(imageUrl: string, tempDir: string): Promise<string> {
+const nodeLookup: LookupFn = async (hostname, options) => {
+  const records = await dnsLookup(hostname, options);
+  return records.map((record) => ({
+    address: record.address,
+    family: record.family,
+  }));
+};
+
+async function writeDataUrlImage(
+  imageUrl: string,
+  tempDir: string,
+): Promise<string> {
   const match = imageUrl.match(/^data:([^;,]+)(;base64)?,(.*)$/s);
   if (!match) {
-    throw new Error("IMAGE_DESCRIPTION requires an http(s) URL or image data URL");
+    throw new Error(
+      "IMAGE_DESCRIPTION requires an http(s) URL or image data URL",
+    );
   }
   const mime = match[1]?.toLowerCase();
   if (!mime?.startsWith("image/")) {
-    throw new Error(`IMAGE_DESCRIPTION data URL is not an image: ${mime ?? "unknown"}`);
+    throw new Error(
+      `IMAGE_DESCRIPTION data URL is not an image: ${mime ?? "unknown"}`,
+    );
   }
   const buffer = match[2]
     ? Buffer.from(match[3] ?? "", "base64")
@@ -419,7 +441,10 @@ async function writeDataUrlImage(imageUrl: string, tempDir: string): Promise<str
   return imagePath;
 }
 
-async function downloadImageUrl(imageUrl: string, tempDir: string): Promise<string> {
+async function downloadImageUrl(
+  imageUrl: string,
+  tempDir: string,
+): Promise<string> {
   if (imageUrl.startsWith("data:")) {
     return writeDataUrlImage(imageUrl, tempDir);
   }
@@ -428,54 +453,70 @@ async function downloadImageUrl(imageUrl: string, tempDir: string): Promise<stri
   try {
     parsed = new URL(imageUrl);
   } catch {
-    throw new Error("IMAGE_DESCRIPTION requires an http(s) URL or image data URL");
+    throw new Error(
+      "IMAGE_DESCRIPTION requires an http(s) URL or image data URL",
+    );
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`IMAGE_DESCRIPTION does not support ${parsed.protocol} URLs`);
+    throw new Error(
+      `IMAGE_DESCRIPTION does not support ${parsed.protocol} URLs`,
+    );
   }
 
-  const abort = new AbortController();
-  const timer = setTimeout(() => abort.abort(), IMAGE_FETCH_TIMEOUT_MS);
-  let response: Response;
+  let response: Response | undefined;
+  let release: (() => Promise<void>) | undefined;
   try {
-    response = await fetch(parsed, { signal: abort.signal });
+    const result = await fetchWithSsrfGuard({
+      url: parsed.toString(),
+      timeoutMs: IMAGE_FETCH_TIMEOUT_MS,
+      lookupFn: nodeLookup,
+    });
+    response = result.response;
+    release = result.release;
   } catch (error) {
     throw new Error(
       `IMAGE_DESCRIPTION image fetch failed: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
-  } finally {
-    clearTimeout(timer);
-  }
-  if (!response.ok) {
-    throw new Error(
-      `IMAGE_DESCRIPTION image fetch failed: ${response.status} ${response.statusText}`,
-    );
-  }
-  const contentLength = Number(response.headers.get("content-length"));
-  if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
-    throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
-  }
-  const contentType = response.headers
-    .get("content-type")
-    ?.split(";")[0]
-    ?.trim()
-    .toLowerCase();
-  if (contentType && !contentType.startsWith("image/")) {
-    throw new Error(`IMAGE_DESCRIPTION URL is not an image: ${contentType}`);
   }
 
-  const buffer = Buffer.from(await response.arrayBuffer());
-  if (buffer.byteLength > MAX_IMAGE_BYTES) {
-    throw new Error(`IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`);
+  try {
+    if (!response.ok) {
+      throw new Error(
+        `IMAGE_DESCRIPTION image fetch failed: ${response.status} ${response.statusText}`,
+      );
+    }
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
+      throw new Error(
+        `IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`,
+      );
+    }
+    const contentType = response.headers
+      .get("content-type")
+      ?.split(";")[0]
+      ?.trim()
+      .toLowerCase();
+    if (contentType && !contentType.startsWith("image/")) {
+      throw new Error(`IMAGE_DESCRIPTION URL is not an image: ${contentType}`);
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    if (buffer.byteLength > MAX_IMAGE_BYTES) {
+      throw new Error(
+        `IMAGE_DESCRIPTION image exceeds ${MAX_IMAGE_BYTES} bytes`,
+      );
+    }
+    const imagePath = path.join(
+      tempDir,
+      `${randomUUID()}${imageExtensionForMime(contentType) || imageExtensionForUrl(parsed)}`,
+    );
+    await writeFile(imagePath, buffer);
+    return imagePath;
+  } finally {
+    await release?.();
   }
-  const imagePath = path.join(
-    tempDir,
-    `${randomUUID()}${imageExtensionForMime(contentType) || imageExtensionForUrl(parsed)}`,
-  );
-  await writeFile(imagePath, buffer);
-  return imagePath;
 }
 
 export async function codexCliImageDescriptionModel(
@@ -494,9 +535,13 @@ export async function codexCliImageDescriptionModel(
     logger.info(
       `[codex-model-provider] running codex exec for IMAGE_DESCRIPTION in ${options.workdir}`,
     );
-    const text = await runCodexExec(buildCodexImageDescriptionPrompt(params), options, {
-      imagePaths: [imagePath],
-    });
+    const text = await runCodexExec(
+      buildCodexImageDescriptionPrompt(params),
+      options,
+      {
+        imagePaths: [imagePath],
+      },
+    );
     return parseCodexImageDescriptionResult(text);
   } finally {
     await rm(tempDir, { recursive: true, force: true });

--- a/plugins/plugin-agent-orchestrator/vitest.config.ts
+++ b/plugins/plugin-agent-orchestrator/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     include: [
       "src/__tests__/task-agent-live.e2e.test.ts",
       "src/__tests__/coding-task-launch-failure-message.test.ts",
+      "src/__tests__/codex-model-provider.test.ts",
       "src/__tests__/task-agent-frameworks.test.ts",
       "src/__tests__/skill-manifest.test.ts",
       "src/__tests__/skill-recommender.test.ts",

--- a/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
+++ b/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
@@ -125,29 +125,31 @@ export const getExecutionsAction: Action = {
       const context = buildConversationContext(message, state);
       const matchResult = workflowIdParam
         ? {
-            matchedWorkflowId: workflowIdParam,
+          matchedWorkflowId: workflowIdParam,
+          confidence: 'high' as const,
+          matches: workflows.map((workflow) => ({
+            id: workflow.id,
+            name: workflow.name,
+            score: workflow.id === workflowIdParam ? 1 : 0,
+          })),
+          reason: 'workflowId parameter',
+        }
+        : workflowNameParam
+          ? {
+            matchedWorkflowId:
+                workflows.find((workflow) =>
+                  workflow.name.toLowerCase().includes(workflowNameParam),
+                )?.id ?? null,
             confidence: 'high' as const,
             matches: workflows.map((workflow) => ({
               id: workflow.id,
               name: workflow.name,
-              score: workflow.id === workflowIdParam ? 1 : 0,
+              score: workflow.name.toLowerCase().includes(workflowNameParam)
+                ? 1
+                : 0,
             })),
-            reason: 'workflowId parameter',
+            reason: 'workflowName parameter',
           }
-        : workflowNameParam
-          ? {
-              matchedWorkflowId:
-                workflows.find((workflow) =>
-                  workflow.name.toLowerCase().includes(workflowNameParam)
-                )?.id ?? null,
-              confidence: 'high' as const,
-              matches: workflows.map((workflow) => ({
-                id: workflow.id,
-                name: workflow.name,
-                score: workflow.name.toLowerCase().includes(workflowNameParam) ? 1 : 0,
-              })),
-              reason: 'workflowName parameter',
-            }
           : await matchWorkflow(runtime, context, workflows);
 
       if (!matchResult.matchedWorkflowId || matchResult.confidence === 'none') {

--- a/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
+++ b/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
@@ -125,31 +125,29 @@ export const getExecutionsAction: Action = {
       const context = buildConversationContext(message, state);
       const matchResult = workflowIdParam
         ? {
-          matchedWorkflowId: workflowIdParam,
-          confidence: 'high' as const,
-          matches: workflows.map((workflow) => ({
-            id: workflow.id,
-            name: workflow.name,
-            score: workflow.id === workflowIdParam ? 1 : 0,
-          })),
-          reason: 'workflowId parameter',
-        }
-        : workflowNameParam
-          ? {
-            matchedWorkflowId:
-                workflows.find((workflow) =>
-                  workflow.name.toLowerCase().includes(workflowNameParam),
-                )?.id ?? null,
+            matchedWorkflowId: workflowIdParam,
             confidence: 'high' as const,
             matches: workflows.map((workflow) => ({
               id: workflow.id,
               name: workflow.name,
-              score: workflow.name.toLowerCase().includes(workflowNameParam)
-                ? 1
-                : 0,
+              score: workflow.id === workflowIdParam ? 1 : 0,
             })),
-            reason: 'workflowName parameter',
+            reason: 'workflowId parameter',
           }
+        : workflowNameParam
+          ? {
+              matchedWorkflowId:
+                workflows.find((workflow) =>
+                  workflow.name.toLowerCase().includes(workflowNameParam)
+                )?.id ?? null,
+              confidence: 'high' as const,
+              matches: workflows.map((workflow) => ({
+                id: workflow.id,
+                name: workflow.name,
+                score: workflow.name.toLowerCase().includes(workflowNameParam) ? 1 : 0,
+              })),
+              reason: 'workflowName parameter',
+            }
           : await matchWorkflow(runtime, context, workflows);
 
       if (!matchResult.matchedWorkflowId || matchResult.confidence === 'none') {

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -26,7 +26,9 @@ const VALID_KINDS: ReadonlySet<N8nClarificationRequest['kind']> = new Set([
 ]);
 
 function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
-  if (!v || typeof v !== 'object') {return false;}
+  if (!v || typeof v !== 'object') {
+    return false;
+  }
   const o = v as Record<string, unknown>;
   if (typeof o.question !== 'string' || o.question.trim().length === 0) {
     return false;
@@ -37,22 +39,26 @@ function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
 }
 
 export function coerceClarifications(raw: unknown): N8nClarificationRequest[] {
-  if (!Array.isArray(raw) || raw.length === 0) {return [];}
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return [];
+  }
   const out: N8nClarificationRequest[] = [];
   for (const item of raw) {
     if (typeof item === 'string') {
       const trimmed = item.trim();
-      if (trimmed.length === 0) {continue;}
+      if (trimmed.length === 0) {
+        continue;
+      }
       out.push({ kind: 'free_text', question: trimmed, paramPath: '' });
       continue;
     }
-    if (!isStructuredClarification(item)) {continue;}
+    if (!isStructuredClarification(item)) {
+      continue;
+    }
     const o = item as unknown as Record<string, unknown>;
     const kindRaw = typeof o.kind === 'string' ? o.kind : 'free_text';
     const kind = (
-      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind'])
-        ? kindRaw
-        : 'free_text'
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind']) ? kindRaw : 'free_text'
     ) as N8nClarificationRequest['kind'];
     const platform = typeof o.platform === 'string' ? o.platform : undefined;
     let scope: { guildId?: string } | undefined;
@@ -118,7 +124,9 @@ export function parseParamPath(path: string): string[] {
     }
     // Identifier run: read until next `.` or `[`.
     let j = i;
-    while (j < n && path[j] !== '.' && path[j] !== '[') {j += 1;}
+    while (j < n && path[j] !== '.' && path[j] !== '[') {
+      j += 1;
+    }
     const ident = path.slice(i, j).trim();
     if (ident.length === 0) {
       throw new Error(`empty identifier at index ${i}`);
@@ -145,7 +153,7 @@ export function parseParamPath(path: string): string[] {
 export function setByDotPath(
   obj: Record<string, unknown>,
   paramPath: string,
-  value: unknown,
+  value: unknown
 ): void {
   const segments = parseParamPath(paramPath);
   let cur: Record<string, unknown> | unknown[] = obj;
@@ -154,9 +162,7 @@ export function setByDotPath(
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
       if (!isArrayIndex) {
-        throw new Error(
-          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
-        );
+        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
       }
       const idx = Number(seg);
       let next = cur[idx];
@@ -165,9 +171,7 @@ export function setByDotPath(
         cur[idx] = next;
       }
       if (typeof next !== 'object' || next === null) {
-        throw new Error(
-          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-        );
+        throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
       }
       cur = next as Record<string, unknown> | unknown[];
       continue;
@@ -178,18 +182,14 @@ export function setByDotPath(
       (cur as Record<string, unknown>)[seg] = next;
     }
     if (typeof next !== 'object' || next === null) {
-      throw new Error(
-        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-      );
+      throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
     }
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
     if (!/^[0-9]+$/.test(last)) {
-      throw new Error(
-        `paramPath terminal segment "${last}" must be numeric at array`,
-      );
+      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
     }
     cur[Number(last)] = value;
   } else {
@@ -199,7 +199,7 @@ export function setByDotPath(
 
 export function applyResolutions(
   draft: Record<string, unknown>,
-  resolutions: ReadonlyArray<N8nClarificationResolution>,
+  resolutions: ReadonlyArray<N8nClarificationResolution>
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
     if (!r || typeof r.paramPath !== 'string') {
@@ -229,9 +229,7 @@ export function applyResolutions(
         notes = meta.userNotes as string[];
       } else {
         notes =
-          meta.userNotes !== null && meta.userNotes !== undefined
-            ? [String(meta.userNotes)]
-            : [];
+          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
         meta.userNotes = notes;
       }
       notes.push(r.value);
@@ -271,12 +269,16 @@ export function applyResolutions(
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
-  freeFormCount = 0,
+  freeFormCount = 0
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
-  if (!meta || typeof meta !== 'object') {return;}
+  if (!meta || typeof meta !== 'object') {
+    return;
+  }
   const list = meta.requiresClarification;
-  if (!Array.isArray(list)) {return;}
+  if (!Array.isArray(list)) {
+    return;
+  }
   let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
     if (typeof item === 'string') {
@@ -292,10 +294,7 @@ export function pruneResolvedClarifications(
         return false;
       }
       // Empty-paramPath object-form: also positional.
-      if (
-        (typeof path !== 'string' || path.length === 0) &&
-        toDropFreeForm > 0
-      ) {
+      if ((typeof path !== 'string' || path.length === 0) && toDropFreeForm > 0) {
         toDropFreeForm -= 1;
         return false;
       }
@@ -328,20 +327,26 @@ export interface CatalogLike {
  */
 export async function buildCatalogSnapshot(
   catalog: CatalogLike,
-  clarifications: ReadonlyArray<N8nClarificationRequest>,
+  clarifications: ReadonlyArray<N8nClarificationRequest>
 ): Promise<N8nClarificationTargetGroup[]> {
   const platforms = new Set<string>();
   for (const c of clarifications) {
-    if (c.platform) {platforms.add(c.platform);}
+    if (c.platform) {
+      platforms.add(c.platform);
+    }
   }
-  if (platforms.size === 0) {return [];}
+  if (platforms.size === 0) {
+    return [];
+  }
   const out: N8nClarificationTargetGroup[] = [];
   const seen = new Set<string>();
   for (const platform of platforms) {
     const groups = await catalog.listGroups({ platform });
     for (const g of groups) {
       const key = `${g.platform}::${g.groupId}`;
-      if (seen.has(key)) {continue;}
+      if (seen.has(key)) {
+        continue;
+      }
       seen.add(key);
       out.push(g);
     }

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -26,9 +26,7 @@ const VALID_KINDS: ReadonlySet<N8nClarificationRequest['kind']> = new Set([
 ]);
 
 function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
-  if (!v || typeof v !== 'object') {
-    return false;
-  }
+  if (!v || typeof v !== 'object') {return false;}
   const o = v as Record<string, unknown>;
   if (typeof o.question !== 'string' || o.question.trim().length === 0) {
     return false;
@@ -39,26 +37,22 @@ function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
 }
 
 export function coerceClarifications(raw: unknown): N8nClarificationRequest[] {
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return [];
-  }
+  if (!Array.isArray(raw) || raw.length === 0) {return [];}
   const out: N8nClarificationRequest[] = [];
   for (const item of raw) {
     if (typeof item === 'string') {
       const trimmed = item.trim();
-      if (trimmed.length === 0) {
-        continue;
-      }
+      if (trimmed.length === 0) {continue;}
       out.push({ kind: 'free_text', question: trimmed, paramPath: '' });
       continue;
     }
-    if (!isStructuredClarification(item)) {
-      continue;
-    }
+    if (!isStructuredClarification(item)) {continue;}
     const o = item as unknown as Record<string, unknown>;
     const kindRaw = typeof o.kind === 'string' ? o.kind : 'free_text';
     const kind = (
-      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind']) ? kindRaw : 'free_text'
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind'])
+        ? kindRaw
+        : 'free_text'
     ) as N8nClarificationRequest['kind'];
     const platform = typeof o.platform === 'string' ? o.platform : undefined;
     let scope: { guildId?: string } | undefined;
@@ -124,9 +118,7 @@ export function parseParamPath(path: string): string[] {
     }
     // Identifier run: read until next `.` or `[`.
     let j = i;
-    while (j < n && path[j] !== '.' && path[j] !== '[') {
-      j += 1;
-    }
+    while (j < n && path[j] !== '.' && path[j] !== '[') {j += 1;}
     const ident = path.slice(i, j).trim();
     if (ident.length === 0) {
       throw new Error(`empty identifier at index ${i}`);
@@ -153,7 +145,7 @@ export function parseParamPath(path: string): string[] {
 export function setByDotPath(
   obj: Record<string, unknown>,
   paramPath: string,
-  value: unknown
+  value: unknown,
 ): void {
   const segments = parseParamPath(paramPath);
   let cur: Record<string, unknown> | unknown[] = obj;
@@ -162,7 +154,9 @@ export function setByDotPath(
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
       if (!isArrayIndex) {
-        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
+        throw new Error(
+          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
+        );
       }
       const idx = Number(seg);
       let next = cur[idx];
@@ -171,7 +165,9 @@ export function setByDotPath(
         cur[idx] = next;
       }
       if (typeof next !== 'object' || next === null) {
-        throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
+        throw new Error(
+          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+        );
       }
       cur = next as Record<string, unknown> | unknown[];
       continue;
@@ -182,14 +178,18 @@ export function setByDotPath(
       (cur as Record<string, unknown>)[seg] = next;
     }
     if (typeof next !== 'object' || next === null) {
-      throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
+      throw new Error(
+        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+      );
     }
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
     if (!/^[0-9]+$/.test(last)) {
-      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
+      throw new Error(
+        `paramPath terminal segment "${last}" must be numeric at array`,
+      );
     }
     cur[Number(last)] = value;
   } else {
@@ -199,7 +199,7 @@ export function setByDotPath(
 
 export function applyResolutions(
   draft: Record<string, unknown>,
-  resolutions: ReadonlyArray<N8nClarificationResolution>
+  resolutions: ReadonlyArray<N8nClarificationResolution>,
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
     if (!r || typeof r.paramPath !== 'string') {
@@ -229,7 +229,9 @@ export function applyResolutions(
         notes = meta.userNotes as string[];
       } else {
         notes =
-          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
+          meta.userNotes !== null && meta.userNotes !== undefined
+            ? [String(meta.userNotes)]
+            : [];
         meta.userNotes = notes;
       }
       notes.push(r.value);
@@ -269,16 +271,12 @@ export function applyResolutions(
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
-  freeFormCount = 0
+  freeFormCount = 0,
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
-  if (!meta || typeof meta !== 'object') {
-    return;
-  }
+  if (!meta || typeof meta !== 'object') {return;}
   const list = meta.requiresClarification;
-  if (!Array.isArray(list)) {
-    return;
-  }
+  if (!Array.isArray(list)) {return;}
   let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
     if (typeof item === 'string') {
@@ -294,7 +292,10 @@ export function pruneResolvedClarifications(
         return false;
       }
       // Empty-paramPath object-form: also positional.
-      if ((typeof path !== 'string' || path.length === 0) && toDropFreeForm > 0) {
+      if (
+        (typeof path !== 'string' || path.length === 0) &&
+        toDropFreeForm > 0
+      ) {
         toDropFreeForm -= 1;
         return false;
       }
@@ -327,26 +328,20 @@ export interface CatalogLike {
  */
 export async function buildCatalogSnapshot(
   catalog: CatalogLike,
-  clarifications: ReadonlyArray<N8nClarificationRequest>
+  clarifications: ReadonlyArray<N8nClarificationRequest>,
 ): Promise<N8nClarificationTargetGroup[]> {
   const platforms = new Set<string>();
   for (const c of clarifications) {
-    if (c.platform) {
-      platforms.add(c.platform);
-    }
+    if (c.platform) {platforms.add(c.platform);}
   }
-  if (platforms.size === 0) {
-    return [];
-  }
+  if (platforms.size === 0) {return [];}
   const out: N8nClarificationTargetGroup[] = [];
   const seen = new Set<string>();
   for (const platform of platforms) {
     const groups = await catalog.listGroups({ platform });
     for (const g of groups) {
       const key = `${g.platform}::${g.groupId}`;
-      if (seen.has(key)) {
-        continue;
-      }
+      if (seen.has(key)) {continue;}
       seen.add(key);
       out.push(g);
     }

--- a/plugins/plugin-n8n-workflow/src/plugin-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/plugin-routes.ts
@@ -32,16 +32,18 @@ function buildState(runtime: unknown): N8nCompatState {
 }
 
 function makeN8nHandler() {
-  return async (req: unknown, res: unknown, runtime: unknown): Promise<void> => {
+  return async (
+    req: unknown,
+    res: unknown,
+    runtime: unknown,
+  ): Promise<void> => {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? '/', 'http://localhost');
     const method = (httpReq.method ?? 'GET').toUpperCase();
     const state = buildState(runtime);
 
-    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {
-      return;
-    }
+    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {return;}
 
     await handleN8nRoutes({
       req: httpReq,

--- a/plugins/plugin-n8n-workflow/src/plugin-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/plugin-routes.ts
@@ -32,18 +32,16 @@ function buildState(runtime: unknown): N8nCompatState {
 }
 
 function makeN8nHandler() {
-  return async (
-    req: unknown,
-    res: unknown,
-    runtime: unknown,
-  ): Promise<void> => {
+  return async (req: unknown, res: unknown, runtime: unknown): Promise<void> => {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? '/', 'http://localhost');
     const method = (httpReq.method ?? 'GET').toUpperCase();
     const state = buildState(runtime);
 
-    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {return;}
+    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {
+      return;
+    }
 
     await handleN8nRoutes({
       req: httpReq,

--- a/plugins/plugin-n8n-workflow/src/register-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/register-routes.ts
@@ -1,6 +1,9 @@
 import { registerAppRoutePluginLoader } from '@elizaos/app-core/runtime/app-route-plugin-registry';
 
-registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', async () => {
-  const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
-  return n8nWorkflowRoutePlugin;
-});
+registerAppRoutePluginLoader(
+  '@elizaos/plugin-n8n-workflow:routes',
+  async () => {
+    const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
+    return n8nWorkflowRoutePlugin;
+  },
+);

--- a/plugins/plugin-n8n-workflow/src/register-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/register-routes.ts
@@ -1,9 +1,6 @@
 import { registerAppRoutePluginLoader } from '@elizaos/app-core/runtime/app-route-plugin-registry';
 
-registerAppRoutePluginLoader(
-  '@elizaos/plugin-n8n-workflow:routes',
-  async () => {
-    const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
-    return n8nWorkflowRoutePlugin;
-  },
-);
+registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', async () => {
+  const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
+  return n8nWorkflowRoutePlugin;
+});

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -27,11 +27,20 @@
  * services/n8n-sidecar.ts rather than being threaded through state.
  */
 
-import type { RouteHelpers, RouteRequestMeta } from '@elizaos/agent/api/route-helpers';
+import type {
+  RouteHelpers,
+  RouteRequestMeta,
+} from '@elizaos/agent/api/route-helpers';
 import { readCompatJsonBody } from '@elizaos/app-core/api/compat-route-shared';
 import { isNativeServerPlatform } from '@elizaos/app-core/platform/is-native-server';
-import { type N8nMode, resolveN8nMode } from '@elizaos/app-core/services/n8n-mode';
-import type { N8nSidecar, N8nSidecarStatus } from '@elizaos/app-core/services/n8n-sidecar';
+import {
+  type N8nMode,
+  resolveN8nMode,
+} from '@elizaos/app-core/services/n8n-mode';
+import type {
+  N8nSidecar,
+  N8nSidecarStatus,
+} from '@elizaos/app-core/services/n8n-sidecar';
 import type { AgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
 import {
@@ -159,7 +168,9 @@ export interface N8nRoutesConfigLike {
   };
 }
 
-export interface N8nRouteContext extends RouteRequestMeta, Pick<RouteHelpers, 'json'> {
+export interface N8nRouteContext
+  extends RouteRequestMeta,
+    Pick<RouteHelpers, 'json'> {
   config: N8nRoutesConfigLike;
   runtime: AgentRuntime | null;
   /**
@@ -213,7 +224,10 @@ export function __resetCloudHealthCacheForTests(): void {
   cloudHealthCache.clear();
 }
 
-async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
+async function probeCloudHealth(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<N8nCloudHealth> {
   const url = `${normalizeBaseUrl(baseUrl)}/api/v1/health`;
   try {
     const res = await fetchImpl(url, {
@@ -224,13 +238,18 @@ async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promi
     return res.ok ? 'ok' : 'degraded';
   } catch (err) {
     logger.debug(
-      `[n8n-routes] cloud health probe failed: ${err instanceof Error ? err.message : String(err)}`
+      `[n8n-routes] cloud health probe failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
     return 'degraded';
   }
 }
 
-async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
+async function getCloudHealth(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<N8nCloudHealth> {
   const key = normalizeBaseUrl(baseUrl);
   const now = Date.now();
   const cached = cloudHealthCache.get(key);
@@ -253,10 +272,8 @@ async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise
  */
 async function loadSidecarModule(): Promise<
   typeof import('@elizaos/app-core/services/n8n-sidecar') | null
-> {
-  if (isNativeServerPlatform()) {
-    return null;
-  }
+  > {
+  if (isNativeServerPlatform()) {return null;}
   return await import('@elizaos/app-core/services/n8n-sidecar');
 }
 
@@ -271,34 +288,44 @@ function normalizeBaseUrl(raw: string | undefined | null): string {
 }
 
 function resolveAgentId(ctx: N8nRouteContext): string {
-  if (ctx.agentId?.trim()) {
-    return ctx.agentId.trim();
-  }
+  if (ctx.agentId?.trim()) {return ctx.agentId.trim();}
   const runtimeAny = ctx.runtime as unknown as {
     agentId?: string;
     character?: { id?: string };
   } | null;
-  return runtimeAny?.agentId ?? runtimeAny?.character?.id ?? '00000000-0000-0000-0000-000000000000';
+  return (
+    runtimeAny?.agentId ??
+    runtimeAny?.character?.id ??
+    '00000000-0000-0000-0000-000000000000'
+  );
 }
 
-function sendJson(ctx: Pick<N8nRouteContext, 'res' | 'json'>, status: number, body: unknown): void {
+function sendJson(
+  ctx: Pick<N8nRouteContext, 'res' | 'json'>,
+  status: number,
+  body: unknown,
+): void {
   // The compat `json` helper signature in app-core is
   // `(res, body, status?) => void`; status defaults to 200 upstream.
-  const json = ctx.json as unknown as (res: typeof ctx.res, body: unknown, status?: number) => void;
+  const json = ctx.json as unknown as (
+    res: typeof ctx.res,
+    body: unknown,
+    status?: number,
+  ) => void;
   json(ctx.res, body, status);
 }
 
 /** Strip any credential material from node descriptors before forwarding. */
 function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {
-    return {};
-  }
+  if (!n || typeof n !== 'object') {return {};}
   const obj = n as Record<string, unknown>;
   return {
     ...(typeof obj.id === 'string' ? { id: obj.id } : {}),
     ...(typeof obj.name === 'string' ? { name: obj.name } : {}),
     ...(typeof obj.type === 'string' ? { type: obj.type } : {}),
-    ...(typeof obj.typeVersion === 'number' ? { typeVersion: obj.typeVersion } : {}),
+    ...(typeof obj.typeVersion === 'number'
+      ? { typeVersion: obj.typeVersion }
+      : {}),
   };
 }
 
@@ -307,9 +334,7 @@ function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
  * parameters (needed by the graph viewer). Credentials are still stripped.
  */
 function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {
-    return {};
-  }
+  if (!n || typeof n !== 'object') {return {};}
   const obj = n as Record<string, unknown>;
   const base = sanitizeNode(n);
 
@@ -334,28 +359,28 @@ function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
     ...(position !== undefined ? { position } : {}),
     ...(parameters !== undefined ? { parameters } : {}),
     ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    ...(typeof obj.notesInFlow === 'boolean' ? { notesInFlow: obj.notesInFlow } : {}),
+    ...(typeof obj.notesInFlow === 'boolean'
+      ? { notesInFlow: obj.notesInFlow }
+      : {}),
   };
 }
 
 /** Normalize an n8n workflow payload to our client-facing shape. */
 function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
+  if (!raw || typeof raw !== 'object') {return null;}
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {
-    return null;
-  }
+  if (!id) {return null;}
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNode);
   return {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
+    ...(typeof obj.description === 'string'
+      ? { description: obj.description }
+      : {}),
     nodes,
     nodeCount: nodes.length,
   };
@@ -371,15 +396,11 @@ function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
  * it needs without a second request.
  */
 function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
+  if (!raw || typeof raw !== 'object') {return null;}
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {
-    return null;
-  }
+  if (!id) {return null;}
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNodeFull);
 
@@ -394,7 +415,9 @@ function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
+    ...(typeof obj.description === 'string'
+      ? { description: obj.description }
+      : {}),
     nodes,
     nodeCount: nodes.length,
     ...(connections !== undefined ? { connections } : {}),
@@ -419,7 +442,7 @@ function resolveProxyTarget(
   ctx: N8nRouteContext,
   subpath: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): {
   target: ProxyTarget | null;
   reason?: {
@@ -487,9 +510,7 @@ function resolveProxyTarget(
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (apiKey) {
-    headers['X-N8N-API-KEY'] = apiKey;
-  }
+  if (apiKey) {headers['X-N8N-API-KEY'] = apiKey;}
 
   // n8n serves TWO parallel workflow APIs:
   //   /rest/workflows   — internal UI endpoint, requires JWT cookie auth.
@@ -508,7 +529,7 @@ function resolveProxyTarget(
 async function fetchTargetAsJson(
   ctx: N8nRouteContext,
   target: ProxyTarget,
-  init: { method: string; body?: string }
+  init: { method: string; body?: string },
 ): Promise<{
   ok: boolean;
   status: number;
@@ -525,7 +546,9 @@ async function fetchTargetAsJson(
     res = await fetchImpl(target.url, {
       method: init.method,
       headers,
-      ...(init.body !== null && init.body !== undefined ? { body: init.body } : {}),
+      ...(init.body !== null && init.body !== undefined
+        ? { body: init.body }
+        : {}),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
@@ -554,30 +577,18 @@ async function fetchTargetAsJson(
  * or `{ data }`. We accept both.
  */
 function extractWorkflowList(body: unknown): unknown[] {
-  if (!body || typeof body !== 'object') {
-    return [];
-  }
+  if (!body || typeof body !== 'object') {return [];}
   const obj = body as Record<string, unknown>;
-  if (Array.isArray(obj.workflows)) {
-    return obj.workflows;
-  }
-  if (Array.isArray(obj.data)) {
-    return obj.data;
-  }
+  if (Array.isArray(obj.workflows)) {return obj.workflows;}
+  if (Array.isArray(obj.data)) {return obj.data;}
   return [];
 }
 
 function extractWorkflowSingle(body: unknown): unknown {
-  if (!body || typeof body !== 'object') {
-    return null;
-  }
+  if (!body || typeof body !== 'object') {return null;}
   const obj = body as Record<string, unknown>;
-  if (obj.data && typeof obj.data === 'object') {
-    return obj.data;
-  }
-  if (obj.workflow && typeof obj.workflow === 'object') {
-    return obj.workflow;
-  }
+  if (obj.data && typeof obj.data === 'object') {return obj.data;}
+  if (obj.workflow && typeof obj.workflow === 'object') {return obj.workflow;}
   return body;
 }
 
@@ -587,19 +598,32 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
+function readOptionalString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const value = obj[key];
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
-function readOptionalBoolean(obj: Record<string, unknown>, key: string): boolean | undefined {
+function readOptionalBoolean(
+  obj: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
   const value = obj[key];
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function readOptionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
+function readOptionalNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const value = obj[key];
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 /**
@@ -634,11 +658,9 @@ interface TriggerContext {
  */
 async function buildTriggerContextFromConversation(
   runtime: AgentRuntime | null | undefined,
-  roomId: string
+  roomId: string,
 ): Promise<TriggerContext | undefined> {
-  if (!runtime || typeof runtime.getMemories !== 'function') {
-    return undefined;
-  }
+  if (!runtime || typeof runtime.getMemories !== 'function') {return undefined;}
   let memories: Array<{
     entityId?: string;
     metadata?: Record<string, unknown>;
@@ -656,21 +678,19 @@ async function buildTriggerContextFromConversation(
     logger.debug?.(
       `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
         err instanceof Error ? err.message : String(err)
-      }`
+      }`,
     );
     return undefined;
   }
-  if (!Array.isArray(memories) || memories.length === 0) {
-    return undefined;
-  }
+  if (!Array.isArray(memories) || memories.length === 0) {return undefined;}
 
   // Tail inbound = most recent memory whose entityId is NOT the agent.
   // `runtime.getMemories` typically returns most-recent-first; defensively
   // handle either order.
-  const inbound = memories.find((m) => m.entityId && m.entityId !== runtime.agentId);
-  if (!inbound?.metadata) {
-    return undefined;
-  }
+  const inbound = memories.find(
+    (m) => m.entityId && m.entityId !== runtime.agentId,
+  );
+  if (!inbound?.metadata) {return undefined;}
 
   const meta = inbound.metadata as Record<string, unknown>;
   const discord = (meta.discord ?? {}) as Record<string, unknown>;
@@ -680,11 +700,16 @@ async function buildTriggerContextFromConversation(
   // Canonical wins; flat fields are the legacy de-facto shape.
   const discordChannelId =
     (typeof discord.channelId === 'string' ? discord.channelId : undefined) ??
-    (typeof meta.discordChannelId === 'string' ? meta.discordChannelId : undefined);
+    (typeof meta.discordChannelId === 'string'
+      ? meta.discordChannelId
+      : undefined);
   const discordGuildId =
     (typeof discord.guildId === 'string' ? discord.guildId : undefined) ??
-    (typeof meta.discordServerId === 'string' ? meta.discordServerId : undefined);
-  const discordThreadId = typeof discord.threadId === 'string' ? discord.threadId : undefined;
+    (typeof meta.discordServerId === 'string'
+      ? meta.discordServerId
+      : undefined);
+  const discordThreadId =
+    typeof discord.threadId === 'string' ? discord.threadId : undefined;
 
   // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
   // id, which equals the chat id only in private 1:1 DMs. In group chats /
@@ -698,12 +723,15 @@ async function buildTriggerContextFromConversation(
       ? telegram.chatId
       : undefined;
   const telegramThreadId =
-    typeof telegram.threadId === 'string' || typeof telegram.threadId === 'number'
+    typeof telegram.threadId === 'string' ||
+    typeof telegram.threadId === 'number'
       ? (telegram.threadId as string | number)
       : undefined;
 
-  const slackChannelId = typeof slack.channelId === 'string' ? slack.channelId : undefined;
-  const slackTeamId = typeof slack.teamId === 'string' ? slack.teamId : undefined;
+  const slackChannelId =
+    typeof slack.channelId === 'string' ? slack.channelId : undefined;
+  const slackTeamId =
+    typeof slack.teamId === 'string' ? slack.teamId : undefined;
 
   if (discordChannelId) {
     return {
@@ -720,7 +748,9 @@ async function buildTriggerContextFromConversation(
       source: 'telegram',
       telegram: {
         chatId: telegramChatId,
-        ...(telegramThreadId !== undefined ? { threadId: telegramThreadId } : {}),
+        ...(telegramThreadId !== undefined
+          ? { threadId: telegramThreadId }
+          : {}),
       },
     };
   }
@@ -745,39 +775,34 @@ function readPosition(value: unknown): [number, number] | null {
     : null;
 }
 
-function readCredentials(value: unknown): Record<string, { id: string; name: string }> | undefined {
+function readCredentials(
+  value: unknown,
+): Record<string, { id: string; name: string }> | undefined {
   const raw = asRecord(value);
-  if (!raw) {
-    return undefined;
-  }
+  if (!raw) {return undefined;}
 
   const credentials: Record<string, { id: string; name: string }> = {};
   for (const [key, credentialValue] of Object.entries(raw)) {
     const credential = asRecord(credentialValue);
-    if (!credential) {
-      continue;
-    }
+    if (!credential) {continue;}
     const id = readOptionalString(credential, 'id');
     const name = readOptionalString(credential, 'name');
-    if (!id || !name) {
-      continue;
-    }
+    if (!id || !name) {continue;}
     credentials[key] = { id, name };
   }
   return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
-function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowWriteNode | null {
+function normalizeWorkflowWriteNode(
+  value: unknown,
+  index: number,
+): N8nWorkflowWriteNode | null {
   const obj = asRecord(value);
-  if (!obj) {
-    return null;
-  }
+  if (!obj) {return null;}
 
   const name = readOptionalString(obj, 'name');
   const type = readOptionalString(obj, 'type');
-  if (!name || !type) {
-    return null;
-  }
+  if (!name || !type) {return null;}
 
   const position = readPosition(obj.position) ?? [index * 260, 0];
   const parameters = asRecord(obj.parameters) ?? {};
@@ -785,7 +810,9 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
   const credentials = readCredentials(obj.credentials);
 
   return {
-    ...(readOptionalString(obj, 'id') ? { id: readOptionalString(obj, 'id') } : {}),
+    ...(readOptionalString(obj, 'id')
+      ? { id: readOptionalString(obj, 'id') }
+      : {}),
     name,
     type,
     typeVersion,
@@ -795,11 +822,15 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
     ...(readOptionalBoolean(obj, 'disabled') !== undefined
       ? { disabled: readOptionalBoolean(obj, 'disabled') }
       : {}),
-    ...(readOptionalString(obj, 'notes') ? { notes: readOptionalString(obj, 'notes') } : {}),
+    ...(readOptionalString(obj, 'notes')
+      ? { notes: readOptionalString(obj, 'notes') }
+      : {}),
     ...(readOptionalBoolean(obj, 'notesInFlow') !== undefined
       ? { notesInFlow: readOptionalBoolean(obj, 'notesInFlow') }
       : {}),
-    ...(readOptionalString(obj, 'color') ? { color: readOptionalString(obj, 'color') } : {}),
+    ...(readOptionalString(obj, 'color')
+      ? { color: readOptionalString(obj, 'color') }
+      : {}),
     ...(readOptionalBoolean(obj, 'continueOnFail') !== undefined
       ? { continueOnFail: readOptionalBoolean(obj, 'continueOnFail') }
       : {}),
@@ -828,37 +859,31 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
 
 function normalizeWorkflowConnections(value: unknown): N8nWorkflowConnections {
   const raw = asRecord(value);
-  if (!raw) {
-    return {};
-  }
+  if (!raw) {return {};}
 
   const connections: N8nWorkflowConnections = {};
   for (const [sourceName, outputValue] of Object.entries(raw)) {
     const outputMap = asRecord(outputValue);
-    if (!outputMap) {
-      continue;
-    }
+    if (!outputMap) {continue;}
     const mainRaw = outputMap.main;
-    if (!Array.isArray(mainRaw)) {
-      continue;
-    }
+    if (!Array.isArray(mainRaw)) {continue;}
     const main = mainRaw.map((group) =>
       Array.isArray(group)
         ? group
-            .map((connection) => {
-              const obj = asRecord(connection);
-              const node = obj ? readOptionalString(obj, 'node') : undefined;
-              if (!obj || !node) {
-                return null;
-              }
-              const index = readOptionalNumber(obj, 'index') ?? 0;
-              return { node, type: 'main' as const, index };
-            })
-            .filter(
-              (connection): connection is { node: string; type: 'main'; index: number } =>
-                connection !== null
-            )
-        : []
+          .map((connection) => {
+            const obj = asRecord(connection);
+            const node = obj ? readOptionalString(obj, 'node') : undefined;
+            if (!obj || !node) {return null;}
+            const index = readOptionalNumber(obj, 'index') ?? 0;
+            return { node, type: 'main' as const, index };
+          })
+          .filter(
+            (
+              connection,
+            ): connection is { node: string; type: 'main'; index: number } =>
+              connection !== null,
+          )
+        : [],
     );
     connections[sourceName] = { main };
   }
@@ -892,8 +917,12 @@ function normalizeWorkflowWritePayload(body: Record<string, unknown>): {
   };
 }
 
-function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: unknown }): void {
-  const status = upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
+function propagateError(
+  ctx: N8nRouteContext,
+  upstream: { status: number; body: unknown },
+): void {
+  const status =
+    upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
   let message = `upstream responded with ${upstream.status}`;
   if (upstream.body && typeof upstream.body === 'object') {
     const b = upstream.body as Record<string, unknown>;
@@ -912,16 +941,12 @@ function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: 
  * Returns null if pathname doesn't match.
  */
 function parseWorkflowPath(
-  pathname: string
+  pathname: string,
 ): { id: string; action: 'get' | 'activate' | 'deactivate' } | null {
   const prefix = '/api/n8n/workflows/';
-  if (!pathname.startsWith(prefix)) {
-    return null;
-  }
+  if (!pathname.startsWith(prefix)) {return null;}
   const rest = pathname.slice(prefix.length);
-  if (!rest) {
-    return null;
-  }
+  if (!rest) {return null;}
   const parts = rest.split('/').filter(Boolean);
   if (parts.length === 1) {
     return { id: decodeURIComponent(parts[0] ?? ''), action: 'get' };
@@ -943,14 +968,10 @@ function parseWorkflowPath(
  */
 async function resolveSidecarForRequest(
   ctx: N8nRouteContext,
-  native: boolean
+  native: boolean,
 ): Promise<N8nSidecar | null> {
-  if (ctx.n8nSidecar !== undefined) {
-    return ctx.n8nSidecar;
-  }
-  if (native) {
-    return null;
-  }
+  if (ctx.n8nSidecar !== undefined) {return ctx.n8nSidecar;}
+  if (native) {return null;}
   const mod = await loadSidecarModule();
   return mod?.peekN8nSidecar() ?? null;
 }
@@ -1004,7 +1025,10 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
-  if (method === 'POST' && pathname === '/api/n8n/workflows/resolve-clarification') {
+  if (
+    method === 'POST' &&
+    pathname === '/api/n8n/workflows/resolve-clarification'
+  ) {
     return handleResolveClarification(ctx);
   }
 
@@ -1044,7 +1068,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
 async function handleStatus(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const { config, runtime } = ctx;
 
@@ -1056,7 +1080,8 @@ async function handleStatus(
   const sidecarState = sidecar?.getState();
   const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
 
-  const host = mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
+  const host =
+    mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
 
   // Cloud health — only probed when we are actually in cloud mode. The
   // probe is cached for 30s (see getCloudHealth) so rapid status polls
@@ -1068,7 +1093,7 @@ async function handleStatus(
     } else {
       cloudHealth = await getCloudHealth(
         config.cloud?.baseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
-        ctx.fetchImpl ?? fetch
+        ctx.fetchImpl ?? fetch,
       );
     }
   }
@@ -1083,10 +1108,10 @@ async function handleStatus(
     cloudHealth,
     ...(sidecarState
       ? {
-          errorMessage: sidecarState.errorMessage,
-          retries: sidecarState.retries,
-          recentOutput: sidecarState.recentOutput,
-        }
+        errorMessage: sidecarState.errorMessage,
+        retries: sidecarState.retries,
+        recentOutput: sidecarState.recentOutput,
+      }
       : {}),
   };
 
@@ -1098,7 +1123,7 @@ async function handleStatus(
 async function handleListWorkflows(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, '', sidecar, native);
   if (!resolved.target) {
@@ -1118,7 +1143,9 @@ async function handleListWorkflows(
   }
 
   const list = extractWorkflowList(upstream.body);
-  const workflows = list.map(normalizeWorkflow).filter((w): w is N8nWorkflow => w !== null);
+  const workflows = list
+    .map(normalizeWorkflow)
+    .filter((w): w is N8nWorkflow => w !== null);
 
   sendJson(ctx, 200, { workflows });
   return true;
@@ -1136,7 +1163,7 @@ async function handleGetWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1177,7 +1204,7 @@ async function writeWorkflow(
   subpath: string,
   payload: N8nWorkflowWritePayload,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, subpath, sidecar, native);
   if (!resolved.target) {
@@ -1210,12 +1237,10 @@ async function writeWorkflow(
 async function handleCreateWorkflow(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1230,7 +1255,7 @@ async function handleUpdateWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1238,9 +1263,7 @@ async function handleUpdateWorkflow(
   }
 
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1248,20 +1271,27 @@ async function handleUpdateWorkflow(
     return true;
   }
 
-  return writeWorkflow(ctx, 'PUT', `/${encodeURIComponent(id)}`, payload, sidecar, native);
+  return writeWorkflow(
+    ctx,
+    'PUT',
+    `/${encodeURIComponent(id)}`,
+    payload,
+    sidecar,
+    native,
+  );
 }
 
 interface N8nWorkflowServiceLike {
   generateWorkflowDraft?: (
     prompt: string,
-    opts?: { triggerContext?: TriggerContext }
+    opts?: { triggerContext?: TriggerContext },
   ) => Promise<{
     id?: string;
     [k: string]: unknown;
   }>;
   deployWorkflow?: (
     workflow: Record<string, unknown>,
-    userId: string
+    userId: string,
   ) => Promise<{
     id: string;
     name: string;
@@ -1271,8 +1301,12 @@ interface N8nWorkflowServiceLike {
   getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
 }
 
-function getN8nWorkflowService(ctx: N8nRouteContext): N8nWorkflowServiceLike | null {
-  const service = ctx.runtime?.getService?.('n8n_workflow') as N8nWorkflowServiceLike | undefined;
+function getN8nWorkflowService(
+  ctx: N8nRouteContext,
+): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.('n8n_workflow') as
+    | N8nWorkflowServiceLike
+    | undefined;
   if (
     typeof service?.generateWorkflowDraft !== 'function' ||
     typeof service.deployWorkflow !== 'function' ||
@@ -1301,7 +1335,7 @@ function getConnectorTargetCatalog(ctx: N8nRouteContext): CatalogLike | null {
 async function deployAndRespond(
   ctx: N8nRouteContext,
   service: N8nWorkflowServiceLike,
-  draft: Record<string, unknown>
+  draft: Record<string, unknown>,
 ): Promise<void> {
   const userId = resolveAgentId(ctx);
   const deployed = await service.deployWorkflow?.(draft, userId);
@@ -1322,9 +1356,7 @@ async function deployAndRespond(
 
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const prompt = readOptionalString(body, 'prompt');
   if (!prompt) {
@@ -1343,7 +1375,10 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   }
 
   const triggerContext = bridgeConversationId
-    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
+    ? await buildTriggerContextFromConversation(
+      ctx.runtime,
+      bridgeConversationId,
+    )
     : undefined;
 
   const draft = triggerContext
@@ -1381,11 +1416,11 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   return true;
 }
 
-async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean> {
+async function handleResolveClarification(
+  ctx: N8nRouteContext,
+): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const draftRaw = (body as Record<string, unknown>).draft;
   if (!draftRaw || typeof draftRaw !== 'object' || Array.isArray(draftRaw)) {
@@ -1415,7 +1450,7 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
 
   const result = applyResolutions(
     draft,
-    resolutions as Array<{ paramPath: string; value: string }>
+    resolutions as Array<{ paramPath: string; value: string }>,
   );
   if (!result.ok) {
     sendJson(ctx, 400, {
@@ -1428,10 +1463,10 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
   const resolvedPaths = new Set(
     resolutions
       .map((r) => r.paramPath)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0)
+      .filter((p): p is string => typeof p === 'string' && p.length > 0),
   );
   const freeFormCount = resolutions.filter(
-    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0
+    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0,
   ).length;
   pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
@@ -1449,7 +1484,9 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
   const remaining = coerceClarifications(meta?.requiresClarification);
   if (remaining.length > 0) {
     const catalogService = getConnectorTargetCatalog(ctx);
-    const catalog = catalogService ? await buildCatalogSnapshot(catalogService, remaining) : [];
+    const catalog = catalogService
+      ? await buildCatalogSnapshot(catalogService, remaining)
+      : [];
     sendJson(ctx, 200, {
       status: 'needs_clarification',
       draft,
@@ -1468,7 +1505,7 @@ async function handleToggleWorkflow(
   id: string,
   activate: boolean,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1516,14 +1553,19 @@ async function handleDeleteWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
     return true;
   }
 
-  const resolved = resolveProxyTarget(ctx, `/${encodeURIComponent(id)}`, sidecar, native);
+  const resolved = resolveProxyTarget(
+    ctx,
+    `/${encodeURIComponent(id)}`,
+    sidecar,
+    native,
+  );
   if (!resolved.target) {
     sendJson(ctx, 503, {
       error: resolved.reason?.message ?? 'n8n not ready',

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -27,20 +27,11 @@
  * services/n8n-sidecar.ts rather than being threaded through state.
  */
 
-import type {
-  RouteHelpers,
-  RouteRequestMeta,
-} from '@elizaos/agent/api/route-helpers';
+import type { RouteHelpers, RouteRequestMeta } from '@elizaos/agent/api/route-helpers';
 import { readCompatJsonBody } from '@elizaos/app-core/api/compat-route-shared';
 import { isNativeServerPlatform } from '@elizaos/app-core/platform/is-native-server';
-import {
-  type N8nMode,
-  resolveN8nMode,
-} from '@elizaos/app-core/services/n8n-mode';
-import type {
-  N8nSidecar,
-  N8nSidecarStatus,
-} from '@elizaos/app-core/services/n8n-sidecar';
+import { type N8nMode, resolveN8nMode } from '@elizaos/app-core/services/n8n-mode';
+import type { N8nSidecar, N8nSidecarStatus } from '@elizaos/app-core/services/n8n-sidecar';
 import type { AgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
 import {
@@ -168,9 +159,7 @@ export interface N8nRoutesConfigLike {
   };
 }
 
-export interface N8nRouteContext
-  extends RouteRequestMeta,
-    Pick<RouteHelpers, 'json'> {
+export interface N8nRouteContext extends RouteRequestMeta, Pick<RouteHelpers, 'json'> {
   config: N8nRoutesConfigLike;
   runtime: AgentRuntime | null;
   /**
@@ -224,10 +213,7 @@ export function __resetCloudHealthCacheForTests(): void {
   cloudHealthCache.clear();
 }
 
-async function probeCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const url = `${normalizeBaseUrl(baseUrl)}/api/v1/health`;
   try {
     const res = await fetchImpl(url, {
@@ -238,18 +224,13 @@ async function probeCloudHealth(
     return res.ok ? 'ok' : 'degraded';
   } catch (err) {
     logger.debug(
-      `[n8n-routes] cloud health probe failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `[n8n-routes] cloud health probe failed: ${err instanceof Error ? err.message : String(err)}`
     );
     return 'degraded';
   }
 }
 
-async function getCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const key = normalizeBaseUrl(baseUrl);
   const now = Date.now();
   const cached = cloudHealthCache.get(key);
@@ -272,8 +253,10 @@ async function getCloudHealth(
  */
 async function loadSidecarModule(): Promise<
   typeof import('@elizaos/app-core/services/n8n-sidecar') | null
-  > {
-  if (isNativeServerPlatform()) {return null;}
+> {
+  if (isNativeServerPlatform()) {
+    return null;
+  }
   return await import('@elizaos/app-core/services/n8n-sidecar');
 }
 
@@ -288,44 +271,34 @@ function normalizeBaseUrl(raw: string | undefined | null): string {
 }
 
 function resolveAgentId(ctx: N8nRouteContext): string {
-  if (ctx.agentId?.trim()) {return ctx.agentId.trim();}
+  if (ctx.agentId?.trim()) {
+    return ctx.agentId.trim();
+  }
   const runtimeAny = ctx.runtime as unknown as {
     agentId?: string;
     character?: { id?: string };
   } | null;
-  return (
-    runtimeAny?.agentId ??
-    runtimeAny?.character?.id ??
-    '00000000-0000-0000-0000-000000000000'
-  );
+  return runtimeAny?.agentId ?? runtimeAny?.character?.id ?? '00000000-0000-0000-0000-000000000000';
 }
 
-function sendJson(
-  ctx: Pick<N8nRouteContext, 'res' | 'json'>,
-  status: number,
-  body: unknown,
-): void {
+function sendJson(ctx: Pick<N8nRouteContext, 'res' | 'json'>, status: number, body: unknown): void {
   // The compat `json` helper signature in app-core is
   // `(res, body, status?) => void`; status defaults to 200 upstream.
-  const json = ctx.json as unknown as (
-    res: typeof ctx.res,
-    body: unknown,
-    status?: number,
-  ) => void;
+  const json = ctx.json as unknown as (res: typeof ctx.res, body: unknown, status?: number) => void;
   json(ctx.res, body, status);
 }
 
 /** Strip any credential material from node descriptors before forwarding. */
 function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   return {
     ...(typeof obj.id === 'string' ? { id: obj.id } : {}),
     ...(typeof obj.name === 'string' ? { name: obj.name } : {}),
     ...(typeof obj.type === 'string' ? { type: obj.type } : {}),
-    ...(typeof obj.typeVersion === 'number'
-      ? { typeVersion: obj.typeVersion }
-      : {}),
+    ...(typeof obj.typeVersion === 'number' ? { typeVersion: obj.typeVersion } : {}),
   };
 }
 
@@ -334,7 +307,9 @@ function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
  * parameters (needed by the graph viewer). Credentials are still stripped.
  */
 function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   const base = sanitizeNode(n);
 
@@ -359,28 +334,28 @@ function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
     ...(position !== undefined ? { position } : {}),
     ...(parameters !== undefined ? { parameters } : {}),
     ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    ...(typeof obj.notesInFlow === 'boolean'
-      ? { notesInFlow: obj.notesInFlow }
-      : {}),
+    ...(typeof obj.notesInFlow === 'boolean' ? { notesInFlow: obj.notesInFlow } : {}),
   };
 }
 
 /** Normalize an n8n workflow payload to our client-facing shape. */
 function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNode);
   return {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
   };
@@ -396,11 +371,15 @@ function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
  * it needs without a second request.
  */
 function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNodeFull);
 
@@ -415,9 +394,7 @@ function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
     ...(connections !== undefined ? { connections } : {}),
@@ -442,7 +419,7 @@ function resolveProxyTarget(
   ctx: N8nRouteContext,
   subpath: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): {
   target: ProxyTarget | null;
   reason?: {
@@ -510,7 +487,9 @@ function resolveProxyTarget(
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (apiKey) {headers['X-N8N-API-KEY'] = apiKey;}
+  if (apiKey) {
+    headers['X-N8N-API-KEY'] = apiKey;
+  }
 
   // n8n serves TWO parallel workflow APIs:
   //   /rest/workflows   — internal UI endpoint, requires JWT cookie auth.
@@ -529,7 +508,7 @@ function resolveProxyTarget(
 async function fetchTargetAsJson(
   ctx: N8nRouteContext,
   target: ProxyTarget,
-  init: { method: string; body?: string },
+  init: { method: string; body?: string }
 ): Promise<{
   ok: boolean;
   status: number;
@@ -546,9 +525,7 @@ async function fetchTargetAsJson(
     res = await fetchImpl(target.url, {
       method: init.method,
       headers,
-      ...(init.body !== null && init.body !== undefined
-        ? { body: init.body }
-        : {}),
+      ...(init.body !== null && init.body !== undefined ? { body: init.body } : {}),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
@@ -577,18 +554,30 @@ async function fetchTargetAsJson(
  * or `{ data }`. We accept both.
  */
 function extractWorkflowList(body: unknown): unknown[] {
-  if (!body || typeof body !== 'object') {return [];}
+  if (!body || typeof body !== 'object') {
+    return [];
+  }
   const obj = body as Record<string, unknown>;
-  if (Array.isArray(obj.workflows)) {return obj.workflows;}
-  if (Array.isArray(obj.data)) {return obj.data;}
+  if (Array.isArray(obj.workflows)) {
+    return obj.workflows;
+  }
+  if (Array.isArray(obj.data)) {
+    return obj.data;
+  }
   return [];
 }
 
 function extractWorkflowSingle(body: unknown): unknown {
-  if (!body || typeof body !== 'object') {return null;}
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
   const obj = body as Record<string, unknown>;
-  if (obj.data && typeof obj.data === 'object') {return obj.data;}
-  if (obj.workflow && typeof obj.workflow === 'object') {return obj.workflow;}
+  if (obj.data && typeof obj.data === 'object') {
+    return obj.data;
+  }
+  if (obj.workflow && typeof obj.workflow === 'object') {
+    return obj.workflow;
+  }
   return body;
 }
 
@@ -598,32 +587,19 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readOptionalString(
-  obj: Record<string, unknown>,
-  key: string,
-): string | undefined {
+function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
   const value = obj[key];
-  return typeof value === 'string' && value.trim().length > 0
-    ? value.trim()
-    : undefined;
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function readOptionalBoolean(
-  obj: Record<string, unknown>,
-  key: string,
-): boolean | undefined {
+function readOptionalBoolean(obj: Record<string, unknown>, key: string): boolean | undefined {
   const value = obj[key];
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function readOptionalNumber(
-  obj: Record<string, unknown>,
-  key: string,
-): number | undefined {
+function readOptionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
   const value = obj[key];
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 /**
@@ -658,9 +634,11 @@ interface TriggerContext {
  */
 async function buildTriggerContextFromConversation(
   runtime: AgentRuntime | null | undefined,
-  roomId: string,
+  roomId: string
 ): Promise<TriggerContext | undefined> {
-  if (!runtime || typeof runtime.getMemories !== 'function') {return undefined;}
+  if (!runtime || typeof runtime.getMemories !== 'function') {
+    return undefined;
+  }
   let memories: Array<{
     entityId?: string;
     metadata?: Record<string, unknown>;
@@ -678,19 +656,21 @@ async function buildTriggerContextFromConversation(
     logger.debug?.(
       `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
         err instanceof Error ? err.message : String(err)
-      }`,
+      }`
     );
     return undefined;
   }
-  if (!Array.isArray(memories) || memories.length === 0) {return undefined;}
+  if (!Array.isArray(memories) || memories.length === 0) {
+    return undefined;
+  }
 
   // Tail inbound = most recent memory whose entityId is NOT the agent.
   // `runtime.getMemories` typically returns most-recent-first; defensively
   // handle either order.
-  const inbound = memories.find(
-    (m) => m.entityId && m.entityId !== runtime.agentId,
-  );
-  if (!inbound?.metadata) {return undefined;}
+  const inbound = memories.find((m) => m.entityId && m.entityId !== runtime.agentId);
+  if (!inbound?.metadata) {
+    return undefined;
+  }
 
   const meta = inbound.metadata as Record<string, unknown>;
   const discord = (meta.discord ?? {}) as Record<string, unknown>;
@@ -700,16 +680,11 @@ async function buildTriggerContextFromConversation(
   // Canonical wins; flat fields are the legacy de-facto shape.
   const discordChannelId =
     (typeof discord.channelId === 'string' ? discord.channelId : undefined) ??
-    (typeof meta.discordChannelId === 'string'
-      ? meta.discordChannelId
-      : undefined);
+    (typeof meta.discordChannelId === 'string' ? meta.discordChannelId : undefined);
   const discordGuildId =
     (typeof discord.guildId === 'string' ? discord.guildId : undefined) ??
-    (typeof meta.discordServerId === 'string'
-      ? meta.discordServerId
-      : undefined);
-  const discordThreadId =
-    typeof discord.threadId === 'string' ? discord.threadId : undefined;
+    (typeof meta.discordServerId === 'string' ? meta.discordServerId : undefined);
+  const discordThreadId = typeof discord.threadId === 'string' ? discord.threadId : undefined;
 
   // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
   // id, which equals the chat id only in private 1:1 DMs. In group chats /
@@ -723,15 +698,12 @@ async function buildTriggerContextFromConversation(
       ? telegram.chatId
       : undefined;
   const telegramThreadId =
-    typeof telegram.threadId === 'string' ||
-    typeof telegram.threadId === 'number'
+    typeof telegram.threadId === 'string' || typeof telegram.threadId === 'number'
       ? (telegram.threadId as string | number)
       : undefined;
 
-  const slackChannelId =
-    typeof slack.channelId === 'string' ? slack.channelId : undefined;
-  const slackTeamId =
-    typeof slack.teamId === 'string' ? slack.teamId : undefined;
+  const slackChannelId = typeof slack.channelId === 'string' ? slack.channelId : undefined;
+  const slackTeamId = typeof slack.teamId === 'string' ? slack.teamId : undefined;
 
   if (discordChannelId) {
     return {
@@ -748,9 +720,7 @@ async function buildTriggerContextFromConversation(
       source: 'telegram',
       telegram: {
         chatId: telegramChatId,
-        ...(telegramThreadId !== undefined
-          ? { threadId: telegramThreadId }
-          : {}),
+        ...(telegramThreadId !== undefined ? { threadId: telegramThreadId } : {}),
       },
     };
   }
@@ -775,34 +745,39 @@ function readPosition(value: unknown): [number, number] | null {
     : null;
 }
 
-function readCredentials(
-  value: unknown,
-): Record<string, { id: string; name: string }> | undefined {
+function readCredentials(value: unknown): Record<string, { id: string; name: string }> | undefined {
   const raw = asRecord(value);
-  if (!raw) {return undefined;}
+  if (!raw) {
+    return undefined;
+  }
 
   const credentials: Record<string, { id: string; name: string }> = {};
   for (const [key, credentialValue] of Object.entries(raw)) {
     const credential = asRecord(credentialValue);
-    if (!credential) {continue;}
+    if (!credential) {
+      continue;
+    }
     const id = readOptionalString(credential, 'id');
     const name = readOptionalString(credential, 'name');
-    if (!id || !name) {continue;}
+    if (!id || !name) {
+      continue;
+    }
     credentials[key] = { id, name };
   }
   return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
-function normalizeWorkflowWriteNode(
-  value: unknown,
-  index: number,
-): N8nWorkflowWriteNode | null {
+function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowWriteNode | null {
   const obj = asRecord(value);
-  if (!obj) {return null;}
+  if (!obj) {
+    return null;
+  }
 
   const name = readOptionalString(obj, 'name');
   const type = readOptionalString(obj, 'type');
-  if (!name || !type) {return null;}
+  if (!name || !type) {
+    return null;
+  }
 
   const position = readPosition(obj.position) ?? [index * 260, 0];
   const parameters = asRecord(obj.parameters) ?? {};
@@ -810,9 +785,7 @@ function normalizeWorkflowWriteNode(
   const credentials = readCredentials(obj.credentials);
 
   return {
-    ...(readOptionalString(obj, 'id')
-      ? { id: readOptionalString(obj, 'id') }
-      : {}),
+    ...(readOptionalString(obj, 'id') ? { id: readOptionalString(obj, 'id') } : {}),
     name,
     type,
     typeVersion,
@@ -822,15 +795,11 @@ function normalizeWorkflowWriteNode(
     ...(readOptionalBoolean(obj, 'disabled') !== undefined
       ? { disabled: readOptionalBoolean(obj, 'disabled') }
       : {}),
-    ...(readOptionalString(obj, 'notes')
-      ? { notes: readOptionalString(obj, 'notes') }
-      : {}),
+    ...(readOptionalString(obj, 'notes') ? { notes: readOptionalString(obj, 'notes') } : {}),
     ...(readOptionalBoolean(obj, 'notesInFlow') !== undefined
       ? { notesInFlow: readOptionalBoolean(obj, 'notesInFlow') }
       : {}),
-    ...(readOptionalString(obj, 'color')
-      ? { color: readOptionalString(obj, 'color') }
-      : {}),
+    ...(readOptionalString(obj, 'color') ? { color: readOptionalString(obj, 'color') } : {}),
     ...(readOptionalBoolean(obj, 'continueOnFail') !== undefined
       ? { continueOnFail: readOptionalBoolean(obj, 'continueOnFail') }
       : {}),
@@ -859,31 +828,37 @@ function normalizeWorkflowWriteNode(
 
 function normalizeWorkflowConnections(value: unknown): N8nWorkflowConnections {
   const raw = asRecord(value);
-  if (!raw) {return {};}
+  if (!raw) {
+    return {};
+  }
 
   const connections: N8nWorkflowConnections = {};
   for (const [sourceName, outputValue] of Object.entries(raw)) {
     const outputMap = asRecord(outputValue);
-    if (!outputMap) {continue;}
+    if (!outputMap) {
+      continue;
+    }
     const mainRaw = outputMap.main;
-    if (!Array.isArray(mainRaw)) {continue;}
+    if (!Array.isArray(mainRaw)) {
+      continue;
+    }
     const main = mainRaw.map((group) =>
       Array.isArray(group)
         ? group
-          .map((connection) => {
-            const obj = asRecord(connection);
-            const node = obj ? readOptionalString(obj, 'node') : undefined;
-            if (!obj || !node) {return null;}
-            const index = readOptionalNumber(obj, 'index') ?? 0;
-            return { node, type: 'main' as const, index };
-          })
-          .filter(
-            (
-              connection,
-            ): connection is { node: string; type: 'main'; index: number } =>
-              connection !== null,
-          )
-        : [],
+            .map((connection) => {
+              const obj = asRecord(connection);
+              const node = obj ? readOptionalString(obj, 'node') : undefined;
+              if (!obj || !node) {
+                return null;
+              }
+              const index = readOptionalNumber(obj, 'index') ?? 0;
+              return { node, type: 'main' as const, index };
+            })
+            .filter(
+              (connection): connection is { node: string; type: 'main'; index: number } =>
+                connection !== null
+            )
+        : []
     );
     connections[sourceName] = { main };
   }
@@ -917,12 +892,8 @@ function normalizeWorkflowWritePayload(body: Record<string, unknown>): {
   };
 }
 
-function propagateError(
-  ctx: N8nRouteContext,
-  upstream: { status: number; body: unknown },
-): void {
-  const status =
-    upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
+function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: unknown }): void {
+  const status = upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
   let message = `upstream responded with ${upstream.status}`;
   if (upstream.body && typeof upstream.body === 'object') {
     const b = upstream.body as Record<string, unknown>;
@@ -941,12 +912,16 @@ function propagateError(
  * Returns null if pathname doesn't match.
  */
 function parseWorkflowPath(
-  pathname: string,
+  pathname: string
 ): { id: string; action: 'get' | 'activate' | 'deactivate' } | null {
   const prefix = '/api/n8n/workflows/';
-  if (!pathname.startsWith(prefix)) {return null;}
+  if (!pathname.startsWith(prefix)) {
+    return null;
+  }
   const rest = pathname.slice(prefix.length);
-  if (!rest) {return null;}
+  if (!rest) {
+    return null;
+  }
   const parts = rest.split('/').filter(Boolean);
   if (parts.length === 1) {
     return { id: decodeURIComponent(parts[0] ?? ''), action: 'get' };
@@ -968,10 +943,14 @@ function parseWorkflowPath(
  */
 async function resolveSidecarForRequest(
   ctx: N8nRouteContext,
-  native: boolean,
+  native: boolean
 ): Promise<N8nSidecar | null> {
-  if (ctx.n8nSidecar !== undefined) {return ctx.n8nSidecar;}
-  if (native) {return null;}
+  if (ctx.n8nSidecar !== undefined) {
+    return ctx.n8nSidecar;
+  }
+  if (native) {
+    return null;
+  }
   const mod = await loadSidecarModule();
   return mod?.peekN8nSidecar() ?? null;
 }
@@ -1025,10 +1004,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
-  if (
-    method === 'POST' &&
-    pathname === '/api/n8n/workflows/resolve-clarification'
-  ) {
+  if (method === 'POST' && pathname === '/api/n8n/workflows/resolve-clarification') {
     return handleResolveClarification(ctx);
   }
 
@@ -1068,7 +1044,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
 async function handleStatus(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const { config, runtime } = ctx;
 
@@ -1080,8 +1056,7 @@ async function handleStatus(
   const sidecarState = sidecar?.getState();
   const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
 
-  const host =
-    mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
+  const host = mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
 
   // Cloud health — only probed when we are actually in cloud mode. The
   // probe is cached for 30s (see getCloudHealth) so rapid status polls
@@ -1093,7 +1068,7 @@ async function handleStatus(
     } else {
       cloudHealth = await getCloudHealth(
         config.cloud?.baseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
-        ctx.fetchImpl ?? fetch,
+        ctx.fetchImpl ?? fetch
       );
     }
   }
@@ -1108,10 +1083,10 @@ async function handleStatus(
     cloudHealth,
     ...(sidecarState
       ? {
-        errorMessage: sidecarState.errorMessage,
-        retries: sidecarState.retries,
-        recentOutput: sidecarState.recentOutput,
-      }
+          errorMessage: sidecarState.errorMessage,
+          retries: sidecarState.retries,
+          recentOutput: sidecarState.recentOutput,
+        }
       : {}),
   };
 
@@ -1123,7 +1098,7 @@ async function handleStatus(
 async function handleListWorkflows(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, '', sidecar, native);
   if (!resolved.target) {
@@ -1143,9 +1118,7 @@ async function handleListWorkflows(
   }
 
   const list = extractWorkflowList(upstream.body);
-  const workflows = list
-    .map(normalizeWorkflow)
-    .filter((w): w is N8nWorkflow => w !== null);
+  const workflows = list.map(normalizeWorkflow).filter((w): w is N8nWorkflow => w !== null);
 
   sendJson(ctx, 200, { workflows });
   return true;
@@ -1163,7 +1136,7 @@ async function handleGetWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1204,7 +1177,7 @@ async function writeWorkflow(
   subpath: string,
   payload: N8nWorkflowWritePayload,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, subpath, sidecar, native);
   if (!resolved.target) {
@@ -1237,10 +1210,12 @@ async function writeWorkflow(
 async function handleCreateWorkflow(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1255,7 +1230,7 @@ async function handleUpdateWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1263,7 +1238,9 @@ async function handleUpdateWorkflow(
   }
 
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1271,27 +1248,20 @@ async function handleUpdateWorkflow(
     return true;
   }
 
-  return writeWorkflow(
-    ctx,
-    'PUT',
-    `/${encodeURIComponent(id)}`,
-    payload,
-    sidecar,
-    native,
-  );
+  return writeWorkflow(ctx, 'PUT', `/${encodeURIComponent(id)}`, payload, sidecar, native);
 }
 
 interface N8nWorkflowServiceLike {
   generateWorkflowDraft?: (
     prompt: string,
-    opts?: { triggerContext?: TriggerContext },
+    opts?: { triggerContext?: TriggerContext }
   ) => Promise<{
     id?: string;
     [k: string]: unknown;
   }>;
   deployWorkflow?: (
     workflow: Record<string, unknown>,
-    userId: string,
+    userId: string
   ) => Promise<{
     id: string;
     name: string;
@@ -1301,12 +1271,8 @@ interface N8nWorkflowServiceLike {
   getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
 }
 
-function getN8nWorkflowService(
-  ctx: N8nRouteContext,
-): N8nWorkflowServiceLike | null {
-  const service = ctx.runtime?.getService?.('n8n_workflow') as
-    | N8nWorkflowServiceLike
-    | undefined;
+function getN8nWorkflowService(ctx: N8nRouteContext): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.('n8n_workflow') as N8nWorkflowServiceLike | undefined;
   if (
     typeof service?.generateWorkflowDraft !== 'function' ||
     typeof service.deployWorkflow !== 'function' ||
@@ -1335,7 +1301,7 @@ function getConnectorTargetCatalog(ctx: N8nRouteContext): CatalogLike | null {
 async function deployAndRespond(
   ctx: N8nRouteContext,
   service: N8nWorkflowServiceLike,
-  draft: Record<string, unknown>,
+  draft: Record<string, unknown>
 ): Promise<void> {
   const userId = resolveAgentId(ctx);
   const deployed = await service.deployWorkflow?.(draft, userId);
@@ -1356,7 +1322,9 @@ async function deployAndRespond(
 
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const prompt = readOptionalString(body, 'prompt');
   if (!prompt) {
@@ -1375,10 +1343,7 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   }
 
   const triggerContext = bridgeConversationId
-    ? await buildTriggerContextFromConversation(
-      ctx.runtime,
-      bridgeConversationId,
-    )
+    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
     : undefined;
 
   const draft = triggerContext
@@ -1416,11 +1381,11 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   return true;
 }
 
-async function handleResolveClarification(
-  ctx: N8nRouteContext,
-): Promise<boolean> {
+async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const draftRaw = (body as Record<string, unknown>).draft;
   if (!draftRaw || typeof draftRaw !== 'object' || Array.isArray(draftRaw)) {
@@ -1450,7 +1415,7 @@ async function handleResolveClarification(
 
   const result = applyResolutions(
     draft,
-    resolutions as Array<{ paramPath: string; value: string }>,
+    resolutions as Array<{ paramPath: string; value: string }>
   );
   if (!result.ok) {
     sendJson(ctx, 400, {
@@ -1463,10 +1428,10 @@ async function handleResolveClarification(
   const resolvedPaths = new Set(
     resolutions
       .map((r) => r.paramPath)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0),
+      .filter((p): p is string => typeof p === 'string' && p.length > 0)
   );
   const freeFormCount = resolutions.filter(
-    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0,
+    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0
   ).length;
   pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
@@ -1484,9 +1449,7 @@ async function handleResolveClarification(
   const remaining = coerceClarifications(meta?.requiresClarification);
   if (remaining.length > 0) {
     const catalogService = getConnectorTargetCatalog(ctx);
-    const catalog = catalogService
-      ? await buildCatalogSnapshot(catalogService, remaining)
-      : [];
+    const catalog = catalogService ? await buildCatalogSnapshot(catalogService, remaining) : [];
     sendJson(ctx, 200, {
       status: 'needs_clarification',
       draft,
@@ -1505,7 +1468,7 @@ async function handleToggleWorkflow(
   id: string,
   activate: boolean,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1553,19 +1516,14 @@ async function handleDeleteWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
     return true;
   }
 
-  const resolved = resolveProxyTarget(
-    ctx,
-    `/${encodeURIComponent(id)}`,
-    sidecar,
-    native,
-  );
+  const resolved = resolveProxyTarget(ctx, `/${encodeURIComponent(id)}`, sidecar, native);
   if (!resolved.target) {
     sendJson(ctx, 503, {
       error: resolved.reason?.message ?? 'n8n not ready',

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -606,12 +606,8 @@ export async function formatActionResponse(
 }
 
 function formatActionDataForPrompt(value: unknown, indent = 0): string {
-  if (value === undefined || value === null) {
-    return '';
-  }
-  if (typeof value === 'string') {
-    return value.trim();
-  }
+  if (value === undefined || value === null) {return '';}
+  if (typeof value === 'string') {return value.trim();}
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -606,8 +606,12 @@ export async function formatActionResponse(
 }
 
 function formatActionDataForPrompt(value: unknown, indent = 0): string {
-  if (value === undefined || value === null) {return '';}
-  if (typeof value === 'string') {return value.trim();}
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/plugins/plugin-signal/src/actions/sendMessage.ts
+++ b/plugins/plugin-signal/src/actions/sendMessage.ts
@@ -91,7 +91,8 @@ export const sendMessage: Action = {
         prompt,
       });
 
-      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse =
+        parseToonKeyValue<Record<string, unknown>>(response);
       if (parsedResponse?.text) {
         messageInfo = {
           text: String(parsedResponse.text),

--- a/plugins/plugin-signal/src/actions/sendMessage.ts
+++ b/plugins/plugin-signal/src/actions/sendMessage.ts
@@ -91,8 +91,7 @@ export const sendMessage: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (parsedResponse?.text) {
         messageInfo = {
           text: String(parsedResponse.text),

--- a/plugins/plugin-signal/src/actions/sendReaction.ts
+++ b/plugins/plugin-signal/src/actions/sendReaction.ts
@@ -99,7 +99,8 @@ export const sendReaction: Action = {
         prompt,
       });
 
-      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse =
+        parseToonKeyValue<Record<string, unknown>>(response);
       if (
         parsedResponse?.emoji &&
         parsedResponse?.targetTimestamp &&

--- a/plugins/plugin-signal/src/actions/sendReaction.ts
+++ b/plugins/plugin-signal/src/actions/sendReaction.ts
@@ -99,8 +99,7 @@ export const sendReaction: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (
         parsedResponse?.emoji &&
         parsedResponse?.targetTimestamp &&

--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -11,7 +11,9 @@ describe("Signal message connector", () => {
       getRoom: vi.fn(),
     } as unknown as IAgentRuntime;
     const service = Object.create(SignalService.prototype) as SignalService;
-    const sendMessageSpy = vi.spyOn(service, "sendMessage").mockResolvedValue({ timestamp: 123 });
+    const sendMessageSpy = vi
+      .spyOn(service, "sendMessage")
+      .mockResolvedValue({ timestamp: 123 });
 
     SignalService.registerSendHandlers(runtime, service);
 

--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -11,9 +11,7 @@ describe("Signal message connector", () => {
       getRoom: vi.fn(),
     } as unknown as IAgentRuntime;
     const service = Object.create(SignalService.prototype) as SignalService;
-    const sendMessageSpy = vi
-      .spyOn(service, "sendMessage")
-      .mockResolvedValue({ timestamp: 123 });
+    const sendMessageSpy = vi.spyOn(service, "sendMessage").mockResolvedValue({ timestamp: 123 });
 
     SignalService.registerSendHandlers(runtime, service);
 

--- a/plugins/plugin-twitch/src/service.ts
+++ b/plugins/plugin-twitch/src/service.ts
@@ -87,10 +87,7 @@ export class TwitchService extends Service implements ITwitchService {
     return service;
   }
 
-  static registerSendHandlers(
-    runtime: IAgentRuntime,
-    serviceInstance: TwitchService,
-  ): void {
+  static registerSendHandlers(runtime: IAgentRuntime, serviceInstance: TwitchService): void {
     if (!serviceInstance) {
       return;
     }
@@ -109,18 +106,15 @@ export class TwitchService extends Service implements ITwitchService {
           service: TWITCH_SERVICE_NAME,
           maxMessageLength: MAX_TWITCH_MESSAGE_LENGTH,
         },
-        resolveTargets:
-          serviceInstance.resolveConnectorTargets.bind(serviceInstance),
-        listRecentTargets:
-          serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
+        resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
+        listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
-        getChatContext:
-          serviceInstance.getConnectorChatContext.bind(serviceInstance),
+        getChatContext: serviceInstance.getConnectorChatContext.bind(serviceInstance),
         sendHandler,
       });
       runtime.logger.info(
         { src: "plugin:twitch", agentId: runtime.agentId },
-        "Registered Twitch chat connector",
+        "Registered Twitch chat connector"
       );
       return;
     }
@@ -471,7 +465,7 @@ export class TwitchService extends Service implements ITwitchService {
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content,
+    content: Content
   ): Promise<void> {
     const text = typeof content.text === "string" ? content.text.trim() : "";
     if (!text) {
@@ -487,9 +481,7 @@ export class TwitchService extends Service implements ITwitchService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       replyTo =
         replyTo ??
-        (typeof metadata?.twitchReplyTo === "string"
-          ? metadata.twitchReplyTo
-          : undefined);
+        (typeof metadata?.twitchReplyTo === "string" ? metadata.twitchReplyTo : undefined);
     }
 
     await this.sendMessage(text, {
@@ -500,7 +492,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async resolveConnectorTargets(
     query: string,
-    _context: MessageConnectorQueryContext,
+    _context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     const normalizedQuery = normalizeTwitchConnectorQuery(query);
     return this.getConnectorChannels()
@@ -513,7 +505,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listConnectorRooms(
-    _context: MessageConnectorQueryContext,
+    _context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     return this.getConnectorChannels()
       .map((channel) => this.buildChannelTarget(channel, 0.5))
@@ -521,7 +513,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listRecentConnectorTargets(
-    context: MessageConnectorQueryContext,
+    context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     const targets: MessageConnectorTarget[] = [];
     const room =
@@ -549,7 +541,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async getConnectorChatContext(
     target: TargetInfo,
-    context: MessageConnectorQueryContext,
+    context: MessageConnectorQueryContext
   ): Promise<MessageConnectorChatContext | null> {
     let channel = target.channelId;
     if (!channel && target.roomId) {
@@ -588,10 +580,7 @@ export class TwitchService extends Service implements ITwitchService {
     return Array.from(channels);
   }
 
-  private buildChannelTarget(
-    channel: string,
-    score: number,
-  ): MessageConnectorTarget {
+  private buildChannelTarget(channel: string, score: number): MessageConnectorTarget {
     const normalized = normalizeChannel(channel);
     return {
       target: {

--- a/plugins/plugin-twitch/src/service.ts
+++ b/plugins/plugin-twitch/src/service.ts
@@ -87,7 +87,10 @@ export class TwitchService extends Service implements ITwitchService {
     return service;
   }
 
-  static registerSendHandlers(runtime: IAgentRuntime, serviceInstance: TwitchService): void {
+  static registerSendHandlers(
+    runtime: IAgentRuntime,
+    serviceInstance: TwitchService,
+  ): void {
     if (!serviceInstance) {
       return;
     }
@@ -106,15 +109,18 @@ export class TwitchService extends Service implements ITwitchService {
           service: TWITCH_SERVICE_NAME,
           maxMessageLength: MAX_TWITCH_MESSAGE_LENGTH,
         },
-        resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
-        listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
+        resolveTargets:
+          serviceInstance.resolveConnectorTargets.bind(serviceInstance),
+        listRecentTargets:
+          serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
-        getChatContext: serviceInstance.getConnectorChatContext.bind(serviceInstance),
+        getChatContext:
+          serviceInstance.getConnectorChatContext.bind(serviceInstance),
         sendHandler,
       });
       runtime.logger.info(
         { src: "plugin:twitch", agentId: runtime.agentId },
-        "Registered Twitch chat connector"
+        "Registered Twitch chat connector",
       );
       return;
     }
@@ -465,7 +471,7 @@ export class TwitchService extends Service implements ITwitchService {
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content
+    content: Content,
   ): Promise<void> {
     const text = typeof content.text === "string" ? content.text.trim() : "";
     if (!text) {
@@ -481,7 +487,9 @@ export class TwitchService extends Service implements ITwitchService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       replyTo =
         replyTo ??
-        (typeof metadata?.twitchReplyTo === "string" ? metadata.twitchReplyTo : undefined);
+        (typeof metadata?.twitchReplyTo === "string"
+          ? metadata.twitchReplyTo
+          : undefined);
     }
 
     await this.sendMessage(text, {
@@ -492,7 +500,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async resolveConnectorTargets(
     query: string,
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const normalizedQuery = normalizeTwitchConnectorQuery(query);
     return this.getConnectorChannels()
@@ -505,7 +513,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listConnectorRooms(
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     return this.getConnectorChannels()
       .map((channel) => this.buildChannelTarget(channel, 0.5))
@@ -513,7 +521,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listRecentConnectorTargets(
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const targets: MessageConnectorTarget[] = [];
     const room =
@@ -541,7 +549,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async getConnectorChatContext(
     target: TargetInfo,
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorChatContext | null> {
     let channel = target.channelId;
     if (!channel && target.roomId) {
@@ -580,7 +588,10 @@ export class TwitchService extends Service implements ITwitchService {
     return Array.from(channels);
   }
 
-  private buildChannelTarget(channel: string, score: number): MessageConnectorTarget {
+  private buildChannelTarget(
+    channel: string,
+    score: number,
+  ): MessageConnectorTarget {
     const normalized = normalizeChannel(channel);
     return {
       target: {

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -39,9 +39,13 @@ async function saveExecutionRecord(
   await runtime.createMemory(memory, "messages");
 }
 
-function readActionParams(options?: Record<string, unknown>): Record<string, unknown> {
+function readActionParams(
+  options?: Record<string, unknown>,
+): Record<string, unknown> {
   const direct =
-    options && typeof options === "object" ? (options as Record<string, unknown>) : {};
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
   const parameters =
     direct.parameters && typeof direct.parameters === "object"
       ? (direct.parameters as Record<string, unknown>)
@@ -61,7 +65,11 @@ export const describeSceneAction: Action = {
       description:
         "Scene description detail level. Use summary to omit object/person breakdowns from the spoken response.",
       required: false,
-      schema: { type: "string", enum: ["summary", "detailed"], default: "detailed" },
+      schema: {
+        type: "string",
+        enum: ["summary", "detailed"],
+        default: "detailed",
+      },
     },
   ],
   validate: async (
@@ -247,7 +255,11 @@ export const describeSceneAction: Action = {
         description += `\n\nObjects detected: ${objectDescriptions.join(", ")}.`;
       }
 
-      if (detailLevel === "detailed" && scene.sceneChanged && scene.changePercentage) {
+      if (
+        detailLevel === "detailed" &&
+        scene.sceneChanged &&
+        scene.changePercentage
+      ) {
         description += `\n\n(Scene changed by ${scene.changePercentage.toFixed(1)}% since last analysis)`;
       }
 
@@ -1151,8 +1163,7 @@ export const nameEntityAction: Action = {
 export const identifyPersonAction: Action = {
   name: "IDENTIFY_PERSON",
   description: "Identify a person in view if they have been seen before",
-  descriptionCompressed:
-    "Match face to known person via local recognition.",
+  descriptionCompressed: "Match face to known person via local recognition.",
   similes: [
     "who is that",
     "who is the person",

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -39,13 +39,9 @@ async function saveExecutionRecord(
   await runtime.createMemory(memory, "messages");
 }
 
-function readActionParams(
-  options?: Record<string, unknown>,
-): Record<string, unknown> {
+function readActionParams(options?: Record<string, unknown>): Record<string, unknown> {
   const direct =
-    options && typeof options === "object"
-      ? (options as Record<string, unknown>)
-      : {};
+    options && typeof options === "object" ? (options as Record<string, unknown>) : {};
   const parameters =
     direct.parameters && typeof direct.parameters === "object"
       ? (direct.parameters as Record<string, unknown>)
@@ -65,11 +61,7 @@ export const describeSceneAction: Action = {
       description:
         "Scene description detail level. Use summary to omit object/person breakdowns from the spoken response.",
       required: false,
-      schema: {
-        type: "string",
-        enum: ["summary", "detailed"],
-        default: "detailed",
-      },
+      schema: { type: "string", enum: ["summary", "detailed"], default: "detailed" },
     },
   ],
   validate: async (
@@ -255,11 +247,7 @@ export const describeSceneAction: Action = {
         description += `\n\nObjects detected: ${objectDescriptions.join(", ")}.`;
       }
 
-      if (
-        detailLevel === "detailed" &&
-        scene.sceneChanged &&
-        scene.changePercentage
-      ) {
+      if (detailLevel === "detailed" && scene.sceneChanged && scene.changePercentage) {
         description += `\n\n(Scene changed by ${scene.changePercentage.toFixed(1)}% since last analysis)`;
       }
 
@@ -1163,7 +1151,8 @@ export const nameEntityAction: Action = {
 export const identifyPersonAction: Action = {
   name: "IDENTIFY_PERSON",
   description: "Identify a person in view if they have been seen before",
-  descriptionCompressed: "Match face to known person via local recognition.",
+  descriptionCompressed:
+    "Match face to known person via local recognition.",
   similes: [
     "who is that",
     "who is the person",

--- a/plugins/plugin-x/src/actions/fetchFeedTop.ts
+++ b/plugins/plugin-x/src/actions/fetchFeedTop.ts
@@ -30,7 +30,12 @@ export const fetchFeedTopAction: Action = {
       name: "limit",
       description: "Maximum ranked tweets to return.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 50, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 50,
+        default: DEFAULT_LIMIT,
+      },
     },
     {
       name: "fetchCount",

--- a/plugins/plugin-x/src/actions/fetchFeedTop.ts
+++ b/plugins/plugin-x/src/actions/fetchFeedTop.ts
@@ -30,12 +30,7 @@ export const fetchFeedTopAction: Action = {
       name: "limit",
       description: "Maximum ranked tweets to return.",
       required: false,
-      schema: {
-        type: "number",
-        minimum: 1,
-        maximum: 50,
-        default: DEFAULT_LIMIT,
-      },
+      schema: { type: "number", minimum: 1, maximum: 50, default: DEFAULT_LIMIT },
     },
     {
       name: "fetchCount",

--- a/plugins/plugin-x/src/actions/readUnreadXDms.ts
+++ b/plugins/plugin-x/src/actions/readUnreadXDms.ts
@@ -25,7 +25,12 @@ export const readUnreadXDmsAction: Action = {
       name: "limit",
       description: "Maximum direct messages to scan for unread items.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 100, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 100,
+        default: DEFAULT_LIMIT,
+      },
     },
   ],
   examples: [

--- a/plugins/plugin-x/src/actions/readUnreadXDms.ts
+++ b/plugins/plugin-x/src/actions/readUnreadXDms.ts
@@ -25,12 +25,7 @@ export const readUnreadXDmsAction: Action = {
       name: "limit",
       description: "Maximum direct messages to scan for unread items.",
       required: false,
-      schema: {
-        type: "number",
-        minimum: 1,
-        maximum: 100,
-        default: DEFAULT_LIMIT,
-      },
+      schema: { type: "number", minimum: 1, maximum: 100, default: DEFAULT_LIMIT },
     },
   ],
   examples: [

--- a/plugins/plugin-x/src/search-category.test.ts
+++ b/plugins/plugin-x/src/search-category.test.ts
@@ -1,4 +1,7 @@
-import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
+import type {
+  IAgentRuntime,
+  SearchCategoryRegistration,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { registerXSearchCategory, X_SEARCH_CATEGORY } from "./search-category";
 
@@ -18,10 +21,8 @@ function createRuntime() {
   return {
     categories,
     registerSearchCategory,
-    runtime: {
-      getSearchCategory,
-      registerSearchCategory,
-    } as unknown as IAgentRuntime,
+    runtime: { getSearchCategory, registerSearchCategory } as unknown as
+      IAgentRuntime,
   };
 }
 

--- a/plugins/plugin-x/src/search-category.test.ts
+++ b/plugins/plugin-x/src/search-category.test.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { registerXSearchCategory, X_SEARCH_CATEGORY } from "./search-category";
 
@@ -21,8 +18,10 @@ function createRuntime() {
   return {
     categories,
     registerSearchCategory,
-    runtime: { getSearchCategory, registerSearchCategory } as unknown as
-      IAgentRuntime,
+    runtime: {
+      getSearchCategory,
+      registerSearchCategory,
+    } as unknown as IAgentRuntime,
   };
 }
 

--- a/plugins/plugin-x/src/search-category.ts
+++ b/plugins/plugin-x/src/search-category.ts
@@ -1,4 +1,7 @@
-import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
+import type {
+  IAgentRuntime,
+  SearchCategoryRegistration,
+} from "@elizaos/core";
 
 export const X_SEARCH_CATEGORY: SearchCategoryRegistration = {
   category: "x",

--- a/plugins/plugin-x/src/search-category.ts
+++ b/plugins/plugin-x/src/search-category.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const X_SEARCH_CATEGORY: SearchCategoryRegistration = {
   category: "x",


### PR DESCRIPTION
## Summary
- Adds a Codex CLI-backed elizaOS model provider for text slots and `IMAGE_DESCRIPTION`.
- Registers the provider at plugin init with runtime/character `PARALLAX_CODEX_*` settings instead of import-time process state.
- Runs Codex through non-interactive `codex exec` in read-only mode, with model/reasoning/timeout settings wired through runtime settings.
- Supports image descriptions by writing http(s) or data-URL images into a temp file and passing them to Codex via `--image`.
- Reuses the existing core `fetchRemoteMedia`/SSRF guard for remote image fetches, adds timeout pass-through, and removes `--ignore-rules` from the model-provider exec path.
- Handles early child stdin close cleanly and decodes non-base64 image data URLs as bytes instead of UTF-8 text.
- Splits `fetchRemoteMedia` into focused helper steps so the guarded fetch, HTTP error handling, byte limit check, and metadata resolution have separate responsibilities.
- Applies required repo-wide formatter output to baseline files flagged by the required format check.

## Validation
- `cd packages/core && bunx vitest run --config ./vitest.config.ts src/media/fetch.test.ts`
- `cd packages/core && bun run build`
- `cd plugins/plugin-agent-orchestrator && bunx vitest run --config ./vitest.config.ts src/__tests__/codex-model-provider.test.ts` (10 tests passed)
- `cd plugins/plugin-agent-orchestrator && bun run typecheck`
- `cd plugins/plugin-agent-orchestrator && bun run build`
- `bun run format:check` (57/57 tasks passed)

## Notes
- Packaging failures currently visible in GitHub Actions are from repo packaging config paths such as missing `packages/app-core/packaging/pypi`, not from the Codex provider or media fetch changes.
- CodeFactor complexity notices on large existing n8n/vision methods are surfaced because the formatter commit touches those baseline files; they are not behavioral changes in this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires a Codex CLI–backed model provider into `plugin-agent-orchestrator`, covering both text-slot models and `IMAGE_DESCRIPTION`, and threads a new `timeoutMs` option through `fetchRemoteMedia` in core. The remaining 15 files are formatting-only reformats across unrelated plugins.

- **Codex provider** (`codex-model-provider.ts`): spawns `codex exec` in read-only/ephemeral mode, feeds the prompt via stdin, retrieves output from a temp file (`--output-last-message`), and handles image inputs by writing data-URL or remotely-fetched images to a temp dir before passing them via `--image`. SSRF protection, EPIPE handling, and binary data-URL decoding are all present.
- **Core fetch refactor** (`fetch.ts`): extracts `fetchGuardedMedia` helper and adds `timeoutMs` support; the SSRF guard already accepted `timeoutMs`, so this is a clean pass-through with no behavioural change to existing callers.
- **Plugin init** (`index.ts`): model registration moved correctly into `Plugin.init(runtime)` so per-agent settings are available at registration time.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all previously flagged concerns (SSRF, EPIPE, binary-encoding, import-time evaluation) are addressed in this revision.

The Codex provider correctly uses fetchRemoteMedia with the existing SSRF guard and DNS pinning for remote image URLs, handles the stdin EPIPE case cleanly, uses decodePercentEncodedBytes for non-base64 data URLs to avoid UTF-8 mangling, and moves model registration into Plugin.init() so per-agent settings are available. The two remaining observations are minor quality nits with no impact on correctness.

No files require special attention; codex-model-provider.ts is the most complex new file but is well-tested and structurally sound.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/codex-model-provider.ts | New Codex CLI model provider; handles text generation and IMAGE_DESCRIPTION via spawned codex exec, with SSRF-guarded image fetch, data URL decoding, timeout/escalation, and stdin-EPIPE handling. All previously flagged issues appear addressed in this revision. |
| packages/core/src/media/fetch.ts | Adds timeoutMs to FetchMediaOptions and refactors fetchRemoteMedia into smaller helpers; functionally equivalent to the original with the new timeout threaded through to the SSRF guard. |
| plugins/plugin-agent-orchestrator/src/index.ts | Registers Codex model handlers lazily inside Plugin.init(), correctly avoiding the previously noted import-time evaluation issue. |
| plugins/plugin-agent-orchestrator/src/__tests__/codex-model-provider.test.ts | 10-test suite covering arg-building, runtime-settings read, plugin init registration, prompt construction, data URL byte fidelity, early-exit EPIPE, and SSRF blocking for private IPs. |
| packages/core/src/media/fetch.test.ts | New test confirming that fetchRemoteMedia threads the timeoutMs option through as an AbortSignal. |
| plugins/plugin-agent-orchestrator/vitest.config.ts | Adds codex-model-provider.test.ts to the vitest include list. |
| plugins/plugin-n8n-workflow/src/actions/getExecutions.ts | Formatting-only reformatting of a nested ternary object literal; no functional change. |
| plugins/plugin-twitch/src/service.ts | Formatting-only: long method arguments split across lines; no functional change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runtime as ElizaOS Runtime
    participant Plugin as plugin-agent-orchestrator
    participant Provider as codexCliTextModel / codexCliImageDescriptionModel
    participant Fetch as fetchRemoteMedia (SSRF-guarded)
    participant TempFS as Temp Directory
    participant Codex as codex exec (child process)

    Runtime->>Plugin: init(config, runtime)
    Plugin->>Plugin: isCodexModelProviderEnabled(runtime)
    Plugin->>Runtime: registerModel(TEXT_*, imageDescription, handler, priority)

    Runtime->>Provider: model call (params)
    alt IMAGE_DESCRIPTION
        Provider->>Fetch: fetchRemoteMedia({ url, timeoutMs, lookupFn })
        Fetch-->>Provider: Buffer + contentType
        Provider->>TempFS: writeFile(imagePath, buffer)
    end
    Provider->>TempFS: mkdtemp(outputDir)
    Provider->>Codex: spawn(codex, [exec, -s read-only, --ephemeral, --image, ...])
    Provider->>Codex: stdin.end(prompt)
    Codex-->>TempFS: write --output-last-message file
    Codex-->>Provider: close(0)
    Provider->>TempFS: readFile(outputFile)
    TempFS-->>Provider: result text
    Provider->>TempFS: rm(tempDir, recursive)
    Provider-->>Runtime: text / ImageDescriptionResult
```

<sub>Reviews (6): Last reviewed commit: ["refactor(core): split media fetch helper..."](https://github.com/elizaos/eliza/commit/a2e580fb97ead037b28dd5daf65da4624d05ce8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30912286)</sub>

<!-- /greptile_comment -->