### PR TITLE
feat(orchestrator): port codex app-build workflow

### DIFF
--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -33,7 +33,6 @@ const {
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
-    getCloudCompatAgentStatus: vi.fn(),
     getRestAuthToken: vi.fn(() => null),
     switchProvider: vi.fn(),
     setBaseUrl: vi.fn(),
@@ -324,14 +323,6 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
         state: "completed",
         created_on: "2026-01-01T00:00:00.000Z",
         completed_on: "2026-01-01T00:00:02.000Z",
-      },
-    });
-    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
-      success: true,
-      data: {
-        status: "running",
-        bridgeUrl: "https://agent-1.elizacloud.ai",
-        webUiUrl: null,
       },
     });
     clientMock.switchProvider.mockResolvedValue({

--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -33,6 +33,7 @@ const {
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
+    getCloudCompatAgentStatus: vi.fn(),
     getRestAuthToken: vi.fn(() => null),
     switchProvider: vi.fn(),
     setBaseUrl: vi.fn(),
@@ -323,6 +324,14 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
         state: "completed",
         created_on: "2026-01-01T00:00:00.000Z",
         completed_on: "2026-01-01T00:00:02.000Z",
+      },
+    });
+    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
+      success: true,
+      data: {
+        status: "running",
+        bridgeUrl: "https://agent-1.elizacloud.ai",
+        webUiUrl: null,
       },
     });
     clientMock.switchProvider.mockResolvedValue({

--- a/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
+++ b/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
@@ -1,0 +1,85 @@
+"use strict";
+
+const adapters = require("coding-agent-adapters");
+
+const CODEX_APPROVAL_FLAGS = {
+  readonly: ["-s", "read-only"],
+  standard: ["-s", "workspace-write"],
+  permissive: ["-s", "workspace-write"],
+  autonomous: ["--yolo"],
+};
+
+const CODEX_TASK_AGENT_REASONING_EFFORT = "xhigh";
+
+function patchCodexAdapter(adapter) {
+  if (!adapter || adapter.adapterType !== "codex") {
+    return adapter;
+  }
+
+  const originalGetArgs = adapter.getArgs.bind(adapter);
+  adapter.getArgs = (config = {}) => {
+    const adapterConfig = config.adapterConfig ?? {};
+    const initialPrompt =
+      typeof adapterConfig.initialPrompt === "string"
+        ? adapterConfig.initialPrompt.trim()
+        : "";
+    if (!initialPrompt) {
+      return originalGetArgs(config);
+    }
+
+    const approvalPreset =
+      typeof adapterConfig.approvalPreset === "string"
+        ? adapterConfig.approvalPreset
+        : "autonomous";
+    const args = ["exec"];
+    args.push("--ignore-rules", "--ephemeral");
+    args.push(
+      "-c",
+      `model_reasoning_effort=${CODEX_TASK_AGENT_REASONING_EFFORT}`,
+    );
+
+    const model =
+      typeof config.env?.OPENAI_MODEL === "string"
+        ? config.env.OPENAI_MODEL.trim()
+        : "";
+    if (model) {
+      args.push("--model", model);
+    }
+
+    args.push(
+      ...(CODEX_APPROVAL_FLAGS[approvalPreset] ??
+        CODEX_APPROVAL_FLAGS.autonomous),
+    );
+
+    if (config.workdir) {
+      args.push("-C", config.workdir);
+    }
+    if (adapterConfig.skipGitRepoCheck === true) {
+      args.push("--skip-git-repo-check");
+    }
+
+    args.push("--color", "never");
+
+    const outputLastMessage =
+      typeof adapterConfig.outputLastMessage === "string"
+        ? adapterConfig.outputLastMessage.trim()
+        : "";
+    if (outputLastMessage) {
+      args.push("--output-last-message", outputLastMessage);
+    }
+
+    args.push(initialPrompt);
+    return args;
+  };
+
+  return adapter;
+}
+
+function createAllAdapters(...args) {
+  return adapters.createAllAdapters(...args).map(patchCodexAdapter);
+}
+
+module.exports = {
+  ...adapters,
+  createAllAdapters,
+};

--- a/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
@@ -1,0 +1,150 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import { splitAgentSpecsParam } from "../actions/coding-task-handlers.js";
+import { shouldSuppressCodexExecPtyManagerEvent } from "../services/pty-service.js";
+import { buildSpawnConfig } from "../services/pty-spawn.js";
+
+const require = createRequire(import.meta.url);
+
+describe("buildSpawnConfig", () => {
+  it("runs Codex initial tasks through non-interactive exec mode", () => {
+    const config = buildSpawnConfig(
+      "session-1",
+      {
+        name: "codex",
+        agentType: "codex",
+        approvalPreset: "autonomous",
+        initialTask: "write the smoke app",
+      },
+      "/tmp/workdir",
+    );
+
+    expect(config.adapterConfig).toMatchObject({
+      interactive: false,
+      initialPrompt: "write the smoke app",
+      skipGitRepoCheck: true,
+      approvalPreset: "autonomous",
+    });
+    expect(config.adapterConfig).not.toHaveProperty("addDirs");
+  });
+
+  it("passes Codex exec output file path through adapter config", () => {
+    const config = buildSpawnConfig(
+      "session-1",
+      {
+        name: "codex",
+        agentType: "codex",
+        approvalPreset: "autonomous",
+        initialTask: "check a domain",
+        metadata: {
+          codexExecOutputFile: "/tmp/codex-last-message.txt",
+        },
+      },
+      "/tmp/workdir",
+    );
+
+    expect(config.adapterConfig).toMatchObject({
+      initialPrompt: "check a domain",
+      outputLastMessage: "/tmp/codex-last-message.txt",
+    });
+  });
+});
+
+describe("Codex exec adapter", () => {
+  it("launches non-interactive workers with deterministic exec flags", () => {
+    const adapters = require("../../scripts/codex-exec-adapters.cjs") as {
+      createAllAdapters(): Array<{
+        adapterType: string;
+        getArgs(config: {
+          workdir?: string;
+          env?: Record<string, string>;
+          adapterConfig?: Record<string, unknown>;
+        }): string[];
+      }>;
+    };
+    const codex = adapters
+      .createAllAdapters()
+      .find((adapter) => adapter.adapterType === "codex");
+
+    const args = codex?.getArgs({
+      workdir: "/tmp/workdir",
+      env: { OPENAI_MODEL: "gpt-codex-test" },
+      adapterConfig: {
+        initialPrompt: "build the app",
+        approvalPreset: "autonomous",
+        skipGitRepoCheck: true,
+        outputLastMessage: "/tmp/codex-last-message.txt",
+      },
+    });
+
+    expect(args).toEqual([
+      "exec",
+      "--ignore-rules",
+      "--ephemeral",
+      "-c",
+      "model_reasoning_effort=xhigh",
+      "--model",
+      "gpt-codex-test",
+      "--yolo",
+      "-C",
+      "/tmp/workdir",
+      "--skip-git-repo-check",
+      "--color",
+      "never",
+      "--output-last-message",
+      "/tmp/codex-last-message.txt",
+      "build the app",
+    ]);
+  });
+});
+
+describe("shouldSuppressCodexExecPtyManagerEvent", () => {
+  it("suppresses pty-manager prompt noise only for Codex exec sessions", () => {
+    expect(
+      shouldSuppressCodexExecPtyManagerEvent({
+        codexExecMode: true,
+        event: "blocked",
+        data: { source: "pty_manager" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressCodexExecPtyManagerEvent({
+        codexExecMode: true,
+        event: "login_required",
+        data: { source: "pty_manager" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSuppressCodexExecPtyManagerEvent({
+        codexExecMode: true,
+        event: "task_complete",
+        data: { source: "adapter_fast_path" },
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressCodexExecPtyManagerEvent({
+        codexExecMode: false,
+        event: "blocked",
+        data: { source: "pty_manager" },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("splitAgentSpecsParam", () => {
+  it("splits planner agent specs while preserving shell pipelines", () => {
+    expect(
+      splitAgentSpecsParam(
+        "build the app | codex:run bun test | sed -n '1,20p' log.txt",
+      ),
+    ).toEqual(["build the app", "codex:run bun test | sed -n '1,20p' log.txt"]);
+  });
+
+  it("does not split quoted pipes", () => {
+    expect(
+      splitAgentSpecsParam(
+        "codex:write 'a | b' into the parser | shell:status",
+      ),
+    ).toEqual(["codex:write 'a | b' into the parser", "shell:status"]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
@@ -1,7 +1,14 @@
+import { mkdtemp, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { splitAgentSpecsParam } from "../actions/coding-task-handlers.js";
 import { shouldSuppressCodexExecPtyManagerEvent } from "../services/pty-service.js";
+import {
+  type SessionIOContext,
+  stopSession as stopSessionIO,
+} from "../services/pty-session-io.js";
 import { buildSpawnConfig } from "../services/pty-spawn.js";
 
 const require = createRequire(import.meta.url);
@@ -128,6 +135,31 @@ describe("shouldSuppressCodexExecPtyManagerEvent", () => {
         data: { source: "pty_manager" },
       }),
     ).toBe(false);
+  });
+});
+
+describe("stopSession", () => {
+  it("removes temporary Codex exec output directories during teardown", async () => {
+    const outputDir = await mkdtemp(join(tmpdir(), "codex-output-test-"));
+    await writeFile(join(outputDir, "last-message.txt"), "done", "utf-8");
+    const metadata = new Map<string, Record<string, unknown>>([
+      ["session-1", { codexExecOutputDir: outputDir }],
+    ]);
+    const ctx = {
+      manager: {
+        get: () => ({ id: "session-1" }),
+        kill: async () => undefined,
+      },
+      usingBunWorker: true,
+      sessionOutputBuffers: new Map(),
+      taskResponseMarkers: new Map(),
+      outputUnsubscribers: new Map(),
+    } as unknown as SessionIOContext;
+
+    await stopSessionIO(ctx, "session-1", metadata, new Map(), () => undefined);
+
+    await expect(stat(outputDir)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(metadata.has("session-1")).toBe(false);
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/__tests__/skill-recommender.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/skill-recommender.test.ts
@@ -1,0 +1,119 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { recommendSkillsForTask } from "../services/skill-recommender.js";
+
+interface FakeSkill {
+  slug: string;
+  name: string;
+  description: string;
+  tags?: string[];
+}
+
+function createRuntime(options: {
+  skills: FakeSkill[];
+  enabled?: Set<string>;
+}): IAgentRuntime {
+  const enabled =
+    options.enabled ?? new Set(options.skills.map((skill) => skill.slug));
+  const service = {
+    getEligibleSkills: async () =>
+      options.skills.map((skill) => ({
+        slug: skill.slug,
+        name: skill.name,
+        description: skill.description,
+        frontmatter: {
+          metadata: {
+            otto: {
+              tags: skill.tags,
+            },
+          },
+        },
+      })),
+    isSkillEnabled: (slug: string) => enabled.has(slug),
+  };
+
+  return {
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    getService: (name: string) =>
+      name === "AGENT_SKILLS_SERVICE" ? service : undefined,
+  } as unknown as IAgentRuntime;
+}
+
+const genericSkills: FakeSkill[] = [
+  {
+    slug: "github-issues",
+    name: "GitHub Issues",
+    description: "Read, create, and comment on GitHub issues.",
+    tags: ["github"],
+  },
+  {
+    slug: "playwright-runner",
+    name: "Playwright Runner",
+    description: "Run browser automation tests against a web app.",
+    tags: ["browser", "tests"],
+  },
+];
+
+const cloudAppSkill: FakeSkill = {
+  slug: "build-monetized-app",
+  name: "Build Monetized App",
+  description:
+    "Build Eliza Cloud apps with container deploys, OAuth, monetized inference, affiliate revenue, and custom domain offers.",
+  tags: ["cloud", "container", "monetization", "domain"],
+};
+
+describe("recommendSkillsForTask", () => {
+  it("forces the Cloud app-build skill for normal app prompts", async () => {
+    const recommendations = await recommendSkillsForTask(
+      createRuntime({ skills: [...genericSkills, cloudAppSkill] }),
+      {
+        taskText: "build me a simple wellness buddy chat app",
+        max: 5,
+        disableLlmPass: true,
+      },
+    );
+
+    expect(recommendations[0]).toMatchObject({
+      slug: "build-monetized-app",
+      score: 1,
+    });
+  });
+
+  it("does not force the Cloud app-build skill when it is disabled", async () => {
+    const recommendations = await recommendSkillsForTask(
+      createRuntime({
+        skills: [...genericSkills, cloudAppSkill],
+        enabled: new Set(genericSkills.map((skill) => skill.slug)),
+      }),
+      {
+        taskText: "make me a dashboard app",
+        max: 5,
+        disableLlmPass: true,
+      },
+    );
+
+    expect(
+      recommendations.find((skill) => skill.slug === "build-monetized-app"),
+    ).toBeUndefined();
+  });
+
+  it("does not force the Cloud app-build skill for writing tasks", async () => {
+    const recommendations = await recommendSkillsForTask(
+      createRuntime({ skills: [...genericSkills, cloudAppSkill] }),
+      {
+        taskText: "write a blog post about a chat app architecture",
+        max: 5,
+        disableLlmPass: true,
+      },
+    );
+
+    expect(
+      recommendations.find((skill) => skill.slug === "build-monetized-app"),
+    ).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/coding-task-handlers.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/coding-task-handlers.ts
@@ -90,6 +90,102 @@ const KNOWN_AGENT_PREFIXES = [
   "bash",
 ] as const;
 
+const SHELL_COMMAND_RE =
+  /(?:^|[:\s])(?:awk|bun|cat|curl|cut|echo|find|gh|git|grep|head|jq|node|npm|pnpm|sed|tail|tee|tr|xargs|yarn)\b\s+(?:[-./~"'({[<>&|]|https?:\/\/|\w+=|\w+\.(?:cjs|css|html|js|json|md|mjs|ts|tsx|yaml|yml)\b|\b(?:add|build|commit|diff|exec|fetch|install|log|pull|push|rebase|run|show|status|test)\b)/;
+
+function isShellPipelineBoundary(
+  left: string,
+  right: string,
+  line: string,
+): boolean {
+  const trimmedLine = line.trim();
+  if (/^\|.*\|$/.test(trimmedLine)) return true;
+
+  const leftTrimmed = left.trim();
+  const rightTrimmed = right.trim();
+  if (!leftTrimmed || !rightTrimmed) return false;
+
+  const leftLooksShell =
+    SHELL_COMMAND_RE.test(leftTrimmed) ||
+    /[`$;]|\$\(|\b[A-Z][A-Z0-9_]*=/.test(leftTrimmed);
+  const rightStartsShell =
+    /^(?:awk|bun|cat|curl|cut|echo|find|gh|git|grep|head|jq|node|npm|pnpm|sed|tail|tee|tr|xargs|yarn)\b/.test(
+      rightTrimmed,
+    );
+  return leftLooksShell && rightStartsShell;
+}
+
+/**
+ * Split the planner's optional multi-agent string without treating shell
+ * pipelines in a single task recipe as agent delimiters.
+ */
+export function splitAgentSpecsParam(input: string): string[] {
+  const specs: string[] = [];
+  let segmentStart = 0;
+  let lineStart = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+
+  const push = (end: number) => {
+    const segment = input.slice(segmentStart, end).trim();
+    if (segment) specs.push(segment);
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    const prev = i > 0 ? input[i - 1] : "";
+
+    if (char === "\n") {
+      lineStart = i + 1;
+      continue;
+    }
+
+    if (
+      char === "'" &&
+      !inDouble &&
+      !inBacktick &&
+      !(/[A-Za-z0-9]/.test(prev) && /[A-Za-z0-9]/.test(input[i + 1] ?? ""))
+    ) {
+      inSingle = !inSingle;
+      continue;
+    }
+    if (char === '"' && !inSingle && !inBacktick && prev !== "\\") {
+      inDouble = !inDouble;
+      continue;
+    }
+    if (char === "`" && !inSingle && !inDouble && prev !== "\\") {
+      inBacktick = !inBacktick;
+      continue;
+    }
+
+    if (char !== "|" || inSingle || inDouble || inBacktick) {
+      continue;
+    }
+
+    const lineEnd = input.indexOf("\n", i);
+    const line = input.slice(
+      lineStart,
+      lineEnd === -1 ? input.length : lineEnd,
+    );
+    if (
+      isShellPipelineBoundary(
+        input.slice(segmentStart, i),
+        input.slice(i + 1, lineEnd === -1 ? input.length : lineEnd),
+        line,
+      )
+    ) {
+      continue;
+    }
+
+    push(i);
+    segmentStart = i + 1;
+  }
+
+  push(input.length);
+  return specs;
+}
+
 /** Filename written into each spawned agent's workspace listing parent skills. */
 const SKILLS_MANIFEST_FILENAME = "SKILLS.md";
 
@@ -694,10 +790,7 @@ export async function handleMultiAgent(
 
   // Parse pipe-delimited agent specs: "task1 | task2 | agentType:task3"
   // A single empty string means "spawn one agent with no initial task".
-  const agentSpecs = agentsParam
-    .split("|")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  const agentSpecs = splitAgentSpecsParam(agentsParam);
 
   // If nothing parsed (e.g. empty string), treat as one agent with no task
   if (agentSpecs.length === 0) {
@@ -725,8 +818,7 @@ export async function handleMultiAgent(
 
   // Skip the spawn callback — the LLM REPLY already says "on it" (character
   // prompt ack rule) and the task-progress-streamer delivers the final
-  // result. Emitting "Launching N agents..." here duplicates the ack and
-  // spams discord. See eliza nubs/full-working-state clean Discord UX fix.
+  // result. Emitting "Launching N agents..." here duplicates the ack.
 
   // Install the child→parent USE_SKILL bridge once per runtime. Idempotent —
   // subsequent task spawns are no-ops. Pass the module-level session allow-

--- a/plugins/plugin-agent-orchestrator/src/actions/start-coding-task.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/start-coding-task.ts
@@ -40,6 +40,7 @@ import type { CodingWorkspaceService } from "../services/workspace-service.js";
 import {
   type CodingTaskContext,
   handleMultiAgent,
+  splitAgentSpecsParam,
 } from "./coding-task-handlers.js";
 
 /**
@@ -633,12 +634,7 @@ export const startCodingTaskAction: BackgroundAction = {
     const agentsParam =
       (params?.agents as string) ?? (content.agents as string);
 
-    const llmSegments = agentsParam
-      ? agentsParam
-          .split("|")
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
+    const llmSegments = agentsParam ? splitAgentSpecsParam(agentsParam) : [];
     const userSegments = splitMultiIntentTask(userText);
 
     if (userSegments.length > llmSegments.length && userSegments.length > 1) {

--- a/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/agent-routes.ts
@@ -532,11 +532,18 @@ export async function handleAgentRoutes(
         agentType,
         workdir: rawWorkdir,
         task,
+        initialTask,
         memoryContent,
         approvalPreset,
         customCredentials,
         metadata,
       } = body;
+      const taskText =
+        typeof task === "string"
+          ? task
+          : typeof initialTask === "string"
+            ? initialTask
+            : undefined;
 
       // Validate workdir: must be within workspace base dir or cwd
       const workspaceBaseDir = path.join(os.homedir(), ".eliza", "workspaces");
@@ -631,13 +638,13 @@ export async function handleAgentRoutes(
         metadata as Record<string, unknown>,
       );
       const taskThread =
-        coordinator && task && !requestedThreadId
+        coordinator && taskText && !requestedThreadId
           ? await coordinator.createTaskThread({
               title:
                 ((metadata as Record<string, unknown>)?.label as
                   | string
                   | undefined) ?? `Task ${Date.now()}`,
-              originalRequest: task as string,
+              originalRequest: taskText,
               scenarioId: evalRunMetadata.scenarioId,
               batchId: evalRunMetadata.batchId,
               metadata: {
@@ -659,9 +666,7 @@ export async function handleAgentRoutes(
         name: `agent-${Date.now()}`,
         agentType: normalizedType,
         workdir: workdir as string,
-        initialTask: piRequested
-          ? toPiCommand(task as string | undefined)
-          : (task as string),
+        initialTask: piRequested ? toPiCommand(taskText) : taskText,
         memoryContent: memoryContent as string | undefined,
         credentials,
         approvalPreset: approvalPreset as
@@ -691,7 +696,7 @@ export async function handleAgentRoutes(
           agentType:
             agentStr as import("../services/pty-service.js").CodingAgentType,
           label: label || `${defaultLabelPrefix}-${session.id.slice(-8)}`,
-          originalTask: (task as string | undefined) ?? "",
+          originalTask: taskText ?? "",
           workdir: session.workdir,
         });
       }

--- a/plugins/plugin-agent-orchestrator/src/services/ansi-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ansi-utils.ts
@@ -197,6 +197,7 @@ export function cleanForFailoverContext(raw: string, workdir?: string): string {
  */
 export function extractCompletionSummary(raw: string): string {
   const stripped = applyAnsiStrip(raw);
+  const strippedLines = stripped.split("\n").map((line) => line.trim());
   const lines: string[] = [];
 
   // PR / issue URLs
@@ -227,6 +228,24 @@ export function extractCompletionSummary(raw: string): string {
   );
   if (diffStat) {
     for (const m of diffStat) lines.push(m.trim());
+  }
+
+  // Hosted app build results. Preserve the user-facing lines the task agent
+  // reports after Cloud registration and domain search.
+  const appResultLines = strippedLines.filter((line) =>
+    /^(?:URL:\s*https?:\/\/|appId:\s*|monetization:\s*|auth:\s*|custom domain options\b|- .+\.(?:com|io|dev|app)\b.*\$|Want me to buy one of these for you\?)/i.test(
+      line,
+    ),
+  );
+  if (appResultLines.length > 0) {
+    for (const line of [...new Set(appResultLines)]) lines.push(line);
+  }
+
+  const domainStatusLines = strippedLines.filter((line) =>
+    /^(?:domain|app|status|verified|zoneId|expires|result):\s*\S/i.test(line),
+  );
+  if (domainStatusLines.length > 0) {
+    for (const line of [...new Set(domainStatusLines)]) lines.push(line);
   }
 
   return lines.join("\n");

--- a/plugins/plugin-agent-orchestrator/src/services/ansi-utils.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ansi-utils.ts
@@ -219,7 +219,7 @@ export function extractCompletionSummary(raw: string): string {
   // Commit hashes
   const commits = stripped.match(/(?:committed|commit)\s+[a-f0-9]{7,40}/gi);
   if (commits) {
-    for (const m of [...new Set(commits)]) lines.push(m.trim());
+    for (const m of new Set(commits)) lines.push(m.trim());
   }
 
   // Files changed summary (e.g. "2 files changed, 15 insertions(+), 3 deletions(-)")
@@ -238,14 +238,14 @@ export function extractCompletionSummary(raw: string): string {
     ),
   );
   if (appResultLines.length > 0) {
-    for (const line of [...new Set(appResultLines)]) lines.push(line);
+    for (const line of new Set(appResultLines)) lines.push(line);
   }
 
   const domainStatusLines = strippedLines.filter((line) =>
     /^(?:domain|app|status|verified|zoneId|expires|result):\s*\S/i.test(line),
   );
   if (domainStatusLines.length > 0) {
-    for (const line of [...new Set(domainStatusLines)]) lines.push(line);
+    for (const line of new Set(domainStatusLines)) lines.push(line);
   }
 
   return lines.join("\n");

--- a/plugins/plugin-agent-orchestrator/src/services/pty-init.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-init.ts
@@ -276,11 +276,18 @@ export async function initializePTYManager(
       reasonOrCode?: string | number,
       signal?: string | number,
     ): Promise<void> => {
+      const metadata =
+        typeof sessionOrId === "string"
+          ? ctx.sessionMetadata.get(sessionOrId)
+          : undefined;
       const session =
         typeof sessionOrId === "string"
           ? ({
               id: sessionOrId,
-              type: "codex",
+              type:
+                typeof metadata?.agentType === "string"
+                  ? metadata.agentType
+                  : "unknown",
               status: "stopped",
             } as WorkerSessionHandle)
           : sessionOrId;

--- a/plugins/plugin-agent-orchestrator/src/services/pty-init.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-init.ts
@@ -8,15 +8,16 @@
  */
 
 import { existsSync, readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { createAllAdapters } from "coding-agent-adapters";
+import { fileURLToPath } from "node:url";
 import type {
   AuthRequiredInfo,
   BunCompatiblePTYManager as BunCompatiblePTYManagerType,
-  PTYManager as PTYManagerType,
   PTYManagerConfig,
+  PTYManager as PTYManagerType,
   SessionHandle,
   SessionMessage,
   StallClassification,
@@ -24,7 +25,7 @@ import type {
   WorkerSessionHandle,
 } from "pty-manager";
 import type { CompletionMethod } from "./agent-metrics.js";
-import { captureTaskResponse } from "./ansi-utils.js";
+import { captureTaskResponse, cleanForChat } from "./ansi-utils.js";
 import type { PTYServiceConfig } from "./pty-types.js";
 
 // Stall detector silence threshold. 60s — long enough that a bash, git,
@@ -48,6 +49,19 @@ try {
 } catch {
   // Fallback to bare specifier if resolve fails (shouldn't happen)
 }
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+for (const candidate of [
+  path.resolve(moduleDir, "../scripts/codex-exec-adapters.cjs"),
+  path.resolve(moduleDir, "../../scripts/codex-exec-adapters.cjs"),
+]) {
+  if (existsSync(candidate)) {
+    resolvedAdapterModule = candidate;
+    break;
+  }
+}
+const { createAllAdapters } = _require(
+  resolvedAdapterModule,
+) as typeof import("coding-agent-adapters");
 let resolvedPtyWorkerPath: string | undefined;
 try {
   resolvedPtyWorkerPath = _require.resolve("pty-manager/worker");
@@ -102,6 +116,7 @@ export interface InitContext {
   ) => Promise<StallClassification | null>;
   emitEvent: (sessionId: string, event: string, data: unknown) => void;
   handleGeminiAuth: (sessionId: string) => void;
+  sessionMetadata: Map<string, Record<string, unknown>>;
   sessionOutputBuffers: Map<string, string[]>;
   taskResponseMarkers: Map<string, number>;
   metricsTracker: {
@@ -124,6 +139,40 @@ export interface InitContext {
   hasTaskActivity?: (sessionId: string) => boolean;
   /** Mark a session's task as delivered (initial ready event processed). */
   markTaskDelivered?: (sessionId: string) => void;
+}
+
+async function captureFastPathTaskResponse(
+  ctx: InitContext,
+  sessionId: string,
+): Promise<string> {
+  const buffered = captureTaskResponse(
+    sessionId,
+    ctx.sessionOutputBuffers,
+    ctx.taskResponseMarkers,
+  );
+  const outputFile = ctx.sessionMetadata.get(sessionId)?.codexExecOutputFile;
+  if (typeof outputFile !== "string" || !outputFile.trim()) {
+    return buffered;
+  }
+
+  try {
+    const fromFile = cleanForChat(await readFile(outputFile, "utf8"));
+    if (fromFile.trim()) {
+      return fromFile.trim();
+    }
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    if (code !== "ENOENT") {
+      ctx.log(
+        `Failed to read Codex exec output file for ${sessionId}: ${error}`,
+      );
+    }
+  }
+
+  return buffered;
 }
 
 // NOTE: A previous implementation defined `forwardReadyAsTaskComplete` here,
@@ -222,11 +271,70 @@ export async function initializePTYManager(
       ctx.markTaskDelivered?.(session.id);
     });
 
-    bunManager.on("session_exit", (id: string, code: number) => {
+    const handleWorkerStopped = async (
+      sessionOrId: WorkerSessionHandle | string,
+      reasonOrCode?: string | number,
+      signal?: string | number,
+    ): Promise<void> => {
+      const session =
+        typeof sessionOrId === "string"
+          ? ({
+              id: sessionOrId,
+              type: "codex",
+              status: "stopped",
+            } as WorkerSessionHandle)
+          : sessionOrId;
+      const id = session.id;
+      const code =
+        typeof reasonOrCode === "number"
+          ? reasonOrCode
+          : typeof session.exitCode === "number"
+            ? session.exitCode
+            : undefined;
+      const reason =
+        typeof reasonOrCode === "string"
+          ? reasonOrCode
+          : typeof code === "number"
+            ? `exit code ${code}`
+            : signal
+              ? `signal ${String(signal)}`
+              : "session stopped";
+      const cleanExit = code === 0 || /\bexit code 0\b/i.test(reason);
+
+      if (cleanExit && ctx.sessionMetadata.get(id)?.codexExecMode === true) {
+        const response = await captureFastPathTaskResponse(ctx, id);
+        ctx.metricsTracker.recordCompletion("codex", "fast-path", 0);
+        ctx.log(
+          `Task complete for ${id} (codex exec exit), response: ${response.length} chars`,
+        );
+        ctx.emitEvent(id, "task_complete", {
+          session,
+          response,
+          source: "adapter_fast_path",
+        });
+        return;
+      }
+
       ctx.emitEvent(id, "stopped", {
-        reason: `exit code ${code}`,
+        reason,
         source: "pty_manager",
       });
+    };
+
+    bunManager.on(
+      "session_stopped",
+      (
+        session: WorkerSessionHandle,
+        reasonOrCode?: string | number,
+        signal?: string | number,
+      ) => {
+        void handleWorkerStopped(session, reasonOrCode, signal);
+      },
+    );
+
+    // Older pty-manager builds exposed this event name.
+    bunManager.on("session_exit", (id: string, code: number) => {
+      void handleWorkerStopped(id, code);
     });
 
     bunManager.on("session_error", (id: string, error: string) => {
@@ -279,12 +387,8 @@ export async function initializePTYManager(
       },
     );
 
-    bunManager.on("task_complete", (session: WorkerSessionHandle) => {
-      const response = captureTaskResponse(
-        session.id,
-        ctx.sessionOutputBuffers,
-        ctx.taskResponseMarkers,
-      );
+    bunManager.on("task_complete", async (session: WorkerSessionHandle) => {
+      const response = await captureFastPathTaskResponse(ctx, session.id);
       const durationMs = session.startedAt
         ? Date.now() - new Date(session.startedAt).getTime()
         : 0;
@@ -449,12 +553,8 @@ export async function initializePTYManager(
     },
   );
 
-  nodeManager.on("task_complete", (session: SessionHandle) => {
-    const response = captureTaskResponse(
-      session.id,
-      ctx.sessionOutputBuffers,
-      ctx.taskResponseMarkers,
-    );
+  nodeManager.on("task_complete", async (session: SessionHandle) => {
+    const response = await captureFastPathTaskResponse(ctx, session.id);
     const durationMs = session.startedAt
       ? Date.now() - new Date(session.startedAt).getTime()
       : 0;
@@ -485,7 +585,30 @@ export async function initializePTYManager(
 
   nodeManager.on(
     "session_stopped",
-    (session: SessionHandle, reason: string) => {
+    async (session: SessionHandle, reason: string) => {
+      const stoppedCleanly =
+        (session as { exitCode?: number }).exitCode === 0 ||
+        /exit code 0/i.test(reason);
+      if (
+        session.type === "codex" &&
+        ctx.sessionMetadata.get(session.id)?.codexExecMode === true &&
+        stoppedCleanly
+      ) {
+        const response = await captureFastPathTaskResponse(ctx, session.id);
+        const durationMs = session.startedAt
+          ? Date.now() - new Date(session.startedAt).getTime()
+          : 0;
+        ctx.metricsTracker.recordCompletion("codex", "fast-path", durationMs);
+        ctx.log(
+          `Task complete for ${session.id} (codex exec stopped), response: ${response.length} chars`,
+        );
+        ctx.emitEvent(session.id, "task_complete", {
+          session,
+          response,
+          source: "adapter_fast_path",
+        });
+        return;
+      }
       ctx.emitEvent(session.id, "stopped", { reason, source: "pty_manager" });
     },
   );

--- a/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
@@ -5,6 +5,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  rm,
   writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
@@ -1071,11 +1072,11 @@ export class PTYService {
       agentType: resolvedAgentType,
       initialTask: resolvedInitialTask,
     });
-    const codexExecOutputFile = codexExecMode
-      ? join(
-          await mkdtemp(join(tmpdir(), `eliza-codex-${sessionId}-`)),
-          "last-message.txt",
-        )
+    const codexExecOutputDir = codexExecMode
+      ? await mkdtemp(join(tmpdir(), `eliza-codex-${sessionId}-`))
+      : undefined;
+    const codexExecOutputFile = codexExecOutputDir
+      ? join(codexExecOutputDir, "last-message.txt")
       : undefined;
     const resolvedMetadata = {
       ...metadataWithoutModelPrefs,
@@ -1083,6 +1084,7 @@ export class PTYService {
       agentType: resolvedAgentType,
       coordinatorManaged: !!options.skipAdapterAutoResponse,
       ...(codexExecMode ? { codexExecMode: true } : {}),
+      ...(codexExecOutputDir ? { codexExecOutputDir } : {}),
       ...(codexExecOutputFile ? { codexExecOutputFile } : {}),
       ...(resolvedModelPrefs ? { modelPrefs: resolvedModelPrefs } : {}),
     };
@@ -1110,6 +1112,14 @@ export class PTYService {
     try {
       session = await this.manager.spawn(spawnConfig);
     } catch (error) {
+      if (codexExecOutputDir) {
+        await rm(codexExecOutputDir, { recursive: true, force: true }).catch(
+          (cleanupError) =>
+            this.log(
+              `Failed to remove Codex exec output dir ${codexExecOutputDir}: ${cleanupError}`,
+            ),
+        );
+      }
       this.sessionMetadata.delete(sessionId);
       throw error;
     }

--- a/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
@@ -34,8 +34,8 @@ import type {
   StallClassification,
   WorkerSessionHandle,
 } from "pty-manager";
+import { buildOpencodeSpawnConfig } from "./agent-credentials.js";
 import { AgentMetricsTracker } from "./agent-metrics.js";
-import { CLAUDE_SKILL_ESSENTIALS } from "./skill-essentials.js";
 import type { AgentSelectionStrategy } from "./agent-selection.js";
 import {
   captureTaskResponse,
@@ -72,6 +72,7 @@ import {
   buildSpawnConfig,
   setupDeferredTaskDelivery,
   setupOutputBuffer,
+  shouldUseCodexExecMode,
 } from "./pty-spawn.js";
 import type {
   CodingAgentType,
@@ -86,7 +87,13 @@ import {
   toOpencodeCommand,
   toPiCommand,
 } from "./pty-types.js";
-import { buildOpencodeSpawnConfig } from "./agent-credentials.js";
+import { CLAUDE_SKILL_ESSENTIALS } from "./skill-essentials.js";
+import {
+  TRAJECTORY_CHILD_STEP_ENV_KEY,
+  TRAJECTORY_CHILD_STEP_METADATA_KEY,
+  TRAJECTORY_PARENT_STEP_METADATA_KEY,
+  withLinkedSpawn,
+} from "./spawn-trajectory.js";
 import {
   classifyAndDecideForCoordinator,
   classifyStallOutput,
@@ -115,12 +122,6 @@ import {
   type TaskAgentFrameworkState,
   type TaskAgentTaskProfileInput,
 } from "./task-agent-frameworks.js";
-import {
-  TRAJECTORY_CHILD_STEP_ENV_KEY,
-  TRAJECTORY_CHILD_STEP_METADATA_KEY,
-  TRAJECTORY_PARENT_STEP_METADATA_KEY,
-  withLinkedSpawn,
-} from "./spawn-trajectory.js";
 
 /**
  * Grace period after `task_complete` before auto-stopping a PTY session.
@@ -130,6 +131,25 @@ import {
  * the PTY parent before it exits.
  */
 const TASK_COMPLETE_STOP_DELAY_MS = 5_000;
+
+export function shouldSuppressCodexExecPtyManagerEvent(options: {
+  codexExecMode: boolean;
+  event: string;
+  data: unknown;
+}): boolean {
+  if (!options.codexExecMode) return false;
+  const payload = options.data as
+    | {
+        source?: unknown;
+      }
+    | undefined;
+  if (payload?.source !== "pty_manager") return false;
+
+  // `codex exec` is non-interactive. Process exit and --output-last-message
+  // are the authoritative completion signals; TUI prompt detectors can
+  // misclassify ordinary exec output as login/blocking prompts.
+  return options.event === "blocked" || options.event === "login_required";
+}
 
 /**
  * Portable safety floor injected into every spawned coding-agent's memory
@@ -637,6 +657,7 @@ export class PTYService {
       classifyStall: (id, out) => this.classifyStall(id, out),
       emitEvent: (id, event, data) => this.emitEvent(id, event, data),
       handleGeminiAuth: (id) => this.handleGeminiAuth(id),
+      sessionMetadata: this.sessionMetadata,
       sessionOutputBuffers: this.sessionOutputBuffers,
       taskResponseMarkers: this.taskResponseMarkers,
       metricsTracker: this.metricsTracker,
@@ -1046,11 +1067,23 @@ export class PTYService {
     );
     const metadataWithoutModelPrefs = { ...(linkedMetadata ?? {}) };
     delete metadataWithoutModelPrefs.modelPrefs;
+    const codexExecMode = shouldUseCodexExecMode({
+      agentType: resolvedAgentType,
+      initialTask: resolvedInitialTask,
+    });
+    const codexExecOutputFile = codexExecMode
+      ? join(
+          await mkdtemp(join(tmpdir(), `eliza-codex-${sessionId}-`)),
+          "last-message.txt",
+        )
+      : undefined;
     const resolvedMetadata = {
       ...metadataWithoutModelPrefs,
       requestedType: linkedMetadata?.requestedType ?? options.agentType,
       agentType: resolvedAgentType,
       coordinatorManaged: !!options.skipAdapterAutoResponse,
+      ...(codexExecMode ? { codexExecMode: true } : {}),
+      ...(codexExecOutputFile ? { codexExecOutputFile } : {}),
       ...(resolvedModelPrefs ? { modelPrefs: resolvedModelPrefs } : {}),
     };
 
@@ -1072,7 +1105,14 @@ export class PTYService {
       },
       workdir,
     );
-    const session = await this.manager.spawn(spawnConfig);
+    this.sessionMetadata.set(sessionId, resolvedMetadata);
+    let session: SessionHandle | WorkerSessionHandle;
+    try {
+      session = await this.manager.spawn(spawnConfig);
+    } catch (error) {
+      this.sessionMetadata.delete(sessionId);
+      throw error;
+    }
     this.terminalSessionStates.delete(session.id);
     this.sessionNames.set(session.id, options.name);
 
@@ -2229,6 +2269,16 @@ export class PTYService {
   }
 
   private emitEvent(sessionId: string, event: string, data: unknown): void {
+    if (
+      shouldSuppressCodexExecPtyManagerEvent({
+        codexExecMode:
+          this.sessionMetadata.get(sessionId)?.codexExecMode === true,
+        event,
+        data,
+      })
+    ) {
+      return;
+    }
     if (
       event === "blocked" &&
       this.shouldSuppressBlockedEvent(sessionId, data)

--- a/plugins/plugin-agent-orchestrator/src/services/pty-session-io.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-session-io.ts
@@ -8,7 +8,7 @@
  * @module services/pty-session-io
  */
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   BunCompatiblePTYManager,
@@ -136,6 +136,18 @@ export async function stopSession(
         await cleanupAgentHooks(workdir, log);
       } catch {
         // Best-effort — don't block shutdown
+      }
+    }
+
+    const metadata = sessionMetadata.get(sessionId);
+    const codexExecOutputDir = metadata?.codexExecOutputDir;
+    if (typeof codexExecOutputDir === "string") {
+      try {
+        await rm(codexExecOutputDir, { recursive: true, force: true });
+      } catch (err) {
+        log(
+          `Failed to remove Codex exec output dir ${codexExecOutputDir}: ${err}`,
+        );
       }
     }
 

--- a/plugins/plugin-agent-orchestrator/src/services/pty-spawn.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-spawn.ts
@@ -145,6 +145,22 @@ const ENV_ALLOWLIST = [
   // GitHub connection card (or set it explicitly via shell), so passthrough
   // here matches an explicit user grant rather than blanket leakage.
   "GITHUB_TOKEN",
+  "GH_TOKEN",
+  // Container app builds may need opt-in registry credentials/config before
+  // Cloud can pull an image. These are forwarded only when the parent runtime
+  // explicitly provides them.
+  "GHCR_TOKEN",
+  "CR_PAT",
+  "ELIZA_APP_IMAGE_REGISTRY",
+  "ELIZA_APP_IMAGE_NAMESPACE",
+  "ELIZA_APP_IMAGE_REPOSITORY",
+  // Cloud app builds need the parent-provided Cloud endpoint and API key to
+  // register apps, enable monetization, and prepare domain offers.
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZA_CLOUD_BASE_URL",
+  "ELIZA_CLOUD_PUBLIC_URL",
+  "ELIZA_CLOUD_URL",
+  "ELIZA_AFFILIATE_CODE",
 ];
 
 /**
@@ -274,6 +290,13 @@ export interface SpawnContext {
   log: (msg: string) => void;
   /** Mark a session's task as delivered in the coordinator. */
   markTaskDelivered: (sessionId: string) => void;
+}
+
+export function shouldUseCodexExecMode(options: {
+  agentType: string;
+  initialTask?: string;
+}): boolean {
+  return options.agentType === "codex" && Boolean(options.initialTask?.trim());
 }
 
 const CURSOR_POSITION_QUERY = "\x1b[6n";
@@ -490,6 +513,13 @@ export function buildSpawnConfig(
   options: SpawnSessionOptions,
   workdir: string,
 ): SpawnConfig & { id: string } {
+  const codexExecMode = shouldUseCodexExecMode(options);
+  const codexExecOutputFile =
+    typeof options.metadata?.codexExecOutputFile === "string" &&
+    options.metadata.codexExecOutputFile.trim()
+      ? options.metadata.codexExecOutputFile.trim()
+      : undefined;
+
   // Map model preferences to adapter-specific env vars
   const modelPrefs = readTaskAgentModelPrefs(options.metadata?.modelPrefs);
   let modelEnv: Record<string, string> | undefined;
@@ -527,9 +557,20 @@ export function buildSpawnConfig(
       ...(options.customCredentials
         ? { custom: options.customCredentials }
         : {}),
-      interactive: true,
+      interactive: !codexExecMode,
+      ...(codexExecMode
+        ? {
+            initialPrompt: options.initialTask?.trim(),
+            skipGitRepoCheck: true,
+            ...(codexExecOutputFile
+              ? { outputLastMessage: codexExecOutputFile }
+              : {}),
+          }
+        : {}),
       approvalPreset:
-        options.agentType === "codex" ? undefined : options.approvalPreset,
+        options.agentType === "codex" && !codexExecMode
+          ? undefined
+          : options.approvalPreset,
       // Forward adapter-relevant metadata (e.g. provider preference for Aider)
       ...(options.metadata?.provider
         ? { provider: options.metadata.provider }

--- a/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts
@@ -16,10 +16,10 @@
  */
 
 import {
-  parseToonKeyValue,
   type IAgentRuntime,
   type Logger,
   ModelType,
+  parseToonKeyValue,
 } from "@elizaos/core";
 import { withTrajectoryContext } from "./trajectory-context.js";
 
@@ -27,6 +27,9 @@ const LOG_PREFIX = "[SkillRecommender]";
 const DEFAULT_MAX = 5;
 const KEYWORD_CANDIDATE_LIMIT = 10;
 const LLM_SHORT_CIRCUIT_SCORE = 0.9;
+const BUILD_MONETIZED_APP_SLUG = "build-monetized-app";
+const APP_BUILD_TASK_RE =
+  /\b(build|create|make|ship|write|develop|generate)\b(?:(?!\b(?:article|blog|post)\b)[\s\S]){0,120}\b(app|site|page|tool|game|dashboard|chatbot|chat\s*bot|chat\s+app|assistant|companion)\b/i;
 // Tokens shorter than this carry no signal — they show up in nearly every
 // task description and would inflate every skill's score equally.
 const MIN_TOKEN_LENGTH = 4;
@@ -223,6 +226,41 @@ function buildKeywordReason(
   return `matched task tokens: ${overlap.join(", ")}`;
 }
 
+function shouldForceCloudAppSkill(taskText: string): boolean {
+  return APP_BUILD_TASK_RE.test(taskText);
+}
+
+function withForcedCloudAppSkill(
+  recommendations: RecommendedSkill[],
+  candidates: SkillCandidate[],
+  taskText: string,
+  max: number,
+): RecommendedSkill[] {
+  if (!shouldForceCloudAppSkill(taskText)) {
+    return recommendations.slice(0, max);
+  }
+
+  const candidate = candidates.find(
+    (skill) => skill.slug === BUILD_MONETIZED_APP_SLUG,
+  );
+  if (!candidate) {
+    return recommendations.slice(0, max);
+  }
+
+  const forced: RecommendedSkill = {
+    slug: candidate.slug,
+    name: candidate.name,
+    score: 1,
+    reason:
+      "standard Eliza Cloud app build, container deploy, monetization, and domain flow",
+  };
+
+  return [
+    forced,
+    ...recommendations.filter((rec) => rec.slug !== BUILD_MONETIZED_APP_SLUG),
+  ].slice(0, max);
+}
+
 function buildLlmScoringPrompt(
   taskText: string,
   taskKind: string | undefined,
@@ -379,7 +417,7 @@ export async function recommendSkillsForTask(
 
   if (scoredCandidates.length === 0) {
     log.debug?.(`${LOG_PREFIX} no keyword overlap for task; skipping LLM pass`);
-    return [];
+    return withForcedCloudAppSkill([], candidates, opts.taskText, max);
   }
 
   const fastPathRecommendations: RecommendedSkill[] = scoredCandidates.map(
@@ -396,12 +434,22 @@ export async function recommendSkillsForTask(
   const llmShortCircuit = topFastScore >= LLM_SHORT_CIRCUIT_SCORE;
 
   if (llmDisabled || llmShortCircuit) {
-    return fastPathRecommendations.slice(0, max);
+    return withForcedCloudAppSkill(
+      fastPathRecommendations,
+      candidates,
+      opts.taskText,
+      max,
+    );
   }
 
   const useModelFn = (runtime as { useModel?: unknown }).useModel;
   if (typeof useModelFn !== "function") {
-    return fastPathRecommendations.slice(0, max);
+    return withForcedCloudAppSkill(
+      fastPathRecommendations,
+      candidates,
+      opts.taskText,
+      max,
+    );
   }
 
   // Pass 2: LLM scoring over surviving candidates.
@@ -433,7 +481,12 @@ export async function recommendSkillsForTask(
     log.debug?.(
       `${LOG_PREFIX} LLM scoring returned no parseable entries; falling back to keyword pass`,
     );
-    return fastPathRecommendations.slice(0, max);
+    return withForcedCloudAppSkill(
+      fastPathRecommendations,
+      candidates,
+      opts.taskText,
+      max,
+    );
   }
 
   const llmBySlug = new Map<string, LlmScoreEntry>();
@@ -473,7 +526,13 @@ export async function recommendSkillsForTask(
     }
   }
 
-  return Array.from(dedupedBySlug.values())
+  const finalRecommendations = Array.from(dedupedBySlug.values())
     .sort((a, b) => b.score - a.score)
     .slice(0, max);
+  return withForcedCloudAppSkill(
+    finalRecommendations,
+    candidates,
+    opts.taskText,
+    max,
+  );
 }

--- a/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
+++ b/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
@@ -125,29 +125,31 @@ export const getExecutionsAction: Action = {
       const context = buildConversationContext(message, state);
       const matchResult = workflowIdParam
         ? {
-            matchedWorkflowId: workflowIdParam,
+          matchedWorkflowId: workflowIdParam,
+          confidence: 'high' as const,
+          matches: workflows.map((workflow) => ({
+            id: workflow.id,
+            name: workflow.name,
+            score: workflow.id === workflowIdParam ? 1 : 0,
+          })),
+          reason: 'workflowId parameter',
+        }
+        : workflowNameParam
+          ? {
+            matchedWorkflowId:
+                workflows.find((workflow) =>
+                  workflow.name.toLowerCase().includes(workflowNameParam),
+                )?.id ?? null,
             confidence: 'high' as const,
             matches: workflows.map((workflow) => ({
               id: workflow.id,
               name: workflow.name,
-              score: workflow.id === workflowIdParam ? 1 : 0,
+              score: workflow.name.toLowerCase().includes(workflowNameParam)
+                ? 1
+                : 0,
             })),
-            reason: 'workflowId parameter',
+            reason: 'workflowName parameter',
           }
-        : workflowNameParam
-          ? {
-              matchedWorkflowId:
-                workflows.find((workflow) =>
-                  workflow.name.toLowerCase().includes(workflowNameParam)
-                )?.id ?? null,
-              confidence: 'high' as const,
-              matches: workflows.map((workflow) => ({
-                id: workflow.id,
-                name: workflow.name,
-                score: workflow.name.toLowerCase().includes(workflowNameParam) ? 1 : 0,
-              })),
-              reason: 'workflowName parameter',
-            }
           : await matchWorkflow(runtime, context, workflows);
 
       if (!matchResult.matchedWorkflowId || matchResult.confidence === 'none') {

--- a/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
+++ b/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
@@ -125,31 +125,29 @@ export const getExecutionsAction: Action = {
       const context = buildConversationContext(message, state);
       const matchResult = workflowIdParam
         ? {
-          matchedWorkflowId: workflowIdParam,
-          confidence: 'high' as const,
-          matches: workflows.map((workflow) => ({
-            id: workflow.id,
-            name: workflow.name,
-            score: workflow.id === workflowIdParam ? 1 : 0,
-          })),
-          reason: 'workflowId parameter',
-        }
-        : workflowNameParam
-          ? {
-            matchedWorkflowId:
-                workflows.find((workflow) =>
-                  workflow.name.toLowerCase().includes(workflowNameParam),
-                )?.id ?? null,
+            matchedWorkflowId: workflowIdParam,
             confidence: 'high' as const,
             matches: workflows.map((workflow) => ({
               id: workflow.id,
               name: workflow.name,
-              score: workflow.name.toLowerCase().includes(workflowNameParam)
-                ? 1
-                : 0,
+              score: workflow.id === workflowIdParam ? 1 : 0,
             })),
-            reason: 'workflowName parameter',
+            reason: 'workflowId parameter',
           }
+        : workflowNameParam
+          ? {
+              matchedWorkflowId:
+                workflows.find((workflow) =>
+                  workflow.name.toLowerCase().includes(workflowNameParam)
+                )?.id ?? null,
+              confidence: 'high' as const,
+              matches: workflows.map((workflow) => ({
+                id: workflow.id,
+                name: workflow.name,
+                score: workflow.name.toLowerCase().includes(workflowNameParam) ? 1 : 0,
+              })),
+              reason: 'workflowName parameter',
+            }
           : await matchWorkflow(runtime, context, workflows);
 
       if (!matchResult.matchedWorkflowId || matchResult.confidence === 'none') {

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -26,7 +26,9 @@ const VALID_KINDS: ReadonlySet<N8nClarificationRequest['kind']> = new Set([
 ]);
 
 function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
-  if (!v || typeof v !== 'object') {return false;}
+  if (!v || typeof v !== 'object') {
+    return false;
+  }
   const o = v as Record<string, unknown>;
   if (typeof o.question !== 'string' || o.question.trim().length === 0) {
     return false;
@@ -37,22 +39,26 @@ function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
 }
 
 export function coerceClarifications(raw: unknown): N8nClarificationRequest[] {
-  if (!Array.isArray(raw) || raw.length === 0) {return [];}
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return [];
+  }
   const out: N8nClarificationRequest[] = [];
   for (const item of raw) {
     if (typeof item === 'string') {
       const trimmed = item.trim();
-      if (trimmed.length === 0) {continue;}
+      if (trimmed.length === 0) {
+        continue;
+      }
       out.push({ kind: 'free_text', question: trimmed, paramPath: '' });
       continue;
     }
-    if (!isStructuredClarification(item)) {continue;}
+    if (!isStructuredClarification(item)) {
+      continue;
+    }
     const o = item as unknown as Record<string, unknown>;
     const kindRaw = typeof o.kind === 'string' ? o.kind : 'free_text';
     const kind = (
-      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind'])
-        ? kindRaw
-        : 'free_text'
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind']) ? kindRaw : 'free_text'
     ) as N8nClarificationRequest['kind'];
     const platform = typeof o.platform === 'string' ? o.platform : undefined;
     let scope: { guildId?: string } | undefined;
@@ -118,7 +124,9 @@ export function parseParamPath(path: string): string[] {
     }
     // Identifier run: read until next `.` or `[`.
     let j = i;
-    while (j < n && path[j] !== '.' && path[j] !== '[') {j += 1;}
+    while (j < n && path[j] !== '.' && path[j] !== '[') {
+      j += 1;
+    }
     const ident = path.slice(i, j).trim();
     if (ident.length === 0) {
       throw new Error(`empty identifier at index ${i}`);
@@ -145,7 +153,7 @@ export function parseParamPath(path: string): string[] {
 export function setByDotPath(
   obj: Record<string, unknown>,
   paramPath: string,
-  value: unknown,
+  value: unknown
 ): void {
   const segments = parseParamPath(paramPath);
   let cur: Record<string, unknown> | unknown[] = obj;
@@ -154,9 +162,7 @@ export function setByDotPath(
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
       if (!isArrayIndex) {
-        throw new Error(
-          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
-        );
+        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
       }
       const idx = Number(seg);
       let next = cur[idx];
@@ -165,9 +171,7 @@ export function setByDotPath(
         cur[idx] = next;
       }
       if (typeof next !== 'object' || next === null) {
-        throw new Error(
-          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-        );
+        throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
       }
       cur = next as Record<string, unknown> | unknown[];
       continue;
@@ -178,18 +182,14 @@ export function setByDotPath(
       (cur as Record<string, unknown>)[seg] = next;
     }
     if (typeof next !== 'object' || next === null) {
-      throw new Error(
-        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-      );
+      throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
     }
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
     if (!/^[0-9]+$/.test(last)) {
-      throw new Error(
-        `paramPath terminal segment "${last}" must be numeric at array`,
-      );
+      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
     }
     cur[Number(last)] = value;
   } else {
@@ -199,7 +199,7 @@ export function setByDotPath(
 
 export function applyResolutions(
   draft: Record<string, unknown>,
-  resolutions: ReadonlyArray<N8nClarificationResolution>,
+  resolutions: ReadonlyArray<N8nClarificationResolution>
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
     if (!r || typeof r.paramPath !== 'string') {
@@ -229,9 +229,7 @@ export function applyResolutions(
         notes = meta.userNotes as string[];
       } else {
         notes =
-          meta.userNotes !== null && meta.userNotes !== undefined
-            ? [String(meta.userNotes)]
-            : [];
+          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
         meta.userNotes = notes;
       }
       notes.push(r.value);
@@ -271,12 +269,16 @@ export function applyResolutions(
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
-  freeFormCount = 0,
+  freeFormCount = 0
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
-  if (!meta || typeof meta !== 'object') {return;}
+  if (!meta || typeof meta !== 'object') {
+    return;
+  }
   const list = meta.requiresClarification;
-  if (!Array.isArray(list)) {return;}
+  if (!Array.isArray(list)) {
+    return;
+  }
   let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
     if (typeof item === 'string') {
@@ -292,10 +294,7 @@ export function pruneResolvedClarifications(
         return false;
       }
       // Empty-paramPath object-form: also positional.
-      if (
-        (typeof path !== 'string' || path.length === 0) &&
-        toDropFreeForm > 0
-      ) {
+      if ((typeof path !== 'string' || path.length === 0) && toDropFreeForm > 0) {
         toDropFreeForm -= 1;
         return false;
       }
@@ -328,20 +327,26 @@ export interface CatalogLike {
  */
 export async function buildCatalogSnapshot(
   catalog: CatalogLike,
-  clarifications: ReadonlyArray<N8nClarificationRequest>,
+  clarifications: ReadonlyArray<N8nClarificationRequest>
 ): Promise<N8nClarificationTargetGroup[]> {
   const platforms = new Set<string>();
   for (const c of clarifications) {
-    if (c.platform) {platforms.add(c.platform);}
+    if (c.platform) {
+      platforms.add(c.platform);
+    }
   }
-  if (platforms.size === 0) {return [];}
+  if (platforms.size === 0) {
+    return [];
+  }
   const out: N8nClarificationTargetGroup[] = [];
   const seen = new Set<string>();
   for (const platform of platforms) {
     const groups = await catalog.listGroups({ platform });
     for (const g of groups) {
       const key = `${g.platform}::${g.groupId}`;
-      if (seen.has(key)) {continue;}
+      if (seen.has(key)) {
+        continue;
+      }
       seen.add(key);
       out.push(g);
     }

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -26,9 +26,7 @@ const VALID_KINDS: ReadonlySet<N8nClarificationRequest['kind']> = new Set([
 ]);
 
 function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
-  if (!v || typeof v !== 'object') {
-    return false;
-  }
+  if (!v || typeof v !== 'object') {return false;}
   const o = v as Record<string, unknown>;
   if (typeof o.question !== 'string' || o.question.trim().length === 0) {
     return false;
@@ -39,26 +37,22 @@ function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
 }
 
 export function coerceClarifications(raw: unknown): N8nClarificationRequest[] {
-  if (!Array.isArray(raw) || raw.length === 0) {
-    return [];
-  }
+  if (!Array.isArray(raw) || raw.length === 0) {return [];}
   const out: N8nClarificationRequest[] = [];
   for (const item of raw) {
     if (typeof item === 'string') {
       const trimmed = item.trim();
-      if (trimmed.length === 0) {
-        continue;
-      }
+      if (trimmed.length === 0) {continue;}
       out.push({ kind: 'free_text', question: trimmed, paramPath: '' });
       continue;
     }
-    if (!isStructuredClarification(item)) {
-      continue;
-    }
+    if (!isStructuredClarification(item)) {continue;}
     const o = item as unknown as Record<string, unknown>;
     const kindRaw = typeof o.kind === 'string' ? o.kind : 'free_text';
     const kind = (
-      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind']) ? kindRaw : 'free_text'
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind'])
+        ? kindRaw
+        : 'free_text'
     ) as N8nClarificationRequest['kind'];
     const platform = typeof o.platform === 'string' ? o.platform : undefined;
     let scope: { guildId?: string } | undefined;
@@ -124,9 +118,7 @@ export function parseParamPath(path: string): string[] {
     }
     // Identifier run: read until next `.` or `[`.
     let j = i;
-    while (j < n && path[j] !== '.' && path[j] !== '[') {
-      j += 1;
-    }
+    while (j < n && path[j] !== '.' && path[j] !== '[') {j += 1;}
     const ident = path.slice(i, j).trim();
     if (ident.length === 0) {
       throw new Error(`empty identifier at index ${i}`);
@@ -153,7 +145,7 @@ export function parseParamPath(path: string): string[] {
 export function setByDotPath(
   obj: Record<string, unknown>,
   paramPath: string,
-  value: unknown
+  value: unknown,
 ): void {
   const segments = parseParamPath(paramPath);
   let cur: Record<string, unknown> | unknown[] = obj;
@@ -162,7 +154,9 @@ export function setByDotPath(
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
       if (!isArrayIndex) {
-        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
+        throw new Error(
+          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
+        );
       }
       const idx = Number(seg);
       let next = cur[idx];
@@ -171,7 +165,9 @@ export function setByDotPath(
         cur[idx] = next;
       }
       if (typeof next !== 'object' || next === null) {
-        throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
+        throw new Error(
+          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+        );
       }
       cur = next as Record<string, unknown> | unknown[];
       continue;
@@ -182,14 +178,18 @@ export function setByDotPath(
       (cur as Record<string, unknown>)[seg] = next;
     }
     if (typeof next !== 'object' || next === null) {
-      throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
+      throw new Error(
+        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
+      );
     }
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
     if (!/^[0-9]+$/.test(last)) {
-      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
+      throw new Error(
+        `paramPath terminal segment "${last}" must be numeric at array`,
+      );
     }
     cur[Number(last)] = value;
   } else {
@@ -199,7 +199,7 @@ export function setByDotPath(
 
 export function applyResolutions(
   draft: Record<string, unknown>,
-  resolutions: ReadonlyArray<N8nClarificationResolution>
+  resolutions: ReadonlyArray<N8nClarificationResolution>,
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
     if (!r || typeof r.paramPath !== 'string') {
@@ -229,7 +229,9 @@ export function applyResolutions(
         notes = meta.userNotes as string[];
       } else {
         notes =
-          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
+          meta.userNotes !== null && meta.userNotes !== undefined
+            ? [String(meta.userNotes)]
+            : [];
         meta.userNotes = notes;
       }
       notes.push(r.value);
@@ -269,16 +271,12 @@ export function applyResolutions(
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
-  freeFormCount = 0
+  freeFormCount = 0,
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
-  if (!meta || typeof meta !== 'object') {
-    return;
-  }
+  if (!meta || typeof meta !== 'object') {return;}
   const list = meta.requiresClarification;
-  if (!Array.isArray(list)) {
-    return;
-  }
+  if (!Array.isArray(list)) {return;}
   let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
     if (typeof item === 'string') {
@@ -294,7 +292,10 @@ export function pruneResolvedClarifications(
         return false;
       }
       // Empty-paramPath object-form: also positional.
-      if ((typeof path !== 'string' || path.length === 0) && toDropFreeForm > 0) {
+      if (
+        (typeof path !== 'string' || path.length === 0) &&
+        toDropFreeForm > 0
+      ) {
         toDropFreeForm -= 1;
         return false;
       }
@@ -327,26 +328,20 @@ export interface CatalogLike {
  */
 export async function buildCatalogSnapshot(
   catalog: CatalogLike,
-  clarifications: ReadonlyArray<N8nClarificationRequest>
+  clarifications: ReadonlyArray<N8nClarificationRequest>,
 ): Promise<N8nClarificationTargetGroup[]> {
   const platforms = new Set<string>();
   for (const c of clarifications) {
-    if (c.platform) {
-      platforms.add(c.platform);
-    }
+    if (c.platform) {platforms.add(c.platform);}
   }
-  if (platforms.size === 0) {
-    return [];
-  }
+  if (platforms.size === 0) {return [];}
   const out: N8nClarificationTargetGroup[] = [];
   const seen = new Set<string>();
   for (const platform of platforms) {
     const groups = await catalog.listGroups({ platform });
     for (const g of groups) {
       const key = `${g.platform}::${g.groupId}`;
-      if (seen.has(key)) {
-        continue;
-      }
+      if (seen.has(key)) {continue;}
       seen.add(key);
       out.push(g);
     }

--- a/plugins/plugin-n8n-workflow/src/plugin-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/plugin-routes.ts
@@ -32,16 +32,18 @@ function buildState(runtime: unknown): N8nCompatState {
 }
 
 function makeN8nHandler() {
-  return async (req: unknown, res: unknown, runtime: unknown): Promise<void> => {
+  return async (
+    req: unknown,
+    res: unknown,
+    runtime: unknown,
+  ): Promise<void> => {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? '/', 'http://localhost');
     const method = (httpReq.method ?? 'GET').toUpperCase();
     const state = buildState(runtime);
 
-    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {
-      return;
-    }
+    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {return;}
 
     await handleN8nRoutes({
       req: httpReq,

--- a/plugins/plugin-n8n-workflow/src/plugin-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/plugin-routes.ts
@@ -32,18 +32,16 @@ function buildState(runtime: unknown): N8nCompatState {
 }
 
 function makeN8nHandler() {
-  return async (
-    req: unknown,
-    res: unknown,
-    runtime: unknown,
-  ): Promise<void> => {
+  return async (req: unknown, res: unknown, runtime: unknown): Promise<void> => {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? '/', 'http://localhost');
     const method = (httpReq.method ?? 'GET').toUpperCase();
     const state = buildState(runtime);
 
-    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {return;}
+    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {
+      return;
+    }
 
     await handleN8nRoutes({
       req: httpReq,

--- a/plugins/plugin-n8n-workflow/src/register-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/register-routes.ts
@@ -1,6 +1,9 @@
 import { registerAppRoutePluginLoader } from '@elizaos/app-core/runtime/app-route-plugin-registry';
 
-registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', async () => {
-  const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
-  return n8nWorkflowRoutePlugin;
-});
+registerAppRoutePluginLoader(
+  '@elizaos/plugin-n8n-workflow:routes',
+  async () => {
+    const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
+    return n8nWorkflowRoutePlugin;
+  },
+);

--- a/plugins/plugin-n8n-workflow/src/register-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/register-routes.ts
@@ -1,9 +1,6 @@
 import { registerAppRoutePluginLoader } from '@elizaos/app-core/runtime/app-route-plugin-registry';
 
-registerAppRoutePluginLoader(
-  '@elizaos/plugin-n8n-workflow:routes',
-  async () => {
-    const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
-    return n8nWorkflowRoutePlugin;
-  },
-);
+registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', async () => {
+  const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
+  return n8nWorkflowRoutePlugin;
+});

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -27,11 +27,20 @@
  * services/n8n-sidecar.ts rather than being threaded through state.
  */
 
-import type { RouteHelpers, RouteRequestMeta } from '@elizaos/agent/api/route-helpers';
+import type {
+  RouteHelpers,
+  RouteRequestMeta,
+} from '@elizaos/agent/api/route-helpers';
 import { readCompatJsonBody } from '@elizaos/app-core/api/compat-route-shared';
 import { isNativeServerPlatform } from '@elizaos/app-core/platform/is-native-server';
-import { type N8nMode, resolveN8nMode } from '@elizaos/app-core/services/n8n-mode';
-import type { N8nSidecar, N8nSidecarStatus } from '@elizaos/app-core/services/n8n-sidecar';
+import {
+  type N8nMode,
+  resolveN8nMode,
+} from '@elizaos/app-core/services/n8n-mode';
+import type {
+  N8nSidecar,
+  N8nSidecarStatus,
+} from '@elizaos/app-core/services/n8n-sidecar';
 import type { AgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
 import {
@@ -159,7 +168,9 @@ export interface N8nRoutesConfigLike {
   };
 }
 
-export interface N8nRouteContext extends RouteRequestMeta, Pick<RouteHelpers, 'json'> {
+export interface N8nRouteContext
+  extends RouteRequestMeta,
+    Pick<RouteHelpers, 'json'> {
   config: N8nRoutesConfigLike;
   runtime: AgentRuntime | null;
   /**
@@ -213,7 +224,10 @@ export function __resetCloudHealthCacheForTests(): void {
   cloudHealthCache.clear();
 }
 
-async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
+async function probeCloudHealth(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<N8nCloudHealth> {
   const url = `${normalizeBaseUrl(baseUrl)}/api/v1/health`;
   try {
     const res = await fetchImpl(url, {
@@ -224,13 +238,18 @@ async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promi
     return res.ok ? 'ok' : 'degraded';
   } catch (err) {
     logger.debug(
-      `[n8n-routes] cloud health probe failed: ${err instanceof Error ? err.message : String(err)}`
+      `[n8n-routes] cloud health probe failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
     return 'degraded';
   }
 }
 
-async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
+async function getCloudHealth(
+  baseUrl: string,
+  fetchImpl: typeof fetch,
+): Promise<N8nCloudHealth> {
   const key = normalizeBaseUrl(baseUrl);
   const now = Date.now();
   const cached = cloudHealthCache.get(key);
@@ -253,10 +272,8 @@ async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise
  */
 async function loadSidecarModule(): Promise<
   typeof import('@elizaos/app-core/services/n8n-sidecar') | null
-> {
-  if (isNativeServerPlatform()) {
-    return null;
-  }
+  > {
+  if (isNativeServerPlatform()) {return null;}
   return await import('@elizaos/app-core/services/n8n-sidecar');
 }
 
@@ -271,34 +288,44 @@ function normalizeBaseUrl(raw: string | undefined | null): string {
 }
 
 function resolveAgentId(ctx: N8nRouteContext): string {
-  if (ctx.agentId?.trim()) {
-    return ctx.agentId.trim();
-  }
+  if (ctx.agentId?.trim()) {return ctx.agentId.trim();}
   const runtimeAny = ctx.runtime as unknown as {
     agentId?: string;
     character?: { id?: string };
   } | null;
-  return runtimeAny?.agentId ?? runtimeAny?.character?.id ?? '00000000-0000-0000-0000-000000000000';
+  return (
+    runtimeAny?.agentId ??
+    runtimeAny?.character?.id ??
+    '00000000-0000-0000-0000-000000000000'
+  );
 }
 
-function sendJson(ctx: Pick<N8nRouteContext, 'res' | 'json'>, status: number, body: unknown): void {
+function sendJson(
+  ctx: Pick<N8nRouteContext, 'res' | 'json'>,
+  status: number,
+  body: unknown,
+): void {
   // The compat `json` helper signature in app-core is
   // `(res, body, status?) => void`; status defaults to 200 upstream.
-  const json = ctx.json as unknown as (res: typeof ctx.res, body: unknown, status?: number) => void;
+  const json = ctx.json as unknown as (
+    res: typeof ctx.res,
+    body: unknown,
+    status?: number,
+  ) => void;
   json(ctx.res, body, status);
 }
 
 /** Strip any credential material from node descriptors before forwarding. */
 function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {
-    return {};
-  }
+  if (!n || typeof n !== 'object') {return {};}
   const obj = n as Record<string, unknown>;
   return {
     ...(typeof obj.id === 'string' ? { id: obj.id } : {}),
     ...(typeof obj.name === 'string' ? { name: obj.name } : {}),
     ...(typeof obj.type === 'string' ? { type: obj.type } : {}),
-    ...(typeof obj.typeVersion === 'number' ? { typeVersion: obj.typeVersion } : {}),
+    ...(typeof obj.typeVersion === 'number'
+      ? { typeVersion: obj.typeVersion }
+      : {}),
   };
 }
 
@@ -307,9 +334,7 @@ function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
  * parameters (needed by the graph viewer). Credentials are still stripped.
  */
 function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {
-    return {};
-  }
+  if (!n || typeof n !== 'object') {return {};}
   const obj = n as Record<string, unknown>;
   const base = sanitizeNode(n);
 
@@ -334,28 +359,28 @@ function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
     ...(position !== undefined ? { position } : {}),
     ...(parameters !== undefined ? { parameters } : {}),
     ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    ...(typeof obj.notesInFlow === 'boolean' ? { notesInFlow: obj.notesInFlow } : {}),
+    ...(typeof obj.notesInFlow === 'boolean'
+      ? { notesInFlow: obj.notesInFlow }
+      : {}),
   };
 }
 
 /** Normalize an n8n workflow payload to our client-facing shape. */
 function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
+  if (!raw || typeof raw !== 'object') {return null;}
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {
-    return null;
-  }
+  if (!id) {return null;}
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNode);
   return {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
+    ...(typeof obj.description === 'string'
+      ? { description: obj.description }
+      : {}),
     nodes,
     nodeCount: nodes.length,
   };
@@ -371,15 +396,11 @@ function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
  * it needs without a second request.
  */
 function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {
-    return null;
-  }
+  if (!raw || typeof raw !== 'object') {return null;}
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {
-    return null;
-  }
+  if (!id) {return null;}
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNodeFull);
 
@@ -394,7 +415,9 @@ function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
+    ...(typeof obj.description === 'string'
+      ? { description: obj.description }
+      : {}),
     nodes,
     nodeCount: nodes.length,
     ...(connections !== undefined ? { connections } : {}),
@@ -419,7 +442,7 @@ function resolveProxyTarget(
   ctx: N8nRouteContext,
   subpath: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): {
   target: ProxyTarget | null;
   reason?: {
@@ -487,9 +510,7 @@ function resolveProxyTarget(
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (apiKey) {
-    headers['X-N8N-API-KEY'] = apiKey;
-  }
+  if (apiKey) {headers['X-N8N-API-KEY'] = apiKey;}
 
   // n8n serves TWO parallel workflow APIs:
   //   /rest/workflows   — internal UI endpoint, requires JWT cookie auth.
@@ -508,7 +529,7 @@ function resolveProxyTarget(
 async function fetchTargetAsJson(
   ctx: N8nRouteContext,
   target: ProxyTarget,
-  init: { method: string; body?: string }
+  init: { method: string; body?: string },
 ): Promise<{
   ok: boolean;
   status: number;
@@ -525,7 +546,9 @@ async function fetchTargetAsJson(
     res = await fetchImpl(target.url, {
       method: init.method,
       headers,
-      ...(init.body !== null && init.body !== undefined ? { body: init.body } : {}),
+      ...(init.body !== null && init.body !== undefined
+        ? { body: init.body }
+        : {}),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
@@ -554,30 +577,18 @@ async function fetchTargetAsJson(
  * or `{ data }`. We accept both.
  */
 function extractWorkflowList(body: unknown): unknown[] {
-  if (!body || typeof body !== 'object') {
-    return [];
-  }
+  if (!body || typeof body !== 'object') {return [];}
   const obj = body as Record<string, unknown>;
-  if (Array.isArray(obj.workflows)) {
-    return obj.workflows;
-  }
-  if (Array.isArray(obj.data)) {
-    return obj.data;
-  }
+  if (Array.isArray(obj.workflows)) {return obj.workflows;}
+  if (Array.isArray(obj.data)) {return obj.data;}
   return [];
 }
 
 function extractWorkflowSingle(body: unknown): unknown {
-  if (!body || typeof body !== 'object') {
-    return null;
-  }
+  if (!body || typeof body !== 'object') {return null;}
   const obj = body as Record<string, unknown>;
-  if (obj.data && typeof obj.data === 'object') {
-    return obj.data;
-  }
-  if (obj.workflow && typeof obj.workflow === 'object') {
-    return obj.workflow;
-  }
+  if (obj.data && typeof obj.data === 'object') {return obj.data;}
+  if (obj.workflow && typeof obj.workflow === 'object') {return obj.workflow;}
   return body;
 }
 
@@ -587,19 +598,32 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
+function readOptionalString(
+  obj: Record<string, unknown>,
+  key: string,
+): string | undefined {
   const value = obj[key];
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
-function readOptionalBoolean(obj: Record<string, unknown>, key: string): boolean | undefined {
+function readOptionalBoolean(
+  obj: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
   const value = obj[key];
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function readOptionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
+function readOptionalNumber(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
   const value = obj[key];
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 /**
@@ -634,11 +658,9 @@ interface TriggerContext {
  */
 async function buildTriggerContextFromConversation(
   runtime: AgentRuntime | null | undefined,
-  roomId: string
+  roomId: string,
 ): Promise<TriggerContext | undefined> {
-  if (!runtime || typeof runtime.getMemories !== 'function') {
-    return undefined;
-  }
+  if (!runtime || typeof runtime.getMemories !== 'function') {return undefined;}
   let memories: Array<{
     entityId?: string;
     metadata?: Record<string, unknown>;
@@ -656,21 +678,19 @@ async function buildTriggerContextFromConversation(
     logger.debug?.(
       `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
         err instanceof Error ? err.message : String(err)
-      }`
+      }`,
     );
     return undefined;
   }
-  if (!Array.isArray(memories) || memories.length === 0) {
-    return undefined;
-  }
+  if (!Array.isArray(memories) || memories.length === 0) {return undefined;}
 
   // Tail inbound = most recent memory whose entityId is NOT the agent.
   // `runtime.getMemories` typically returns most-recent-first; defensively
   // handle either order.
-  const inbound = memories.find((m) => m.entityId && m.entityId !== runtime.agentId);
-  if (!inbound?.metadata) {
-    return undefined;
-  }
+  const inbound = memories.find(
+    (m) => m.entityId && m.entityId !== runtime.agentId,
+  );
+  if (!inbound?.metadata) {return undefined;}
 
   const meta = inbound.metadata as Record<string, unknown>;
   const discord = (meta.discord ?? {}) as Record<string, unknown>;
@@ -680,11 +700,16 @@ async function buildTriggerContextFromConversation(
   // Canonical wins; flat fields are the legacy de-facto shape.
   const discordChannelId =
     (typeof discord.channelId === 'string' ? discord.channelId : undefined) ??
-    (typeof meta.discordChannelId === 'string' ? meta.discordChannelId : undefined);
+    (typeof meta.discordChannelId === 'string'
+      ? meta.discordChannelId
+      : undefined);
   const discordGuildId =
     (typeof discord.guildId === 'string' ? discord.guildId : undefined) ??
-    (typeof meta.discordServerId === 'string' ? meta.discordServerId : undefined);
-  const discordThreadId = typeof discord.threadId === 'string' ? discord.threadId : undefined;
+    (typeof meta.discordServerId === 'string'
+      ? meta.discordServerId
+      : undefined);
+  const discordThreadId =
+    typeof discord.threadId === 'string' ? discord.threadId : undefined;
 
   // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
   // id, which equals the chat id only in private 1:1 DMs. In group chats /
@@ -698,12 +723,15 @@ async function buildTriggerContextFromConversation(
       ? telegram.chatId
       : undefined;
   const telegramThreadId =
-    typeof telegram.threadId === 'string' || typeof telegram.threadId === 'number'
+    typeof telegram.threadId === 'string' ||
+    typeof telegram.threadId === 'number'
       ? (telegram.threadId as string | number)
       : undefined;
 
-  const slackChannelId = typeof slack.channelId === 'string' ? slack.channelId : undefined;
-  const slackTeamId = typeof slack.teamId === 'string' ? slack.teamId : undefined;
+  const slackChannelId =
+    typeof slack.channelId === 'string' ? slack.channelId : undefined;
+  const slackTeamId =
+    typeof slack.teamId === 'string' ? slack.teamId : undefined;
 
   if (discordChannelId) {
     return {
@@ -720,7 +748,9 @@ async function buildTriggerContextFromConversation(
       source: 'telegram',
       telegram: {
         chatId: telegramChatId,
-        ...(telegramThreadId !== undefined ? { threadId: telegramThreadId } : {}),
+        ...(telegramThreadId !== undefined
+          ? { threadId: telegramThreadId }
+          : {}),
       },
     };
   }
@@ -745,39 +775,34 @@ function readPosition(value: unknown): [number, number] | null {
     : null;
 }
 
-function readCredentials(value: unknown): Record<string, { id: string; name: string }> | undefined {
+function readCredentials(
+  value: unknown,
+): Record<string, { id: string; name: string }> | undefined {
   const raw = asRecord(value);
-  if (!raw) {
-    return undefined;
-  }
+  if (!raw) {return undefined;}
 
   const credentials: Record<string, { id: string; name: string }> = {};
   for (const [key, credentialValue] of Object.entries(raw)) {
     const credential = asRecord(credentialValue);
-    if (!credential) {
-      continue;
-    }
+    if (!credential) {continue;}
     const id = readOptionalString(credential, 'id');
     const name = readOptionalString(credential, 'name');
-    if (!id || !name) {
-      continue;
-    }
+    if (!id || !name) {continue;}
     credentials[key] = { id, name };
   }
   return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
-function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowWriteNode | null {
+function normalizeWorkflowWriteNode(
+  value: unknown,
+  index: number,
+): N8nWorkflowWriteNode | null {
   const obj = asRecord(value);
-  if (!obj) {
-    return null;
-  }
+  if (!obj) {return null;}
 
   const name = readOptionalString(obj, 'name');
   const type = readOptionalString(obj, 'type');
-  if (!name || !type) {
-    return null;
-  }
+  if (!name || !type) {return null;}
 
   const position = readPosition(obj.position) ?? [index * 260, 0];
   const parameters = asRecord(obj.parameters) ?? {};
@@ -785,7 +810,9 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
   const credentials = readCredentials(obj.credentials);
 
   return {
-    ...(readOptionalString(obj, 'id') ? { id: readOptionalString(obj, 'id') } : {}),
+    ...(readOptionalString(obj, 'id')
+      ? { id: readOptionalString(obj, 'id') }
+      : {}),
     name,
     type,
     typeVersion,
@@ -795,11 +822,15 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
     ...(readOptionalBoolean(obj, 'disabled') !== undefined
       ? { disabled: readOptionalBoolean(obj, 'disabled') }
       : {}),
-    ...(readOptionalString(obj, 'notes') ? { notes: readOptionalString(obj, 'notes') } : {}),
+    ...(readOptionalString(obj, 'notes')
+      ? { notes: readOptionalString(obj, 'notes') }
+      : {}),
     ...(readOptionalBoolean(obj, 'notesInFlow') !== undefined
       ? { notesInFlow: readOptionalBoolean(obj, 'notesInFlow') }
       : {}),
-    ...(readOptionalString(obj, 'color') ? { color: readOptionalString(obj, 'color') } : {}),
+    ...(readOptionalString(obj, 'color')
+      ? { color: readOptionalString(obj, 'color') }
+      : {}),
     ...(readOptionalBoolean(obj, 'continueOnFail') !== undefined
       ? { continueOnFail: readOptionalBoolean(obj, 'continueOnFail') }
       : {}),
@@ -828,37 +859,31 @@ function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowW
 
 function normalizeWorkflowConnections(value: unknown): N8nWorkflowConnections {
   const raw = asRecord(value);
-  if (!raw) {
-    return {};
-  }
+  if (!raw) {return {};}
 
   const connections: N8nWorkflowConnections = {};
   for (const [sourceName, outputValue] of Object.entries(raw)) {
     const outputMap = asRecord(outputValue);
-    if (!outputMap) {
-      continue;
-    }
+    if (!outputMap) {continue;}
     const mainRaw = outputMap.main;
-    if (!Array.isArray(mainRaw)) {
-      continue;
-    }
+    if (!Array.isArray(mainRaw)) {continue;}
     const main = mainRaw.map((group) =>
       Array.isArray(group)
         ? group
-            .map((connection) => {
-              const obj = asRecord(connection);
-              const node = obj ? readOptionalString(obj, 'node') : undefined;
-              if (!obj || !node) {
-                return null;
-              }
-              const index = readOptionalNumber(obj, 'index') ?? 0;
-              return { node, type: 'main' as const, index };
-            })
-            .filter(
-              (connection): connection is { node: string; type: 'main'; index: number } =>
-                connection !== null
-            )
-        : []
+          .map((connection) => {
+            const obj = asRecord(connection);
+            const node = obj ? readOptionalString(obj, 'node') : undefined;
+            if (!obj || !node) {return null;}
+            const index = readOptionalNumber(obj, 'index') ?? 0;
+            return { node, type: 'main' as const, index };
+          })
+          .filter(
+            (
+              connection,
+            ): connection is { node: string; type: 'main'; index: number } =>
+              connection !== null,
+          )
+        : [],
     );
     connections[sourceName] = { main };
   }
@@ -892,8 +917,12 @@ function normalizeWorkflowWritePayload(body: Record<string, unknown>): {
   };
 }
 
-function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: unknown }): void {
-  const status = upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
+function propagateError(
+  ctx: N8nRouteContext,
+  upstream: { status: number; body: unknown },
+): void {
+  const status =
+    upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
   let message = `upstream responded with ${upstream.status}`;
   if (upstream.body && typeof upstream.body === 'object') {
     const b = upstream.body as Record<string, unknown>;
@@ -912,16 +941,12 @@ function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: 
  * Returns null if pathname doesn't match.
  */
 function parseWorkflowPath(
-  pathname: string
+  pathname: string,
 ): { id: string; action: 'get' | 'activate' | 'deactivate' } | null {
   const prefix = '/api/n8n/workflows/';
-  if (!pathname.startsWith(prefix)) {
-    return null;
-  }
+  if (!pathname.startsWith(prefix)) {return null;}
   const rest = pathname.slice(prefix.length);
-  if (!rest) {
-    return null;
-  }
+  if (!rest) {return null;}
   const parts = rest.split('/').filter(Boolean);
   if (parts.length === 1) {
     return { id: decodeURIComponent(parts[0] ?? ''), action: 'get' };
@@ -943,14 +968,10 @@ function parseWorkflowPath(
  */
 async function resolveSidecarForRequest(
   ctx: N8nRouteContext,
-  native: boolean
+  native: boolean,
 ): Promise<N8nSidecar | null> {
-  if (ctx.n8nSidecar !== undefined) {
-    return ctx.n8nSidecar;
-  }
-  if (native) {
-    return null;
-  }
+  if (ctx.n8nSidecar !== undefined) {return ctx.n8nSidecar;}
+  if (native) {return null;}
   const mod = await loadSidecarModule();
   return mod?.peekN8nSidecar() ?? null;
 }
@@ -1004,7 +1025,10 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
-  if (method === 'POST' && pathname === '/api/n8n/workflows/resolve-clarification') {
+  if (
+    method === 'POST' &&
+    pathname === '/api/n8n/workflows/resolve-clarification'
+  ) {
     return handleResolveClarification(ctx);
   }
 
@@ -1044,7 +1068,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
 async function handleStatus(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const { config, runtime } = ctx;
 
@@ -1056,7 +1080,8 @@ async function handleStatus(
   const sidecarState = sidecar?.getState();
   const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
 
-  const host = mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
+  const host =
+    mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
 
   // Cloud health — only probed when we are actually in cloud mode. The
   // probe is cached for 30s (see getCloudHealth) so rapid status polls
@@ -1068,7 +1093,7 @@ async function handleStatus(
     } else {
       cloudHealth = await getCloudHealth(
         config.cloud?.baseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
-        ctx.fetchImpl ?? fetch
+        ctx.fetchImpl ?? fetch,
       );
     }
   }
@@ -1083,10 +1108,10 @@ async function handleStatus(
     cloudHealth,
     ...(sidecarState
       ? {
-          errorMessage: sidecarState.errorMessage,
-          retries: sidecarState.retries,
-          recentOutput: sidecarState.recentOutput,
-        }
+        errorMessage: sidecarState.errorMessage,
+        retries: sidecarState.retries,
+        recentOutput: sidecarState.recentOutput,
+      }
       : {}),
   };
 
@@ -1098,7 +1123,7 @@ async function handleStatus(
 async function handleListWorkflows(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, '', sidecar, native);
   if (!resolved.target) {
@@ -1118,7 +1143,9 @@ async function handleListWorkflows(
   }
 
   const list = extractWorkflowList(upstream.body);
-  const workflows = list.map(normalizeWorkflow).filter((w): w is N8nWorkflow => w !== null);
+  const workflows = list
+    .map(normalizeWorkflow)
+    .filter((w): w is N8nWorkflow => w !== null);
 
   sendJson(ctx, 200, { workflows });
   return true;
@@ -1136,7 +1163,7 @@ async function handleGetWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1177,7 +1204,7 @@ async function writeWorkflow(
   subpath: string,
   payload: N8nWorkflowWritePayload,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, subpath, sidecar, native);
   if (!resolved.target) {
@@ -1210,12 +1237,10 @@ async function writeWorkflow(
 async function handleCreateWorkflow(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1230,7 +1255,7 @@ async function handleUpdateWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1238,9 +1263,7 @@ async function handleUpdateWorkflow(
   }
 
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1248,20 +1271,27 @@ async function handleUpdateWorkflow(
     return true;
   }
 
-  return writeWorkflow(ctx, 'PUT', `/${encodeURIComponent(id)}`, payload, sidecar, native);
+  return writeWorkflow(
+    ctx,
+    'PUT',
+    `/${encodeURIComponent(id)}`,
+    payload,
+    sidecar,
+    native,
+  );
 }
 
 interface N8nWorkflowServiceLike {
   generateWorkflowDraft?: (
     prompt: string,
-    opts?: { triggerContext?: TriggerContext }
+    opts?: { triggerContext?: TriggerContext },
   ) => Promise<{
     id?: string;
     [k: string]: unknown;
   }>;
   deployWorkflow?: (
     workflow: Record<string, unknown>,
-    userId: string
+    userId: string,
   ) => Promise<{
     id: string;
     name: string;
@@ -1271,8 +1301,12 @@ interface N8nWorkflowServiceLike {
   getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
 }
 
-function getN8nWorkflowService(ctx: N8nRouteContext): N8nWorkflowServiceLike | null {
-  const service = ctx.runtime?.getService?.('n8n_workflow') as N8nWorkflowServiceLike | undefined;
+function getN8nWorkflowService(
+  ctx: N8nRouteContext,
+): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.('n8n_workflow') as
+    | N8nWorkflowServiceLike
+    | undefined;
   if (
     typeof service?.generateWorkflowDraft !== 'function' ||
     typeof service.deployWorkflow !== 'function' ||
@@ -1301,7 +1335,7 @@ function getConnectorTargetCatalog(ctx: N8nRouteContext): CatalogLike | null {
 async function deployAndRespond(
   ctx: N8nRouteContext,
   service: N8nWorkflowServiceLike,
-  draft: Record<string, unknown>
+  draft: Record<string, unknown>,
 ): Promise<void> {
   const userId = resolveAgentId(ctx);
   const deployed = await service.deployWorkflow?.(draft, userId);
@@ -1322,9 +1356,7 @@ async function deployAndRespond(
 
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const prompt = readOptionalString(body, 'prompt');
   if (!prompt) {
@@ -1343,7 +1375,10 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   }
 
   const triggerContext = bridgeConversationId
-    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
+    ? await buildTriggerContextFromConversation(
+      ctx.runtime,
+      bridgeConversationId,
+    )
     : undefined;
 
   const draft = triggerContext
@@ -1381,11 +1416,11 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   return true;
 }
 
-async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean> {
+async function handleResolveClarification(
+  ctx: N8nRouteContext,
+): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {
-    return true;
-  }
+  if (!body) {return true;}
 
   const draftRaw = (body as Record<string, unknown>).draft;
   if (!draftRaw || typeof draftRaw !== 'object' || Array.isArray(draftRaw)) {
@@ -1415,7 +1450,7 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
 
   const result = applyResolutions(
     draft,
-    resolutions as Array<{ paramPath: string; value: string }>
+    resolutions as Array<{ paramPath: string; value: string }>,
   );
   if (!result.ok) {
     sendJson(ctx, 400, {
@@ -1428,10 +1463,10 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
   const resolvedPaths = new Set(
     resolutions
       .map((r) => r.paramPath)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0)
+      .filter((p): p is string => typeof p === 'string' && p.length > 0),
   );
   const freeFormCount = resolutions.filter(
-    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0
+    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0,
   ).length;
   pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
@@ -1449,7 +1484,9 @@ async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean
   const remaining = coerceClarifications(meta?.requiresClarification);
   if (remaining.length > 0) {
     const catalogService = getConnectorTargetCatalog(ctx);
-    const catalog = catalogService ? await buildCatalogSnapshot(catalogService, remaining) : [];
+    const catalog = catalogService
+      ? await buildCatalogSnapshot(catalogService, remaining)
+      : [];
     sendJson(ctx, 200, {
       status: 'needs_clarification',
       draft,
@@ -1468,7 +1505,7 @@ async function handleToggleWorkflow(
   id: string,
   activate: boolean,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1516,14 +1553,19 @@ async function handleDeleteWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean
+  native: boolean,
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
     return true;
   }
 
-  const resolved = resolveProxyTarget(ctx, `/${encodeURIComponent(id)}`, sidecar, native);
+  const resolved = resolveProxyTarget(
+    ctx,
+    `/${encodeURIComponent(id)}`,
+    sidecar,
+    native,
+  );
   if (!resolved.target) {
     sendJson(ctx, 503, {
       error: resolved.reason?.message ?? 'n8n not ready',

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -27,20 +27,11 @@
  * services/n8n-sidecar.ts rather than being threaded through state.
  */
 
-import type {
-  RouteHelpers,
-  RouteRequestMeta,
-} from '@elizaos/agent/api/route-helpers';
+import type { RouteHelpers, RouteRequestMeta } from '@elizaos/agent/api/route-helpers';
 import { readCompatJsonBody } from '@elizaos/app-core/api/compat-route-shared';
 import { isNativeServerPlatform } from '@elizaos/app-core/platform/is-native-server';
-import {
-  type N8nMode,
-  resolveN8nMode,
-} from '@elizaos/app-core/services/n8n-mode';
-import type {
-  N8nSidecar,
-  N8nSidecarStatus,
-} from '@elizaos/app-core/services/n8n-sidecar';
+import { type N8nMode, resolveN8nMode } from '@elizaos/app-core/services/n8n-mode';
+import type { N8nSidecar, N8nSidecarStatus } from '@elizaos/app-core/services/n8n-sidecar';
 import type { AgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
 import {
@@ -168,9 +159,7 @@ export interface N8nRoutesConfigLike {
   };
 }
 
-export interface N8nRouteContext
-  extends RouteRequestMeta,
-    Pick<RouteHelpers, 'json'> {
+export interface N8nRouteContext extends RouteRequestMeta, Pick<RouteHelpers, 'json'> {
   config: N8nRoutesConfigLike;
   runtime: AgentRuntime | null;
   /**
@@ -224,10 +213,7 @@ export function __resetCloudHealthCacheForTests(): void {
   cloudHealthCache.clear();
 }
 
-async function probeCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const url = `${normalizeBaseUrl(baseUrl)}/api/v1/health`;
   try {
     const res = await fetchImpl(url, {
@@ -238,18 +224,13 @@ async function probeCloudHealth(
     return res.ok ? 'ok' : 'degraded';
   } catch (err) {
     logger.debug(
-      `[n8n-routes] cloud health probe failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `[n8n-routes] cloud health probe failed: ${err instanceof Error ? err.message : String(err)}`
     );
     return 'degraded';
   }
 }
 
-async function getCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const key = normalizeBaseUrl(baseUrl);
   const now = Date.now();
   const cached = cloudHealthCache.get(key);
@@ -272,8 +253,10 @@ async function getCloudHealth(
  */
 async function loadSidecarModule(): Promise<
   typeof import('@elizaos/app-core/services/n8n-sidecar') | null
-  > {
-  if (isNativeServerPlatform()) {return null;}
+> {
+  if (isNativeServerPlatform()) {
+    return null;
+  }
   return await import('@elizaos/app-core/services/n8n-sidecar');
 }
 
@@ -288,44 +271,34 @@ function normalizeBaseUrl(raw: string | undefined | null): string {
 }
 
 function resolveAgentId(ctx: N8nRouteContext): string {
-  if (ctx.agentId?.trim()) {return ctx.agentId.trim();}
+  if (ctx.agentId?.trim()) {
+    return ctx.agentId.trim();
+  }
   const runtimeAny = ctx.runtime as unknown as {
     agentId?: string;
     character?: { id?: string };
   } | null;
-  return (
-    runtimeAny?.agentId ??
-    runtimeAny?.character?.id ??
-    '00000000-0000-0000-0000-000000000000'
-  );
+  return runtimeAny?.agentId ?? runtimeAny?.character?.id ?? '00000000-0000-0000-0000-000000000000';
 }
 
-function sendJson(
-  ctx: Pick<N8nRouteContext, 'res' | 'json'>,
-  status: number,
-  body: unknown,
-): void {
+function sendJson(ctx: Pick<N8nRouteContext, 'res' | 'json'>, status: number, body: unknown): void {
   // The compat `json` helper signature in app-core is
   // `(res, body, status?) => void`; status defaults to 200 upstream.
-  const json = ctx.json as unknown as (
-    res: typeof ctx.res,
-    body: unknown,
-    status?: number,
-  ) => void;
+  const json = ctx.json as unknown as (res: typeof ctx.res, body: unknown, status?: number) => void;
   json(ctx.res, body, status);
 }
 
 /** Strip any credential material from node descriptors before forwarding. */
 function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   return {
     ...(typeof obj.id === 'string' ? { id: obj.id } : {}),
     ...(typeof obj.name === 'string' ? { name: obj.name } : {}),
     ...(typeof obj.type === 'string' ? { type: obj.type } : {}),
-    ...(typeof obj.typeVersion === 'number'
-      ? { typeVersion: obj.typeVersion }
-      : {}),
+    ...(typeof obj.typeVersion === 'number' ? { typeVersion: obj.typeVersion } : {}),
   };
 }
 
@@ -334,7 +307,9 @@ function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
  * parameters (needed by the graph viewer). Credentials are still stripped.
  */
 function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   const base = sanitizeNode(n);
 
@@ -359,28 +334,28 @@ function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
     ...(position !== undefined ? { position } : {}),
     ...(parameters !== undefined ? { parameters } : {}),
     ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    ...(typeof obj.notesInFlow === 'boolean'
-      ? { notesInFlow: obj.notesInFlow }
-      : {}),
+    ...(typeof obj.notesInFlow === 'boolean' ? { notesInFlow: obj.notesInFlow } : {}),
   };
 }
 
 /** Normalize an n8n workflow payload to our client-facing shape. */
 function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNode);
   return {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
   };
@@ -396,11 +371,15 @@ function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
  * it needs without a second request.
  */
 function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNodeFull);
 
@@ -415,9 +394,7 @@ function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
     ...(connections !== undefined ? { connections } : {}),
@@ -442,7 +419,7 @@ function resolveProxyTarget(
   ctx: N8nRouteContext,
   subpath: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): {
   target: ProxyTarget | null;
   reason?: {
@@ -510,7 +487,9 @@ function resolveProxyTarget(
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (apiKey) {headers['X-N8N-API-KEY'] = apiKey;}
+  if (apiKey) {
+    headers['X-N8N-API-KEY'] = apiKey;
+  }
 
   // n8n serves TWO parallel workflow APIs:
   //   /rest/workflows   — internal UI endpoint, requires JWT cookie auth.
@@ -529,7 +508,7 @@ function resolveProxyTarget(
 async function fetchTargetAsJson(
   ctx: N8nRouteContext,
   target: ProxyTarget,
-  init: { method: string; body?: string },
+  init: { method: string; body?: string }
 ): Promise<{
   ok: boolean;
   status: number;
@@ -546,9 +525,7 @@ async function fetchTargetAsJson(
     res = await fetchImpl(target.url, {
       method: init.method,
       headers,
-      ...(init.body !== null && init.body !== undefined
-        ? { body: init.body }
-        : {}),
+      ...(init.body !== null && init.body !== undefined ? { body: init.body } : {}),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
@@ -577,18 +554,30 @@ async function fetchTargetAsJson(
  * or `{ data }`. We accept both.
  */
 function extractWorkflowList(body: unknown): unknown[] {
-  if (!body || typeof body !== 'object') {return [];}
+  if (!body || typeof body !== 'object') {
+    return [];
+  }
   const obj = body as Record<string, unknown>;
-  if (Array.isArray(obj.workflows)) {return obj.workflows;}
-  if (Array.isArray(obj.data)) {return obj.data;}
+  if (Array.isArray(obj.workflows)) {
+    return obj.workflows;
+  }
+  if (Array.isArray(obj.data)) {
+    return obj.data;
+  }
   return [];
 }
 
 function extractWorkflowSingle(body: unknown): unknown {
-  if (!body || typeof body !== 'object') {return null;}
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
   const obj = body as Record<string, unknown>;
-  if (obj.data && typeof obj.data === 'object') {return obj.data;}
-  if (obj.workflow && typeof obj.workflow === 'object') {return obj.workflow;}
+  if (obj.data && typeof obj.data === 'object') {
+    return obj.data;
+  }
+  if (obj.workflow && typeof obj.workflow === 'object') {
+    return obj.workflow;
+  }
   return body;
 }
 
@@ -598,32 +587,19 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readOptionalString(
-  obj: Record<string, unknown>,
-  key: string,
-): string | undefined {
+function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
   const value = obj[key];
-  return typeof value === 'string' && value.trim().length > 0
-    ? value.trim()
-    : undefined;
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function readOptionalBoolean(
-  obj: Record<string, unknown>,
-  key: string,
-): boolean | undefined {
+function readOptionalBoolean(obj: Record<string, unknown>, key: string): boolean | undefined {
   const value = obj[key];
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function readOptionalNumber(
-  obj: Record<string, unknown>,
-  key: string,
-): number | undefined {
+function readOptionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
   const value = obj[key];
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 /**
@@ -658,9 +634,11 @@ interface TriggerContext {
  */
 async function buildTriggerContextFromConversation(
   runtime: AgentRuntime | null | undefined,
-  roomId: string,
+  roomId: string
 ): Promise<TriggerContext | undefined> {
-  if (!runtime || typeof runtime.getMemories !== 'function') {return undefined;}
+  if (!runtime || typeof runtime.getMemories !== 'function') {
+    return undefined;
+  }
   let memories: Array<{
     entityId?: string;
     metadata?: Record<string, unknown>;
@@ -678,19 +656,21 @@ async function buildTriggerContextFromConversation(
     logger.debug?.(
       `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
         err instanceof Error ? err.message : String(err)
-      }`,
+      }`
     );
     return undefined;
   }
-  if (!Array.isArray(memories) || memories.length === 0) {return undefined;}
+  if (!Array.isArray(memories) || memories.length === 0) {
+    return undefined;
+  }
 
   // Tail inbound = most recent memory whose entityId is NOT the agent.
   // `runtime.getMemories` typically returns most-recent-first; defensively
   // handle either order.
-  const inbound = memories.find(
-    (m) => m.entityId && m.entityId !== runtime.agentId,
-  );
-  if (!inbound?.metadata) {return undefined;}
+  const inbound = memories.find((m) => m.entityId && m.entityId !== runtime.agentId);
+  if (!inbound?.metadata) {
+    return undefined;
+  }
 
   const meta = inbound.metadata as Record<string, unknown>;
   const discord = (meta.discord ?? {}) as Record<string, unknown>;
@@ -700,16 +680,11 @@ async function buildTriggerContextFromConversation(
   // Canonical wins; flat fields are the legacy de-facto shape.
   const discordChannelId =
     (typeof discord.channelId === 'string' ? discord.channelId : undefined) ??
-    (typeof meta.discordChannelId === 'string'
-      ? meta.discordChannelId
-      : undefined);
+    (typeof meta.discordChannelId === 'string' ? meta.discordChannelId : undefined);
   const discordGuildId =
     (typeof discord.guildId === 'string' ? discord.guildId : undefined) ??
-    (typeof meta.discordServerId === 'string'
-      ? meta.discordServerId
-      : undefined);
-  const discordThreadId =
-    typeof discord.threadId === 'string' ? discord.threadId : undefined;
+    (typeof meta.discordServerId === 'string' ? meta.discordServerId : undefined);
+  const discordThreadId = typeof discord.threadId === 'string' ? discord.threadId : undefined;
 
   // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
   // id, which equals the chat id only in private 1:1 DMs. In group chats /
@@ -723,15 +698,12 @@ async function buildTriggerContextFromConversation(
       ? telegram.chatId
       : undefined;
   const telegramThreadId =
-    typeof telegram.threadId === 'string' ||
-    typeof telegram.threadId === 'number'
+    typeof telegram.threadId === 'string' || typeof telegram.threadId === 'number'
       ? (telegram.threadId as string | number)
       : undefined;
 
-  const slackChannelId =
-    typeof slack.channelId === 'string' ? slack.channelId : undefined;
-  const slackTeamId =
-    typeof slack.teamId === 'string' ? slack.teamId : undefined;
+  const slackChannelId = typeof slack.channelId === 'string' ? slack.channelId : undefined;
+  const slackTeamId = typeof slack.teamId === 'string' ? slack.teamId : undefined;
 
   if (discordChannelId) {
     return {
@@ -748,9 +720,7 @@ async function buildTriggerContextFromConversation(
       source: 'telegram',
       telegram: {
         chatId: telegramChatId,
-        ...(telegramThreadId !== undefined
-          ? { threadId: telegramThreadId }
-          : {}),
+        ...(telegramThreadId !== undefined ? { threadId: telegramThreadId } : {}),
       },
     };
   }
@@ -775,34 +745,39 @@ function readPosition(value: unknown): [number, number] | null {
     : null;
 }
 
-function readCredentials(
-  value: unknown,
-): Record<string, { id: string; name: string }> | undefined {
+function readCredentials(value: unknown): Record<string, { id: string; name: string }> | undefined {
   const raw = asRecord(value);
-  if (!raw) {return undefined;}
+  if (!raw) {
+    return undefined;
+  }
 
   const credentials: Record<string, { id: string; name: string }> = {};
   for (const [key, credentialValue] of Object.entries(raw)) {
     const credential = asRecord(credentialValue);
-    if (!credential) {continue;}
+    if (!credential) {
+      continue;
+    }
     const id = readOptionalString(credential, 'id');
     const name = readOptionalString(credential, 'name');
-    if (!id || !name) {continue;}
+    if (!id || !name) {
+      continue;
+    }
     credentials[key] = { id, name };
   }
   return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
-function normalizeWorkflowWriteNode(
-  value: unknown,
-  index: number,
-): N8nWorkflowWriteNode | null {
+function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowWriteNode | null {
   const obj = asRecord(value);
-  if (!obj) {return null;}
+  if (!obj) {
+    return null;
+  }
 
   const name = readOptionalString(obj, 'name');
   const type = readOptionalString(obj, 'type');
-  if (!name || !type) {return null;}
+  if (!name || !type) {
+    return null;
+  }
 
   const position = readPosition(obj.position) ?? [index * 260, 0];
   const parameters = asRecord(obj.parameters) ?? {};
@@ -810,9 +785,7 @@ function normalizeWorkflowWriteNode(
   const credentials = readCredentials(obj.credentials);
 
   return {
-    ...(readOptionalString(obj, 'id')
-      ? { id: readOptionalString(obj, 'id') }
-      : {}),
+    ...(readOptionalString(obj, 'id') ? { id: readOptionalString(obj, 'id') } : {}),
     name,
     type,
     typeVersion,
@@ -822,15 +795,11 @@ function normalizeWorkflowWriteNode(
     ...(readOptionalBoolean(obj, 'disabled') !== undefined
       ? { disabled: readOptionalBoolean(obj, 'disabled') }
       : {}),
-    ...(readOptionalString(obj, 'notes')
-      ? { notes: readOptionalString(obj, 'notes') }
-      : {}),
+    ...(readOptionalString(obj, 'notes') ? { notes: readOptionalString(obj, 'notes') } : {}),
     ...(readOptionalBoolean(obj, 'notesInFlow') !== undefined
       ? { notesInFlow: readOptionalBoolean(obj, 'notesInFlow') }
       : {}),
-    ...(readOptionalString(obj, 'color')
-      ? { color: readOptionalString(obj, 'color') }
-      : {}),
+    ...(readOptionalString(obj, 'color') ? { color: readOptionalString(obj, 'color') } : {}),
     ...(readOptionalBoolean(obj, 'continueOnFail') !== undefined
       ? { continueOnFail: readOptionalBoolean(obj, 'continueOnFail') }
       : {}),
@@ -859,31 +828,37 @@ function normalizeWorkflowWriteNode(
 
 function normalizeWorkflowConnections(value: unknown): N8nWorkflowConnections {
   const raw = asRecord(value);
-  if (!raw) {return {};}
+  if (!raw) {
+    return {};
+  }
 
   const connections: N8nWorkflowConnections = {};
   for (const [sourceName, outputValue] of Object.entries(raw)) {
     const outputMap = asRecord(outputValue);
-    if (!outputMap) {continue;}
+    if (!outputMap) {
+      continue;
+    }
     const mainRaw = outputMap.main;
-    if (!Array.isArray(mainRaw)) {continue;}
+    if (!Array.isArray(mainRaw)) {
+      continue;
+    }
     const main = mainRaw.map((group) =>
       Array.isArray(group)
         ? group
-          .map((connection) => {
-            const obj = asRecord(connection);
-            const node = obj ? readOptionalString(obj, 'node') : undefined;
-            if (!obj || !node) {return null;}
-            const index = readOptionalNumber(obj, 'index') ?? 0;
-            return { node, type: 'main' as const, index };
-          })
-          .filter(
-            (
-              connection,
-            ): connection is { node: string; type: 'main'; index: number } =>
-              connection !== null,
-          )
-        : [],
+            .map((connection) => {
+              const obj = asRecord(connection);
+              const node = obj ? readOptionalString(obj, 'node') : undefined;
+              if (!obj || !node) {
+                return null;
+              }
+              const index = readOptionalNumber(obj, 'index') ?? 0;
+              return { node, type: 'main' as const, index };
+            })
+            .filter(
+              (connection): connection is { node: string; type: 'main'; index: number } =>
+                connection !== null
+            )
+        : []
     );
     connections[sourceName] = { main };
   }
@@ -917,12 +892,8 @@ function normalizeWorkflowWritePayload(body: Record<string, unknown>): {
   };
 }
 
-function propagateError(
-  ctx: N8nRouteContext,
-  upstream: { status: number; body: unknown },
-): void {
-  const status =
-    upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
+function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: unknown }): void {
+  const status = upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
   let message = `upstream responded with ${upstream.status}`;
   if (upstream.body && typeof upstream.body === 'object') {
     const b = upstream.body as Record<string, unknown>;
@@ -941,12 +912,16 @@ function propagateError(
  * Returns null if pathname doesn't match.
  */
 function parseWorkflowPath(
-  pathname: string,
+  pathname: string
 ): { id: string; action: 'get' | 'activate' | 'deactivate' } | null {
   const prefix = '/api/n8n/workflows/';
-  if (!pathname.startsWith(prefix)) {return null;}
+  if (!pathname.startsWith(prefix)) {
+    return null;
+  }
   const rest = pathname.slice(prefix.length);
-  if (!rest) {return null;}
+  if (!rest) {
+    return null;
+  }
   const parts = rest.split('/').filter(Boolean);
   if (parts.length === 1) {
     return { id: decodeURIComponent(parts[0] ?? ''), action: 'get' };
@@ -968,10 +943,14 @@ function parseWorkflowPath(
  */
 async function resolveSidecarForRequest(
   ctx: N8nRouteContext,
-  native: boolean,
+  native: boolean
 ): Promise<N8nSidecar | null> {
-  if (ctx.n8nSidecar !== undefined) {return ctx.n8nSidecar;}
-  if (native) {return null;}
+  if (ctx.n8nSidecar !== undefined) {
+    return ctx.n8nSidecar;
+  }
+  if (native) {
+    return null;
+  }
   const mod = await loadSidecarModule();
   return mod?.peekN8nSidecar() ?? null;
 }
@@ -1025,10 +1004,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
-  if (
-    method === 'POST' &&
-    pathname === '/api/n8n/workflows/resolve-clarification'
-  ) {
+  if (method === 'POST' && pathname === '/api/n8n/workflows/resolve-clarification') {
     return handleResolveClarification(ctx);
   }
 
@@ -1068,7 +1044,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
 async function handleStatus(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const { config, runtime } = ctx;
 
@@ -1080,8 +1056,7 @@ async function handleStatus(
   const sidecarState = sidecar?.getState();
   const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
 
-  const host =
-    mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
+  const host = mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
 
   // Cloud health — only probed when we are actually in cloud mode. The
   // probe is cached for 30s (see getCloudHealth) so rapid status polls
@@ -1093,7 +1068,7 @@ async function handleStatus(
     } else {
       cloudHealth = await getCloudHealth(
         config.cloud?.baseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
-        ctx.fetchImpl ?? fetch,
+        ctx.fetchImpl ?? fetch
       );
     }
   }
@@ -1108,10 +1083,10 @@ async function handleStatus(
     cloudHealth,
     ...(sidecarState
       ? {
-        errorMessage: sidecarState.errorMessage,
-        retries: sidecarState.retries,
-        recentOutput: sidecarState.recentOutput,
-      }
+          errorMessage: sidecarState.errorMessage,
+          retries: sidecarState.retries,
+          recentOutput: sidecarState.recentOutput,
+        }
       : {}),
   };
 
@@ -1123,7 +1098,7 @@ async function handleStatus(
 async function handleListWorkflows(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, '', sidecar, native);
   if (!resolved.target) {
@@ -1143,9 +1118,7 @@ async function handleListWorkflows(
   }
 
   const list = extractWorkflowList(upstream.body);
-  const workflows = list
-    .map(normalizeWorkflow)
-    .filter((w): w is N8nWorkflow => w !== null);
+  const workflows = list.map(normalizeWorkflow).filter((w): w is N8nWorkflow => w !== null);
 
   sendJson(ctx, 200, { workflows });
   return true;
@@ -1163,7 +1136,7 @@ async function handleGetWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1204,7 +1177,7 @@ async function writeWorkflow(
   subpath: string,
   payload: N8nWorkflowWritePayload,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, subpath, sidecar, native);
   if (!resolved.target) {
@@ -1237,10 +1210,12 @@ async function writeWorkflow(
 async function handleCreateWorkflow(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1255,7 +1230,7 @@ async function handleUpdateWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1263,7 +1238,9 @@ async function handleUpdateWorkflow(
   }
 
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1271,27 +1248,20 @@ async function handleUpdateWorkflow(
     return true;
   }
 
-  return writeWorkflow(
-    ctx,
-    'PUT',
-    `/${encodeURIComponent(id)}`,
-    payload,
-    sidecar,
-    native,
-  );
+  return writeWorkflow(ctx, 'PUT', `/${encodeURIComponent(id)}`, payload, sidecar, native);
 }
 
 interface N8nWorkflowServiceLike {
   generateWorkflowDraft?: (
     prompt: string,
-    opts?: { triggerContext?: TriggerContext },
+    opts?: { triggerContext?: TriggerContext }
   ) => Promise<{
     id?: string;
     [k: string]: unknown;
   }>;
   deployWorkflow?: (
     workflow: Record<string, unknown>,
-    userId: string,
+    userId: string
   ) => Promise<{
     id: string;
     name: string;
@@ -1301,12 +1271,8 @@ interface N8nWorkflowServiceLike {
   getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
 }
 
-function getN8nWorkflowService(
-  ctx: N8nRouteContext,
-): N8nWorkflowServiceLike | null {
-  const service = ctx.runtime?.getService?.('n8n_workflow') as
-    | N8nWorkflowServiceLike
-    | undefined;
+function getN8nWorkflowService(ctx: N8nRouteContext): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.('n8n_workflow') as N8nWorkflowServiceLike | undefined;
   if (
     typeof service?.generateWorkflowDraft !== 'function' ||
     typeof service.deployWorkflow !== 'function' ||
@@ -1335,7 +1301,7 @@ function getConnectorTargetCatalog(ctx: N8nRouteContext): CatalogLike | null {
 async function deployAndRespond(
   ctx: N8nRouteContext,
   service: N8nWorkflowServiceLike,
-  draft: Record<string, unknown>,
+  draft: Record<string, unknown>
 ): Promise<void> {
   const userId = resolveAgentId(ctx);
   const deployed = await service.deployWorkflow?.(draft, userId);
@@ -1356,7 +1322,9 @@ async function deployAndRespond(
 
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const prompt = readOptionalString(body, 'prompt');
   if (!prompt) {
@@ -1375,10 +1343,7 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   }
 
   const triggerContext = bridgeConversationId
-    ? await buildTriggerContextFromConversation(
-      ctx.runtime,
-      bridgeConversationId,
-    )
+    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
     : undefined;
 
   const draft = triggerContext
@@ -1416,11 +1381,11 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   return true;
 }
 
-async function handleResolveClarification(
-  ctx: N8nRouteContext,
-): Promise<boolean> {
+async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const draftRaw = (body as Record<string, unknown>).draft;
   if (!draftRaw || typeof draftRaw !== 'object' || Array.isArray(draftRaw)) {
@@ -1450,7 +1415,7 @@ async function handleResolveClarification(
 
   const result = applyResolutions(
     draft,
-    resolutions as Array<{ paramPath: string; value: string }>,
+    resolutions as Array<{ paramPath: string; value: string }>
   );
   if (!result.ok) {
     sendJson(ctx, 400, {
@@ -1463,10 +1428,10 @@ async function handleResolveClarification(
   const resolvedPaths = new Set(
     resolutions
       .map((r) => r.paramPath)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0),
+      .filter((p): p is string => typeof p === 'string' && p.length > 0)
   );
   const freeFormCount = resolutions.filter(
-    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0,
+    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0
   ).length;
   pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
@@ -1484,9 +1449,7 @@ async function handleResolveClarification(
   const remaining = coerceClarifications(meta?.requiresClarification);
   if (remaining.length > 0) {
     const catalogService = getConnectorTargetCatalog(ctx);
-    const catalog = catalogService
-      ? await buildCatalogSnapshot(catalogService, remaining)
-      : [];
+    const catalog = catalogService ? await buildCatalogSnapshot(catalogService, remaining) : [];
     sendJson(ctx, 200, {
       status: 'needs_clarification',
       draft,
@@ -1505,7 +1468,7 @@ async function handleToggleWorkflow(
   id: string,
   activate: boolean,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1553,19 +1516,14 @@ async function handleDeleteWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
     return true;
   }
 
-  const resolved = resolveProxyTarget(
-    ctx,
-    `/${encodeURIComponent(id)}`,
-    sidecar,
-    native,
-  );
+  const resolved = resolveProxyTarget(ctx, `/${encodeURIComponent(id)}`, sidecar, native);
   if (!resolved.target) {
     sendJson(ctx, 503, {
       error: resolved.reason?.message ?? 'n8n not ready',

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -606,12 +606,8 @@ export async function formatActionResponse(
 }
 
 function formatActionDataForPrompt(value: unknown, indent = 0): string {
-  if (value === undefined || value === null) {
-    return '';
-  }
-  if (typeof value === 'string') {
-    return value.trim();
-  }
+  if (value === undefined || value === null) {return '';}
+  if (typeof value === 'string') {return value.trim();}
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -606,8 +606,12 @@ export async function formatActionResponse(
 }
 
 function formatActionDataForPrompt(value: unknown, indent = 0): string {
-  if (value === undefined || value === null) {return '';}
-  if (typeof value === 'string') {return value.trim();}
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/plugins/plugin-signal/src/actions/sendMessage.ts
+++ b/plugins/plugin-signal/src/actions/sendMessage.ts
@@ -91,7 +91,8 @@ export const sendMessage: Action = {
         prompt,
       });
 
-      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse =
+        parseToonKeyValue<Record<string, unknown>>(response);
       if (parsedResponse?.text) {
         messageInfo = {
           text: String(parsedResponse.text),

--- a/plugins/plugin-signal/src/actions/sendMessage.ts
+++ b/plugins/plugin-signal/src/actions/sendMessage.ts
@@ -91,8 +91,7 @@ export const sendMessage: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (parsedResponse?.text) {
         messageInfo = {
           text: String(parsedResponse.text),

--- a/plugins/plugin-signal/src/actions/sendReaction.ts
+++ b/plugins/plugin-signal/src/actions/sendReaction.ts
@@ -99,7 +99,8 @@ export const sendReaction: Action = {
         prompt,
       });
 
-      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse =
+        parseToonKeyValue<Record<string, unknown>>(response);
       if (
         parsedResponse?.emoji &&
         parsedResponse?.targetTimestamp &&

--- a/plugins/plugin-signal/src/actions/sendReaction.ts
+++ b/plugins/plugin-signal/src/actions/sendReaction.ts
@@ -99,8 +99,7 @@ export const sendReaction: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (
         parsedResponse?.emoji &&
         parsedResponse?.targetTimestamp &&

--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -11,7 +11,9 @@ describe("Signal message connector", () => {
       getRoom: vi.fn(),
     } as unknown as IAgentRuntime;
     const service = Object.create(SignalService.prototype) as SignalService;
-    const sendMessageSpy = vi.spyOn(service, "sendMessage").mockResolvedValue({ timestamp: 123 });
+    const sendMessageSpy = vi
+      .spyOn(service, "sendMessage")
+      .mockResolvedValue({ timestamp: 123 });
 
     SignalService.registerSendHandlers(runtime, service);
 

--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -11,9 +11,7 @@ describe("Signal message connector", () => {
       getRoom: vi.fn(),
     } as unknown as IAgentRuntime;
     const service = Object.create(SignalService.prototype) as SignalService;
-    const sendMessageSpy = vi
-      .spyOn(service, "sendMessage")
-      .mockResolvedValue({ timestamp: 123 });
+    const sendMessageSpy = vi.spyOn(service, "sendMessage").mockResolvedValue({ timestamp: 123 });
 
     SignalService.registerSendHandlers(runtime, service);
 

--- a/plugins/plugin-twitch/src/service.ts
+++ b/plugins/plugin-twitch/src/service.ts
@@ -87,10 +87,7 @@ export class TwitchService extends Service implements ITwitchService {
     return service;
   }
 
-  static registerSendHandlers(
-    runtime: IAgentRuntime,
-    serviceInstance: TwitchService,
-  ): void {
+  static registerSendHandlers(runtime: IAgentRuntime, serviceInstance: TwitchService): void {
     if (!serviceInstance) {
       return;
     }
@@ -109,18 +106,15 @@ export class TwitchService extends Service implements ITwitchService {
           service: TWITCH_SERVICE_NAME,
           maxMessageLength: MAX_TWITCH_MESSAGE_LENGTH,
         },
-        resolveTargets:
-          serviceInstance.resolveConnectorTargets.bind(serviceInstance),
-        listRecentTargets:
-          serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
+        resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
+        listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
-        getChatContext:
-          serviceInstance.getConnectorChatContext.bind(serviceInstance),
+        getChatContext: serviceInstance.getConnectorChatContext.bind(serviceInstance),
         sendHandler,
       });
       runtime.logger.info(
         { src: "plugin:twitch", agentId: runtime.agentId },
-        "Registered Twitch chat connector",
+        "Registered Twitch chat connector"
       );
       return;
     }
@@ -471,7 +465,7 @@ export class TwitchService extends Service implements ITwitchService {
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content,
+    content: Content
   ): Promise<void> {
     const text = typeof content.text === "string" ? content.text.trim() : "";
     if (!text) {
@@ -487,9 +481,7 @@ export class TwitchService extends Service implements ITwitchService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       replyTo =
         replyTo ??
-        (typeof metadata?.twitchReplyTo === "string"
-          ? metadata.twitchReplyTo
-          : undefined);
+        (typeof metadata?.twitchReplyTo === "string" ? metadata.twitchReplyTo : undefined);
     }
 
     await this.sendMessage(text, {
@@ -500,7 +492,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async resolveConnectorTargets(
     query: string,
-    _context: MessageConnectorQueryContext,
+    _context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     const normalizedQuery = normalizeTwitchConnectorQuery(query);
     return this.getConnectorChannels()
@@ -513,7 +505,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listConnectorRooms(
-    _context: MessageConnectorQueryContext,
+    _context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     return this.getConnectorChannels()
       .map((channel) => this.buildChannelTarget(channel, 0.5))
@@ -521,7 +513,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listRecentConnectorTargets(
-    context: MessageConnectorQueryContext,
+    context: MessageConnectorQueryContext
   ): Promise<MessageConnectorTarget[]> {
     const targets: MessageConnectorTarget[] = [];
     const room =
@@ -549,7 +541,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async getConnectorChatContext(
     target: TargetInfo,
-    context: MessageConnectorQueryContext,
+    context: MessageConnectorQueryContext
   ): Promise<MessageConnectorChatContext | null> {
     let channel = target.channelId;
     if (!channel && target.roomId) {
@@ -588,10 +580,7 @@ export class TwitchService extends Service implements ITwitchService {
     return Array.from(channels);
   }
 
-  private buildChannelTarget(
-    channel: string,
-    score: number,
-  ): MessageConnectorTarget {
+  private buildChannelTarget(channel: string, score: number): MessageConnectorTarget {
     const normalized = normalizeChannel(channel);
     return {
       target: {

--- a/plugins/plugin-twitch/src/service.ts
+++ b/plugins/plugin-twitch/src/service.ts
@@ -87,7 +87,10 @@ export class TwitchService extends Service implements ITwitchService {
     return service;
   }
 
-  static registerSendHandlers(runtime: IAgentRuntime, serviceInstance: TwitchService): void {
+  static registerSendHandlers(
+    runtime: IAgentRuntime,
+    serviceInstance: TwitchService,
+  ): void {
     if (!serviceInstance) {
       return;
     }
@@ -106,15 +109,18 @@ export class TwitchService extends Service implements ITwitchService {
           service: TWITCH_SERVICE_NAME,
           maxMessageLength: MAX_TWITCH_MESSAGE_LENGTH,
         },
-        resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
-        listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
+        resolveTargets:
+          serviceInstance.resolveConnectorTargets.bind(serviceInstance),
+        listRecentTargets:
+          serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
-        getChatContext: serviceInstance.getConnectorChatContext.bind(serviceInstance),
+        getChatContext:
+          serviceInstance.getConnectorChatContext.bind(serviceInstance),
         sendHandler,
       });
       runtime.logger.info(
         { src: "plugin:twitch", agentId: runtime.agentId },
-        "Registered Twitch chat connector"
+        "Registered Twitch chat connector",
       );
       return;
     }
@@ -465,7 +471,7 @@ export class TwitchService extends Service implements ITwitchService {
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content
+    content: Content,
   ): Promise<void> {
     const text = typeof content.text === "string" ? content.text.trim() : "";
     if (!text) {
@@ -481,7 +487,9 @@ export class TwitchService extends Service implements ITwitchService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       replyTo =
         replyTo ??
-        (typeof metadata?.twitchReplyTo === "string" ? metadata.twitchReplyTo : undefined);
+        (typeof metadata?.twitchReplyTo === "string"
+          ? metadata.twitchReplyTo
+          : undefined);
     }
 
     await this.sendMessage(text, {
@@ -492,7 +500,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async resolveConnectorTargets(
     query: string,
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const normalizedQuery = normalizeTwitchConnectorQuery(query);
     return this.getConnectorChannels()
@@ -505,7 +513,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listConnectorRooms(
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     return this.getConnectorChannels()
       .map((channel) => this.buildChannelTarget(channel, 0.5))
@@ -513,7 +521,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listRecentConnectorTargets(
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const targets: MessageConnectorTarget[] = [];
     const room =
@@ -541,7 +549,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async getConnectorChatContext(
     target: TargetInfo,
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorChatContext | null> {
     let channel = target.channelId;
     if (!channel && target.roomId) {
@@ -580,7 +588,10 @@ export class TwitchService extends Service implements ITwitchService {
     return Array.from(channels);
   }
 
-  private buildChannelTarget(channel: string, score: number): MessageConnectorTarget {
+  private buildChannelTarget(
+    channel: string,
+    score: number,
+  ): MessageConnectorTarget {
     const normalized = normalizeChannel(channel);
     return {
       target: {

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -39,9 +39,13 @@ async function saveExecutionRecord(
   await runtime.createMemory(memory, "messages");
 }
 
-function readActionParams(options?: Record<string, unknown>): Record<string, unknown> {
+function readActionParams(
+  options?: Record<string, unknown>,
+): Record<string, unknown> {
   const direct =
-    options && typeof options === "object" ? (options as Record<string, unknown>) : {};
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
   const parameters =
     direct.parameters && typeof direct.parameters === "object"
       ? (direct.parameters as Record<string, unknown>)
@@ -61,7 +65,11 @@ export const describeSceneAction: Action = {
       description:
         "Scene description detail level. Use summary to omit object/person breakdowns from the spoken response.",
       required: false,
-      schema: { type: "string", enum: ["summary", "detailed"], default: "detailed" },
+      schema: {
+        type: "string",
+        enum: ["summary", "detailed"],
+        default: "detailed",
+      },
     },
   ],
   validate: async (
@@ -247,7 +255,11 @@ export const describeSceneAction: Action = {
         description += `\n\nObjects detected: ${objectDescriptions.join(", ")}.`;
       }
 
-      if (detailLevel === "detailed" && scene.sceneChanged && scene.changePercentage) {
+      if (
+        detailLevel === "detailed" &&
+        scene.sceneChanged &&
+        scene.changePercentage
+      ) {
         description += `\n\n(Scene changed by ${scene.changePercentage.toFixed(1)}% since last analysis)`;
       }
 
@@ -1151,8 +1163,7 @@ export const nameEntityAction: Action = {
 export const identifyPersonAction: Action = {
   name: "IDENTIFY_PERSON",
   description: "Identify a person in view if they have been seen before",
-  descriptionCompressed:
-    "Match face to known person via local recognition.",
+  descriptionCompressed: "Match face to known person via local recognition.",
   similes: [
     "who is that",
     "who is the person",

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -39,13 +39,9 @@ async function saveExecutionRecord(
   await runtime.createMemory(memory, "messages");
 }
 
-function readActionParams(
-  options?: Record<string, unknown>,
-): Record<string, unknown> {
+function readActionParams(options?: Record<string, unknown>): Record<string, unknown> {
   const direct =
-    options && typeof options === "object"
-      ? (options as Record<string, unknown>)
-      : {};
+    options && typeof options === "object" ? (options as Record<string, unknown>) : {};
   const parameters =
     direct.parameters && typeof direct.parameters === "object"
       ? (direct.parameters as Record<string, unknown>)
@@ -65,11 +61,7 @@ export const describeSceneAction: Action = {
       description:
         "Scene description detail level. Use summary to omit object/person breakdowns from the spoken response.",
       required: false,
-      schema: {
-        type: "string",
-        enum: ["summary", "detailed"],
-        default: "detailed",
-      },
+      schema: { type: "string", enum: ["summary", "detailed"], default: "detailed" },
     },
   ],
   validate: async (
@@ -255,11 +247,7 @@ export const describeSceneAction: Action = {
         description += `\n\nObjects detected: ${objectDescriptions.join(", ")}.`;
       }
 
-      if (
-        detailLevel === "detailed" &&
-        scene.sceneChanged &&
-        scene.changePercentage
-      ) {
+      if (detailLevel === "detailed" && scene.sceneChanged && scene.changePercentage) {
         description += `\n\n(Scene changed by ${scene.changePercentage.toFixed(1)}% since last analysis)`;
       }
 
@@ -1163,7 +1151,8 @@ export const nameEntityAction: Action = {
 export const identifyPersonAction: Action = {
   name: "IDENTIFY_PERSON",
   description: "Identify a person in view if they have been seen before",
-  descriptionCompressed: "Match face to known person via local recognition.",
+  descriptionCompressed:
+    "Match face to known person via local recognition.",
   similes: [
     "who is that",
     "who is the person",

--- a/plugins/plugin-x/src/actions/fetchFeedTop.ts
+++ b/plugins/plugin-x/src/actions/fetchFeedTop.ts
@@ -30,7 +30,12 @@ export const fetchFeedTopAction: Action = {
       name: "limit",
       description: "Maximum ranked tweets to return.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 50, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 50,
+        default: DEFAULT_LIMIT,
+      },
     },
     {
       name: "fetchCount",

--- a/plugins/plugin-x/src/actions/fetchFeedTop.ts
+++ b/plugins/plugin-x/src/actions/fetchFeedTop.ts
@@ -30,12 +30,7 @@ export const fetchFeedTopAction: Action = {
       name: "limit",
       description: "Maximum ranked tweets to return.",
       required: false,
-      schema: {
-        type: "number",
-        minimum: 1,
-        maximum: 50,
-        default: DEFAULT_LIMIT,
-      },
+      schema: { type: "number", minimum: 1, maximum: 50, default: DEFAULT_LIMIT },
     },
     {
       name: "fetchCount",

--- a/plugins/plugin-x/src/actions/readUnreadXDms.ts
+++ b/plugins/plugin-x/src/actions/readUnreadXDms.ts
@@ -25,7 +25,12 @@ export const readUnreadXDmsAction: Action = {
       name: "limit",
       description: "Maximum direct messages to scan for unread items.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 100, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 100,
+        default: DEFAULT_LIMIT,
+      },
     },
   ],
   examples: [

--- a/plugins/plugin-x/src/actions/readUnreadXDms.ts
+++ b/plugins/plugin-x/src/actions/readUnreadXDms.ts
@@ -25,12 +25,7 @@ export const readUnreadXDmsAction: Action = {
       name: "limit",
       description: "Maximum direct messages to scan for unread items.",
       required: false,
-      schema: {
-        type: "number",
-        minimum: 1,
-        maximum: 100,
-        default: DEFAULT_LIMIT,
-      },
+      schema: { type: "number", minimum: 1, maximum: 100, default: DEFAULT_LIMIT },
     },
   ],
   examples: [

--- a/plugins/plugin-x/src/search-category.test.ts
+++ b/plugins/plugin-x/src/search-category.test.ts
@@ -1,4 +1,7 @@
-import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
+import type {
+  IAgentRuntime,
+  SearchCategoryRegistration,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { registerXSearchCategory, X_SEARCH_CATEGORY } from "./search-category";
 
@@ -18,10 +21,8 @@ function createRuntime() {
   return {
     categories,
     registerSearchCategory,
-    runtime: {
-      getSearchCategory,
-      registerSearchCategory,
-    } as unknown as IAgentRuntime,
+    runtime: { getSearchCategory, registerSearchCategory } as unknown as
+      IAgentRuntime,
   };
 }
 

--- a/plugins/plugin-x/src/search-category.test.ts
+++ b/plugins/plugin-x/src/search-category.test.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { registerXSearchCategory, X_SEARCH_CATEGORY } from "./search-category";
 
@@ -21,8 +18,10 @@ function createRuntime() {
   return {
     categories,
     registerSearchCategory,
-    runtime: { getSearchCategory, registerSearchCategory } as unknown as
-      IAgentRuntime,
+    runtime: {
+      getSearchCategory,
+      registerSearchCategory,
+    } as unknown as IAgentRuntime,
   };
 }
 

--- a/plugins/plugin-x/src/search-category.ts
+++ b/plugins/plugin-x/src/search-category.ts
@@ -1,4 +1,7 @@
-import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
+import type {
+  IAgentRuntime,
+  SearchCategoryRegistration,
+} from "@elizaos/core";
 
 export const X_SEARCH_CATEGORY: SearchCategoryRegistration = {
   category: "x",

--- a/plugins/plugin-x/src/search-category.ts
+++ b/plugins/plugin-x/src/search-category.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const X_SEARCH_CATEGORY: SearchCategoryRegistration = {
   category: "x",


### PR DESCRIPTION
## Summary
- Ports the standalone Codex app-build workflow into the monorepo plugin-agent-orchestrator package.
- Adds Codex app-build agent metadata, Cloud app/task memory rules, and Codex execution wiring for the existing PTY/task-agent lifecycle.
- Preserves Claude/Gemini/etc. behavior while adding Codex-specific auto-response handling, output capture, and session cleanup.
- Fixes review feedback by cleaning Codex exec temp output directories on spawn failure/session stop and preserving the real session type in legacy stop events.
- Replaces redundant Set spread allocations in the completion-summary path flagged by CodeFactor.
- Applies required repo-wide formatter output to baseline files flagged by the required format check.

## Validation
- `cd plugins/plugin-agent-orchestrator && bunx vitest run --config ./vitest.config.ts src/__tests__/pty-auto-response.test.ts src/__tests__/skill-recommender.test.ts` (10 tests passed)
- `cd plugins/plugin-agent-orchestrator && bun run typecheck`
- `cd plugins/plugin-agent-orchestrator && bun run build`
- `bun run format:check` (57/57 tasks passed)
- `cd packages/app-core && bunx vitest run src/components/shell/RuntimeGate.cloud-provisioning.test.tsx` (8 tests passed earlier on this PR line)

## Supersedes
- Supersedes the archived standalone plugin PR elizaos-plugins/plugin-agent-orchestrator#55. This monorepo PR is the active path.

## Notes
- CodeFactor still reports complexity on large existing orchestrator/n8n/vision methods. The direct redundant-spread issues introduced in this PR are fixed; the remaining complexity warnings are not behavioral regressions from the Codex app-build path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the standalone Codex `app-build` workflow into `plugin-agent-orchestrator`, wiring up a non-interactive `codex exec` session mode alongside the existing interactive PTY lifecycle. It also addresses previous review feedback on temp-directory leaks and the hardcoded `type: "codex"` in legacy `session_exit` events. The remaining files outside `plugin-agent-orchestrator` are formatting-only changes.

- **Codex exec mode** (`pty-spawn.ts`, `pty-service.ts`, `codex-exec-adapters.cjs`): when `agentType === "codex"` and an `initialTask` is provided, the session is spawned with `interactive: false`, `--output-last-message <tmpfile>`, and on process exit the output file is read to synthesise `task_complete`. Temp directories are cleaned on spawn failure and on `stopSession`.
- **Shell-pipeline-aware agent-spec parser** (`coding-task-handlers.ts`): replaces the naive `.split("|")` in `handleMultiAgent` with `splitAgentSpecsParam`, which skips `|` that look like shell pipelines inside a task description.
- **Cloud app skill pinning** (`skill-recommender.ts`): adds `withForcedCloudAppSkill` which promotes `build-monetized-app` to rank 1 for any task matching the `APP_BUILD_TASK_RE` verb + noun pattern, applied consistently across all four early-return paths.

<h3>Confidence Score: 5/5</h3>

The core codex exec session lifecycle is coherent and both previously flagged issues have been addressed — the change is safe to merge.

The codex exec fast-path correctly reads the output file on clean exit and falls back to buffered pty output. Temp directories are removed in both the spawn-failure catch block and the stopSession finally block. The two findings are a multi-line edge-case in the quote-state parser and a minor regex inconsistency in the fallback cleanExit check — neither affects the primary codex exec flow.

pty-init.ts carries the most complexity with the dual session_stopped/session_exit handler merging and the two parallel fast-paths (bun worker vs node manager), worth a second look if issues are reported post-merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/pty-init.ts | Adds handleWorkerStopped to unify session_stopped/session_exit handling, emits task_complete from output file on clean codex exec exit; fixes previous type=codex hardcode in legacy session_exit path. |
| plugins/plugin-agent-orchestrator/src/services/pty-service.ts | Adds codex exec mode detection, mkdtemp lifecycle for output file, spawn-failure cleanup, and shouldSuppressCodexExecPtyManagerEvent to block spurious blocked/login_required events from non-interactive exec sessions. |
| plugins/plugin-agent-orchestrator/src/services/pty-session-io.ts | Adds rm(codexExecOutputDir) in the finally block of stopSession, ensuring temp directories are always cleaned up on explicit session teardown. |
| plugins/plugin-agent-orchestrator/src/services/pty-spawn.ts | Introduces shouldUseCodexExecMode and extends buildSpawnConfig to set interactive: false, initialPrompt, skipGitRepoCheck, and outputLastMessage for codex exec sessions; also expands env var allowlist with cloud-related keys. |
| plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs | New CJS shim that monkey-patches the codex adapter getArgs to emit codex exec CLI flags when initialPrompt is present; exports the full coding-agent-adapters surface so it can be drop-in required. |
| plugins/plugin-agent-orchestrator/src/actions/coding-task-handlers.ts | Adds splitAgentSpecsParam to replace naive .split('|') with a quote- and shell-pipeline-aware parser; the quote state is not reset on newlines, which can suppress separators in multi-line inputs. |
| plugins/plugin-agent-orchestrator/src/services/skill-recommender.ts | Adds withForcedCloudAppSkill that pins build-monetized-app to the top of recommendations for any task matching APP_BUILD_TASK_RE; applied consistently across all four early-return paths. |
| plugins/plugin-agent-orchestrator/src/services/ansi-utils.ts | Extends extractCompletionSummary with app-build result lines and domain-status lines; minor dedup fix changes spread-of-Set to direct Set iteration. |
| plugins/plugin-agent-orchestrator/src/api/agent-routes.ts | Accepts initialTask as an alias for task in the spawn body so callers can pass codex exec prompts without conflating with the task-thread creation field. |
| plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts | Formatting-only changes: import grouping, function signature line-breaking, and brace style normalisation — no behavioural changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as Agent Route
    participant PTYSvc as PTYService
    participant PTYMgr as PTY Manager (bun)
    participant Codex as Codex Process
    participant File as last-message.txt

    API->>PTYSvc: spawnSession(agentType=codex, task)
    PTYSvc->>PTYSvc: shouldUseCodexExecMode() true
    PTYSvc->>PTYSvc: mkdtemp() eliza-codex-id-rand/
    PTYSvc->>PTYSvc: sessionMetadata.set(id, metadata)
    PTYSvc->>PTYMgr: spawn(non-interactive, initialPrompt, outputLastMessage)
    PTYMgr->>Codex: codex exec --ephemeral --output-last-message file task
    Codex->>File: write last assistant message
    Codex-->>PTYMgr: exit(0)
    PTYMgr->>PTYSvc: session_stopped / session_exit
    PTYSvc->>File: readFile(outputFile) via captureFastPathTaskResponse
    PTYSvc->>API: emitEvent(task_complete, response)
    API->>PTYSvc: stopSession(id)
    PTYSvc->>PTYSvc: rm(outputDir, recursive) cleanup
    PTYSvc->>PTYSvc: sessionMetadata.delete(id)
```

<sub>Reviews (4): Last reviewed commit: ["fix(orchestrator): avoid redundant set s..."](https://github.com/elizaos/eliza/commit/3ac76c293e53ad9ebed1155989c9f395f417953f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30917700)</sub>

<!-- /greptile_comment -->