### PR TITLE
feat(chat): structured no_provider gate end-to-end

### DIFF
--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -320,7 +320,8 @@ const INSUFFICIENT_CREDITS_CHAT_REPLY =
 // Used by paths #1-#3: planner picked IGNORE/NONE/empty REPLY, action ran but
 // emitted no text callback, or normalized text became a placeholder. None of
 // these are provider failures, so the message must not blame the provider.
-const NO_RESPONSE_FALLBACK_REPLY = "I don't have a reply for that — try rephrasing?";
+const NO_RESPONSE_FALLBACK_REPLY =
+  "I don't have a reply for that — try rephrasing?";
 // Routed-model errors raised by the model router when no provider plugin is
 // loaded for a requested model class (e.g. TEXT_SMALL). Identifies the OOB
 // "no provider configured" case so chat routes can return a structured 503
@@ -526,7 +527,37 @@ export function getChatFailureReply(
   ) {
     return pickInsufficientCreditsChatReply();
   }
+  if (isNoProviderError(err)) {
+    return NO_PROVIDER_CHAT_MESSAGE;
+  }
   return getProviderIssueChatReply();
+}
+
+/**
+ * Discriminator the conversation route includes in its 200 response so the
+ * renderer can distinguish "provider configured but throwing" from "no
+ * provider configured at all" — the latter is a UX gate ("Connect a
+ * provider"), not a chat reply.
+ */
+export type ChatFailureKind =
+  | "insufficient_credits"
+  | "no_provider"
+  | "provider_issue";
+
+export function classifyChatFailure(
+  err: unknown,
+  logBuffer: LogEntry[],
+): ChatFailureKind {
+  if (
+    isInsufficientCreditsError(err) ||
+    findRecentInsufficientCreditsLog(logBuffer)
+  ) {
+    return "insufficient_credits";
+  }
+  if (isNoProviderError(err)) {
+    return "no_provider";
+  }
+  return "provider_issue";
 }
 
 export function normalizeChatResponseText(

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -29,6 +29,7 @@ import type { ElizaConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { ChatGenerationResult, LogEntry } from "./chat-routes.js";
 import {
+  classifyChatFailure,
   generateChatResponse,
   generateConversationTitle,
   getChatFailureReply,
@@ -1350,6 +1351,7 @@ export async function handleConversationRoutes(
             "Chat generation failed with no streamed text",
           );
           const providerIssueReply = getChatFailureReply(err, state.logBuffer);
+          const failureKind = classifyChatFailure(err, state.logBuffer);
           try {
             await persistAssistantConversationMemory(
               runtime,
@@ -1362,6 +1364,9 @@ export async function handleConversationRoutes(
               type: "done",
               fullText: providerIssueReply,
               agentName: state.agentName,
+              // See non-streaming branch — renderer gates chat input on
+              // failureKind === "no_provider".
+              failureKind,
             });
           } catch (persistErr) {
             writeSse(res, {
@@ -1521,6 +1526,7 @@ export async function handleConversationRoutes(
         `[conversations] POST /messages failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       const providerIssueReply = getChatFailureReply(err, state.logBuffer);
+      const failureKind = classifyChatFailure(err, state.logBuffer);
       try {
         await persistAssistantConversationMemory(
           runtime,
@@ -1532,6 +1538,11 @@ export async function handleConversationRoutes(
         json(res, {
           text: providerIssueReply,
           agentName: state.agentName,
+          // Renderer keys off this discriminator. "no_provider" means the
+          // chat input should be gated with a "Connect a provider" CTA
+          // instead of treating the message text as a normal assistant
+          // reply (the user can't make progress without taking action).
+          failureKind,
         });
       } catch (persistErr) {
         error(res, getErrorMessage(persistErr), 500);

--- a/packages/app-core/src/api/client-chat.ts
+++ b/packages/app-core/src/api/client-chat.ts
@@ -187,6 +187,14 @@ declare module "./client-base" {
       agentName: string;
       blocks?: ContentBlock[];
       noResponseReason?: "ignored";
+      /**
+       * Set when chat generation threw and the server returned a
+       * fallback message in `text`. Renderer keys off
+       * `failureKind === "no_provider"` to gate the chat input on a
+       * "Connect a provider" CTA instead of treating the fallback
+       * as a normal assistant reply.
+       */
+      failureKind?: "insufficient_credits" | "no_provider" | "provider_issue";
     }>;
     sendConversationMessageStream(
       id: string,
@@ -203,6 +211,8 @@ declare module "./client-base" {
       completed: boolean;
       noResponseReason?: "ignored";
       usage?: ChatTokenUsage;
+      /** See sendConversationMessage above. */
+      failureKind?: "insufficient_credits" | "no_provider" | "provider_issue";
     }>;
     requestGreeting(
       id: string,

--- a/packages/app-core/src/api/client-types-chat.ts
+++ b/packages/app-core/src/api/client-types-chat.ts
@@ -116,6 +116,14 @@ export interface ConversationMessage {
   reactions?: ConversationMessageReaction[];
   /** True when the SSE stream was interrupted before receiving a "done" event. */
   interrupted?: boolean;
+  /**
+   * When set, this assistant turn is the server's no-provider /
+   * provider-issue / insufficient-credits fallback. The renderer can
+   * substitute a structured gate UI (e.g. "Connect a provider →
+   * Settings") for `failureKind === "no_provider"` instead of rendering
+   * the fallback `text` as a normal reply bubble.
+   */
+  failureKind?: "insufficient_credits" | "no_provider" | "provider_issue";
 }
 
 export type ConversationChannelType =

--- a/packages/app-core/src/components/chat/MessageContent.tsx
+++ b/packages/app-core/src/components/chat/MessageContent.tsx
@@ -872,7 +872,8 @@ export function MessageContent({
   message,
   analysisMode = false,
 }: MessageContentProps) {
-  const { sendActionMessage } = useApp();
+  const app = useApp();
+  const { sendActionMessage } = app;
 
   // Parse segments — memoize to avoid re-parsing on every render
   const segments = useMemo(() => {
@@ -890,6 +891,32 @@ export function MessageContent({
     },
     [sendActionMessage],
   );
+
+  const handleOpenSettings = useCallback(() => {
+    app.setTab?.("settings");
+  }, [app.setTab]);
+
+  // The server flags failed assistant turns with `failureKind`. For
+  // `no_provider` specifically the user can't make progress without
+  // wiring up a provider, so render a structured gate (banner + CTA)
+  // instead of the fallback text — clicking jumps to Settings where
+  // ProviderSwitcher lives. Other failure kinds (insufficient_credits,
+  // provider_issue) still render as normal text bubbles; the user has
+  // separate, clearer in-product affordances for those (Cloud billing
+  // banner, retry).
+  if (message.failureKind === "no_provider") {
+    return (
+      <div className="border border-warn/30 bg-warn/5 rounded-md p-3 text-sm">
+        <div className="font-medium mb-1">Connect a provider to chat</div>
+        <div className="text-muted whitespace-pre-wrap mb-2">
+          {message.text}
+        </div>
+        <Button type="button" size="sm" onClick={handleOpenSettings}>
+          Open Settings
+        </Button>
+      </div>
+    );
+  }
 
   // Fast path: single plain-text segment (most messages)
   if (segments.length === 1 && segments[0].kind === "text") {

--- a/packages/app-core/src/state/useChatSend.ts
+++ b/packages/app-core/src/state/useChatSend.ts
@@ -703,12 +703,32 @@ export function useChatSend(deps: UseChatSendDeps) {
             let changed = false;
             const next = prev.map((message) => {
               if (message.id !== assistantMsgId) return message;
-              if (message.text === data.text) return message;
+              if (
+                message.text === data.text &&
+                message.failureKind === data.failureKind
+              ) {
+                return message;
+              }
               changed = true;
-              return { ...message, text: data.text };
+              return {
+                ...message,
+                text: data.text,
+                ...(data.failureKind ? { failureKind: data.failureKind } : {}),
+              };
             });
             return changed ? next : prev;
           });
+        } else if (data.failureKind) {
+          // Streaming text already matched but the server flagged a failure
+          // class — stamp it on the assistant turn so the renderer can swap
+          // in the gate UI (e.g. "Connect a provider").
+          setConversationMessages((prev) =>
+            prev.map((message) =>
+              message.id === assistantMsgId
+                ? { ...message, failureKind: data.failureKind }
+                : message,
+            ),
+          );
         }
         if (data.usage) {
           setChatLastUsage({
@@ -808,6 +828,9 @@ export function useChatSend(deps: UseChatSendDeps) {
                   role: "assistant",
                   text: retryData.text,
                   timestamp: Date.now(),
+                  ...(retryData.failureKind
+                    ? { failureKind: retryData.failureKind }
+                    : {}),
                 },
               ]),
             );
@@ -1061,12 +1084,31 @@ export function useChatSend(deps: UseChatSendDeps) {
               let changed = false;
               const next = prev.map((message) => {
                 if (message.id !== assistantMsgId) return message;
-                if (message.text === data.text) return message;
+                if (
+                  message.text === data.text &&
+                  message.failureKind === data.failureKind
+                ) {
+                  return message;
+                }
                 changed = true;
-                return { ...message, text: data.text };
+                return {
+                  ...message,
+                  text: data.text,
+                  ...(data.failureKind
+                    ? { failureKind: data.failureKind }
+                    : {}),
+                };
               });
               return changed ? next : prev;
             });
+          } else if (data.failureKind) {
+            setConversationMessages((prev) =>
+              prev.map((message) =>
+                message.id === assistantMsgId
+                  ? { ...message, failureKind: data.failureKind }
+                  : message,
+              ),
+            );
           }
 
           if (!data.completed && streamedAssistantText.trim()) {


### PR DESCRIPTION
## Summary

Pairs with the API-layer no_provider gate from oob-batch-1. Surfaces "no provider configured" as a structured UX gate instead of a fallback-text bubble.

Backend (chat-routes + conversation-routes): \`classifyChatFailure()\` returns \"insufficient_credits\" | \"no_provider\" | \"provider_issue\". Conversation route includes \`failureKind\` in the response.

Renderer: ConversationMessage has \`failureKind\`, useChatSend stamps it on optimistic messages, MessageContent renders a banner card with "Open Settings" button when \`failureKind === \"no_provider\"\`.

## Test plan
- [x] typecheck clean
- [x] backend gate verified by smoke test on oob-batch-1

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires a structured `no_provider` gate end-to-end: the backend's new `classifyChatFailure()` discriminator stamps `failureKind` on both the SSE and JSON error responses, `ConversationMessage` carries the field, `useChatSend` stamps it onto optimistic messages, and `MessageContent` renders a banner card with an \"Open Settings\" CTA when `failureKind === \"no_provider\"`.

- **Backend (`chat-routes.ts`, `conversation-routes.ts`)**: `classifyChatFailure()` and `ChatFailureKind` are clean additions; `failureKind` is correctly injected into both the streaming SSE `\"done\"` event and the non-streaming JSON response.
- **Client streaming gap**: `streamChatEndpoint` in `client-base.ts` (not in this diff) does not parse `failureKind` from the SSE `\"done\"` payload, so `sendConversationMessageStream` always returns `failureKind: undefined` — the gate UI is unreachable on the streaming path (the common case).
- **Type duplication**: The `\"insufficient_credits\" | \"no_provider\" | \"provider_issue\"` union is copied verbatim in three frontend locations rather than shared from a single source.
</details>


<h3>Confidence Score: 3/5</h3>

The headline feature — the 'Connect a provider' banner — will not appear on the streaming path, which is how most users trigger chat; streaming requests silently fall back to a plain text bubble.

The `streamChatEndpoint` base method never extracts `failureKind` from the SSE `"done"` event it receives, so the value is always absent from the resolved promise. Every change in `useChatSend.ts` that handles `data.failureKind` on the streaming side is therefore dead code, and the banner card in `MessageContent.tsx` is unreachable for streaming conversations. The non-streaming path is complete and correct, but it is the minority path.

`packages/app-core/src/api/client-base.ts` needs to be updated alongside this PR — the `streamChatEndpoint` `"done"` handler must capture and return `failureKind`. `packages/app-core/src/api/client-chat.ts` declares the correct return type but is backed by the unfixed base method.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/agent/src/api/chat-routes.ts | Adds `classifyChatFailure()` and `ChatFailureKind` type; `isNoProviderError` check is correctly inserted before the generic provider-issue fallback in `getChatFailureReply`. |
| packages/agent/src/api/conversation-routes.ts | Stamps `failureKind` on both the SSE `"done"` event (streaming error branch) and the non-streaming JSON response; logic is correct but the streaming `failureKind` is not parsed by the client. |
| packages/app-core/src/api/client-chat.ts | Declares `failureKind` in both `sendConversationMessage` and `sendConversationMessageStream` return types, but the streaming implementation delegates to `streamChatEndpoint` which never parses or returns `failureKind`, making the streaming type declaration misleading. |
| packages/app-core/src/api/client-types-chat.ts | Adds `failureKind` to `ConversationMessage`; the union type is a copy of the server-side `ChatFailureKind` without a shared contract. |
| packages/app-core/src/components/chat/MessageContent.tsx | Renders the `no_provider` banner card with an "Open Settings" CTA; optional chaining on `app.setTab?.` is safe given the interface, and the early-return pattern cleanly separates the gate UI from normal rendering. |
| packages/app-core/src/state/useChatSend.ts | Stamps `failureKind` onto optimistic messages in both streaming and non-streaming paths; the `else if (data.failureKind)` branch for streaming is dead code until `streamChatEndpoint` is fixed to propagate `failureKind`. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as MessageContent
    participant CS as useChatSend
    participant CC as client-chat
    participant CB as client-base (streamChatEndpoint)
    participant CR as conversation-routes
    participant CH as chat-routes

    CS->>CC: sendConversationMessageStream(...)
    CC->>CB: streamChatEndpoint(...)
    CB->>CR: POST /messages/stream (SSE)
    CR->>CH: classifyChatFailure(err, logBuffer)
    CH-->>CR: no_provider
    CR-->>CB: SSE done { fullText, failureKind: no_provider }
    Note over CB: failureKind NOT parsed from done event
    CB-->>CC: { text, agentName, completed } no failureKind
    CC-->>CS: data.failureKind === undefined
    CS-->>UI: message.failureKind === undefined
    Note over UI: Banner card never renders (streaming path)

    Note over CS,CR: Non-streaming path works correctly
    CS->>CC: sendConversationMessage(...)
    CC->>CR: POST /messages
    CR->>CH: classifyChatFailure(err, logBuffer)
    CH-->>CR: no_provider
    CR-->>CC: JSON { text, failureKind: no_provider }
    CC-->>CS: data.failureKind === no_provider
    CS-->>UI: message.failureKind === no_provider
    Note over UI: Banner card renders
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/api/client-base.ts`, line 826-846 ([link](https://github.com/elizaos/eliza/blob/33ebc56843acab44d3b4b975026311e8478dfe30/packages/app-core/src/api/client-base.ts#L826-L846)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`failureKind` silently dropped by `streamChatEndpoint`**

   The server sends `failureKind` inside the SSE `"done"` payload (see `conversation-routes.ts` line 1364), but `parseDataLine` in `streamChatEndpoint` never reads or stores it, so the field is never included in the object returned by `streamChatEndpoint`. Because `sendConversationMessageStream` is implemented entirely by delegating to `streamChatEndpoint`, its declared return type includes `failureKind` but the value is always `undefined` at runtime.

   Concretely: when a streaming request hits a no-provider error, `data.failureKind` in `useChatSend.ts` is always `undefined`, so the `no_provider` banner card is never rendered — the user sees a plain text bubble instead of the "Open Settings" CTA. The non-streaming path works correctly because it reads `failureKind` from a regular JSON response, but streaming (the typical path) is broken.

   To fix, add `failureKind?` to `parsed`'s local type, capture it in a `let doneFailureKind` variable on `"done"`, and include it in the returned object (matching the same pattern used for `doneUsage`).

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%0ALine%3A%20826-846%0A%0AComment%3A%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=elizaos%2Feliza&pr=7413&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Fchat-no-provider-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Fchat-no-provider-gate%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%0ALine%3A%20826-846%0A%0AComment%3A%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%0ALine%3A%20826-846%0A%0AComment%3A%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=7413&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%3A826-846%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-types-chat.ts%3A126%0A**%60ChatFailureKind%60%20duplicated%20across%20package%20boundaries**%0A%0AThe%20union%20%60%22insufficient_credits%22%20%7C%20%22no_provider%22%20%7C%20%22provider_issue%22%60%20is%20defined%20as%20%60ChatFailureKind%60%20in%20%60packages%2Fagent%2Fsrc%2Fapi%2Fchat-routes.ts%60%20and%20then%20re-stated%20verbatim%20in%20%60client-types-chat.ts%60%20and%20twice%20in%20%60client-chat.ts%60.%20If%20a%20new%20variant%20is%20added%20server-side%2C%20the%20client%20types%20silently%20diverge%20and%20TypeScript%20won't%20catch%20mismatches%20at%20the%20API%20boundary.%20Extracting%20the%20type%20to%20a%20shared%20package%20%28or%20at%20least%20a%20single%20client-side%20re-export%29%20would%20make%20the%20contract%20single-source-of-truth.%0A%0A&repo=elizaos%2Feliza&pr=7413&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Fchat-no-provider-gate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Fchat-no-provider-gate%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%3A826-846%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-types-chat.ts%3A126%0A**%60ChatFailureKind%60%20duplicated%20across%20package%20boundaries**%0A%0AThe%20union%20%60%22insufficient_credits%22%20%7C%20%22no_provider%22%20%7C%20%22provider_issue%22%60%20is%20defined%20as%20%60ChatFailureKind%60%20in%20%60packages%2Fagent%2Fsrc%2Fapi%2Fchat-routes.ts%60%20and%20then%20re-stated%20verbatim%20in%20%60client-types-chat.ts%60%20and%20twice%20in%20%60client-chat.ts%60.%20If%20a%20new%20variant%20is%20added%20server-side%2C%20the%20client%20types%20silently%20diverge%20and%20TypeScript%20won't%20catch%20mismatches%20at%20the%20API%20boundary.%20Extracting%20the%20type%20to%20a%20shared%20package%20%28or%20at%20least%20a%20single%20client-side%20re-export%29%20would%20make%20the%20contract%20single-source-of-truth.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-base.ts%3A826-846%0A**%60failureKind%60%20silently%20dropped%20by%20%60streamChatEndpoint%60**%0A%0AThe%20server%20sends%20%60failureKind%60%20inside%20the%20SSE%20%60%22done%22%60%20payload%20%28see%20%60conversation-routes.ts%60%20line%201364%29%2C%20but%20%60parseDataLine%60%20in%20%60streamChatEndpoint%60%20never%20reads%20or%20stores%20it%2C%20so%20the%20field%20is%20never%20included%20in%20the%20object%20returned%20by%20%60streamChatEndpoint%60.%20Because%20%60sendConversationMessageStream%60%20is%20implemented%20entirely%20by%20delegating%20to%20%60streamChatEndpoint%60%2C%20its%20declared%20return%20type%20includes%20%60failureKind%60%20but%20the%20value%20is%20always%20%60undefined%60%20at%20runtime.%0A%0AConcretely%3A%20when%20a%20streaming%20request%20hits%20a%20no-provider%20error%2C%20%60data.failureKind%60%20in%20%60useChatSend.ts%60%20is%20always%20%60undefined%60%2C%20so%20the%20%60no_provider%60%20banner%20card%20is%20never%20rendered%20%E2%80%94%20the%20user%20sees%20a%20plain%20text%20bubble%20instead%20of%20the%20%22Open%20Settings%22%20CTA.%20The%20non-streaming%20path%20works%20correctly%20because%20it%20reads%20%60failureKind%60%20from%20a%20regular%20JSON%20response%2C%20but%20streaming%20%28the%20typical%20path%29%20is%20broken.%0A%0ATo%20fix%2C%20add%20%60failureKind%3F%60%20to%20%60parsed%60's%20local%20type%2C%20capture%20it%20in%20a%20%60let%20doneFailureKind%60%20variable%20on%20%60%22done%22%60%2C%20and%20include%20it%20in%20the%20returned%20object%20%28matching%20the%20same%20pattern%20used%20for%20%60doneUsage%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fclient-types-chat.ts%3A126%0A**%60ChatFailureKind%60%20duplicated%20across%20package%20boundaries**%0A%0AThe%20union%20%60%22insufficient_credits%22%20%7C%20%22no_provider%22%20%7C%20%22provider_issue%22%60%20is%20defined%20as%20%60ChatFailureKind%60%20in%20%60packages%2Fagent%2Fsrc%2Fapi%2Fchat-routes.ts%60%20and%20then%20re-stated%20verbatim%20in%20%60client-types-chat.ts%60%20and%20twice%20in%20%60client-chat.ts%60.%20If%20a%20new%20variant%20is%20added%20server-side%2C%20the%20client%20types%20silently%20diverge%20and%20TypeScript%20won't%20catch%20mismatches%20at%20the%20API%20boundary.%20Extracting%20the%20type%20to%20a%20shared%20package%20%28or%20at%20least%20a%20single%20client-side%20re-export%29%20would%20make%20the%20contract%20single-source-of-truth.%0A%0A&pr=7413&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;milady/oob-batch-1&#39; into m..."](https://github.com/elizaos/eliza/commit/33ebc56843acab44d3b4b975026311e8478dfe30) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951692)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->