### PR TITLE
fix(auth): expose pair code to loopback dashboards

### DIFF
--- a/packages/app-core/src/api/auth-pairing-compat-routes.test.ts
+++ b/packages/app-core/src/api/auth-pairing-compat-routes.test.ts
@@ -1,0 +1,234 @@
+import crypto from "node:crypto";
+import type http from "node:http";
+import { Readable } from "node:stream";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { CompatRuntimeState } from "./compat-route-shared";
+
+const mocks = vi.hoisted(() => ({
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    warn: mocks.loggerWarn,
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+  stringToUuid: (value: string) => value,
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  loadElizaConfig: () => ({ meta: {}, agents: {} }),
+}));
+
+vi.mock("@elizaos/agent/config", () => ({
+  loadElizaConfig: () => ({ meta: {}, agents: {} }),
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  isLoopbackBindHost: (host: string) => {
+    const trimmed = host.trim().toLowerCase();
+    let hostname = trimmed;
+    try {
+      hostname = new URL(`http://${trimmed}`).hostname.replace(/^\[|\]$/g, "");
+    } catch {
+      hostname = trimmed.split(":")[0] ?? trimmed;
+    }
+    return (
+      hostname === "localhost" ||
+      hostname === "::1" ||
+      hostname === "0:0:0:0:0:0:0:1" ||
+      hostname.startsWith("127.")
+    );
+  },
+  normalizeOnboardingProviderId: (value: unknown) =>
+    typeof value === "string" ? value.trim().toLowerCase() : null,
+  resolveApiToken: (env: NodeJS.ProcessEnv) =>
+    env.ELIZA_API_TOKEN?.trim() || null,
+  resolveDeploymentTargetInConfig: () => ({}),
+  resolveServiceRoutingInConfig: () => ({}),
+}));
+
+vi.mock("./auth", () => ({
+  ensureRouteAuthorized: vi.fn(async () => true),
+  getCompatApiToken: () => process.env.ELIZA_API_TOKEN?.trim() || null,
+  getProvidedApiToken: (req: Pick<http.IncomingMessage, "headers">) => {
+    const header = req.headers.authorization;
+    const value = Array.isArray(header) ? header[0] : header;
+    return value?.replace(/^Bearer\s+/i, "").trim() || null;
+  },
+  tokenMatches: (expected: string, provided: string) => expected === provided,
+}));
+
+vi.mock("./auth/sessions", () => ({
+  findActiveSession: vi.fn(async () => null),
+  parseSessionCookie: vi.fn(() => null),
+}));
+
+vi.mock("./server-onboarding-compat", () => ({
+  isCloudProvisioned: () => process.env.ELIZA_CLOUD_PROVISIONED === "1",
+}));
+
+const STATE: CompatRuntimeState = {
+  current: null,
+  pendingAgentName: null,
+  pendingRestartReasons: [],
+};
+
+interface FakeRes {
+  res: http.ServerResponse;
+  body(): unknown;
+  status(): number;
+}
+
+let handleAuthPairingCompatRoutes: typeof import("./auth-pairing-compat-routes").handleAuthPairingCompatRoutes;
+let resetAuthPairingStateForTests: typeof import("./auth-pairing-compat-routes")._resetAuthPairingStateForTests;
+
+function fakeRes(): FakeRes {
+  let bodyText = "";
+  const res = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader() {},
+    end(chunk?: string | Buffer) {
+      if (typeof chunk === "string") bodyText += chunk;
+      else if (chunk) bodyText += chunk.toString("utf8");
+    },
+  } as unknown as http.ServerResponse;
+  return {
+    res,
+    body() {
+      return bodyText.length > 0 ? JSON.parse(bodyText) : null;
+    },
+    status() {
+      return (res as unknown as { statusCode: number }).statusCode;
+    },
+  };
+}
+
+function fakeReq(opts: {
+  method: string;
+  pathname: string;
+  ip?: string;
+  host?: string;
+  headers?: http.IncomingHttpHeaders;
+}): http.IncomingMessage {
+  const stream = Readable.from([]) as unknown as http.IncomingMessage;
+  Object.assign(stream, {
+    method: opts.method,
+    url: opts.pathname,
+    headers: { host: opts.host ?? "example.com", ...(opts.headers ?? {}) },
+    socket: {
+      remoteAddress: opts.ip ?? "203.0.113.10",
+    },
+  });
+  return stream;
+}
+
+describe("auth pairing pair-code route", () => {
+  const originalToken = process.env.ELIZA_API_TOKEN;
+  const originalPairingDisabled = process.env.ELIZA_PAIRING_DISABLED;
+  const originalCloudProvisioned = process.env.ELIZA_CLOUD_PROVISIONED;
+
+  beforeAll(async () => {
+    const routeModule = await import("./auth-pairing-compat-routes");
+    handleAuthPairingCompatRoutes = routeModule.handleAuthPairingCompatRoutes;
+    resetAuthPairingStateForTests = routeModule._resetAuthPairingStateForTests;
+  });
+
+  beforeEach(() => {
+    resetAuthPairingStateForTests();
+    mocks.loggerWarn.mockReset();
+    process.env.ELIZA_API_TOKEN = "pairing-test-token";
+    delete process.env.ELIZA_PAIRING_DISABLED;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+  });
+
+  afterEach(() => {
+    resetAuthPairingStateForTests();
+    vi.restoreAllMocks();
+    if (originalToken === undefined) delete process.env.ELIZA_API_TOKEN;
+    else process.env.ELIZA_API_TOKEN = originalToken;
+    if (originalPairingDisabled === undefined) {
+      delete process.env.ELIZA_PAIRING_DISABLED;
+    } else {
+      process.env.ELIZA_PAIRING_DISABLED = originalPairingDisabled;
+    }
+    if (originalCloudProvisioned === undefined) {
+      delete process.env.ELIZA_CLOUD_PROVISIONED;
+    } else {
+      process.env.ELIZA_CLOUD_PROVISIONED = originalCloudProvisioned;
+    }
+  });
+
+  it("returns the current pair code to loopback callers", async () => {
+    vi.spyOn(crypto, "randomInt").mockReturnValue(0);
+
+    const res = fakeRes();
+    await handleAuthPairingCompatRoutes(
+      fakeReq({
+        method: "GET",
+        pathname: "/api/auth/pair-code",
+        ip: "127.0.0.1",
+        host: "localhost:2138",
+      }),
+      res.res,
+      STATE,
+    );
+
+    expect(res.status()).toBe(200);
+    expect(res.body()).toMatchObject({
+      code: "AAAA-AAAA-AAAA",
+      expiresAt: expect.any(Number),
+    });
+  });
+
+  it("blocks remote and proxied remote callers", async () => {
+    for (const req of [
+      fakeReq({ method: "GET", pathname: "/api/auth/pair-code" }),
+      fakeReq({
+        method: "GET",
+        pathname: "/api/auth/pair-code",
+        ip: "127.0.0.1",
+        host: "localhost:2138",
+        headers: { "x-forwarded-for": "203.0.113.10" },
+      }),
+    ]) {
+      const res = fakeRes();
+      await handleAuthPairingCompatRoutes(req, res.res, STATE);
+
+      expect(res.status()).toBe(403);
+      expect(res.body()).toMatchObject({
+        error: "Pair code visible on loopback only",
+      });
+    }
+  });
+
+  it("does not reveal a code when pairing is disabled", async () => {
+    process.env.ELIZA_PAIRING_DISABLED = "1";
+
+    const res = fakeRes();
+    await handleAuthPairingCompatRoutes(
+      fakeReq({
+        method: "GET",
+        pathname: "/api/auth/pair-code",
+        ip: "127.0.0.1",
+        host: "localhost:2138",
+      }),
+      res.res,
+      STATE,
+    );
+
+    expect(res.status()).toBe(503);
+    expect(res.body()).toMatchObject({ error: "Pairing not enabled" });
+  });
+});

