### PR TITLE
test(app-core): mock cloud agent status in RuntimeGate

### DIFF
--- a/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx
@@ -30,6 +30,7 @@ const {
   clientMock: {
     getCloudCompatAgents: vi.fn(),
     getCloudCompatAgent: vi.fn(),
+    getCloudCompatAgentStatus: vi.fn(),
     createCloudCompatAgent: vi.fn(),
     provisionCloudCompatAgent: vi.fn(),
     getCloudCompatJobStatus: vi.fn(),
@@ -296,6 +297,18 @@ describe("RuntimeGate cloud provisioning startup handoff", () => {
     clientMock.getCloudCompatAgent.mockResolvedValue({
       success: true,
       data: RUNNING_AGENT,
+    });
+    clientMock.getCloudCompatAgentStatus.mockResolvedValue({
+      success: true,
+      data: {
+        status: "running",
+        lastHeartbeat: null,
+        bridgeUrl: "https://agent-1.elizacloud.ai",
+        webUiUrl: null,
+        currentNode: null,
+        suspendedReason: null,
+        databaseStatus: "ready",
+      },
     });
     clientMock.createCloudCompatAgent.mockResolvedValue({
       success: true,

--- a/packages/core/src/__tests__/description-compressed-lint.test.ts
+++ b/packages/core/src/__tests__/description-compressed-lint.test.ts
@@ -142,8 +142,7 @@ describe("lintDescriptionCompressed", () => {
 	});
 
 	it("returns multiple violations for a description that breaks several rules at once", () => {
-		const text =
-			"This action will basically simply forward messages to the user — please use this action when in order to send configuration data, currently with the agent.";
+		const text = `This action will ${"x".repeat(MAX_DESCRIPTION_LENGTH)} messages configuration basically simply please use this action in order to reach the user and the agent currently.`;
 		const result = lintDescriptionCompressed(text);
 		expect(result.ok).toBe(false);
 

--- a/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
+++ b/plugins/plugin-n8n-workflow/src/actions/getExecutions.ts
@@ -125,31 +125,29 @@ export const getExecutionsAction: Action = {
       const context = buildConversationContext(message, state);
       const matchResult = workflowIdParam
         ? {
-          matchedWorkflowId: workflowIdParam,
-          confidence: 'high' as const,
-          matches: workflows.map((workflow) => ({
-            id: workflow.id,
-            name: workflow.name,
-            score: workflow.id === workflowIdParam ? 1 : 0,
-          })),
-          reason: 'workflowId parameter',
-        }
-        : workflowNameParam
-          ? {
-            matchedWorkflowId:
-                workflows.find((workflow) =>
-                  workflow.name.toLowerCase().includes(workflowNameParam),
-                )?.id ?? null,
+            matchedWorkflowId: workflowIdParam,
             confidence: 'high' as const,
             matches: workflows.map((workflow) => ({
               id: workflow.id,
               name: workflow.name,
-              score: workflow.name.toLowerCase().includes(workflowNameParam)
-                ? 1
-                : 0,
+              score: workflow.id === workflowIdParam ? 1 : 0,
             })),
-            reason: 'workflowName parameter',
+            reason: 'workflowId parameter',
           }
+        : workflowNameParam
+          ? {
+              matchedWorkflowId:
+                workflows.find((workflow) =>
+                  workflow.name.toLowerCase().includes(workflowNameParam)
+                )?.id ?? null,
+              confidence: 'high' as const,
+              matches: workflows.map((workflow) => ({
+                id: workflow.id,
+                name: workflow.name,
+                score: workflow.name.toLowerCase().includes(workflowNameParam) ? 1 : 0,
+              })),
+              reason: 'workflowName parameter',
+            }
           : await matchWorkflow(runtime, context, workflows);
 
       if (!matchResult.matchedWorkflowId || matchResult.confidence === 'none') {

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -26,7 +26,9 @@ const VALID_KINDS: ReadonlySet<N8nClarificationRequest['kind']> = new Set([
 ]);
 
 function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
-  if (!v || typeof v !== 'object') {return false;}
+  if (!v || typeof v !== 'object') {
+    return false;
+  }
   const o = v as Record<string, unknown>;
   if (typeof o.question !== 'string' || o.question.trim().length === 0) {
     return false;
@@ -37,22 +39,26 @@ function isStructuredClarification(v: unknown): v is N8nClarificationRequest {
 }
 
 export function coerceClarifications(raw: unknown): N8nClarificationRequest[] {
-  if (!Array.isArray(raw) || raw.length === 0) {return [];}
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return [];
+  }
   const out: N8nClarificationRequest[] = [];
   for (const item of raw) {
     if (typeof item === 'string') {
       const trimmed = item.trim();
-      if (trimmed.length === 0) {continue;}
+      if (trimmed.length === 0) {
+        continue;
+      }
       out.push({ kind: 'free_text', question: trimmed, paramPath: '' });
       continue;
     }
-    if (!isStructuredClarification(item)) {continue;}
+    if (!isStructuredClarification(item)) {
+      continue;
+    }
     const o = item as unknown as Record<string, unknown>;
     const kindRaw = typeof o.kind === 'string' ? o.kind : 'free_text';
     const kind = (
-      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind'])
-        ? kindRaw
-        : 'free_text'
+      VALID_KINDS.has(kindRaw as N8nClarificationRequest['kind']) ? kindRaw : 'free_text'
     ) as N8nClarificationRequest['kind'];
     const platform = typeof o.platform === 'string' ? o.platform : undefined;
     let scope: { guildId?: string } | undefined;
@@ -118,7 +124,9 @@ export function parseParamPath(path: string): string[] {
     }
     // Identifier run: read until next `.` or `[`.
     let j = i;
-    while (j < n && path[j] !== '.' && path[j] !== '[') {j += 1;}
+    while (j < n && path[j] !== '.' && path[j] !== '[') {
+      j += 1;
+    }
     const ident = path.slice(i, j).trim();
     if (ident.length === 0) {
       throw new Error(`empty identifier at index ${i}`);
@@ -145,7 +153,7 @@ export function parseParamPath(path: string): string[] {
 export function setByDotPath(
   obj: Record<string, unknown>,
   paramPath: string,
-  value: unknown,
+  value: unknown
 ): void {
   const segments = parseParamPath(paramPath);
   let cur: Record<string, unknown> | unknown[] = obj;
@@ -154,9 +162,7 @@ export function setByDotPath(
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
       if (!isArrayIndex) {
-        throw new Error(
-          `paramPath segment "${seg}" is not a valid array index at depth ${i}`,
-        );
+        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
       }
       const idx = Number(seg);
       let next = cur[idx];
@@ -165,9 +171,7 @@ export function setByDotPath(
         cur[idx] = next;
       }
       if (typeof next !== 'object' || next === null) {
-        throw new Error(
-          `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-        );
+        throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
       }
       cur = next as Record<string, unknown> | unknown[];
       continue;
@@ -178,18 +182,14 @@ export function setByDotPath(
       (cur as Record<string, unknown>)[seg] = next;
     }
     if (typeof next !== 'object' || next === null) {
-      throw new Error(
-        `paramPath cannot descend into non-object at "${seg}" (depth ${i})`,
-      );
+      throw new Error(`paramPath cannot descend into non-object at "${seg}" (depth ${i})`);
     }
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
     if (!/^[0-9]+$/.test(last)) {
-      throw new Error(
-        `paramPath terminal segment "${last}" must be numeric at array`,
-      );
+      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
     }
     cur[Number(last)] = value;
   } else {
@@ -199,7 +199,7 @@ export function setByDotPath(
 
 export function applyResolutions(
   draft: Record<string, unknown>,
-  resolutions: ReadonlyArray<N8nClarificationResolution>,
+  resolutions: ReadonlyArray<N8nClarificationResolution>
 ): { ok: true } | { ok: false; error: string; paramPath?: string } {
   for (const r of resolutions) {
     if (!r || typeof r.paramPath !== 'string') {
@@ -229,9 +229,7 @@ export function applyResolutions(
         notes = meta.userNotes as string[];
       } else {
         notes =
-          meta.userNotes !== null && meta.userNotes !== undefined
-            ? [String(meta.userNotes)]
-            : [];
+          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
         meta.userNotes = notes;
       }
       notes.push(r.value);
@@ -271,12 +269,16 @@ export function applyResolutions(
 export function pruneResolvedClarifications(
   draft: Record<string, unknown>,
   resolved: ReadonlySet<string>,
-  freeFormCount = 0,
+  freeFormCount = 0
 ): void {
   const meta = (draft as { _meta?: Record<string, unknown> })._meta;
-  if (!meta || typeof meta !== 'object') {return;}
+  if (!meta || typeof meta !== 'object') {
+    return;
+  }
   const list = meta.requiresClarification;
-  if (!Array.isArray(list)) {return;}
+  if (!Array.isArray(list)) {
+    return;
+  }
   let toDropFreeForm = freeFormCount;
   const remaining = list.filter((item) => {
     if (typeof item === 'string') {
@@ -292,10 +294,7 @@ export function pruneResolvedClarifications(
         return false;
       }
       // Empty-paramPath object-form: also positional.
-      if (
-        (typeof path !== 'string' || path.length === 0) &&
-        toDropFreeForm > 0
-      ) {
+      if ((typeof path !== 'string' || path.length === 0) && toDropFreeForm > 0) {
         toDropFreeForm -= 1;
         return false;
       }
@@ -328,20 +327,26 @@ export interface CatalogLike {
  */
 export async function buildCatalogSnapshot(
   catalog: CatalogLike,
-  clarifications: ReadonlyArray<N8nClarificationRequest>,
+  clarifications: ReadonlyArray<N8nClarificationRequest>
 ): Promise<N8nClarificationTargetGroup[]> {
   const platforms = new Set<string>();
   for (const c of clarifications) {
-    if (c.platform) {platforms.add(c.platform);}
+    if (c.platform) {
+      platforms.add(c.platform);
+    }
   }
-  if (platforms.size === 0) {return [];}
+  if (platforms.size === 0) {
+    return [];
+  }
   const out: N8nClarificationTargetGroup[] = [];
   const seen = new Set<string>();
   for (const platform of platforms) {
     const groups = await catalog.listGroups({ platform });
     for (const g of groups) {
       const key = `${g.platform}::${g.groupId}`;
-      if (seen.has(key)) {continue;}
+      if (seen.has(key)) {
+        continue;
+      }
       seen.add(key);
       out.push(g);
     }

--- a/plugins/plugin-n8n-workflow/src/plugin-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/plugin-routes.ts
@@ -32,18 +32,16 @@ function buildState(runtime: unknown): N8nCompatState {
 }
 
 function makeN8nHandler() {
-  return async (
-    req: unknown,
-    res: unknown,
-    runtime: unknown,
-  ): Promise<void> => {
+  return async (req: unknown, res: unknown, runtime: unknown): Promise<void> => {
     const httpReq = req as http.IncomingMessage;
     const httpRes = res as http.ServerResponse;
     const url = new URL(httpReq.url ?? '/', 'http://localhost');
     const method = (httpReq.method ?? 'GET').toUpperCase();
     const state = buildState(runtime);
 
-    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {return;}
+    if (!(await ensureRouteAuthorized(httpReq, httpRes, state))) {
+      return;
+    }
 
     await handleN8nRoutes({
       req: httpReq,

--- a/plugins/plugin-n8n-workflow/src/register-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/register-routes.ts
@@ -1,9 +1,6 @@
 import { registerAppRoutePluginLoader } from '@elizaos/app-core/runtime/app-route-plugin-registry';
 
-registerAppRoutePluginLoader(
-  '@elizaos/plugin-n8n-workflow:routes',
-  async () => {
-    const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
-    return n8nWorkflowRoutePlugin;
-  },
-);
+registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', async () => {
+  const { n8nWorkflowRoutePlugin } = await import('./plugin-routes');
+  return n8nWorkflowRoutePlugin;
+});

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -27,20 +27,11 @@
  * services/n8n-sidecar.ts rather than being threaded through state.
  */
 
-import type {
-  RouteHelpers,
-  RouteRequestMeta,
-} from '@elizaos/agent/api/route-helpers';
+import type { RouteHelpers, RouteRequestMeta } from '@elizaos/agent/api/route-helpers';
 import { readCompatJsonBody } from '@elizaos/app-core/api/compat-route-shared';
 import { isNativeServerPlatform } from '@elizaos/app-core/platform/is-native-server';
-import {
-  type N8nMode,
-  resolveN8nMode,
-} from '@elizaos/app-core/services/n8n-mode';
-import type {
-  N8nSidecar,
-  N8nSidecarStatus,
-} from '@elizaos/app-core/services/n8n-sidecar';
+import { type N8nMode, resolveN8nMode } from '@elizaos/app-core/services/n8n-mode';
+import type { N8nSidecar, N8nSidecarStatus } from '@elizaos/app-core/services/n8n-sidecar';
 import type { AgentRuntime } from '@elizaos/core';
 import { logger } from '@elizaos/core';
 import {
@@ -168,9 +159,7 @@ export interface N8nRoutesConfigLike {
   };
 }
 
-export interface N8nRouteContext
-  extends RouteRequestMeta,
-    Pick<RouteHelpers, 'json'> {
+export interface N8nRouteContext extends RouteRequestMeta, Pick<RouteHelpers, 'json'> {
   config: N8nRoutesConfigLike;
   runtime: AgentRuntime | null;
   /**
@@ -224,10 +213,7 @@ export function __resetCloudHealthCacheForTests(): void {
   cloudHealthCache.clear();
 }
 
-async function probeCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function probeCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const url = `${normalizeBaseUrl(baseUrl)}/api/v1/health`;
   try {
     const res = await fetchImpl(url, {
@@ -238,18 +224,13 @@ async function probeCloudHealth(
     return res.ok ? 'ok' : 'degraded';
   } catch (err) {
     logger.debug(
-      `[n8n-routes] cloud health probe failed: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
+      `[n8n-routes] cloud health probe failed: ${err instanceof Error ? err.message : String(err)}`
     );
     return 'degraded';
   }
 }
 
-async function getCloudHealth(
-  baseUrl: string,
-  fetchImpl: typeof fetch,
-): Promise<N8nCloudHealth> {
+async function getCloudHealth(baseUrl: string, fetchImpl: typeof fetch): Promise<N8nCloudHealth> {
   const key = normalizeBaseUrl(baseUrl);
   const now = Date.now();
   const cached = cloudHealthCache.get(key);
@@ -272,8 +253,10 @@ async function getCloudHealth(
  */
 async function loadSidecarModule(): Promise<
   typeof import('@elizaos/app-core/services/n8n-sidecar') | null
-  > {
-  if (isNativeServerPlatform()) {return null;}
+> {
+  if (isNativeServerPlatform()) {
+    return null;
+  }
   return await import('@elizaos/app-core/services/n8n-sidecar');
 }
 
@@ -288,44 +271,34 @@ function normalizeBaseUrl(raw: string | undefined | null): string {
 }
 
 function resolveAgentId(ctx: N8nRouteContext): string {
-  if (ctx.agentId?.trim()) {return ctx.agentId.trim();}
+  if (ctx.agentId?.trim()) {
+    return ctx.agentId.trim();
+  }
   const runtimeAny = ctx.runtime as unknown as {
     agentId?: string;
     character?: { id?: string };
   } | null;
-  return (
-    runtimeAny?.agentId ??
-    runtimeAny?.character?.id ??
-    '00000000-0000-0000-0000-000000000000'
-  );
+  return runtimeAny?.agentId ?? runtimeAny?.character?.id ?? '00000000-0000-0000-0000-000000000000';
 }
 
-function sendJson(
-  ctx: Pick<N8nRouteContext, 'res' | 'json'>,
-  status: number,
-  body: unknown,
-): void {
+function sendJson(ctx: Pick<N8nRouteContext, 'res' | 'json'>, status: number, body: unknown): void {
   // The compat `json` helper signature in app-core is
   // `(res, body, status?) => void`; status defaults to 200 upstream.
-  const json = ctx.json as unknown as (
-    res: typeof ctx.res,
-    body: unknown,
-    status?: number,
-  ) => void;
+  const json = ctx.json as unknown as (res: typeof ctx.res, body: unknown, status?: number) => void;
   json(ctx.res, body, status);
 }
 
 /** Strip any credential material from node descriptors before forwarding. */
 function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   return {
     ...(typeof obj.id === 'string' ? { id: obj.id } : {}),
     ...(typeof obj.name === 'string' ? { name: obj.name } : {}),
     ...(typeof obj.type === 'string' ? { type: obj.type } : {}),
-    ...(typeof obj.typeVersion === 'number'
-      ? { typeVersion: obj.typeVersion }
-      : {}),
+    ...(typeof obj.typeVersion === 'number' ? { typeVersion: obj.typeVersion } : {}),
   };
 }
 
@@ -334,7 +307,9 @@ function sanitizeNode(n: unknown): N8nWorkflowNodeLike {
  * parameters (needed by the graph viewer). Credentials are still stripped.
  */
 function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
-  if (!n || typeof n !== 'object') {return {};}
+  if (!n || typeof n !== 'object') {
+    return {};
+  }
   const obj = n as Record<string, unknown>;
   const base = sanitizeNode(n);
 
@@ -359,28 +334,28 @@ function sanitizeNodeFull(n: unknown): N8nWorkflowNodeLike {
     ...(position !== undefined ? { position } : {}),
     ...(parameters !== undefined ? { parameters } : {}),
     ...(typeof obj.notes === 'string' ? { notes: obj.notes } : {}),
-    ...(typeof obj.notesInFlow === 'boolean'
-      ? { notesInFlow: obj.notesInFlow }
-      : {}),
+    ...(typeof obj.notesInFlow === 'boolean' ? { notesInFlow: obj.notesInFlow } : {}),
   };
 }
 
 /** Normalize an n8n workflow payload to our client-facing shape. */
 function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNode);
   return {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
   };
@@ -396,11 +371,15 @@ function normalizeWorkflow(raw: unknown): N8nWorkflow | null {
  * it needs without a second request.
  */
 function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
-  if (!raw || typeof raw !== 'object') {return null;}
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
   const obj = raw as Record<string, unknown>;
   const id = typeof obj.id === 'string' ? obj.id : String(obj.id ?? '');
   const name = typeof obj.name === 'string' ? obj.name : '';
-  if (!id) {return null;}
+  if (!id) {
+    return null;
+  }
   const nodesRaw = Array.isArray(obj.nodes) ? obj.nodes : [];
   const nodes = nodesRaw.map(sanitizeNodeFull);
 
@@ -415,9 +394,7 @@ function normalizeWorkflowFull(raw: unknown): N8nWorkflow | null {
     id,
     name,
     active: Boolean(obj.active),
-    ...(typeof obj.description === 'string'
-      ? { description: obj.description }
-      : {}),
+    ...(typeof obj.description === 'string' ? { description: obj.description } : {}),
     nodes,
     nodeCount: nodes.length,
     ...(connections !== undefined ? { connections } : {}),
@@ -442,7 +419,7 @@ function resolveProxyTarget(
   ctx: N8nRouteContext,
   subpath: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): {
   target: ProxyTarget | null;
   reason?: {
@@ -510,7 +487,9 @@ function resolveProxyTarget(
   const headers: Record<string, string> = {
     Accept: 'application/json',
   };
-  if (apiKey) {headers['X-N8N-API-KEY'] = apiKey;}
+  if (apiKey) {
+    headers['X-N8N-API-KEY'] = apiKey;
+  }
 
   // n8n serves TWO parallel workflow APIs:
   //   /rest/workflows   — internal UI endpoint, requires JWT cookie auth.
@@ -529,7 +508,7 @@ function resolveProxyTarget(
 async function fetchTargetAsJson(
   ctx: N8nRouteContext,
   target: ProxyTarget,
-  init: { method: string; body?: string },
+  init: { method: string; body?: string }
 ): Promise<{
   ok: boolean;
   status: number;
@@ -546,9 +525,7 @@ async function fetchTargetAsJson(
     res = await fetchImpl(target.url, {
       method: init.method,
       headers,
-      ...(init.body !== null && init.body !== undefined
-        ? { body: init.body }
-        : {}),
+      ...(init.body !== null && init.body !== undefined ? { body: init.body } : {}),
       signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
@@ -577,18 +554,30 @@ async function fetchTargetAsJson(
  * or `{ data }`. We accept both.
  */
 function extractWorkflowList(body: unknown): unknown[] {
-  if (!body || typeof body !== 'object') {return [];}
+  if (!body || typeof body !== 'object') {
+    return [];
+  }
   const obj = body as Record<string, unknown>;
-  if (Array.isArray(obj.workflows)) {return obj.workflows;}
-  if (Array.isArray(obj.data)) {return obj.data;}
+  if (Array.isArray(obj.workflows)) {
+    return obj.workflows;
+  }
+  if (Array.isArray(obj.data)) {
+    return obj.data;
+  }
   return [];
 }
 
 function extractWorkflowSingle(body: unknown): unknown {
-  if (!body || typeof body !== 'object') {return null;}
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
   const obj = body as Record<string, unknown>;
-  if (obj.data && typeof obj.data === 'object') {return obj.data;}
-  if (obj.workflow && typeof obj.workflow === 'object') {return obj.workflow;}
+  if (obj.data && typeof obj.data === 'object') {
+    return obj.data;
+  }
+  if (obj.workflow && typeof obj.workflow === 'object') {
+    return obj.workflow;
+  }
   return body;
 }
 
@@ -598,32 +587,19 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function readOptionalString(
-  obj: Record<string, unknown>,
-  key: string,
-): string | undefined {
+function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined {
   const value = obj[key];
-  return typeof value === 'string' && value.trim().length > 0
-    ? value.trim()
-    : undefined;
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-function readOptionalBoolean(
-  obj: Record<string, unknown>,
-  key: string,
-): boolean | undefined {
+function readOptionalBoolean(obj: Record<string, unknown>, key: string): boolean | undefined {
   const value = obj[key];
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function readOptionalNumber(
-  obj: Record<string, unknown>,
-  key: string,
-): number | undefined {
+function readOptionalNumber(obj: Record<string, unknown>, key: string): number | undefined {
   const value = obj[key];
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 /**
@@ -658,9 +634,11 @@ interface TriggerContext {
  */
 async function buildTriggerContextFromConversation(
   runtime: AgentRuntime | null | undefined,
-  roomId: string,
+  roomId: string
 ): Promise<TriggerContext | undefined> {
-  if (!runtime || typeof runtime.getMemories !== 'function') {return undefined;}
+  if (!runtime || typeof runtime.getMemories !== 'function') {
+    return undefined;
+  }
   let memories: Array<{
     entityId?: string;
     metadata?: Record<string, unknown>;
@@ -678,19 +656,21 @@ async function buildTriggerContextFromConversation(
     logger.debug?.(
       `[n8n-routes] buildTriggerContextFromConversation: getMemories threw: ${
         err instanceof Error ? err.message : String(err)
-      }`,
+      }`
     );
     return undefined;
   }
-  if (!Array.isArray(memories) || memories.length === 0) {return undefined;}
+  if (!Array.isArray(memories) || memories.length === 0) {
+    return undefined;
+  }
 
   // Tail inbound = most recent memory whose entityId is NOT the agent.
   // `runtime.getMemories` typically returns most-recent-first; defensively
   // handle either order.
-  const inbound = memories.find(
-    (m) => m.entityId && m.entityId !== runtime.agentId,
-  );
-  if (!inbound?.metadata) {return undefined;}
+  const inbound = memories.find((m) => m.entityId && m.entityId !== runtime.agentId);
+  if (!inbound?.metadata) {
+    return undefined;
+  }
 
   const meta = inbound.metadata as Record<string, unknown>;
   const discord = (meta.discord ?? {}) as Record<string, unknown>;
@@ -700,16 +680,11 @@ async function buildTriggerContextFromConversation(
   // Canonical wins; flat fields are the legacy de-facto shape.
   const discordChannelId =
     (typeof discord.channelId === 'string' ? discord.channelId : undefined) ??
-    (typeof meta.discordChannelId === 'string'
-      ? meta.discordChannelId
-      : undefined);
+    (typeof meta.discordChannelId === 'string' ? meta.discordChannelId : undefined);
   const discordGuildId =
     (typeof discord.guildId === 'string' ? discord.guildId : undefined) ??
-    (typeof meta.discordServerId === 'string'
-      ? meta.discordServerId
-      : undefined);
-  const discordThreadId =
-    typeof discord.threadId === 'string' ? discord.threadId : undefined;
+    (typeof meta.discordServerId === 'string' ? meta.discordServerId : undefined);
+  const discordThreadId = typeof discord.threadId === 'string' ? discord.threadId : undefined;
 
   // No `meta.fromId` fallback for Telegram: `fromId` is the sender's user
   // id, which equals the chat id only in private 1:1 DMs. In group chats /
@@ -723,15 +698,12 @@ async function buildTriggerContextFromConversation(
       ? telegram.chatId
       : undefined;
   const telegramThreadId =
-    typeof telegram.threadId === 'string' ||
-    typeof telegram.threadId === 'number'
+    typeof telegram.threadId === 'string' || typeof telegram.threadId === 'number'
       ? (telegram.threadId as string | number)
       : undefined;
 
-  const slackChannelId =
-    typeof slack.channelId === 'string' ? slack.channelId : undefined;
-  const slackTeamId =
-    typeof slack.teamId === 'string' ? slack.teamId : undefined;
+  const slackChannelId = typeof slack.channelId === 'string' ? slack.channelId : undefined;
+  const slackTeamId = typeof slack.teamId === 'string' ? slack.teamId : undefined;
 
   if (discordChannelId) {
     return {
@@ -748,9 +720,7 @@ async function buildTriggerContextFromConversation(
       source: 'telegram',
       telegram: {
         chatId: telegramChatId,
-        ...(telegramThreadId !== undefined
-          ? { threadId: telegramThreadId }
-          : {}),
+        ...(telegramThreadId !== undefined ? { threadId: telegramThreadId } : {}),
       },
     };
   }
@@ -775,34 +745,39 @@ function readPosition(value: unknown): [number, number] | null {
     : null;
 }
 
-function readCredentials(
-  value: unknown,
-): Record<string, { id: string; name: string }> | undefined {
+function readCredentials(value: unknown): Record<string, { id: string; name: string }> | undefined {
   const raw = asRecord(value);
-  if (!raw) {return undefined;}
+  if (!raw) {
+    return undefined;
+  }
 
   const credentials: Record<string, { id: string; name: string }> = {};
   for (const [key, credentialValue] of Object.entries(raw)) {
     const credential = asRecord(credentialValue);
-    if (!credential) {continue;}
+    if (!credential) {
+      continue;
+    }
     const id = readOptionalString(credential, 'id');
     const name = readOptionalString(credential, 'name');
-    if (!id || !name) {continue;}
+    if (!id || !name) {
+      continue;
+    }
     credentials[key] = { id, name };
   }
   return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
-function normalizeWorkflowWriteNode(
-  value: unknown,
-  index: number,
-): N8nWorkflowWriteNode | null {
+function normalizeWorkflowWriteNode(value: unknown, index: number): N8nWorkflowWriteNode | null {
   const obj = asRecord(value);
-  if (!obj) {return null;}
+  if (!obj) {
+    return null;
+  }
 
   const name = readOptionalString(obj, 'name');
   const type = readOptionalString(obj, 'type');
-  if (!name || !type) {return null;}
+  if (!name || !type) {
+    return null;
+  }
 
   const position = readPosition(obj.position) ?? [index * 260, 0];
   const parameters = asRecord(obj.parameters) ?? {};
@@ -810,9 +785,7 @@ function normalizeWorkflowWriteNode(
   const credentials = readCredentials(obj.credentials);
 
   return {
-    ...(readOptionalString(obj, 'id')
-      ? { id: readOptionalString(obj, 'id') }
-      : {}),
+    ...(readOptionalString(obj, 'id') ? { id: readOptionalString(obj, 'id') } : {}),
     name,
     type,
     typeVersion,
@@ -822,15 +795,11 @@ function normalizeWorkflowWriteNode(
     ...(readOptionalBoolean(obj, 'disabled') !== undefined
       ? { disabled: readOptionalBoolean(obj, 'disabled') }
       : {}),
-    ...(readOptionalString(obj, 'notes')
-      ? { notes: readOptionalString(obj, 'notes') }
-      : {}),
+    ...(readOptionalString(obj, 'notes') ? { notes: readOptionalString(obj, 'notes') } : {}),
     ...(readOptionalBoolean(obj, 'notesInFlow') !== undefined
       ? { notesInFlow: readOptionalBoolean(obj, 'notesInFlow') }
       : {}),
-    ...(readOptionalString(obj, 'color')
-      ? { color: readOptionalString(obj, 'color') }
-      : {}),
+    ...(readOptionalString(obj, 'color') ? { color: readOptionalString(obj, 'color') } : {}),
     ...(readOptionalBoolean(obj, 'continueOnFail') !== undefined
       ? { continueOnFail: readOptionalBoolean(obj, 'continueOnFail') }
       : {}),
@@ -859,31 +828,37 @@ function normalizeWorkflowWriteNode(
 
 function normalizeWorkflowConnections(value: unknown): N8nWorkflowConnections {
   const raw = asRecord(value);
-  if (!raw) {return {};}
+  if (!raw) {
+    return {};
+  }
 
   const connections: N8nWorkflowConnections = {};
   for (const [sourceName, outputValue] of Object.entries(raw)) {
     const outputMap = asRecord(outputValue);
-    if (!outputMap) {continue;}
+    if (!outputMap) {
+      continue;
+    }
     const mainRaw = outputMap.main;
-    if (!Array.isArray(mainRaw)) {continue;}
+    if (!Array.isArray(mainRaw)) {
+      continue;
+    }
     const main = mainRaw.map((group) =>
       Array.isArray(group)
         ? group
-          .map((connection) => {
-            const obj = asRecord(connection);
-            const node = obj ? readOptionalString(obj, 'node') : undefined;
-            if (!obj || !node) {return null;}
-            const index = readOptionalNumber(obj, 'index') ?? 0;
-            return { node, type: 'main' as const, index };
-          })
-          .filter(
-            (
-              connection,
-            ): connection is { node: string; type: 'main'; index: number } =>
-              connection !== null,
-          )
-        : [],
+            .map((connection) => {
+              const obj = asRecord(connection);
+              const node = obj ? readOptionalString(obj, 'node') : undefined;
+              if (!obj || !node) {
+                return null;
+              }
+              const index = readOptionalNumber(obj, 'index') ?? 0;
+              return { node, type: 'main' as const, index };
+            })
+            .filter(
+              (connection): connection is { node: string; type: 'main'; index: number } =>
+                connection !== null
+            )
+        : []
     );
     connections[sourceName] = { main };
   }
@@ -917,12 +892,8 @@ function normalizeWorkflowWritePayload(body: Record<string, unknown>): {
   };
 }
 
-function propagateError(
-  ctx: N8nRouteContext,
-  upstream: { status: number; body: unknown },
-): void {
-  const status =
-    upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
+function propagateError(ctx: N8nRouteContext, upstream: { status: number; body: unknown }): void {
+  const status = upstream.status >= 400 && upstream.status < 600 ? upstream.status : 502;
   let message = `upstream responded with ${upstream.status}`;
   if (upstream.body && typeof upstream.body === 'object') {
     const b = upstream.body as Record<string, unknown>;
@@ -941,12 +912,16 @@ function propagateError(
  * Returns null if pathname doesn't match.
  */
 function parseWorkflowPath(
-  pathname: string,
+  pathname: string
 ): { id: string; action: 'get' | 'activate' | 'deactivate' } | null {
   const prefix = '/api/n8n/workflows/';
-  if (!pathname.startsWith(prefix)) {return null;}
+  if (!pathname.startsWith(prefix)) {
+    return null;
+  }
   const rest = pathname.slice(prefix.length);
-  if (!rest) {return null;}
+  if (!rest) {
+    return null;
+  }
   const parts = rest.split('/').filter(Boolean);
   if (parts.length === 1) {
     return { id: decodeURIComponent(parts[0] ?? ''), action: 'get' };
@@ -968,10 +943,14 @@ function parseWorkflowPath(
  */
 async function resolveSidecarForRequest(
   ctx: N8nRouteContext,
-  native: boolean,
+  native: boolean
 ): Promise<N8nSidecar | null> {
-  if (ctx.n8nSidecar !== undefined) {return ctx.n8nSidecar;}
-  if (native) {return null;}
+  if (ctx.n8nSidecar !== undefined) {
+    return ctx.n8nSidecar;
+  }
+  if (native) {
+    return null;
+  }
   const mod = await loadSidecarModule();
   return mod?.peekN8nSidecar() ?? null;
 }
@@ -1025,10 +1004,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     return handleGenerateWorkflow(ctx);
   }
 
-  if (
-    method === 'POST' &&
-    pathname === '/api/n8n/workflows/resolve-clarification'
-  ) {
+  if (method === 'POST' && pathname === '/api/n8n/workflows/resolve-clarification') {
     return handleResolveClarification(ctx);
   }
 
@@ -1068,7 +1044,7 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
 async function handleStatus(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const { config, runtime } = ctx;
 
@@ -1080,8 +1056,7 @@ async function handleStatus(
   const sidecarState = sidecar?.getState();
   const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
 
-  const host =
-    mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
+  const host = mode === 'local' ? (sidecarState?.host ?? config.n8n?.host ?? null) : null;
 
   // Cloud health — only probed when we are actually in cloud mode. The
   // probe is cached for 30s (see getCloudHealth) so rapid status polls
@@ -1093,7 +1068,7 @@ async function handleStatus(
     } else {
       cloudHealth = await getCloudHealth(
         config.cloud?.baseUrl ?? DEFAULT_CLOUD_API_BASE_URL,
-        ctx.fetchImpl ?? fetch,
+        ctx.fetchImpl ?? fetch
       );
     }
   }
@@ -1108,10 +1083,10 @@ async function handleStatus(
     cloudHealth,
     ...(sidecarState
       ? {
-        errorMessage: sidecarState.errorMessage,
-        retries: sidecarState.retries,
-        recentOutput: sidecarState.recentOutput,
-      }
+          errorMessage: sidecarState.errorMessage,
+          retries: sidecarState.retries,
+          recentOutput: sidecarState.recentOutput,
+        }
       : {}),
   };
 
@@ -1123,7 +1098,7 @@ async function handleStatus(
 async function handleListWorkflows(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, '', sidecar, native);
   if (!resolved.target) {
@@ -1143,9 +1118,7 @@ async function handleListWorkflows(
   }
 
   const list = extractWorkflowList(upstream.body);
-  const workflows = list
-    .map(normalizeWorkflow)
-    .filter((w): w is N8nWorkflow => w !== null);
+  const workflows = list.map(normalizeWorkflow).filter((w): w is N8nWorkflow => w !== null);
 
   sendJson(ctx, 200, { workflows });
   return true;
@@ -1163,7 +1136,7 @@ async function handleGetWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1204,7 +1177,7 @@ async function writeWorkflow(
   subpath: string,
   payload: N8nWorkflowWritePayload,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const resolved = resolveProxyTarget(ctx, subpath, sidecar, native);
   if (!resolved.target) {
@@ -1237,10 +1210,12 @@ async function writeWorkflow(
 async function handleCreateWorkflow(
   ctx: N8nRouteContext,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1255,7 +1230,7 @@ async function handleUpdateWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1263,7 +1238,9 @@ async function handleUpdateWorkflow(
   }
 
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const { payload, error } = normalizeWorkflowWritePayload(body);
   if (!payload) {
@@ -1271,27 +1248,20 @@ async function handleUpdateWorkflow(
     return true;
   }
 
-  return writeWorkflow(
-    ctx,
-    'PUT',
-    `/${encodeURIComponent(id)}`,
-    payload,
-    sidecar,
-    native,
-  );
+  return writeWorkflow(ctx, 'PUT', `/${encodeURIComponent(id)}`, payload, sidecar, native);
 }
 
 interface N8nWorkflowServiceLike {
   generateWorkflowDraft?: (
     prompt: string,
-    opts?: { triggerContext?: TriggerContext },
+    opts?: { triggerContext?: TriggerContext }
   ) => Promise<{
     id?: string;
     [k: string]: unknown;
   }>;
   deployWorkflow?: (
     workflow: Record<string, unknown>,
-    userId: string,
+    userId: string
   ) => Promise<{
     id: string;
     name: string;
@@ -1301,12 +1271,8 @@ interface N8nWorkflowServiceLike {
   getWorkflow?: (id: string) => Promise<Record<string, unknown>>;
 }
 
-function getN8nWorkflowService(
-  ctx: N8nRouteContext,
-): N8nWorkflowServiceLike | null {
-  const service = ctx.runtime?.getService?.('n8n_workflow') as
-    | N8nWorkflowServiceLike
-    | undefined;
+function getN8nWorkflowService(ctx: N8nRouteContext): N8nWorkflowServiceLike | null {
+  const service = ctx.runtime?.getService?.('n8n_workflow') as N8nWorkflowServiceLike | undefined;
   if (
     typeof service?.generateWorkflowDraft !== 'function' ||
     typeof service.deployWorkflow !== 'function' ||
@@ -1335,7 +1301,7 @@ function getConnectorTargetCatalog(ctx: N8nRouteContext): CatalogLike | null {
 async function deployAndRespond(
   ctx: N8nRouteContext,
   service: N8nWorkflowServiceLike,
-  draft: Record<string, unknown>,
+  draft: Record<string, unknown>
 ): Promise<void> {
   const userId = resolveAgentId(ctx);
   const deployed = await service.deployWorkflow?.(draft, userId);
@@ -1356,7 +1322,9 @@ async function deployAndRespond(
 
 async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const prompt = readOptionalString(body, 'prompt');
   if (!prompt) {
@@ -1375,10 +1343,7 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   }
 
   const triggerContext = bridgeConversationId
-    ? await buildTriggerContextFromConversation(
-      ctx.runtime,
-      bridgeConversationId,
-    )
+    ? await buildTriggerContextFromConversation(ctx.runtime, bridgeConversationId)
     : undefined;
 
   const draft = triggerContext
@@ -1416,11 +1381,11 @@ async function handleGenerateWorkflow(ctx: N8nRouteContext): Promise<boolean> {
   return true;
 }
 
-async function handleResolveClarification(
-  ctx: N8nRouteContext,
-): Promise<boolean> {
+async function handleResolveClarification(ctx: N8nRouteContext): Promise<boolean> {
   const body = await readCompatJsonBody(ctx.req, ctx.res);
-  if (!body) {return true;}
+  if (!body) {
+    return true;
+  }
 
   const draftRaw = (body as Record<string, unknown>).draft;
   if (!draftRaw || typeof draftRaw !== 'object' || Array.isArray(draftRaw)) {
@@ -1450,7 +1415,7 @@ async function handleResolveClarification(
 
   const result = applyResolutions(
     draft,
-    resolutions as Array<{ paramPath: string; value: string }>,
+    resolutions as Array<{ paramPath: string; value: string }>
   );
   if (!result.ok) {
     sendJson(ctx, 400, {
@@ -1463,10 +1428,10 @@ async function handleResolveClarification(
   const resolvedPaths = new Set(
     resolutions
       .map((r) => r.paramPath)
-      .filter((p): p is string => typeof p === 'string' && p.length > 0),
+      .filter((p): p is string => typeof p === 'string' && p.length > 0)
   );
   const freeFormCount = resolutions.filter(
-    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0,
+    (r) => typeof r.paramPath !== 'string' || r.paramPath.length === 0
   ).length;
   pruneResolvedClarifications(draft, resolvedPaths, freeFormCount);
 
@@ -1484,9 +1449,7 @@ async function handleResolveClarification(
   const remaining = coerceClarifications(meta?.requiresClarification);
   if (remaining.length > 0) {
     const catalogService = getConnectorTargetCatalog(ctx);
-    const catalog = catalogService
-      ? await buildCatalogSnapshot(catalogService, remaining)
-      : [];
+    const catalog = catalogService ? await buildCatalogSnapshot(catalogService, remaining) : [];
     sendJson(ctx, 200, {
       status: 'needs_clarification',
       draft,
@@ -1505,7 +1468,7 @@ async function handleToggleWorkflow(
   id: string,
   activate: boolean,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
@@ -1553,19 +1516,14 @@ async function handleDeleteWorkflow(
   ctx: N8nRouteContext,
   id: string,
   sidecar: N8nSidecar | null,
-  native: boolean,
+  native: boolean
 ): Promise<boolean> {
   if (!id) {
     sendJson(ctx, 400, { error: 'workflow id required' });
     return true;
   }
 
-  const resolved = resolveProxyTarget(
-    ctx,
-    `/${encodeURIComponent(id)}`,
-    sidecar,
-    native,
-  );
+  const resolved = resolveProxyTarget(ctx, `/${encodeURIComponent(id)}`, sidecar, native);
   if (!resolved.target) {
     sendJson(ctx, 503, {
       error: resolved.reason?.message ?? 'n8n not ready',

--- a/plugins/plugin-n8n-workflow/src/utils/generation.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/generation.ts
@@ -606,8 +606,12 @@ export async function formatActionResponse(
 }
 
 function formatActionDataForPrompt(value: unknown, indent = 0): string {
-  if (value === undefined || value === null) {return '';}
-  if (typeof value === 'string') {return value.trim();}
+  if (value === undefined || value === null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value.trim();
+  }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/plugins/plugin-signal/src/actions/sendMessage.ts
+++ b/plugins/plugin-signal/src/actions/sendMessage.ts
@@ -91,8 +91,7 @@ export const sendMessage: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (parsedResponse?.text) {
         messageInfo = {
           text: String(parsedResponse.text),

--- a/plugins/plugin-signal/src/actions/sendReaction.ts
+++ b/plugins/plugin-signal/src/actions/sendReaction.ts
@@ -99,8 +99,7 @@ export const sendReaction: Action = {
         prompt,
       });
 
-      const parsedResponse =
-        parseToonKeyValue<Record<string, unknown>>(response);
+      const parsedResponse = parseToonKeyValue<Record<string, unknown>>(response);
       if (
         parsedResponse?.emoji &&
         parsedResponse?.targetTimestamp &&

--- a/plugins/plugin-signal/src/connector.test.ts
+++ b/plugins/plugin-signal/src/connector.test.ts
@@ -11,9 +11,7 @@ describe("Signal message connector", () => {
       getRoom: vi.fn(),
     } as unknown as IAgentRuntime;
     const service = Object.create(SignalService.prototype) as SignalService;
-    const sendMessageSpy = vi
-      .spyOn(service, "sendMessage")
-      .mockResolvedValue({ timestamp: 123 });
+    const sendMessageSpy = vi.spyOn(service, "sendMessage").mockResolvedValue({ timestamp: 123 });
 
     SignalService.registerSendHandlers(runtime, service);
 

--- a/plugins/plugin-twitch/src/service.ts
+++ b/plugins/plugin-twitch/src/service.ts
@@ -18,8 +18,8 @@ import {
 import { RefreshingAuthProvider, StaticAuthProvider } from "@twurple/auth";
 import { ChatClient, type ChatMessage } from "@twurple/chat";
 import {
-  type ITwitchService,
   formatChannelForDisplay,
+  type ITwitchService,
   MAX_TWITCH_MESSAGE_LENGTH,
   normalizeChannel,
   splitMessageForTwitch,
@@ -87,7 +87,10 @@ export class TwitchService extends Service implements ITwitchService {
     return service;
   }
 
-  static registerSendHandlers(runtime: IAgentRuntime, serviceInstance: TwitchService): void {
+  static registerSendHandlers(
+    runtime: IAgentRuntime,
+    serviceInstance: TwitchService,
+  ): void {
     if (!serviceInstance) {
       return;
     }
@@ -106,15 +109,18 @@ export class TwitchService extends Service implements ITwitchService {
           service: TWITCH_SERVICE_NAME,
           maxMessageLength: MAX_TWITCH_MESSAGE_LENGTH,
         },
-        resolveTargets: serviceInstance.resolveConnectorTargets.bind(serviceInstance),
-        listRecentTargets: serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
+        resolveTargets:
+          serviceInstance.resolveConnectorTargets.bind(serviceInstance),
+        listRecentTargets:
+          serviceInstance.listRecentConnectorTargets.bind(serviceInstance),
         listRooms: serviceInstance.listConnectorRooms.bind(serviceInstance),
-        getChatContext: serviceInstance.getConnectorChatContext.bind(serviceInstance),
+        getChatContext:
+          serviceInstance.getConnectorChatContext.bind(serviceInstance),
         sendHandler,
       });
       runtime.logger.info(
         { src: "plugin:twitch", agentId: runtime.agentId },
-        "Registered Twitch chat connector"
+        "Registered Twitch chat connector",
       );
       return;
     }
@@ -465,7 +471,7 @@ export class TwitchService extends Service implements ITwitchService {
   async handleSendMessage(
     runtime: IAgentRuntime,
     target: TargetInfo,
-    content: Content
+    content: Content,
   ): Promise<void> {
     const text = typeof content.text === "string" ? content.text.trim() : "";
     if (!text) {
@@ -481,7 +487,9 @@ export class TwitchService extends Service implements ITwitchService {
       const metadata = room?.metadata as Record<string, unknown> | undefined;
       replyTo =
         replyTo ??
-        (typeof metadata?.twitchReplyTo === "string" ? metadata.twitchReplyTo : undefined);
+        (typeof metadata?.twitchReplyTo === "string"
+          ? metadata.twitchReplyTo
+          : undefined);
     }
 
     await this.sendMessage(text, {
@@ -492,7 +500,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async resolveConnectorTargets(
     query: string,
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const normalizedQuery = normalizeTwitchConnectorQuery(query);
     return this.getConnectorChannels()
@@ -505,7 +513,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listConnectorRooms(
-    _context: MessageConnectorQueryContext
+    _context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     return this.getConnectorChannels()
       .map((channel) => this.buildChannelTarget(channel, 0.5))
@@ -513,7 +521,7 @@ export class TwitchService extends Service implements ITwitchService {
   }
 
   async listRecentConnectorTargets(
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorTarget[]> {
     const targets: MessageConnectorTarget[] = [];
     const room =
@@ -541,7 +549,7 @@ export class TwitchService extends Service implements ITwitchService {
 
   async getConnectorChatContext(
     target: TargetInfo,
-    context: MessageConnectorQueryContext
+    context: MessageConnectorQueryContext,
   ): Promise<MessageConnectorChatContext | null> {
     let channel = target.channelId;
     if (!channel && target.roomId) {
@@ -580,7 +588,10 @@ export class TwitchService extends Service implements ITwitchService {
     return Array.from(channels);
   }
 
-  private buildChannelTarget(channel: string, score: number): MessageConnectorTarget {
+  private buildChannelTarget(
+    channel: string,
+    score: number,
+  ): MessageConnectorTarget {
     const normalized = normalizeChannel(channel);
     return {
       target: {

--- a/plugins/plugin-vision/src/action.ts
+++ b/plugins/plugin-vision/src/action.ts
@@ -39,9 +39,13 @@ async function saveExecutionRecord(
   await runtime.createMemory(memory, "messages");
 }
 
-function readActionParams(options?: Record<string, unknown>): Record<string, unknown> {
+function readActionParams(
+  options?: Record<string, unknown>,
+): Record<string, unknown> {
   const direct =
-    options && typeof options === "object" ? (options as Record<string, unknown>) : {};
+    options && typeof options === "object"
+      ? (options as Record<string, unknown>)
+      : {};
   const parameters =
     direct.parameters && typeof direct.parameters === "object"
       ? (direct.parameters as Record<string, unknown>)
@@ -61,7 +65,11 @@ export const describeSceneAction: Action = {
       description:
         "Scene description detail level. Use summary to omit object/person breakdowns from the spoken response.",
       required: false,
-      schema: { type: "string", enum: ["summary", "detailed"], default: "detailed" },
+      schema: {
+        type: "string",
+        enum: ["summary", "detailed"],
+        default: "detailed",
+      },
     },
   ],
   validate: async (
@@ -247,7 +255,11 @@ export const describeSceneAction: Action = {
         description += `\n\nObjects detected: ${objectDescriptions.join(", ")}.`;
       }
 
-      if (detailLevel === "detailed" && scene.sceneChanged && scene.changePercentage) {
+      if (
+        detailLevel === "detailed" &&
+        scene.sceneChanged &&
+        scene.changePercentage
+      ) {
         description += `\n\n(Scene changed by ${scene.changePercentage.toFixed(1)}% since last analysis)`;
       }
 
@@ -1151,8 +1163,7 @@ export const nameEntityAction: Action = {
 export const identifyPersonAction: Action = {
   name: "IDENTIFY_PERSON",
   description: "Identify a person in view if they have been seen before",
-  descriptionCompressed:
-    "Match face to known person via local recognition.",
+  descriptionCompressed: "Match face to known person via local recognition.",
   similes: [
     "who is that",
     "who is the person",

--- a/plugins/plugin-x/src/actions/fetchFeedTop.ts
+++ b/plugins/plugin-x/src/actions/fetchFeedTop.ts
@@ -30,7 +30,12 @@ export const fetchFeedTopAction: Action = {
       name: "limit",
       description: "Maximum ranked tweets to return.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 50, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 50,
+        default: DEFAULT_LIMIT,
+      },
     },
     {
       name: "fetchCount",

--- a/plugins/plugin-x/src/actions/readUnreadXDms.ts
+++ b/plugins/plugin-x/src/actions/readUnreadXDms.ts
@@ -25,7 +25,12 @@ export const readUnreadXDmsAction: Action = {
       name: "limit",
       description: "Maximum direct messages to scan for unread items.",
       required: false,
-      schema: { type: "number", minimum: 1, maximum: 100, default: DEFAULT_LIMIT },
+      schema: {
+        type: "number",
+        minimum: 1,
+        maximum: 100,
+        default: DEFAULT_LIMIT,
+      },
     },
   ],
   examples: [

--- a/plugins/plugin-x/src/search-category.test.ts
+++ b/plugins/plugin-x/src/search-category.test.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { registerXSearchCategory, X_SEARCH_CATEGORY } from "./search-category";
 
@@ -21,8 +18,10 @@ function createRuntime() {
   return {
     categories,
     registerSearchCategory,
-    runtime: { getSearchCategory, registerSearchCategory } as unknown as
-      IAgentRuntime,
+    runtime: {
+      getSearchCategory,
+      registerSearchCategory,
+    } as unknown as IAgentRuntime,
   };
 }
 

--- a/plugins/plugin-x/src/search-category.ts
+++ b/plugins/plugin-x/src/search-category.ts
@@ -1,7 +1,4 @@
-import type {
-  IAgentRuntime,
-  SearchCategoryRegistration,
-} from "@elizaos/core";
+import type { IAgentRuntime, SearchCategoryRegistration } from "@elizaos/core";
 
 export const X_SEARCH_CATEGORY: SearchCategoryRegistration = {
   category: "x",


### PR DESCRIPTION
## Summary
- add the missing `getCloudCompatAgentStatus` method to the RuntimeGate cloud provisioning test mock
- return the same running-agent bridge URL shape that `RuntimeGate` already reads from the real client
- stabilize the compressed-description lint test fixture so the length-rule assertion uses `MAX_DESCRIPTION_LENGTH` instead of a fragile hardcoded sentence
- apply formatter output for existing package-level CI format drift in plugin-signal, plugin-twitch, plugin-x, plugin-vision, and plugin-n8n-workflow

## Why
GitHub server tests currently fail because `RuntimeGate` calls `client.getCloudCompatAgentStatus()`, which exists on the real client, but the jsdom test mock did not define it. This is a test fixture update only; runtime behavior is unchanged.

The plugin formatting edits are formatter-only and match root `bun run format:check` failures/warnings reported by CI on this branch. The root formatter exits on the first failing package, so these packages were revealed sequentially while validating the PR.

## Validation
- `bunx vitest run --config packages/app-core/vitest.config.ts packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx`
- `bunx vitest run --config packages/core/vitest.config.ts packages/core/src/__tests__/description-compressed-lint.test.ts`
- `bunx biome check packages/core/src/__tests__/description-compressed-lint.test.ts`
- `bunx @biomejs/biome format packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx plugins/plugin-signal/src/actions/sendMessage.ts plugins/plugin-signal/src/actions/sendReaction.ts plugins/plugin-signal/src/connector.test.ts plugins/plugin-twitch/src/service.ts plugins/plugin-vision/src/action.ts`
- `bunx @biomejs/biome check plugins/plugin-twitch/src/service.ts`
- `bunx prettier --check plugins/plugin-x/src/actions/fetchFeedTop.ts plugins/plugin-x/src/actions/readUnreadXDms.ts plugins/plugin-x/src/search-category.test.ts plugins/plugin-x/src/search-category.ts plugins/plugin-n8n-workflow/src/actions/getExecutions.ts plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts plugins/plugin-n8n-workflow/src/plugin-routes.ts plugins/plugin-n8n-workflow/src/register-routes.ts plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts plugins/plugin-n8n-workflow/src/utils/generation.ts`

Notes:
- local package-level `bun run format:check` for plugin-twitch is blocked in this scratch worktree by Bun postinstall state from `--ignore-scripts`; direct Biome validation passes.
- the plugin-signal/plugin-twitch/plugin-x/plugin-vision/plugin-n8n-workflow edits are formatter-only; no runtime behavior changes.
- current mobile smoke failures are separate dependency/bootstrap issues: Android cannot resolve workspace packages such as `@elizaos/plugin-pdf`, and iOS cannot load `sharp` for brand asset generation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two broken CI items and applies formatter-only cleanup across five plugins. The substantive fixes are: adding the missing `getCloudCompatAgentStatus` mock to the `RuntimeGate` cloud-provisioning test, and correcting the "multiple violations" lint test whose original 155-character string never triggered the length check (max is 160).

- **`RuntimeGate.cloud-provisioning.test.tsx`**: declares `getCloudCompatAgentStatus: vi.fn()` in the hoisted mock and calls `mockResolvedValue` with the camelCase shape (`bridgeUrl`, `webUiUrl`, `suspendedReason`) that `RuntimeGate.tsx` reads at lines 706–732, fixing the test-time `TypeError` on the missing method.
- **`description-compressed-lint.test.ts`**: replaces the too-short hardcoded string with a template literal that injects `"x".repeat(MAX_DESCRIPTION_LENGTH)`, guaranteeing the length violation fires alongside the phrase/word/non-imperative checks already present.
- **Formatter changes** (plugin-signal, plugin-twitch, plugin-x, plugin-vision, plugin-n8n-workflow): pure whitespace/line-length reformatting by Biome and Prettier; no logic or runtime behavior changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are either test fixture repairs or formatter-only rewrites with no production code touched.

The only non-formatting logic changes are in test files. The `getCloudCompatAgentStatus` mock shape was verified against the actual `RuntimeGate.tsx` code that reads `s.bridgeUrl`, `s.webUiUrl`, and `s.suspendedReason`. The lint-test text change correctly triggers all four violation categories the assertions expect. No production paths were modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/shell/RuntimeGate.cloud-provisioning.test.tsx | Adds missing `getCloudCompatAgentStatus` mock (declaration + `mockResolvedValue`) so the existing provisioning test no longer throws; mock shape matches what the component actually reads. |
| packages/core/src/__tests__/description-compressed-lint.test.ts | Fixes a latent broken assertion: original 155-char string never exceeded MAX_DESCRIPTION_LENGTH (160); new template-literal text is 310+ chars and reliably triggers all four violation categories. |
| plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts | Formatter-only: collapses long multi-line function signatures, expands single-statement if bodies to block form — no logic changes. |
| plugins/plugin-twitch/src/service.ts | Formatter-only (Biome): expands long single-line function signatures to multi-line and adds trailing commas — no logic changes. |
| plugins/plugin-signal/src/actions/sendMessage.ts | Formatter-only: collapses a two-line variable assignment onto one line. |
| plugins/plugin-vision/src/action.ts | Formatter-only (Biome): expands long function signatures and object literals to multi-line form — no logic changes. |
| plugins/plugin-x/src/search-category.ts | Formatter-only (Prettier): collapses multi-line named import to a single line. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as RuntimeGate.test.tsx
    participant RG as RuntimeGate.tsx
    participant Mock as clientMock

    Test->>RG: render(<RuntimeGate />)
    Test->>RG: click Select Cloud
    RG->>Mock: getCloudCompatAgents()
    Mock-->>RG: { success: true, data: [STOPPED_AGENT] }
    RG->>Mock: provisionCloudCompatAgent(agent-1)
    Mock-->>RG: { success: true, data: { jobId: job-1 } }
    RG->>Mock: getCloudCompatJobStatus(job-1)
    Mock-->>RG: { status: completed }
    RG->>Mock: getCloudCompatAgentStatus(agent-1) NEW mock
    Mock-->>RG: { success: true, data: { status: running, bridgeUrl: ... } }
    RG->>Mock: getCloudCompatAgent(agent-1)
    Mock-->>RG: { success: true, data: RUNNING_AGENT }
    RG->>Mock: setBaseUrl(https://agent-1.elizacloud.ai)
    RG->>RG: completeOnboarding()
```

<sub>Reviews (6): Last reviewed commit: ["test(core): stabilize compressed descrip..."](https://github.com/elizaos/eliza/commit/0f812b63de0ff929aeeba768149c3445ca2ccf68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30934236)</sub>

<!-- /greptile_comment -->