### PR TITLE
fix(ci): accept current iOS bundle ID app.eliza in mobile-build-smoke validator

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -67,10 +67,14 @@ jobs:
           echo "Built app at: $APP_PATH"
           BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$APP_PATH/Info.plist")
           echo "Bundle ID: $BUNDLE_ID"
-          # iOS project under packages/app-core/platforms/ios is currently
-          # ai.elizaos.app. Allow a future eliza brand id alongside it.
+          # Bundle ID source of truth is packages/app/app.config.ts (read
+          # by run-mobile-build.mjs via regex). Current value is
+          # `app.eliza` since commit d042ed57b5 renamed it from the
+          # legacy `ai.elizaos.app`. The two prior ids remain accepted
+          # because release branches and downstream forks may not have
+          # rebased onto the rename yet.
           case "$BUNDLE_ID" in
-            ai.elizaos.app|ai.elizaos.Eliza) ;;
+            app.eliza|ai.elizaos.app|ai.elizaos.Eliza) ;;
             *)
               echo "ERROR: Unexpected bundle ID: $BUNDLE_ID"
               exit 1


### PR DESCRIPTION
## Summary

Commit d042ed57b5 renamed `appId` in `packages/app/app.config.ts` from `ai.elizaos.app` to `app.eliza` (and `appName` from `elizaOS` to `Eliza`). `run-mobile-build.mjs` reads these via regex and passes them through to the produced `Info.plist`, so the build now correctly produces `CFBundleIdentifier = app.eliza`.

The validator step in `.github/workflows/mobile-build-smoke.yml` wasn't updated alongside the rename, so every PR's **iOS Simulator Build** fails with:

```
ERROR: Unexpected bundle ID: app.eliza
```

## Fix

Updated the case clause in the validator to accept `app.eliza` (the actual current id), keeping the two legacy ids accepted alongside it for release branches and downstream forks that haven't rebased onto the rename yet.

```diff
-          # iOS project under packages/app-core/platforms/ios is currently
-          # ai.elizaos.app. Allow a future eliza brand id alongside it.
+          # Bundle ID source of truth is packages/app/app.config.ts (read
+          # by run-mobile-build.mjs via regex). Current value is
+          # `app.eliza` since commit d042ed57b5 renamed it from the
+          # legacy `ai.elizaos.app`.
           case "$BUNDLE_ID" in
-            ai.elizaos.app|ai.elizaos.Eliza) ;;
+            app.eliza|ai.elizaos.app|ai.elizaos.Eliza) ;;
```

## Test plan

- [ ] iOS Simulator Build CI check on this PR comes back green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a CI validator that was rejecting the current iOS bundle ID (`app.eliza`) after a previous rename in `packages/app/app.config.ts` left the smoke-test workflow out of sync. The fix is a one-line addition to the `case` statement that validates `CFBundleIdentifier` extracted from the built `Info.plist`.

- `app.eliza` is added as the primary accepted value, matching the current `appId` in `packages/app/app.config.ts` (line 23).
- The two legacy IDs (`ai.elizaos.app` and `ai.elizaos.Eliza`) are preserved to keep release branches and downstream forks that haven't rebased onto the rename from breaking.
- The inline comment is updated to identify `packages/app/app.config.ts` as the authoritative source of truth for the bundle ID.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line addition to a CI validator case statement that aligns the workflow with the already-merged app ID rename.

The fix directly matches the appId: 'app.eliza' value in packages/app/app.config.ts and preserves the two legacy IDs for backward compatibility. There are no logic changes outside the validator, and the surrounding workflow steps are untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mobile-build-smoke.yml | Adds `app.eliza` to the accepted iOS bundle ID case list; retains legacy IDs for backward compatibility; updates the inline comment to point to the source-of-truth file. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[iOS Simulator Build\nrun-mobile-build.mjs] --> B[Find App.app in DerivedData]
    B --> C{App.app found?}
    C -- No --> D[ERROR: exit 1]
    C -- Yes --> E[PlistBuddy: read CFBundleIdentifier]
    E --> F{Bundle ID match?}
    F -- app.eliza --> G[✅ Pass]
    F -- ai.elizaos.app --> G
    F -- ai.elizaos.Eliza --> G
    F -- anything else --> H[ERROR: Unexpected bundle ID\nexit 1]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): accept current iOS bundle ID ap..."](https://github.com/elizaos/eliza/commit/2f00b27cdfb029337d86aa13940bd33fb6cab9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30933658)</sub>

<!-- /greptile_comment -->