--- a/packages/app-core/src/api/auth-pairing-compat-routes.ts
+++ b/packages/app-core/src/api/auth-pairing-compat-routes.ts
@@ -148,6 +148,7 @@ function rateLimitPairing(ip: string | null): boolean {
  *
  * - `GET  /api/onboarding/status`
  * - `GET  /api/auth/status`
+ * - `GET  /api/auth/pair-code`
  * - `POST /api/auth/pair`
  */
 export async function handleAuthPairingCompatRoutes(
@@ -232,6 +233,23 @@ export async function handleAuthPairingCompatRoutes(
       pairingEnabled: enabled,
       expiresAt: enabled ? pairingExpiresAt : null,
     });
+    return true;
+  }
+
+  // ── GET /api/auth/pair-code ─────────────────────────────────────────
+  // Loopback-only helper for local dashboards/operators. External clients
+  // must use the normal pairing flow and never receive the code directly.
+  if (method === "GET" && url.pathname === "/api/auth/pair-code") {
+    if (!isTrustedLocalRequest(req)) {
+      sendJsonErrorResponse(res, 403, "Pair code visible on loopback only");
+      return true;
+    }
+    const code = ensurePairingCode();
+    if (!code) {
+      sendJsonErrorResponse(res, 503, "Pairing not enabled");
+      return true;
+    }
+    sendJsonResponse(res, 200, { code, expiresAt: pairingExpiresAt });
     return true;
   }
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1907,6 +1907,7 @@ export default defineConfig({
       "/api": {
         target: `http://127.0.0.1:${apiPort}`,
         changeOrigin: true,
+        xfwd: true,
         configure: (proxy) => {
           proxy.on("error", (_err, _req, res) => {
             if (!res.headersSent) {


### PR DESCRIPTION
## Summary
- add `GET /api/auth/pair-code` for local dashboards/operators
- keep the endpoint loopback-only via the existing `isTrustedLocalRequest` policy
- enable forwarded client IP headers on the app dev proxy so proxied public clients do not inherit loopback trust
- add focused coverage for loopback success, remote/proxied remote denial, and disabled pairing

## Verification
- `./node_modules/.bin/biome check packages/app-core/src/api/auth-pairing-compat-routes.ts packages/app-core/src/api/auth-pairing-compat-routes.test.ts packages/app/vite.config.ts`
- `./node_modules/.bin/vitest run --config packages/app-core/vitest.config.ts packages/app-core/src/api/auth-pairing-compat-routes.test.ts`
- live VPS smoke: local `127.0.0.1:2138/api/auth/pair-code` returns a redacted `XXXX-XXXX-XXXX` code shape
- live VPS smoke: public `147.93.44.246:2138/api/auth/pair-code` returns 403
- live VPS smoke: loopback request with `X-Forwarded-For: 203.0.113.10` returns 403

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `GET /api/auth/pair-code` endpoint that exposes the current pairing code exclusively to loopback callers, and simultaneously hardens the Vite dev proxy so remote clients proxied through it can no longer impersonate a local request.

- **New endpoint** (`auth-pairing-compat-routes.ts`): delegates to the existing `isTrustedLocalRequest` guard (which checks socket IP, proxy-forwarding headers, `host`, `sec-fetch-site`, `origin`, and `referer`) and `ensurePairingCode()`; responds 403 for non-loopback callers and 503 when pairing is disabled.
- **Dev proxy fix** (`vite.config.ts`): `xfwd: true` is added to the `/api` proxy entry so the Vite dev server injects the real client IP into `X-Forwarded-For`, causing `isTrustedLocalRequest` to correctly reject remote clients that were previously invisible to the loopback check.
- **Tests** (`auth-pairing-compat-routes.test.ts`): cover loopback success, plain-remote denial, proxied-loopback denial, and pairing-disabled; the two denial scenarios are batched in a single `it` loop, which can obscure which case failed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new endpoint is guarded by a comprehensive loopback-trust check and the proxy fix closes the real-IP visibility gap that motivated the PR.

The route handler and xfwd addition are both correct, and the security-sensitive isTrustedLocalRequest guard is reused rather than reimplemented. The only finding is a test style issue where two distinct denial scenarios are bundled in a single it loop — not a correctness problem, just a maintenance friction point.

The test file is the only one worth a closer look: the batched denial assertions make it harder to pinpoint which scenario triggered a future failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/auth-pairing-compat-routes.ts | Adds GET /api/auth/pair-code restricted to loopback-only callers via isTrustedLocalRequest; correctly returns 403 for remote/proxied-remote and 503 when pairing is disabled. No new attack surface introduced. |
| packages/app-core/src/api/auth-pairing-compat-routes.test.ts | New test file covering loopback success, remote denial, proxied-remote denial, and disabled-pairing; two distinct scenarios are batched in one it-block making failure diagnosis harder. |
| packages/app/vite.config.ts | Adds xfwd: true to the /api dev proxy so the real client IP is forwarded, preventing remote clients from inheriting loopback trust through the proxy. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as Browser (localhost)
    participant Vite as Vite Dev Proxy
    participant API as API Server (127.0.0.1)

    Note over Browser,API: Local developer request
    Browser->>Vite: GET /api/auth/pair-code (socket=127.0.0.1)
    Vite->>API: GET /api/auth/pair-code X-Forwarded-For: 127.0.0.1
    API->>API: isTrustedLocalRequest() socket=loopback, XFF=loopback → true
    API-->>Vite: 200 { code, expiresAt }
    Vite-->>Browser: 200 { code, expiresAt }

    Note over Browser,API: Remote client request (blocked)
    Browser->>Vite: GET /api/auth/pair-code (socket=203.0.113.10)
    Vite->>API: GET /api/auth/pair-code X-Forwarded-For: 203.0.113.10
    API->>API: isTrustedLocalRequest() XFF=non-loopback → false
    API-->>Vite: 403 Pair code visible on loopback only
    Vite-->>Browser: 403

    Note over Browser,API: Pairing disabled
    Browser->>Vite: GET /api/auth/pair-code (loopback)
    Vite->>API: GET /api/auth/pair-code X-Forwarded-For: 127.0.0.1
    API->>API: isTrustedLocalRequest() → true, ensurePairingCode() → null
    API-->>Vite: 503 Pairing not enabled
    Vite-->>Browser: 503
```

<sub>Reviews (1): Last reviewed commit: ["fix(auth): expose pair code to loopback ..."](https://github.com/elizaos/eliza/commit/a995e6ccae578885d15c663698a78ce8995642fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951730)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->