### PR TITLE
feat(runtime-gate): guided local setup wizard before completing onboarding

### DIFF
--- a/packages/app-core/src/components/shell/RuntimeGate.tsx
+++ b/packages/app-core/src/components/shell/RuntimeGate.tsx
@@ -50,6 +50,10 @@ import {
   isIOS,
 } from "../../platform/init";
 import {
+  ONBOARDING_PROVIDER_CATALOG,
+  type OnboardingProviderOption,
+} from "../../providers";
+import {
   addAgentProfile,
   clearPersistedActiveServer,
   savePersistedActiveServer,
@@ -113,7 +117,7 @@ function normalizeRemoteTarget(value: string): string | null {
   }
 }
 
-type SubView = "chooser" | "cloud" | "remote";
+type SubView = "chooser" | "cloud" | "remote" | "local";
 type RuntimeChoice = "cloud" | "local" | "remote";
 
 type CloudStage =
@@ -124,6 +128,8 @@ type CloudStage =
   | "creating"
   | "provisioning"
   | "connecting";
+
+type LocalStage = "provider" | "config";
 
 function normalizeRuntimeUrl(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -347,6 +353,29 @@ export function RuntimeGate() {
 
   // Local embeddings toggle (elizacloud only, default unchecked)
   const [useLocalEmbeddings, setUseLocalEmbeddings] = useState(false);
+
+  // Local-runtime setup wizard. When the user picks "Local" in the
+  // chooser we render an in-place wizard (provider list → API key entry)
+  // before completing onboarding. Without this, finishAsLocal() drops
+  // the user straight into chat with no model provider configured —
+  // their first send hits the no_provider gate (commit 28e19c8023) and
+  // they have to backtrack to Settings. The wizard saves the round-trip.
+  const [localStage, setLocalStage] = useState<LocalStage>("provider");
+  const [localProviderId, setLocalProviderId] = useState<string | null>(null);
+  const [localApiKey, setLocalApiKey] = useState("");
+  const [localSaving, setLocalSaving] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  // Filter catalog to direct API-key providers (group:"local" excludes
+  // managed cloud + subscription paths — those have their own flows).
+  const localProviderCatalog = useMemo<readonly OnboardingProviderOption[]>(
+    () =>
+      ONBOARDING_PROVIDER_CATALOG.filter(
+        (provider) =>
+          provider.group === "local" && provider.authMode === "api-key",
+      ),
+    [],
+  );
 
   // Local-tile readiness. Desktop/dev are local-capable synchronously.
   // Android probes the on-device agent's `/api/health` so ElizaOS can
@@ -643,13 +672,78 @@ export function RuntimeGate() {
         setSubView("cloud");
         return;
       case "local":
-        finishAsLocal();
+        // ElizaOS / Android pre-seed paths still want the immediate
+        // finishAsLocal() — the on-device runtime is the only legitimate
+        // option there and the chooser is bypassed entirely on stock
+        // builds. Desktop/iOS/web users actively pick Local and need a
+        // provider before the runtime can answer chat.
+        if (elizaOSAutoLocal || isAndroid) {
+          finishAsLocal();
+          return;
+        }
+        setLocalStage("provider");
+        setLocalProviderId(null);
+        setLocalApiKey("");
+        setLocalError(null);
+        setSubView("local");
         return;
       case "remote":
         setSubView("remote");
         return;
     }
-  }, [finishAsLocal, selectedChoice]);
+  }, [elizaOSAutoLocal, finishAsLocal, selectedChoice]);
+
+  const handleLocalSelectProvider = useCallback((providerId: string) => {
+    setLocalProviderId(providerId);
+    setLocalApiKey("");
+    setLocalError(null);
+    setLocalStage("config");
+  }, []);
+
+  const handleLocalConfigBack = useCallback(() => {
+    setLocalStage("provider");
+    setLocalError(null);
+  }, []);
+
+  const handleLocalSave = useCallback(async () => {
+    if (!localProviderId) {
+      setLocalError(
+        t("runtimegate.localPickProvider", {
+          defaultValue: "Pick a provider first.",
+        }),
+      );
+      return;
+    }
+    const trimmedKey = localApiKey.trim();
+    if (!trimmedKey) {
+      setLocalError(
+        t("runtimegate.localApiKeyRequired", {
+          defaultValue: "Enter an API key for the selected provider.",
+        }),
+      );
+      return;
+    }
+
+    setLocalSaving(true);
+    setLocalError(null);
+    try {
+      // switchProvider writes the canonical config (cloud.* off,
+      // serviceRouting.llmText.{backend,transport:"direct"}, env key).
+      // Routing-mode "local-only" + the provider's API key = the runtime
+      // boots with a registered provider and chat works immediately.
+      await client.switchProvider(localProviderId, trimmedKey);
+      finishAsLocal();
+    } catch (err) {
+      setLocalSaving(false);
+      setLocalError(
+        err instanceof Error
+          ? err.message
+          : t("runtimegate.localSaveFailed", {
+              defaultValue: "Failed to save provider — please try again.",
+            }),
+      );
+    }
+  }, [finishAsLocal, localApiKey, localProviderId, t]);
 
   // ── Cloud: provision + connect ─────────────────────────────────────
 
