### PR TITLE
chore(ui): drop cva-cast indirection across 10 primitives

### DIFF
--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -1,13 +1,9 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-type BadgeVariantsProps = {
-  variant?: "default" | "secondary" | "destructive" | "outline" | null;
-};
-
-const _badgeVariants = cva(
+const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
@@ -26,12 +22,9 @@ const _badgeVariants = cva(
   },
 );
 
-const badgeVariants: (props?: BadgeVariantsProps) => string =
-  _badgeVariants as (props?: BadgeVariantsProps) => string;
-
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    BadgeVariantsProps {}
+    VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/packages/ui/src/components/ui/banner.tsx
+++ b/packages/ui/src/components/ui/banner.tsx
@@ -1,14 +1,10 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { AlertTriangle, Info, X, XCircle } from "lucide-react";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "./button";
 
-type BannerVariantsProps = {
-  variant?: "error" | "warning" | "info" | null;
-};
-
-const _bannerVariants = cva(
+const bannerVariants = cva(
   "flex items-center gap-3 border px-4 py-2.5 text-xs",
   {
     variants: {
@@ -24,9 +20,6 @@ const _bannerVariants = cva(
   },
 );
 
-const bannerVariants: (props?: BannerVariantsProps) => string =
-  _bannerVariants as (props?: BannerVariantsProps) => string;
-
 const ICONS: Record<string, React.ElementType> = {
   error: XCircle,
   warning: AlertTriangle,
@@ -35,7 +28,7 @@ const ICONS: Record<string, React.ElementType> = {
 
 export interface BannerProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    BannerVariantsProps {
+    VariantProps<typeof bannerVariants> {
   /** Optional action element (button, link) */
   action?: React.ReactNode;
   /** Show dismiss button */

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,26 +1,10 @@
 import { Slot } from "@radix-ui/react-slot";
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-type ButtonVariantsProps = {
-  variant?:
-    | "default"
-    | "surface"
-    | "surfaceAccent"
-    | "surfaceDestructive"
-    | "destructive"
-    | "outline"
-    | "secondary"
-    | "ghost"
-    | "link"
-    | null;
-  size?: "default" | "sm" | "lg" | "icon" | null;
-  className?: string | null | undefined;
-};
-
-const _buttonVariants = cva(
+const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-bg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
@@ -58,12 +42,9 @@ const _buttonVariants = cva(
   },
 );
 
-const buttonVariants: (props?: ButtonVariantsProps) => string =
-  _buttonVariants as (props?: ButtonVariantsProps) => string;
-
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    Omit<ButtonVariantsProps, "className"> {
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -1,13 +1,9 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-type CardVariantsProps = {
-  variant?: "default" | "interactive" | "status" | "setting" | "flat" | null;
-};
-
-const _cardVariants = cva(
+const cardVariants = cva(
   "rounded-xl border border-border bg-card text-card-fg",
   {
     variants: {
@@ -27,13 +23,9 @@ const _cardVariants = cva(
   },
 );
 
-const cardVariants: (props?: CardVariantsProps) => string = _cardVariants as (
-  props?: CardVariantsProps,
-) => string;
-
 export interface CardProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    CardVariantsProps {}
+    VariantProps<typeof cardVariants> {}
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, variant, ...props }, ref) => (

--- a/packages/ui/src/components/ui/grid.tsx
+++ b/packages/ui/src/components/ui/grid.tsx
@@ -1,13 +1,8 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-type GridVariantsProps = {
-  columns?: 1 | 2 | 3 | 4 | 6 | 12 | null;
-  spacing?: "none" | "sm" | "md" | "lg" | null;
-};
-
-const _gridVariants = cva("grid", {
+const gridVariants = cva("grid", {
   variants: {
     columns: {
       1: "grid-cols-1",
@@ -30,13 +25,9 @@ const _gridVariants = cva("grid", {
   },
 });
 
-const gridVariants: (props?: GridVariantsProps) => string = _gridVariants as (
-  props?: GridVariantsProps,
-) => string;
-
 export interface GridProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    GridVariantsProps {}
+    VariantProps<typeof gridVariants> {}
 
 export const Grid = React.forwardRef<HTMLDivElement, GridProps>(
   ({ className, columns, spacing, ...props }, ref) => {

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,14 +1,9 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-export interface InputVariantProps {
-  variant?: "default" | "form" | "config" | null;
-  density?: "default" | "compact" | "relaxed" | null;
-}
-
-const _inputVariants = cva(
+const inputVariants = cva(
   "w-full border text-sm transition-[border-color,box-shadow,background-color] disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
@@ -32,13 +27,9 @@ const _inputVariants = cva(
   },
 );
 
-const inputVariants: (props?: InputVariantProps) => string = _inputVariants as (
-  props?: InputVariantProps,
-) => string;
-
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement>,
-    InputVariantProps {
+    VariantProps<typeof inputVariants> {
   hasError?: boolean;
 }
 

--- a/packages/ui/src/components/ui/label.tsx
+++ b/packages/ui/src/components/ui/label.tsx
@@ -1,15 +1,10 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
-import { cva } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-const _labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-);
-
-const labelVariants: (props?: Record<string, never>) => string =
-  _labelVariants as (props?: Record<string, never>) => string;
+const LABEL_BASE_CLASS =
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70";
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
@@ -17,7 +12,7 @@ const Label = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn(labelVariants(), className)}
+    className={cn(LABEL_BASE_CLASS, className)}
     {...props}
   />
 ));

--- a/packages/ui/src/components/ui/stack.tsx
+++ b/packages/ui/src/components/ui/stack.tsx
@@ -1,15 +1,8 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-export interface StackVariantProps {
-  direction?: "row" | "col" | null;
-  align?: "start" | "center" | "end" | "stretch" | "baseline" | null;
-  justify?: "start" | "center" | "end" | "between" | null;
-  spacing?: "none" | "sm" | "md" | "lg" | null;
-}
-
-const _stackVariants = cva("flex", {
+const stackVariants = cva("flex", {
   variants: {
     direction: {
       row: "flex-row",
@@ -41,13 +34,9 @@ const _stackVariants = cva("flex", {
   },
 });
 
-const stackVariants: (props?: StackVariantProps) => string = _stackVariants as (
-  props?: StackVariantProps,
-) => string;
-
 export interface StackProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    StackVariantProps {}
+    VariantProps<typeof stackVariants> {}
 
 export const Stack = React.forwardRef<HTMLDivElement, StackProps>(
   ({ className, direction, align, justify, spacing, ...props }, ref) => {

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -1,14 +1,9 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-export interface TextareaVariantProps {
-  variant?: "default" | "form" | "config" | null;
-  density?: "default" | "compact" | "relaxed" | null;
-}
-
-const _textareaVariants = cva(
+const textareaVariants = cva(
   "w-full border text-sm resize-y transition-[border-color,box-shadow,background-color] disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
@@ -32,12 +27,9 @@ const _textareaVariants = cva(
   },
 );
 
-const textareaVariants: (props?: TextareaVariantProps) => string =
-  _textareaVariants as (props?: TextareaVariantProps) => string;
-
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-    TextareaVariantProps {
+    VariantProps<typeof textareaVariants> {
   hasError?: boolean;
 }
 

--- a/packages/ui/src/components/ui/typography.tsx
+++ b/packages/ui/src/components/ui/typography.tsx
@@ -1,13 +1,9 @@
-import { cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-export interface TextVariantProps {
-  variant?: "default" | "medium" | "small" | "muted" | "lead" | "large" | null;
-}
-
-const _textVariants = cva("text-txt", {
+const textVariants = cva("text-txt", {
   variants: {
     variant: {
       default: "text-base",
@@ -23,13 +19,9 @@ const _textVariants = cva("text-txt", {
   },
 });
 
-const textVariants: (props?: TextVariantProps) => string = _textVariants as (
-  props?: TextVariantProps,
-) => string;
-
 export interface TextProps
   extends React.HTMLAttributes<HTMLParagraphElement>,
-    TextVariantProps {
+    VariantProps<typeof textVariants> {
   asChild?: boolean;
 }
 
@@ -47,11 +39,7 @@ export const Text = React.forwardRef<HTMLParagraphElement, TextProps>(
 );
 Text.displayName = "Text";
 
-export interface HeadingVariantProps {
-  level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | null;
-}
-
-const _headingVariants = cva("text-txt font-semibold tracking-tight", {
+const headingVariants = cva("text-txt font-semibold tracking-tight", {
   variants: {
     level: {
       h1: "text-4xl font-extrabold lg:text-5xl",
@@ -67,12 +55,9 @@ const _headingVariants = cva("text-txt font-semibold tracking-tight", {
   },
 });
 
-const headingVariants: (props?: HeadingVariantProps) => string =
-  _headingVariants as (props?: HeadingVariantProps) => string;
-
 export interface HeadingProps
   extends React.HTMLAttributes<HTMLHeadingElement>,
-    HeadingVariantProps {}
+    VariantProps<typeof headingVariants> {}
 
 export const Heading = React.forwardRef<HTMLHeadingElement, HeadingProps>(
   ({ className, level = "h1", ...props }, ref) => {


### PR DESCRIPTION
## Summary

Layer 5b audit Section G #4 + Section D. Replaced the boilerplate that repeated across every cva-using primitive:

\`\`\`ts
type XVariantsProps = { variant?: ... };
const _xVariants = cva(...);
const xVariants: ... = _xVariants as ...;
export interface XProps extends ..., XVariantsProps {}
\`\`\`

with cva's own \`VariantProps<typeof xVariants>\` helper.

Files swept: badge, banner, button, card, grid, input, label, stack, textarea, typography (10).

Special case: label.tsx was using cva to wrap a single static class with no variants — replaced with plain const.

Verified zero downstream refs to deleted hand-written *VariantProps interfaces.

**Net −98 LOC across 10 files.**

## Test plan
- [x] typecheck clean (packages/ui, packages/app-core)
- [x] biome clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This is a pure refactoring chore that removes 98 lines of handwritten `_*Variants` cast boilerplate from 10 UI primitives, replacing each `type XVariantsProps` + unsafe `as` cast with cva's built-in `VariantProps<typeof xVariants>` helper. `label.tsx` is handled as a special case by dropping `cva` entirely in favour of a plain class-name constant.

- The mechanics are correct across all 10 files: `VariantProps` produces type unions that are identical to the removed hand-written ones (including `button`'s `Omit<…, \"className\">`, which `VariantProps` handles automatically, and `grid`'s numeric literal keys).
- Five of the deleted types — `InputVariantProps`, `StackVariantProps`, `TextareaVariantProps`, `TextVariantProps`, and `HeadingVariantProps` — were `export interface`s re-exported through the package barrel, making their removal a breaking change for any external consumer of the package (no internal refs exist in the monorepo).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the monorepo; the only open question is whether external consumers of the published package depend on the five removed exported variant-props interfaces.

All 10 component rewrites are mechanically correct — variant unions are preserved, the button's className omission is handled implicitly by VariantProps, and the label simplification is equivalent. The sole concern is that InputVariantProps, StackVariantProps, TextareaVariantProps, TextVariantProps, and HeadingVariantProps were exported from the package's public barrel and are now gone with no re-export shim, which would break any external caller that imports them by name.

input.tsx, stack.tsx, textarea.tsx, and typography.tsx — each silently drops a previously exported interface from the package public API.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/ui/badge.tsx | Replaces hand-written BadgeVariantsProps + cast with VariantProps<typeof badgeVariants>; straightforward and correct. |
| packages/ui/src/components/ui/banner.tsx | Drops BannerVariantsProps cast indirection; VariantProps produces the same "error" | "warning" | "info" | null union — no behavior change. |
| packages/ui/src/components/ui/button.tsx | Old Omit<ButtonVariantsProps, "className"> is equivalent to VariantProps (which already omits className per cva's type helper); no functional change. |
| packages/ui/src/components/ui/card.tsx | Clean removal of CardVariantsProps + cast; VariantProps derives an identical union from the cva definition. |
| packages/ui/src/components/ui/grid.tsx | Numeric variant keys (1|2|3|4|6|12) are inferred as numeric literal types by VariantProps, matching the old hand-written union exactly. |
| packages/ui/src/components/ui/input.tsx | Deletes exported InputVariantProps interface — previously part of the public package API; no internal refs found, but external consumers would break. |
| packages/ui/src/components/ui/label.tsx | Replaces a no-variant cva() wrapper with a plain const string — functionally identical and clearer. |
| packages/ui/src/components/ui/stack.tsx | Deletes exported StackVariantProps interface — same public-API concern as InputVariantProps. |
| packages/ui/src/components/ui/textarea.tsx | Deletes exported TextareaVariantProps interface — same public-API concern as InputVariantProps and StackVariantProps. |
| packages/ui/src/components/ui/typography.tsx | Deletes both exported TextVariantProps and HeadingVariantProps interfaces — same public-API concern; component behaviour is unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component Props Interface] -->|before| B["hand-written XVariantsProps\n+ _xVariants = cva(…)\n+ xVariants = _xVariants as (props?) => string"]
    A -->|after| C["VariantProps<typeof xVariants>\n(cva native helper)"]
    B --> D["export interface XProps\n extends HTMLAttributes, XVariantsProps"]
    C --> E["export interface XProps\n extends HTMLAttributes, VariantProps<typeof xVariants>"]
    D --> F[Component renders xVariants variant props]
    E --> F
    G[label.tsx special case] -->|before| H["cva(single static class)\n+ cast boilerplate"]
    G -->|after| I["const LABEL_BASE_CLASS = '…'\ncn(LABEL_BASE_CLASS, className)"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fui%2Finput.tsx%3A1-9%0A**Removed%20exported%20interfaces%20break%20the%20public%20package%20API**%0A%0A%60InputVariantProps%60%2C%20%60StackVariantProps%60%2C%20%60TextareaVariantProps%60%2C%20%60TextVariantProps%60%2C%20and%20%60HeadingVariantProps%60%20were%20all%20exported%20via%20%60export%20interface%60%20and%20re-exported%20through%20%60packages%2Fui%2Fsrc%2Fcomponents%2Fprimitives%2Findex.ts%60%20%E2%86%92%20%60packages%2Fui%2Fsrc%2Findex.ts%60.%20Any%20external%20consumer%20who%20imported%20these%20named%20types%20%28e.g.%20%60import%20type%20%7B%20InputVariantProps%20%7D%20from%20%22%40elizaos%2Fui%22%60%29%20will%20get%20a%20compile%20error%20after%20this%20change.%20The%20monorepo%20itself%20has%20zero%20refs%2C%20but%20published%20package%20consumers%20are%20unguarded.%20If%20the%20package%20targets%20external%20audiences%2C%20consider%20adding%20type%20aliases%20%28%60export%20type%20InputVariantProps%20%3D%20VariantProps%3Ctypeof%20inputVariants%3E%60%29%20to%20preserve%20the%20public%20surface.%0A%0A&repo=elizaos%2Feliza&pr=7419&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22milady%2Flayer5b-cva-typed%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22milady%2Flayer5b-cva-typed%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fui%2Finput.tsx%3A1-9%0A**Removed%20exported%20interfaces%20break%20the%20public%20package%20API**%0A%0A%60InputVariantProps%60%2C%20%60StackVariantProps%60%2C%20%60TextareaVariantProps%60%2C%20%60TextVariantProps%60%2C%20and%20%60HeadingVariantProps%60%20were%20all%20exported%20via%20%60export%20interface%60%20and%20re-exported%20through%20%60packages%2Fui%2Fsrc%2Fcomponents%2Fprimitives%2Findex.ts%60%20%E2%86%92%20%60packages%2Fui%2Fsrc%2Findex.ts%60.%20Any%20external%20consumer%20who%20imported%20these%20named%20types%20%28e.g.%20%60import%20type%20%7B%20InputVariantProps%20%7D%20from%20%22%40elizaos%2Fui%22%60%29%20will%20get%20a%20compile%20error%20after%20this%20change.%20The%20monorepo%20itself%20has%20zero%20refs%2C%20but%20published%20package%20consumers%20are%20unguarded.%20If%20the%20package%20targets%20external%20audiences%2C%20consider%20adding%20type%20aliases%20%28%60export%20type%20InputVariantProps%20%3D%20VariantProps%3Ctypeof%20inputVariants%3E%60%29%20to%20preserve%20the%20public%20surface.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fui%2Finput.tsx%3A1-9%0A**Removed%20exported%20interfaces%20break%20the%20public%20package%20API**%0A%0A%60InputVariantProps%60%2C%20%60StackVariantProps%60%2C%20%60TextareaVariantProps%60%2C%20%60TextVariantProps%60%2C%20and%20%60HeadingVariantProps%60%20were%20all%20exported%20via%20%60export%20interface%60%20and%20re-exported%20through%20%60packages%2Fui%2Fsrc%2Fcomponents%2Fprimitives%2Findex.ts%60%20%E2%86%92%20%60packages%2Fui%2Fsrc%2Findex.ts%60.%20Any%20external%20consumer%20who%20imported%20these%20named%20types%20%28e.g.%20%60import%20type%20%7B%20InputVariantProps%20%7D%20from%20%22%40elizaos%2Fui%22%60%29%20will%20get%20a%20compile%20error%20after%20this%20change.%20The%20monorepo%20itself%20has%20zero%20refs%2C%20but%20published%20package%20consumers%20are%20unguarded.%20If%20the%20package%20targets%20external%20audiences%2C%20consider%20adding%20type%20aliases%20%28%60export%20type%20InputVariantProps%20%3D%20VariantProps%3Ctypeof%20inputVariants%3E%60%29%20to%20preserve%20the%20public%20surface.%0A%0A&pr=7419&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(ui): drop cva-cast indirection acr..."](https://github.com/elizaos/eliza/commit/cafb8fd646a2620da911e5100d9da1389a64d8f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951782)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->