### PR TITLE
chore(platform): drop misleading LEGACY_ prefix on onboarding-complete storage key

### DIFF
--- a/packages/app-core/src/platform/onboarding-reset.ts
+++ b/packages/app-core/src/platform/onboarding-reset.ts
@@ -8,7 +8,7 @@ import type {
 const ACTIVE_SERVER_STORAGE_KEY = "elizaos:active-server";
 const ONBOARDING_STEP_STORAGE_KEY = "eliza:onboarding:step";
 const LEGACY_ONBOARDING_STEP_STORAGE_KEY = "eliza:onboarding-step";
-const LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY = "eliza:onboarding-complete";
+const ONBOARDING_COMPLETE_STORAGE_KEY = "eliza:onboarding-complete";
 const FORCE_FRESH_ONBOARDING_STORAGE_KEY = "elizaos:onboarding:force-fresh";
 const RESET_QUERY_PARAM = "reset";
 const PATCH_STATE = Symbol.for("elizaos.forceFreshOnboardingPatch");
@@ -90,7 +90,7 @@ export function applyForceFreshOnboardingReset(args?: {
       resolvedStorage.removeItem(ACTIVE_SERVER_STORAGE_KEY);
       resolvedStorage.removeItem(ONBOARDING_STEP_STORAGE_KEY);
       resolvedStorage.removeItem(LEGACY_ONBOARDING_STEP_STORAGE_KEY);
-      resolvedStorage.removeItem(LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY);
+      resolvedStorage.removeItem(ONBOARDING_COMPLETE_STORAGE_KEY);
       resolvedStorage.setItem(FORCE_FRESH_ONBOARDING_STORAGE_KEY, "1");
     } catch {
       // Ignore storage failures during startup.


### PR DESCRIPTION
## Summary

Closes Task 12 from the OOB-correctness work. Investigation found that `eliza:onboarding-complete` localStorage IS the correct cache (durable on iOS via storage-bridge), but the local constant `LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY` in `platform/onboarding-reset.ts` was a misleading rename relic — it has the same value as the canonical key in `state/persistence.ts`. Renamed to drop the false LEGACY prefix.

Net: 1 file, 2 lines, no behavior change. Documents that "vault prefs" doesn't apply here per the audit.

## Test plan
- [x] typecheck clean
- [x] biome clean
- [x] No localStorage lookups changed — semantic identity preserved

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR drops the misleading `LEGACY_` prefix from the local `ONBOARDING_COMPLETE_STORAGE_KEY` constant in `platform/onboarding-reset.ts`. The underlying localStorage key value (`"eliza:onboarding-complete"`) is untouched, so there is no behavior change.

- Renames `LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY` → `ONBOARDING_COMPLETE_STORAGE_KEY` at both the declaration (line 11) and the single call site (line 93).
- The renamed constant now matches the identical constant in `state/persistence.ts` by name and value, making the codebase internally consistent.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the storage key string is unchanged, so no data is lost or misread for any existing users.

The only modification is renaming a local constant; the underlying localStorage key is identical before and after, so no user data or runtime behaviour is affected. The one minor note is that the same key string is now declared in three separate locations without a shared source of truth, but that pre-existed this PR and is not introduced by it.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/platform/onboarding-reset.ts | Renames local constant from LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY to ONBOARDING_COMPLETE_STORAGE_KEY; storage key value "eliza:onboarding-complete" is unchanged — pure cosmetic fix with no behavior change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["applyForceFreshOnboardingReset()"] --> B{reset param present?}
    B -- No --> C[return false]
    B -- Yes --> D[removeItem ACTIVE_SERVER_STORAGE_KEY]
    D --> E[removeItem ONBOARDING_STEP_STORAGE_KEY]
    E --> F[removeItem LEGACY_ONBOARDING_STEP_STORAGE_KEY]
    F --> G["removeItem ONBOARDING_COMPLETE_STORAGE_KEY\n(was: LEGACY_ONBOARDING_COMPLETE_STORAGE_KEY)\nvalue: 'eliza:onboarding-complete' — unchanged"]
    G --> H[setItem FORCE_FRESH_ONBOARDING_STORAGE_KEY = '1']
    H --> I[replaceState — strip ?reset param]
    I --> J[return true]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fplatform%2Fonboarding-reset.ts%3A11%0A**Duplicated%20storage%20key%20constant%20across%20modules**%0A%0A%60ONBOARDING_COMPLETE_STORAGE_KEY%60%20is%20now%20defined%20identically%20in%20both%20this%20file%20%28line%2011%29%20and%20%60state%2Fpersistence.ts%60%20%28line%20377%29%2C%20and%20the%20raw%20string%20%60%22eliza%3Aonboarding-complete%22%60%20also%20appears%20in%20%60bridge%2Fstorage-bridge.ts%60.%20If%20the%20key%20ever%20needs%20to%20change%2C%20all%20three%20sites%20must%20be%20updated%20in%20lockstep.%20Exporting%20the%20constant%20from%20a%20single%20shared%20location%20%28e.g.%20%60state%2Fpersistence.ts%60%29%20and%20importing%20it%20here%20would%20eliminate%20the%20silent%20drift%20risk.%0A%0A&repo=elizaos%2Feliza&pr=7411&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Fonboarding-vault-prefs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Fonboarding-vault-prefs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fplatform%2Fonboarding-reset.ts%3A11%0A**Duplicated%20storage%20key%20constant%20across%20modules**%0A%0A%60ONBOARDING_COMPLETE_STORAGE_KEY%60%20is%20now%20defined%20identically%20in%20both%20this%20file%20%28line%2011%29%20and%20%60state%2Fpersistence.ts%60%20%28line%20377%29%2C%20and%20the%20raw%20string%20%60%22eliza%3Aonboarding-complete%22%60%20also%20appears%20in%20%60bridge%2Fstorage-bridge.ts%60.%20If%20the%20key%20ever%20needs%20to%20change%2C%20all%20three%20sites%20must%20be%20updated%20in%20lockstep.%20Exporting%20the%20constant%20from%20a%20single%20shared%20location%20%28e.g.%20%60state%2Fpersistence.ts%60%29%20and%20importing%20it%20here%20would%20eliminate%20the%20silent%20drift%20risk.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fplatform%2Fonboarding-reset.ts%3A11%0A**Duplicated%20storage%20key%20constant%20across%20modules**%0A%0A%60ONBOARDING_COMPLETE_STORAGE_KEY%60%20is%20now%20defined%20identically%20in%20both%20this%20file%20%28line%2011%29%20and%20%60state%2Fpersistence.ts%60%20%28line%20377%29%2C%20and%20the%20raw%20string%20%60%22eliza%3Aonboarding-complete%22%60%20also%20appears%20in%20%60bridge%2Fstorage-bridge.ts%60.%20If%20the%20key%20ever%20needs%20to%20change%2C%20all%20three%20sites%20must%20be%20updated%20in%20lockstep.%20Exporting%20the%20constant%20from%20a%20single%20shared%20location%20%28e.g.%20%60state%2Fpersistence.ts%60%29%20and%20importing%20it%20here%20would%20eliminate%20the%20silent%20drift%20risk.%0A%0A&pr=7411&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(platform): drop misleading LEGACY\_..."](https://github.com/elizaos/eliza/commit/617102e6192fbf4151c845b42b439a3244146e7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951669)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->