@@ -1261,6 +1355,139 @@ export function RuntimeGate() {
     );
   }
 
+  // ── Render: local setup wizard ─────────────────────────────────────
+  if (subView === "local") {
+    const selectedProvider = localProviderId
+      ? localProviderCatalog.find((p) => p.id === localProviderId)
+      : null;
+    return (
+      <GateShell
+        uiLanguage={uiLanguage}
+        setUiLanguage={setUiLanguage}
+        uiTheme={uiTheme}
+        setUiTheme={setUiTheme}
+        t={t}
+      >
+        <GateHeader t={t} />
+
+        <div className="mt-4 flex w-full max-w-[34rem] flex-col gap-3 text-left">
+          <p
+            style={{ fontFamily: MONO_FONT }}
+            className="text-3xs uppercase text-white/60"
+          >
+            {localStage === "provider"
+              ? t("runtimegate.localPickEyebrow", {
+                  defaultValue: "Pick a model provider",
+                })
+              : t("runtimegate.localConfigEyebrow", {
+                  defaultValue: "Add your API key",
+                })}
+          </p>
+
+          {localStage === "provider" && (
+            <div className="flex flex-col gap-2">
+              {localProviderCatalog.map((provider) => (
+                <Card
+                  key={provider.id}
+                  className="border-2 border-[#f0b90b]/40 bg-black/58 text-white shadow-[4px_4px_0_rgba(0,0,0,0.52)]"
+                  style={{ borderRadius: 0 }}
+                >
+                  <CardContent className="flex items-center justify-between gap-3 px-3 py-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-white/95">
+                        {provider.name}
+                      </p>
+                      <p className="truncate text-xs-tight text-white/52">
+                        {provider.description}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0 rounded-none border-2 border-black bg-[#ffe600] text-xs font-black uppercase tracking-[0.12em] text-black hover:bg-white"
+                      onClick={() => handleLocalSelectProvider(provider.id)}
+                    >
+                      {t("common.choose", { defaultValue: "Choose" })}
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+              <BackButton t={t} onClick={() => setSubView("chooser")} />
+            </div>
+          )}
+
+          {localStage === "config" && selectedProvider && (
+            <div className="flex flex-col gap-3">
+              <Card
+                className="border-2 border-[#f0b90b]/40 bg-black/58 text-white shadow-[4px_4px_0_rgba(0,0,0,0.52)]"
+                style={{ borderRadius: 0 }}
+              >
+                <CardContent className="flex flex-col gap-1 px-3 py-3">
+                  <p className="text-sm font-semibold text-white/95">
+                    {selectedProvider.name}
+                  </p>
+                  <p className="text-xs-tight text-white/52">
+                    {selectedProvider.description}
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Input
+                type="password"
+                autoComplete="off"
+                placeholder={
+                  selectedProvider.keyPrefix
+                    ? t("runtimegate.localApiKeyPlaceholderPrefixed", {
+                        defaultValue: "{{prefix}}…",
+                        prefix: selectedProvider.keyPrefix,
+                      })
+                    : t("runtimegate.localApiKeyPlaceholder", {
+                        defaultValue: "API key",
+                      })
+                }
+                value={localApiKey}
+                onChange={(e) => setLocalApiKey(e.target.value)}
+                disabled={localSaving}
+                className="!h-11 !rounded-none !border-2 !border-black !bg-white !px-3 !text-sm !text-black"
+              />
+
+              {localError ? (
+                <p className="text-xs text-danger">{localError}</p>
+              ) : null}
+
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  className="rounded-none border-2 border-black bg-[#ffe600] text-xs font-black uppercase tracking-[0.12em] text-black hover:bg-white"
+                  onClick={() => void handleLocalSave()}
+                  disabled={localSaving || !localApiKey.trim()}
+                >
+                  {localSaving ? (
+                    <span className="inline-flex items-center gap-2">
+                      <Spinner className="h-3 w-3" />
+                      {t("common.saving", { defaultValue: "Saving…" })}
+                    </span>
+                  ) : (
+                    t("runtimegate.localSaveContinue", {
+                      defaultValue: "Continue to chat",
+                    })
+                  )}
+                </Button>
+                <BackButton
+                  t={t}
+                  onClick={handleLocalConfigBack}
+                  disabled={localSaving}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </GateShell>
+    );
+  }
+
   // ── Render: remote ─────────────────────────────────────────────────
 
   return (
@@ -1641,16 +1868,19 @@ function ElizaOSLocalSplash({ message }: { message: string }) {
 function BackButton({
   t,
   onClick,
+  disabled = false,
 }: {
   t: (key: string, values?: Record<string, unknown>) => string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       style={{ fontFamily: MONO_FONT }}
-      className="mt-2 self-center text-3xs uppercase text-white/60 underline hover:text-white"
+      className="mt-2 self-center text-3xs uppercase text-white/60 underline hover:text-white disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-white/60"
     >
       {t("common.back", { defaultValue: "Back" })}
     </button>


### PR DESCRIPTION
## Summary

Pairs with the no_provider chat gate. That gate fires when chat sends without a provider; this wizard prevents the user from getting there.

Before: clicking "Local" in RuntimeGate dropped the user straight into chat with no provider configured. First send hit the (now-structured) no_provider gate.

After: in-place 2-step wizard (provider list → API key → switchProvider → finishAsLocal). Mirrors the existing cloud/remote sub-view pattern.

ElizaOS / Android still take the immediate finishAsLocal path — they pre-seed the on-device runtime.

## Test plan
- [x] typecheck clean
- [x] BackButton extended with optional disabled prop

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR inserts a 2-step in-place wizard (provider list → API key entry → `switchProvider` → `finishAsLocal`) between the "Local" tile selection and onboarding completion for desktop/web/iOS users, preventing them from reaching chat without a configured provider. ElizaOS and Android still bypass the wizard via `finishAsLocal()` directly.

- The wizard filters the shared catalog to providers with `group === "local" && authMode === "api-key"` and calls `client.switchProvider` before completing onboarding; saving is gated behind a non-empty, trimmed key.
- `BackButton` gains an optional `disabled` prop used to lock navigation during an in-flight save, with matching Tailwind disabled styles.
- Ollama (`authMode: "local"`) is excluded from the wizard and there is no skip affordance, so desktop/web/iOS users who intend to use Ollama can no longer reach chat through the Local path.
</details>

<h3>Confidence Score: 3/5</h3>

The wizard itself is well-structured and handles the happy path cleanly, but it inadvertently removes the only onboarding route to chat for desktop/web/iOS users who intend to use Ollama or other non-API-key local providers.

The Ollama exclusion is a concrete regression: users who previously reached chat (and hit the no-provider gate there) now cannot complete local onboarding at all via the Local path, because the wizard has no skip option and Ollama is filtered out. This affects a meaningful subset of self-hosted users.

packages/app-core/src/components/shell/RuntimeGate.tsx — specifically the `localProviderCatalog` filter and the missing fallback branch when `localStage === "config"` but `selectedProvider` is falsy.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/shell/RuntimeGate.tsx | Adds a 2-step local-setup wizard (provider selection → API key entry) that runs before `finishAsLocal()` for desktop/web/iOS users; extends `BackButton` with a `disabled` prop. Ollama and other non-API-key local providers are excluded from the wizard with no skip path, blocking those users from completing local onboarding. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects Local] --> B{ElizaOS or Android?}
    B -- Yes --> C[finishAsLocal]
    B -- No --> D[Open local wizard]
    D --> E[Stage: provider\nShow api-key providers only]
    E --> F{User action}
    F -- Back --> G[Return to chooser]
    F -- Choose provider --> H[Stage: config\nShow key input]
    H --> I{User action}
    I -- Back --> E
    I -- Continue --> J[switchProvider call]
    J -- Error --> K[Show error message\nRe-enable button]
    J -- Success --> C
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A371-378%0A**Ollama%20users%20blocked%20from%20completing%20local%20onboarding**%0A%0AThe%20filter%20%60authMode%20%3D%3D%3D%20%22api-key%22%60%20excludes%20Ollama%20%28which%20has%20%60authMode%3A%20%22local%22%60%20in%20the%20catalog%29.%20On%20desktop%2Fweb%2FiOS%20a%20user%20who%20picks%20%22Local%22%20and%20wants%20to%20use%20Ollama%20is%20routed%20into%20this%20wizard%2C%20sees%20no%20Ollama%20card%2C%20has%20no%20%22skip%22%20affordance%2C%20and%20cannot%20reach%20chat.%20Clicking%20%22Back%22%20only%20returns%20them%20to%20the%20chooser.%20Before%20this%20PR%2C%20those%20same%20users%20were%20at%20least%20forwarded%20to%20chat%20%28where%20the%20%60no_provider%60%20gate%20handled%20the%20gap%29.%20Adding%20a%20%22Skip%20%2F%20configure%20later%22%20route%2C%20or%20including%20%60authMode%20%3D%3D%3D%20%22local%22%60%20providers%20with%20a%20%22no%20key%20needed%22%20confirmation%2C%20would%20restore%20parity.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1420-1485%0A**Silent%20dead-end%20when%20%60selectedProvider%60%20is%20undefined%20in%20%22config%22%20stage**%0A%0AThe%20%60%7BlocalStage%20%3D%3D%3D%20%22config%22%20%26%26%20selectedProvider%20%26%26%20%28...%29%7D%60%20guard%20silently%20renders%20nothing%20if%20%60selectedProvider%60%20is%20%60undefined%60.%20The%20%22provider%22%20stage%20UI%20is%20also%20suppressed%20at%20that%20point%2C%20so%20the%20user%20sees%20only%20the%20eyebrow%20label%20%28%22Add%20your%20API%20key%22%29%20with%20zero%20interactive%20elements%20%E2%80%94%20no%20form%2C%20no%20back%20button.%20A%20defensive%20fallback%20%E2%80%94%20at%20minimum%20an%20explicit%20%60else%60%20branch%20that%20resets%20to%20the%20%22provider%22%20stage%20or%20shows%20a%20back%20button%20%E2%80%94%20would%20prevent%20the%20dead-end.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1387-1417%0A**No%20empty-state%20message%20when%20%60localProviderCatalog%60%20is%20empty**%0A%0AIf%20every%20catalog%20entry%20is%20filtered%20out%2C%20the%20%22provider%22%20stage%20renders%20an%20empty%20%60%3Cdiv%3E%60%20with%20only%20the%20%22Back%22%20button%20and%20no%20explanation.%20Adding%20a%20short%20fallback%20message%20%28e.g.%2C%20%22No%20providers%20available%20%E2%80%94%20check%20Settings%22%29%20would%20prevent%20a%20confusing%20blank%20panel.%0A%0A&repo=elizaos%2Feliza&pr=7414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Flocal-setup-wizard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Flocal-setup-wizard%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A371-378%0A**Ollama%20users%20blocked%20from%20completing%20local%20onboarding**%0A%0AThe%20filter%20%60authMode%20%3D%3D%3D%20%22api-key%22%60%20excludes%20Ollama%20%28which%20has%20%60authMode%3A%20%22local%22%60%20in%20the%20catalog%29.%20On%20desktop%2Fweb%2FiOS%20a%20user%20who%20picks%20%22Local%22%20and%20wants%20to%20use%20Ollama%20is%20routed%20into%20this%20wizard%2C%20sees%20no%20Ollama%20card%2C%20has%20no%20%22skip%22%20affordance%2C%20and%20cannot%20reach%20chat.%20Clicking%20%22Back%22%20only%20returns%20them%20to%20the%20chooser.%20Before%20this%20PR%2C%20those%20same%20users%20were%20at%20least%20forwarded%20to%20chat%20%28where%20the%20%60no_provider%60%20gate%20handled%20the%20gap%29.%20Adding%20a%20%22Skip%20%2F%20configure%20later%22%20route%2C%20or%20including%20%60authMode%20%3D%3D%3D%20%22local%22%60%20providers%20with%20a%20%22no%20key%20needed%22%20confirmation%2C%20would%20restore%20parity.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1420-1485%0A**Silent%20dead-end%20when%20%60selectedProvider%60%20is%20undefined%20in%20%22config%22%20stage**%0A%0AThe%20%60%7BlocalStage%20%3D%3D%3D%20%22config%22%20%26%26%20selectedProvider%20%26%26%20%28...%29%7D%60%20guard%20silently%20renders%20nothing%20if%20%60selectedProvider%60%20is%20%60undefined%60.%20The%20%22provider%22%20stage%20UI%20is%20also%20suppressed%20at%20that%20point%2C%20so%20the%20user%20sees%20only%20the%20eyebrow%20label%20%28%22Add%20your%20API%20key%22%29%20with%20zero%20interactive%20elements%20%E2%80%94%20no%20form%2C%20no%20back%20button.%20A%20defensive%20fallback%20%E2%80%94%20at%20minimum%20an%20explicit%20%60else%60%20branch%20that%20resets%20to%20the%20%22provider%22%20stage%20or%20shows%20a%20back%20button%20%E2%80%94%20would%20prevent%20the%20dead-end.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1387-1417%0A**No%20empty-state%20message%20when%20%60localProviderCatalog%60%20is%20empty**%0A%0AIf%20every%20catalog%20entry%20is%20filtered%20out%2C%20the%20%22provider%22%20stage%20renders%20an%20empty%20%60%3Cdiv%3E%60%20with%20only%20the%20%22Back%22%20button%20and%20no%20explanation.%20Adding%20a%20short%20fallback%20message%20%28e.g.%2C%20%22No%20providers%20available%20%E2%80%94%20check%20Settings%22%29%20would%20prevent%20a%20confusing%20blank%20panel.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A371-378%0A**Ollama%20users%20blocked%20from%20completing%20local%20onboarding**%0A%0AThe%20filter%20%60authMode%20%3D%3D%3D%20%22api-key%22%60%20excludes%20Ollama%20%28which%20has%20%60authMode%3A%20%22local%22%60%20in%20the%20catalog%29.%20On%20desktop%2Fweb%2FiOS%20a%20user%20who%20picks%20%22Local%22%20and%20wants%20to%20use%20Ollama%20is%20routed%20into%20this%20wizard%2C%20sees%20no%20Ollama%20card%2C%20has%20no%20%22skip%22%20affordance%2C%20and%20cannot%20reach%20chat.%20Clicking%20%22Back%22%20only%20returns%20them%20to%20the%20chooser.%20Before%20this%20PR%2C%20those%20same%20users%20were%20at%20least%20forwarded%20to%20chat%20%28where%20the%20%60no_provider%60%20gate%20handled%20the%20gap%29.%20Adding%20a%20%22Skip%20%2F%20configure%20later%22%20route%2C%20or%20including%20%60authMode%20%3D%3D%3D%20%22local%22%60%20providers%20with%20a%20%22no%20key%20needed%22%20confirmation%2C%20would%20restore%20parity.%0A%0A%23%23%23%20Issue%202%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1420-1485%0A**Silent%20dead-end%20when%20%60selectedProvider%60%20is%20undefined%20in%20%22config%22%20stage**%0A%0AThe%20%60%7BlocalStage%20%3D%3D%3D%20%22config%22%20%26%26%20selectedProvider%20%26%26%20%28...%29%7D%60%20guard%20silently%20renders%20nothing%20if%20%60selectedProvider%60%20is%20%60undefined%60.%20The%20%22provider%22%20stage%20UI%20is%20also%20suppressed%20at%20that%20point%2C%20so%20the%20user%20sees%20only%20the%20eyebrow%20label%20%28%22Add%20your%20API%20key%22%29%20with%20zero%20interactive%20elements%20%E2%80%94%20no%20form%2C%20no%20back%20button.%20A%20defensive%20fallback%20%E2%80%94%20at%20minimum%20an%20explicit%20%60else%60%20branch%20that%20resets%20to%20the%20%22provider%22%20stage%20or%20shows%20a%20back%20button%20%E2%80%94%20would%20prevent%20the%20dead-end.%0A%0A%23%23%23%20Issue%203%20of%203%0Apackages%2Fapp-core%2Fsrc%2Fcomponents%2Fshell%2FRuntimeGate.tsx%3A1387-1417%0A**No%20empty-state%20message%20when%20%60localProviderCatalog%60%20is%20empty**%0A%0AIf%20every%20catalog%20entry%20is%20filtered%20out%2C%20the%20%22provider%22%20stage%20renders%20an%20empty%20%60%3Cdiv%3E%60%20with%20only%20the%20%22Back%22%20button%20and%20no%20explanation.%20Adding%20a%20short%20fallback%20message%20%28e.g.%2C%20%22No%20providers%20available%20%E2%80%94%20check%20Settings%22%29%20would%20prevent%20a%20confusing%20blank%20panel.%0A%0A&pr=7414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(runtime-gate): guided local setup w..."](https://github.com/elizaos/eliza/commit/0999cb8297602ffb2a323f6a7f9e4f7f2b4f0dfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951708)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->