### PR TITLE
fix(install): explicitly symlink packages/native-plugins/* workspaces (bun glob bug)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "24.15.0"
   },
   "scripts": {
-    "postinstall": "bun scripts/patch-nested-core-dist.mjs && bun scripts/patch-tsup-dts.mjs",
+    "postinstall": "bun scripts/patch-nested-core-dist.mjs && bun scripts/patch-tsup-dts.mjs && node scripts/ensure-native-plugins-linked.mjs",
     "fix-deps": "bun scripts/fix-workspace-deps.mjs",
     "fix-deps:check": "bun scripts/fix-workspace-deps.mjs --check",
     "fix-deps:restore": "bun scripts/fix-workspace-deps.mjs --restore",

--- a/scripts/ensure-native-plugins-linked.mjs
+++ b/scripts/ensure-native-plugins-linked.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Workaround for a Bun workspace bug: packages declared via the
+ * `packages/native-plugins/*` workspace glob are recognised by
+ * `bun pm ls` but never symlinked into `node_modules/@elizaos/...`,
+ * even on a fresh `bun install --ignore-scripts` against a deleted
+ * node_modules tree. The same pattern works for `plugins/*` and
+ * `packages/*` — only `packages/native-plugins/*` is affected.
+ *
+ * Symptom downstream: `bun run --cwd packages/agent build:mobile`
+ * fails with `Could not resolve: "@elizaos/capacitor-contacts"`
+ * (and the other 19 native-plugin packages) because the agent's
+ * static imports can't be linked at bundle time.
+ *
+ * This script runs after `bun install` (wired into the root
+ * `postinstall`) and explicitly creates the missing
+ * `node_modules/@elizaos/<name>` → `../../packages/native-plugins/<dir>`
+ * symlinks. Idempotent: existing correct symlinks are left alone.
+ */
+
+import { existsSync, readdirSync, readFileSync, lstatSync, symlinkSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const nativePluginsRoot = path.join(repoRoot, "packages", "native-plugins");
+const nodeModulesRoot = path.join(repoRoot, "node_modules");
+
+if (!existsSync(nativePluginsRoot)) {
+  process.exit(0);
+}
+
+let linked = 0;
+let alreadyOk = 0;
+let skipped = 0;
+
+for (const dirName of readdirSync(nativePluginsRoot)) {
+  const pkgDir = path.join(nativePluginsRoot, dirName);
+  const pkgJsonPath = path.join(pkgDir, "package.json");
+  if (!existsSync(pkgJsonPath)) {
+    skipped += 1;
+    continue;
+  }
+  let pkgName;
+  try {
+    pkgName = JSON.parse(readFileSync(pkgJsonPath, "utf8")).name;
+  } catch {
+    skipped += 1;
+    continue;
+  }
+  if (typeof pkgName !== "string" || pkgName.length === 0) {
+    skipped += 1;
+    continue;
+  }
+
+  const targetDir = path.join(nodeModulesRoot, ...pkgName.split("/"));
+  const parentDir = path.dirname(targetDir);
+  // Relative path from the symlink location to the workspace dir, so the
+  // symlink keeps working if node_modules is moved with the repo (it
+  // shouldn't be, but a stable target is more portable than an absolute
+  // /Users/... path).
+  const relativeTarget = path.relative(parentDir, pkgDir);
+
+  // Already a correct symlink? Leave it.
+  let needLink = true;
+  if (existsSync(targetDir)) {
+    try {
+      const stat = lstatSync(targetDir);
+      if (stat.isSymbolicLink()) {
+        needLink = false;
+        alreadyOk += 1;
+      } else {
+        // Real directory at the same path — bun installed something
+        // unrelated under the same name. Leave it; printing here would
+        // surface a real conflict.
+        skipped += 1;
+        continue;
+      }
+    } catch {
+      // Stat failure — fall through to (re)create.
+      try {
+        rmSync(targetDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+
+  if (needLink) {
+    mkdirSync(parentDir, { recursive: true });
+    try {
+      symlinkSync(relativeTarget, targetDir, "dir");
+      linked += 1;
+    } catch (err) {
+      console.error(
+        `[ensure-native-plugins-linked] failed to link ${pkgName} → ${pkgDir}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}
+
+if (linked > 0) {
+  console.log(
+    `[ensure-native-plugins-linked] linked ${linked} workspace package(s); ${alreadyOk} already in place; ${skipped} skipped.`,
+  );
+}


### PR DESCRIPTION
## Summary

`bun install` recognises packages declared via the `packages/native-plugins/*` workspace glob (they appear in `bun pm ls`) but never creates the corresponding `node_modules/@elizaos/<name>` symlinks for any of the **20 packages** under that root. The same `*` glob works fine for `plugins/*` and `packages/*` — only `packages/native-plugins/*` is affected.

**Symptom downstream:** every `Mobile Build Smoke Test / Android Debug Build` PR check fails with:

```
error: Could not resolve: "@elizaos/capacitor-contacts". Maybe you need to "bun install"?
error: Could not resolve: "@elizaos/plugin-agent-skills". Maybe you need to "bun install"?
error: Could not resolve: "@elizaos/plugin-pdf". Maybe you need to "bun install"?
error: script "build:mobile" exited with code 1
```

…when `bun run --cwd packages/agent build:mobile` tries to bundle the agent runtime.

## Repro

```bash
rm -rf node_modules bun.lock
bun install --ignore-scripts
ls node_modules/@elizaos/capacitor-contacts
# => No such file or directory
bun pm ls | grep capacitor-contacts
# => @elizaos/capacitor-contacts@workspace:packages/native-plugins/contacts  ✓ recognised
```

So the resolver knows about it, but the linker skips creating the node_modules entry. Confirmed against current `origin/develop`.

## Fix

`scripts/ensure-native-plugins-linked.mjs`:
- Reads each `packages/native-plugins/*/package.json`'s `name` field.
- Creates `node_modules/<scope>/<name>` → `../../packages/native-plugins/<dir>` symlink (relative path so it survives directory moves).
- Idempotent: leaves existing correct symlinks alone, skips dirs without `package.json` (activity-tracker, agent — no manifest checked in).
- Pure `node:fs` (no Bun APIs) so it runs even before bun's npm-package binary placeholder has been materialised.

Wired into the root `postinstall`:
```diff
-"postinstall": "bun scripts/patch-nested-core-dist.mjs && bun scripts/patch-tsup-dts.mjs"
+"postinstall": "bun scripts/patch-nested-core-dist.mjs && bun scripts/patch-tsup-dts.mjs && node scripts/ensure-native-plugins-linked.mjs"
```

## Verification

```
$ rm -rf node_modules/@elizaos/capacitor-* && node scripts/ensure-native-plugins-linked.mjs
[ensure-native-plugins-linked] linked 20 workspace package(s); 0 already in place; 2 skipped.

$ ls -la node_modules/@elizaos/capacitor-contacts
lrwxr-xr-x → ../../packages/native-plugins/contacts
```

## Long-term

This should be a Bun bug report — `packages/native-plugins/*` recognised in resolver but skipped in linker is unambiguous. Once the upstream Bun fix lands, this script can be deleted.

## Test plan

- [ ] Android Debug Build CI check on this PR comes back green
- [ ] No regression in any other CI check (the script runs in postinstall, only adds symlinks where they're missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `postinstall` workaround script that manually creates the missing `node_modules/@elizaos/<name>` symlinks for all packages under `packages/native-plugins/*`, which Bun recognises in its resolver but omits from the linker step.

- `scripts/ensure-native-plugins-linked.mjs` iterates every sub-directory of `packages/native-plugins/`, reads `package.json`, and calls `symlinkSync` using a repo-relative path; it is guarded to skip directories without a manifest and to leave existing symlinks alone.
- `package.json` appends the new script to the root `postinstall` chain, run via `node` (not `bun`) so it executes before Bun's own binary placeholders are materialised.
</details>

<h3>Confidence Score: 3/5</h3>

The postinstall script correctly handles the common path but has two defects that can leave symlinks missing without surfacing a build-blocking failure.

The dangling-symlink detection gap means that on developer machines where the repo was moved or where a previous install left stale symlinks, the script logs an EEXIST error and moves on — the affected packages remain un-linked and the downstream build fails with the same resolution errors this PR is meant to fix. Compounding this, the script always exits 0 when a link fails, so postinstall appears green while the install is actually broken; the symptom only surfaces later at bundle time.

scripts/ensure-native-plugins-linked.mjs — the symlink-detection and exit-code logic both need attention before this behaves reliably outside of a clean CI environment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ensure-native-plugins-linked.mjs | New postinstall script that manually symlinks native-plugin workspaces Bun misses; contains a dangling-symlink detection bug (existsSync follows symlinks) and swallows link failures with exit 0. |
| package.json | Appends the new ensure-native-plugins-linked.mjs to the postinstall chain; the change itself is correct and minimal. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["bun install"] --> B["postinstall"]
    B --> C["patch-nested-core-dist.mjs"]
    C --> D["patch-tsup-dts.mjs"]
    D --> E["ensure-native-plugins-linked.mjs"]
    E --> F{"packages/native-plugins exists?"}
    F -- No --> G["exit 0"]
    F -- Yes --> H["readdirSync native-plugins/*"]
    H --> I{"package.json present?\nname valid?"}
    I -- No --> J["skipped++; next dir"]
    I -- Yes --> K["compute targetDir"]
    K --> L{"existsSync targetDir?"}
    L -- No --> M["needLink = true"]
    L -- Yes --> N{"lstatSync isSymbolicLink?"}
    N -- Yes --> O["alreadyOk++"]
    N -- No --> P["skipped++"]
    N -- throws --> Q["rmSync; needLink=true"]
    M --> R["symlinkSync"]
    Q --> R
    O --> S{needLink?}
    R --> S
    S -- Yes --> T["symlinkSync"]
    T -- success --> U["linked++"]
    T -- fails --> V["console.error; exit 0 bug"]
    S -- No --> W["next dir"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A64-85%0A%60existsSync%60%20follows%20symlinks%3A%20it%20returns%20%60false%60%20for%20a%20**dangling%20symlink**%20%28one%20whose%20target%20has%20been%20deleted%20or%20is%20on%20a%20path%20that%20was%20moved%29.%20So%20if%20%60targetDir%60%20is%20a%20dangling%20symlink%2C%20the%20%60if%20%28existsSync%28targetDir%29%29%60%20block%20is%20skipped%2C%20%60needLink%60%20stays%20%60true%60%2C%20and%20%60symlinkSync%60%20throws%20%60EEXIST%60%20%E2%80%94%20because%20the%20symlink%20path%20itself%20still%20occupies%20the%20filesystem.%20The%20error%20is%20caught%20and%20logged%2C%20but%20the%20package%20ends%20up%20un-linked.%20On%20a%20developer%20machine%20that%20previously%20ran%20this%20script%20and%20then%20moved%20the%20repo%2C%20every%20package%20would%20print%20an%20error%20and%20remain%20broken.%20Use%20%60lstatSync%60%20directly%20%28in%20a%20%60try%2Fcatch%60%29%20instead%3B%20it%20does%20not%20follow%20symlinks%20and%20correctly%20detects%20dangling%20ones.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Already%20a%20correct%20symlink%3F%20Leave%20it.%0A%20%20let%20needLink%20%3D%20true%3B%0A%20%20%2F%2F%20Use%20lstatSync%20%28not%20existsSync%29%20so%20dangling%20symlinks%20are%20detected%3B%0A%20%20%2F%2F%20existsSync%20follows%20symlinks%20and%20returns%20false%20for%20dangling%20ones%2C%0A%20%20%2F%2F%20which%20would%20cause%20symlinkSync%20to%20throw%20EEXIST.%0A%20%20let%20existingStat%20%3D%20null%3B%0A%20%20try%20%7B%0A%20%20%20%20existingStat%20%3D%20lstatSync%28targetDir%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20%2F%2F%20Nothing%20at%20targetDir%20%E2%80%94%20fall%20through%20to%20create.%0A%20%20%7D%0A%20%20if%20%28existingStat%20!%3D%3D%20null%29%20%7B%0A%20%20%20%20if%20%28existingStat.isSymbolicLink%28%29%29%20%7B%0A%20%20%20%20%20%20needLink%20%3D%20false%3B%0A%20%20%20%20%20%20alreadyOk%20%2B%3D%201%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20Real%20directory%20at%20the%20same%20path%20%E2%80%94%20bun%20installed%20something%0A%20%20%20%20%20%20%2F%2F%20unrelated%20under%20the%20same%20name.%20Leave%20it%3B%20printing%20here%20would%0A%20%20%20%20%20%20%2F%2F%20surface%20a%20real%20conflict.%0A%20%20%20%20%20%20skipped%20%2B%3D%201%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A89-98%0AWhen%20%60symlinkSync%60%20fails%2C%20only%20%60console.error%60%20is%20called%20and%20the%20loop%20continues%2C%20so%20%60postinstall%60%20exits%20%600%60%20even%20when%20one%20or%20more%20packages%20couldn't%20be%20linked.%20The%20downstream%20build%20will%20then%20fail%20with%20the%20original%20%22Could%20not%20resolve%22%20error%20%E2%80%94%20the%20same%20symptom%20this%20script%20was%20meant%20to%20fix%20%E2%80%94%20but%20without%20any%20indication%20that%20%60postinstall%60%20itself%20was%20the%20point%20of%20failure.%20Setting%20%60process.exitCode%20%3D%201%60%20surfaces%20the%20problem%20at%20install%20time%20rather%20than%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20symlinkSync%28relativeTarget%2C%20targetDir%2C%20%22dir%22%29%3B%0A%20%20%20%20%20%20linked%20%2B%3D%201%3B%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20console.error%28%0A%20%20%20%20%20%20%20%20%60%5Bensure-native-plugins-linked%5D%20failed%20to%20link%20%24%7BpkgName%7D%20%E2%86%92%20%24%7BpkgDir%7D%3A%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20err%20instanceof%20Error%20%3F%20err.message%20%3A%20String%28err%29%0A%20%20%20%20%20%20%20%20%7D%60%2C%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=elizaos%2Feliza&pr=7406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Ffix-android-build-mobile%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Ffix-android-build-mobile%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A64-85%0A%60existsSync%60%20follows%20symlinks%3A%20it%20returns%20%60false%60%20for%20a%20**dangling%20symlink**%20%28one%20whose%20target%20has%20been%20deleted%20or%20is%20on%20a%20path%20that%20was%20moved%29.%20So%20if%20%60targetDir%60%20is%20a%20dangling%20symlink%2C%20the%20%60if%20%28existsSync%28targetDir%29%29%60%20block%20is%20skipped%2C%20%60needLink%60%20stays%20%60true%60%2C%20and%20%60symlinkSync%60%20throws%20%60EEXIST%60%20%E2%80%94%20because%20the%20symlink%20path%20itself%20still%20occupies%20the%20filesystem.%20The%20error%20is%20caught%20and%20logged%2C%20but%20the%20package%20ends%20up%20un-linked.%20On%20a%20developer%20machine%20that%20previously%20ran%20this%20script%20and%20then%20moved%20the%20repo%2C%20every%20package%20would%20print%20an%20error%20and%20remain%20broken.%20Use%20%60lstatSync%60%20directly%20%28in%20a%20%60try%2Fcatch%60%29%20instead%3B%20it%20does%20not%20follow%20symlinks%20and%20correctly%20detects%20dangling%20ones.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Already%20a%20correct%20symlink%3F%20Leave%20it.%0A%20%20let%20needLink%20%3D%20true%3B%0A%20%20%2F%2F%20Use%20lstatSync%20%28not%20existsSync%29%20so%20dangling%20symlinks%20are%20detected%3B%0A%20%20%2F%2F%20existsSync%20follows%20symlinks%20and%20returns%20false%20for%20dangling%20ones%2C%0A%20%20%2F%2F%20which%20would%20cause%20symlinkSync%20to%20throw%20EEXIST.%0A%20%20let%20existingStat%20%3D%20null%3B%0A%20%20try%20%7B%0A%20%20%20%20existingStat%20%3D%20lstatSync%28targetDir%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20%2F%2F%20Nothing%20at%20targetDir%20%E2%80%94%20fall%20through%20to%20create.%0A%20%20%7D%0A%20%20if%20%28existingStat%20!%3D%3D%20null%29%20%7B%0A%20%20%20%20if%20%28existingStat.isSymbolicLink%28%29%29%20%7B%0A%20%20%20%20%20%20needLink%20%3D%20false%3B%0A%20%20%20%20%20%20alreadyOk%20%2B%3D%201%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20Real%20directory%20at%20the%20same%20path%20%E2%80%94%20bun%20installed%20something%0A%20%20%20%20%20%20%2F%2F%20unrelated%20under%20the%20same%20name.%20Leave%20it%3B%20printing%20here%20would%0A%20%20%20%20%20%20%2F%2F%20surface%20a%20real%20conflict.%0A%20%20%20%20%20%20skipped%20%2B%3D%201%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A89-98%0AWhen%20%60symlinkSync%60%20fails%2C%20only%20%60console.error%60%20is%20called%20and%20the%20loop%20continues%2C%20so%20%60postinstall%60%20exits%20%600%60%20even%20when%20one%20or%20more%20packages%20couldn't%20be%20linked.%20The%20downstream%20build%20will%20then%20fail%20with%20the%20original%20%22Could%20not%20resolve%22%20error%20%E2%80%94%20the%20same%20symptom%20this%20script%20was%20meant%20to%20fix%20%E2%80%94%20but%20without%20any%20indication%20that%20%60postinstall%60%20itself%20was%20the%20point%20of%20failure.%20Setting%20%60process.exitCode%20%3D%201%60%20surfaces%20the%20problem%20at%20install%20time%20rather%20than%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20symlinkSync%28relativeTarget%2C%20targetDir%2C%20%22dir%22%29%3B%0A%20%20%20%20%20%20linked%20%2B%3D%201%3B%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20console.error%28%0A%20%20%20%20%20%20%20%20%60%5Bensure-native-plugins-linked%5D%20failed%20to%20link%20%24%7BpkgName%7D%20%E2%86%92%20%24%7BpkgDir%7D%3A%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20err%20instanceof%20Error%20%3F%20err.message%20%3A%20String%28err%29%0A%20%20%20%20%20%20%20%20%7D%60%2C%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A64-85%0A%60existsSync%60%20follows%20symlinks%3A%20it%20returns%20%60false%60%20for%20a%20**dangling%20symlink**%20%28one%20whose%20target%20has%20been%20deleted%20or%20is%20on%20a%20path%20that%20was%20moved%29.%20So%20if%20%60targetDir%60%20is%20a%20dangling%20symlink%2C%20the%20%60if%20%28existsSync%28targetDir%29%29%60%20block%20is%20skipped%2C%20%60needLink%60%20stays%20%60true%60%2C%20and%20%60symlinkSync%60%20throws%20%60EEXIST%60%20%E2%80%94%20because%20the%20symlink%20path%20itself%20still%20occupies%20the%20filesystem.%20The%20error%20is%20caught%20and%20logged%2C%20but%20the%20package%20ends%20up%20un-linked.%20On%20a%20developer%20machine%20that%20previously%20ran%20this%20script%20and%20then%20moved%20the%20repo%2C%20every%20package%20would%20print%20an%20error%20and%20remain%20broken.%20Use%20%60lstatSync%60%20directly%20%28in%20a%20%60try%2Fcatch%60%29%20instead%3B%20it%20does%20not%20follow%20symlinks%20and%20correctly%20detects%20dangling%20ones.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Already%20a%20correct%20symlink%3F%20Leave%20it.%0A%20%20let%20needLink%20%3D%20true%3B%0A%20%20%2F%2F%20Use%20lstatSync%20%28not%20existsSync%29%20so%20dangling%20symlinks%20are%20detected%3B%0A%20%20%2F%2F%20existsSync%20follows%20symlinks%20and%20returns%20false%20for%20dangling%20ones%2C%0A%20%20%2F%2F%20which%20would%20cause%20symlinkSync%20to%20throw%20EEXIST.%0A%20%20let%20existingStat%20%3D%20null%3B%0A%20%20try%20%7B%0A%20%20%20%20existingStat%20%3D%20lstatSync%28targetDir%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20%2F%2F%20Nothing%20at%20targetDir%20%E2%80%94%20fall%20through%20to%20create.%0A%20%20%7D%0A%20%20if%20%28existingStat%20!%3D%3D%20null%29%20%7B%0A%20%20%20%20if%20%28existingStat.isSymbolicLink%28%29%29%20%7B%0A%20%20%20%20%20%20needLink%20%3D%20false%3B%0A%20%20%20%20%20%20alreadyOk%20%2B%3D%201%3B%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%2F%2F%20Real%20directory%20at%20the%20same%20path%20%E2%80%94%20bun%20installed%20something%0A%20%20%20%20%20%20%2F%2F%20unrelated%20under%20the%20same%20name.%20Leave%20it%3B%20printing%20here%20would%0A%20%20%20%20%20%20%2F%2F%20surface%20a%20real%20conflict.%0A%20%20%20%20%20%20skipped%20%2B%3D%201%3B%0A%20%20%20%20%20%20continue%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fensure-native-plugins-linked.mjs%3A89-98%0AWhen%20%60symlinkSync%60%20fails%2C%20only%20%60console.error%60%20is%20called%20and%20the%20loop%20continues%2C%20so%20%60postinstall%60%20exits%20%600%60%20even%20when%20one%20or%20more%20packages%20couldn't%20be%20linked.%20The%20downstream%20build%20will%20then%20fail%20with%20the%20original%20%22Could%20not%20resolve%22%20error%20%E2%80%94%20the%20same%20symptom%20this%20script%20was%20meant%20to%20fix%20%E2%80%94%20but%20without%20any%20indication%20that%20%60postinstall%60%20itself%20was%20the%20point%20of%20failure.%20Setting%20%60process.exitCode%20%3D%201%60%20surfaces%20the%20problem%20at%20install%20time%20rather%20than%20at%20build%20time.%0A%0A%60%60%60suggestion%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20symlinkSync%28relativeTarget%2C%20targetDir%2C%20%22dir%22%29%3B%0A%20%20%20%20%20%20linked%20%2B%3D%201%3B%0A%20%20%20%20%7D%20catch%20%28err%29%20%7B%0A%20%20%20%20%20%20console.error%28%0A%20%20%20%20%20%20%20%20%60%5Bensure-native-plugins-linked%5D%20failed%20to%20link%20%24%7BpkgName%7D%20%E2%86%92%20%24%7BpkgDir%7D%3A%20%24%7B%0A%20%20%20%20%20%20%20%20%20%20err%20instanceof%20Error%20%3F%20err.message%20%3A%20String%28err%29%0A%20%20%20%20%20%20%20%20%7D%60%2C%0A%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20process.exitCode%20%3D%201%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A&pr=7406&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(install): explicitly symlink package..."](https://github.com/elizaos/eliza/commit/f6d90d3ad9e51e46b3ebcd3b8563f4a8430f45ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30934355)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->