### PR TITLE
fix(settings): "Use local only" actually disconnects cloud

### DIFF
--- a/packages/app-core/src/components/settings/ProviderSwitcher.tsx
+++ b/packages/app-core/src/components/settings/ProviderSwitcher.tsx
@@ -660,26 +660,18 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
     setCloudCallsDisabled(true);
     setRoutingModeSaving(true);
     try {
-      const cfg = await client.getConfig();
-      const cloud = asRecord(cfg.cloud) ?? {};
-      const services = asRecord(cloud.services) ?? {};
-      await client.updateConfig({
-        deploymentTarget: { runtime: "local" },
-        cloud: {
-          ...cloud,
-          enabled: false,
-          inferenceMode: "local",
-          services: {
-            ...services,
-            inference: false,
-            media: false,
-            tts: false,
-            embeddings: false,
-            rpc: false,
-          },
-        },
-        serviceRouting: null,
-      });
+      // Route through the canonical cloud disconnect path so we get the full
+      // teardown (POST /api/cloud/disconnect → cloudManager.disconnect(),
+      // delete cloud.apiKey, applyCanonicalOnboardingConfig with
+      // linkedAccounts.elizacloud=unlinked + clearRoutes, env wipe, runtime
+      // character-secrets wipe) plus the renderer-side state reset
+      // (elizaCloud{Enabled,Connected,Credits,UserId,...} all flipped). The
+      // previous bespoke client.updateConfig({ cloud: { enabled: false, ... } })
+      // toggled flags but left cloud.apiKey, linkedAccounts, env vars and
+      // runtime secrets intact, so the next "use cloud" path silently reused
+      // stale state. skipConfirmation: true because clicking "Use local only"
+      // IS the confirmation — no need for a second dialog.
+      await app.handleCloudDisconnect({ skipConfirmation: true });
       void client.restartAgent().catch((err) => {
         notifySelectionFailure("Local-only mode saved; restart failed", err);
       });
@@ -691,6 +683,7 @@ export function ProviderSwitcher(props: ProviderSwitcherProps = {}) {
       setRoutingModeSaving(false);
     }
   }, [
+    app,
     cloudCallsDisabled,
     notifySelectionFailure,
     resolvedSelectedId,

--- a/packages/app-core/src/state/types.ts
+++ b/packages/app-core/src/state/types.ts
@@ -946,7 +946,9 @@ export interface AppActions {
 
   // Cloud
   handleCloudLogin: (prePoppedWindow?: Window | null) => Promise<void>;
-  handleCloudDisconnect: () => Promise<void>;
+  handleCloudDisconnect: (opts?: {
+    skipConfirmation?: boolean;
+  }) => Promise<void>;
 
   // Multi-agent
   switchAgentProfile: (profileId: string) => void;

--- a/packages/app-core/src/state/useCloudState.ts
+++ b/packages/app-core/src/state/useCloudState.ts
@@ -596,50 +596,98 @@ export function useCloudState({
   // Keep forward ref in sync so handleOnboardingNext can call it.
   handleCloudLoginRef.current = handleCloudLogin;
 
-  const handleCloudDisconnect = useCallback(async () => {
-    const MAIN_CONFIRM_DISCONNECT_MS = 300_000;
-    const MAIN_POST_ONLY_MS = 12_000;
-    const RENDERER_DISCONNECT_MS = 12_000;
+  const handleCloudDisconnect = useCallback(
+    async (opts?: { skipConfirmation?: boolean }): Promise<void> => {
+      const MAIN_CONFIRM_DISCONNECT_MS = 300_000;
+      const MAIN_POST_ONLY_MS = 12_000;
+      const RENDERER_DISCONNECT_MS = 12_000;
+      const skipConfirmation = opts?.skipConfirmation === true;
 
-    elizaCloudDisconnectInFlightRef.current = true;
-    setElizaCloudDisconnecting(true);
+      elizaCloudDisconnectInFlightRef.current = true;
+      setElizaCloudDisconnecting(true);
 
-    try {
-      let needRendererDisconnect = true;
+      try {
+        let needRendererDisconnect = true;
 
-      if (isElectrobunRuntime()) {
-        const combined = await invokeDesktopBridgeRequestWithTimeout<
-          { cancelled: true } | { ok: true } | { ok: false; error?: string }
-        >({
-          rpcMethod: "agentCloudDisconnectWithConfirm",
-          ipcChannel: "agent:cloudDisconnectWithConfirm",
-          params: {
-            apiBase: client.getBaseUrl().trim() || undefined,
-            bearerToken: client.getRestAuthToken() ?? undefined,
-          },
-          timeoutMs: MAIN_CONFIRM_DISCONNECT_MS,
-        });
+        if (isElectrobunRuntime()) {
+          if (!skipConfirmation) {
+            const combined = await invokeDesktopBridgeRequestWithTimeout<
+              { cancelled: true } | { ok: true } | { ok: false; error?: string }
+            >({
+              rpcMethod: "agentCloudDisconnectWithConfirm",
+              ipcChannel: "agent:cloudDisconnectWithConfirm",
+              params: {
+                apiBase: client.getBaseUrl().trim() || undefined,
+                bearerToken: client.getRestAuthToken() ?? undefined,
+              },
+              timeoutMs: MAIN_CONFIRM_DISCONNECT_MS,
+            });
 
-        if (combined.status === "ok" && combined.value) {
-          const v = combined.value;
-          if ("cancelled" in v && v.cancelled) {
-            return;
+            if (combined.status === "ok" && combined.value) {
+              const v = combined.value;
+              if ("cancelled" in v && v.cancelled) {
+                return;
+              }
+              if ("ok" in v) {
+                if (
+                  v.ok === false &&
+                  typeof v.error === "string" &&
+                  v.error.trim()
+                ) {
+                  throw new Error(v.error.trim());
+                }
+                if (v.ok === true) {
+                  needRendererDisconnect = false;
+                }
+              }
+            }
           }
-          if ("ok" in v) {
+
+          if (needRendererDisconnect) {
             if (
-              v.ok === false &&
-              typeof v.error === "string" &&
-              v.error.trim()
+              !skipConfirmation &&
+              !(await confirmDesktopAction({
+                title: "Disconnect from Eliza Cloud",
+                message:
+                  "The agent will need a local AI provider to continue working.",
+                confirmLabel: "Disconnect",
+                cancelLabel: "Cancel",
+                type: "warning",
+              }))
             ) {
-              throw new Error(v.error.trim());
+              return;
             }
-            if (v.ok === true) {
-              needRendererDisconnect = false;
+            if (!skipConfirmation) {
+              await yieldHttpAfterNativeMessageBox();
+            }
+
+            const postOutcome = await invokeDesktopBridgeRequestWithTimeout<{
+              ok: boolean;
+              error?: string;
+            }>({
+              rpcMethod: "agentPostCloudDisconnect",
+              ipcChannel: "agent:postCloudDisconnect",
+              params: {
+                apiBase: client.getBaseUrl().trim() || undefined,
+                bearerToken: client.getRestAuthToken() ?? undefined,
+              },
+              timeoutMs: MAIN_POST_ONLY_MS,
+            });
+
+            if (postOutcome.status === "ok" && postOutcome.value) {
+              const mr = postOutcome.value;
+              if (mr.ok === true) {
+                needRendererDisconnect = false;
+              } else if (
+                mr.ok === false &&
+                typeof mr.error === "string" &&
+                mr.error.trim()
+              ) {
+                throw new Error(mr.error.trim());
+              }
             }
           }
-        }
-
-        if (needRendererDisconnect) {
+        } else if (!skipConfirmation) {
           if (
             !(await confirmDesktopAction({
               title: "Disconnect from Eliza Cloud",
@@ -653,93 +701,55 @@ export function useCloudState({
             return;
           }
           await yieldHttpAfterNativeMessageBox();
-
-          const postOutcome = await invokeDesktopBridgeRequestWithTimeout<{
-            ok: boolean;
-            error?: string;
-          }>({
-            rpcMethod: "agentPostCloudDisconnect",
-            ipcChannel: "agent:postCloudDisconnect",
-            params: {
-              apiBase: client.getBaseUrl().trim() || undefined,
-              bearerToken: client.getRestAuthToken() ?? undefined,
-            },
-            timeoutMs: MAIN_POST_ONLY_MS,
-          });
-
-          if (postOutcome.status === "ok" && postOutcome.value) {
-            const mr = postOutcome.value;
-            if (mr.ok === true) {
-              needRendererDisconnect = false;
-            } else if (
-              mr.ok === false &&
-              typeof mr.error === "string" &&
-              mr.error.trim()
-            ) {
-              throw new Error(mr.error.trim());
-            }
-          }
         }
-      } else if (
-        !(await confirmDesktopAction({
-          title: "Disconnect from Eliza Cloud",
-          message:
-            "The agent will need a local AI provider to continue working.",
-          confirmLabel: "Disconnect",
-          cancelLabel: "Cancel",
-          type: "warning",
-        }))
-      ) {
-        return;
-      } else {
-        await yieldHttpAfterNativeMessageBox();
-      }
 
-      if (needRendererDisconnect) {
-        await Promise.race([
-          client.cloudDisconnect(),
-          new Promise<never>((_, reject) => {
-            window.setTimeout(() => {
-              reject(
-                new Error(
-                  `Disconnect timed out after ${RENDERER_DISCONNECT_MS / 1000}s`,
-                ),
-              );
-            }, RENDERER_DISCONNECT_MS);
-          }),
-        ]);
-      }
+        if (needRendererDisconnect) {
+          await Promise.race([
+            client.cloudDisconnect(),
+            new Promise<never>((_, reject) => {
+              window.setTimeout(() => {
+                reject(
+                  new Error(
+                    `Disconnect timed out after ${RENDERER_DISCONNECT_MS / 1000}s`,
+                  ),
+                );
+              }, RENDERER_DISCONNECT_MS);
+            }),
+          ]);
+        }
 
-      setElizaCloudEnabled(false);
-      setElizaCloudConnected(false);
-      publishElizaCloudVoiceSnapshot(setElizaCloudHasPersistedKey, {
-        apiConnected: false,
-        enabled: false,
-        cloudVoiceProxyAvailable: false,
-        hasPersistedApiKey: false,
-      });
-      setElizaCloudVoiceProxyAvailable(false);
-      setElizaCloudCredits(null);
-      setElizaCloudCreditsLow(false);
-      setElizaCloudCreditsCritical(false);
-      setElizaCloudAuthRejected(false);
-      setElizaCloudCreditsError(null);
-      setElizaCloudUserId(null);
-      setElizaCloudStatusReason(null);
-      lastElizaCloudPollConnectedRef.current = false;
-      elizaCloudPreferDisconnectedUntilLoginRef.current = true;
-      setActionNotice("Disconnected from Eliza Cloud.", "success");
-    } catch (err) {
-      setActionNotice(
-        `Failed to disconnect: ${err instanceof Error ? err.message : err}`,
-        "error",
-      );
-    } finally {
-      elizaCloudDisconnectInFlightRef.current = false;
-      setElizaCloudDisconnecting(false);
-      void pollCloudCredits();
-    }
-  }, [pollCloudCredits, setActionNotice]);
+        setElizaCloudEnabled(false);
+        setElizaCloudConnected(false);
+        publishElizaCloudVoiceSnapshot(setElizaCloudHasPersistedKey, {
+          apiConnected: false,
+          enabled: false,
+          cloudVoiceProxyAvailable: false,
+          hasPersistedApiKey: false,
+        });
+        setElizaCloudVoiceProxyAvailable(false);
+        setElizaCloudCredits(null);
+        setElizaCloudCreditsLow(false);
+        setElizaCloudCreditsCritical(false);
+        setElizaCloudAuthRejected(false);
+        setElizaCloudCreditsError(null);
+        setElizaCloudUserId(null);
+        setElizaCloudStatusReason(null);
+        lastElizaCloudPollConnectedRef.current = false;
+        elizaCloudPreferDisconnectedUntilLoginRef.current = true;
+        setActionNotice("Disconnected from Eliza Cloud.", "success");
+      } catch (err) {
+        setActionNotice(
+          `Failed to disconnect: ${err instanceof Error ? err.message : err}`,
+          "error",
+        );
+      } finally {
+        elizaCloudDisconnectInFlightRef.current = false;
+        setElizaCloudDisconnecting(false);
+        void pollCloudCredits();
+      }
+    },
+    [pollCloudCredits, setActionNotice],
+  );
 
   // ── Effects ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes Task 13 — Make 'Use local' atomic + actually disconnect cloud.

Before: \`handleSelectLocalOnly\` issued a bespoke partial \`client.updateConfig\` that toggled flags but left \`cloud.apiKey\`, \`linkedAccounts.elizacloud=linked\`, \`process.env.ELIZAOS_CLOUD_*\`, runtime character secrets, and the server-side cloudManager session intact. Next 'use cloud' silently reused stale state.

After: routes through canonical \`handleCloudDisconnect({ skipConfirmation: true })\` — same path the cloud-disconnect button uses. Full server teardown + renderer state reset in one operation.

## Test plan
- [x] typecheck clean
- [x] no API change to handleCloudDisconnect's existing callers (skipConfirmation defaults false)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the "Use local only" button in `ProviderSwitcher` by routing through the canonical `handleCloudDisconnect` path instead of a partial `client.updateConfig` call, ensuring full server-side teardown (API key removal, env wipe, session cleanup) and renderer state reset.

- **`ProviderSwitcher.tsx`**: Replaces the bespoke `client.updateConfig` call with `app.handleCloudDisconnect({ skipConfirmation: true })`, delegating all teardown to the shared disconnect handler.
- **`useCloudState.ts`**: Adds `skipConfirmation` option to `handleCloudDisconnect`, gating all confirmation dialogs and the combined IPC method behind `!skipConfirmation` while still issuing `agentPostCloudDisconnect` on desktop runtimes.
- **`types.ts`**: Extends `AppActions.handleCloudDisconnect` with an optional `opts` object — fully backward-compatible.
</details>


<h3>Confidence Score: 3/5</h3>

The happy path (disconnect succeeds) works correctly, but any disconnect failure leaves the UI in an inconsistent state with no recovery.

When `handleCloudDisconnect` fails internally, it shows an error notice but does not re-throw. This makes the `catch` block in `handleSelectLocalOnly` unreachable, so `restoreSelection` and `setCloudCallsDisabled` are never called — the UI shows local-only mode even though cloud is still connected. On top of that, `restartAgent` fires unconditionally, restarting the agent while cloud credentials remain intact. The old `client.updateConfig` path had a working catch block that properly rolled back UI state on failure; this regression affects every user who encounters a disconnect error.

`ProviderSwitcher.tsx` — the error-recovery path needs attention; `useCloudState.ts` is otherwise clean.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/settings/ProviderSwitcher.tsx | Routes 'Use local only' through `handleCloudDisconnect` for a full teardown, but the catch block for state restoration is now dead because `handleCloudDisconnect` swallows errors internally; agent restart also fires unconditionally on failure. |
| packages/app-core/src/state/useCloudState.ts | Adds optional `skipConfirmation` to `handleCloudDisconnect`; correctly gates confirmation dialog and IPC method behind `!skipConfirmation`, preserving the existing fallback path (`client.cloudDisconnect()`) when the desktop IPC path fails. |
| packages/app-core/src/state/types.ts | Extends `AppActions.handleCloudDisconnect` signature with an optional `opts` parameter; backward-compatible change. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant U as User (click "Use local only")
    participant PS as ProviderSwitcher
    participant HCD as handleCloudDisconnect
    participant IPC as Desktop IPC (Electrobun)
    participant REST as client.cloudDisconnect()
    participant Server as Server /api/cloud/disconnect

    U->>PS: handleSelectLocalOnly()
    PS->>HCD: handleCloudDisconnect({ skipConfirmation: true })
    HCD->>HCD: skip confirmation dialog
    alt isElectrobunRuntime()
        HCD->>IPC: agentPostCloudDisconnect (no confirm RPC)
        IPC->>Server: POST /api/cloud/disconnect
        Server-->>IPC: { ok: true }
        IPC-->>HCD: needRendererDisconnect = false
    else web runtime
        HCD->>REST: client.cloudDisconnect()
        REST->>Server: POST /api/cloud/disconnect
        Server-->>REST: ok
    end
    HCD->>HCD: reset all elizaCloud* state
    HCD-->>PS: (returns, errors swallowed)
    PS->>PS: void client.restartAgent() [always fires]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/components/settings/ProviderSwitcher.tsx`, line 678-681 ([link](https://github.com/elizaos/eliza/blob/5a223f0e8af94adc5b5f41567a2806edb74d9162/packages/app-core/src/components/settings/ProviderSwitcher.tsx#L678-L681)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Dead catch block — state not restored on disconnect failure**

   `handleCloudDisconnect` wraps its entire body in its own try/catch and calls `setActionNotice` without re-throwing (see `useCloudState.ts` lines 740–744). That means the `catch` here is unreachable: when disconnect fails, `restoreSelection`, `setCloudCallsDisabled(previousCloudCallsDisabled)`, and `notifySelectionFailure` are all skipped. Worse, the `void client.restartAgent()` on line 675 still fires, so the agent is restarted while cloud state is still intact. The previous `client.updateConfig`-based implementation had a reachable catch block that correctly restored the selection.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%0ALine%3A%20678-681%0A%0AComment%3A%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=elizaos%2Feliza&pr=7412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Fuse-local-atomic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Fuse-local-atomic%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%0ALine%3A%20678-681%0A%0AComment%3A%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%0ALine%3A%20678-681%0A%0AComment%3A%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=7412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%3A678-681%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0A&repo=elizaos%2Feliza&pr=7412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Fuse-local-atomic%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Fuse-local-atomic%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%3A678-681%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fsettings%2FProviderSwitcher.tsx%3A678-681%0A**Dead%20catch%20block%20%E2%80%94%20state%20not%20restored%20on%20disconnect%20failure**%0A%0A%60handleCloudDisconnect%60%20wraps%20its%20entire%20body%20in%20its%20own%20try%2Fcatch%20and%20calls%20%60setActionNotice%60%20without%20re-throwing%20%28see%20%60useCloudState.ts%60%20lines%20740%E2%80%93744%29.%20That%20means%20the%20%60catch%60%20here%20is%20unreachable%3A%20when%20disconnect%20fails%2C%20%60restoreSelection%60%2C%20%60setCloudCallsDisabled%28previousCloudCallsDisabled%29%60%2C%20and%20%60notifySelectionFailure%60%20are%20all%20skipped.%20Worse%2C%20the%20%60void%20client.restartAgent%28%29%60%20on%20line%20675%20still%20fires%2C%20so%20the%20agent%20is%20restarted%20while%20cloud%20state%20is%20still%20intact.%20The%20previous%20%60client.updateConfig%60-based%20implementation%20had%20a%20reachable%20catch%20block%20that%20correctly%20restored%20the%20selection.%0A%0A&pr=7412&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(settings): &quot;Use local only&quot; actually..."](https://github.com/elizaos/eliza/commit/5a223f0e8af94adc5b5f41567a2806edb74d9162) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951680)</sub>

<!-- /greptile_comment -->