### PR TITLE
fix(test): extend description-compressed-lint sample past MAX_DESCRIPTION_LENGTH

### DIFF
--- a/packages/core/src/__tests__/description-compressed-lint.test.ts
+++ b/packages/core/src/__tests__/description-compressed-lint.test.ts
@@ -142,8 +142,13 @@ describe("lintDescriptionCompressed", () => {
 	});
 
 	it("returns multiple violations for a description that breaks several rules at once", () => {
+		// Text length must exceed MAX_DESCRIPTION_LENGTH (160) so the length
+		// hit fires alongside the phrase / word / lead-imperative hits the
+		// rest of the test asserts. Earlier wording (155 chars) sat just
+		// below the limit, so the lengthHits assertion failed even though
+		// the violation classes were correct.
 		const text =
-			"This action will basically simply forward messages to the user — please use this action when in order to send configuration data, currently with the agent.";
+			"This action will basically simply forward every kind of messages to the user — please use this action when in order to send configuration data, currently with the agent.";
 		const result = lintDescriptionCompressed(text);
 		expect(result.ok).toBe(false);
 


### PR DESCRIPTION
## Summary

`packages/core/src/__tests__/description-compressed-lint.test.ts` has one failing test on `develop` that blocks the **Server Tests** check on every PR:

```
FAIL src/__tests__/description-compressed-lint.test.ts > lintDescriptionCompressed >
     returns multiple violations for a description that breaks several rules at once
AssertionError: expected 0 to be greater than or equal to 1
```

The test asserts that one maximally-bad description trips **length**, **banned-phrase**, **banned-word**, and **non-imperative** rule classes simultaneously. The sample text was **155 characters**, but `MAX_DESCRIPTION_LENGTH = 160`. The length rule never fired, so `lengthHits.length >= 1` always failed.

`lintDescriptionCompressed` itself is correct — the other 10 tests in the file pass, and the function correctly emits 12 violations (9 phrase, 2 word, 1 lead) for the sample, just not a length one. Bug is purely in the test fixture.

## Fix

Extended the sample text by 14 characters to **169** (`every kind of` injected before `messages`). Still natural-sounding, still trips all four rule classes the test checks.

## Verification

```
$ cd packages/core && bunx vitest run src/__tests__/description-compressed-lint.test.ts
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Test plan

- [x] `bunx vitest run packages/core/src/__tests__/description-compressed-lint.test.ts` passes
- [ ] Server Tests CI check on this PR comes back green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The test fixture for the "breaks several rules at once" case was 155 characters — 5 characters short of `MAX_DESCRIPTION_LENGTH = 160` — so the `lengthHits` assertion always produced 0 hits and the test always failed. Adding "every kind of" (14 chars) pushes the string to 169 characters, making all four violation classes fire as expected.

- The change is confined to one test file; `lintDescriptionCompressed` and all other tests are untouched.
- A clear comment is added to explain why the text must exceed the threshold, preventing the same regression in future edits.
</details>

<h3>Confidence Score: 5/5</h3>

This is a one-line test fixture correction with no production code changes; safe to merge.

The change adds 14 characters to a test string so the string exceeds the 160-character limit that the test was already checking for. The fix is mechanically correct (169 > 160), the comment documents the rationale, and no logic in lintDescriptionCompressed is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/core/src/__tests__/description-compressed-lint.test.ts | Extends the "all-violations-at-once" test fixture from 155 chars to 169 chars so it exceeds MAX_DESCRIPTION_LENGTH (160) and the length violation actually fires; adds a comment explaining the original bug. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Test fixture text (169 chars)"] --> B{"text.length > MAX_DESCRIPTION_LENGTH (160)?"}
    B -- "YES (was NO with 155-char text)" --> C["Emit length: violation"]
    B -- "NO" --> D["No length violation — old bug"]
    A --> E["Banned phrases detected"]
    A --> F["Banned words detected"]
    A --> G["Non-imperative lead detected"]
    C --> H["lengthHits >= 1 ✓"]
    E --> I["phraseHits >= 5 ✓"]
    F --> J["wordHits >= 2 ✓"]
    G --> K["leadHits == 1 ✓"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): extend description-compressed..."](https://github.com/elizaos/eliza/commit/af893fc18c905b57f2263e1df165ebd14d6211ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30933538)</sub>

<!-- /greptile_comment -->