### PR TITLE
chore(app-core): fold pages/settings/ into settings/

### DIFF
--- a/packages/app-core/src/components/pages/SettingsView.tsx
+++ b/packages/app-core/src/components/pages/SettingsView.tsx
@@ -54,16 +54,16 @@ import {
 import { AppearanceSettingsSection } from "../settings/AppearanceSettingsSection";
 import { AppsManagementSection } from "../settings/AppsManagementSection";
 import { CapabilitiesSection } from "../settings/CapabilitiesSection";
+import { IdentitySettingsSection } from "../settings/IdentitySettingsSection";
 import { PermissionsSection } from "../settings/PermissionsSection";
 import { ProviderSwitcher } from "../settings/ProviderSwitcher";
+import { RuntimeSettingsSection } from "../settings/RuntimeSettingsSection";
 import { SecretsManagerSection } from "../settings/SecretsManagerSection";
 import { SecuritySettingsSection } from "../settings/SecuritySettingsSection";
 import { WalletKeysSection } from "../settings/WalletKeysSection";
 import { AppPageSidebar } from "../shared/AppPageSidebar";
 import { ConfigPageView } from "./ConfigPageView";
 import { ReleaseCenterView } from "./ReleaseCenterView";
-import { IdentitySettingsSection } from "./settings/IdentitySettingsSection";
-import { RuntimeSettingsSection } from "./settings/RuntimeSettingsSection";
 
 const SETTINGS_SIDEBAR_WIDTH_KEY = "eliza:settings:sidebar:width";
 const SETTINGS_SIDEBAR_COLLAPSED_KEY = "eliza:settings:sidebar:collapsed";

--- a/packages/app-core/src/components/settings/IdentitySettingsSection.tsx
+++ b/packages/app-core/src/components/settings/IdentitySettingsSection.tsx
@@ -8,28 +8,25 @@ import {
 } from "@elizaos/ui";
 import { Volume2, VolumeX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { client, type VoiceConfig } from "../../../api";
-import {
-  dispatchWindowEvent,
-  VOICE_CONFIG_UPDATED_EVENT,
-} from "../../../events";
-import { useApp } from "../../../state";
-import { replaceNameTokens } from "../../../utils/name-tokens";
+import { client, type VoiceConfig } from "../../api";
+import { dispatchWindowEvent, VOICE_CONFIG_UPDATED_EVENT } from "../../events";
+import { useApp } from "../../state";
+import { replaceNameTokens } from "../../utils/name-tokens";
 import {
   EDGE_BACKUP_VOICES,
   hasConfiguredApiKey,
   PREMADE_VOICES,
   sanitizeApiKey,
-} from "../../../voice/types";
+} from "../../voice/types";
 import {
   DEFAULT_ELEVEN_FAST_MODEL,
   EDGE_VOICE_GROUPS,
   ELEVENLABS_VOICE_GROUPS,
-} from "../../character/character-voice-config";
+} from "../character/character-voice-config";
 import {
   SettingsField,
   SettingsFieldLabel,
-} from "../../settings/settings-control-primitives";
+} from "./settings-control-primitives";
 
 function resolveEditableVoiceSelectionKey(config: VoiceConfig | null): string {
   const elevenLabsVoiceId =

--- a/packages/app-core/src/components/settings/RuntimeSettingsSection.tsx
+++ b/packages/app-core/src/components/settings/RuntimeSettingsSection.tsx
@@ -18,8 +18,8 @@
 
 import { Button } from "@elizaos/ui";
 import { useCallback } from "react";
-import { reloadIntoRuntimePicker } from "../../../onboarding/reload-into-runtime-picker";
-import { useApp } from "../../../state";
+import { reloadIntoRuntimePicker } from "../../onboarding/reload-into-runtime-picker";
+import { useApp } from "../../state";
 
 export function RuntimeSettingsSection() {
   const { t } = useApp();


### PR DESCRIPTION
Layer 7 audit Hard win #3 — Settings folder collapse. Two files (IdentitySettingsSection, RuntimeSettingsSection) moved from components/pages/settings/ into the canonical components/settings/ folder. SettingsView import paths updated. Net 0 LOC, one fewer folder seam.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves `IdentitySettingsSection` and `RuntimeSettingsSection` from `components/pages/settings/` into the canonical `components/settings/` folder, then updates the import paths in `SettingsView.tsx` and within the moved files. There are no logic or API changes.

- `SettingsView.tsx` import paths for the two components updated from `./settings/*` to `../settings/*`.
- Both component files relocated and all relative imports adjusted by one directory level; the `pages/settings/` subdirectory is now empty and removed.
</details>

<h3>Confidence Score: 5/5</h3>

This is a pure file-move refactor with no logic changes; all import paths resolve correctly and no stale references remain in the codebase.

Both component files were relocated to the canonical `settings/` folder and every relative import was updated consistently. A grep across the package confirmed no remaining references to the old `pages/settings/` path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/pages/SettingsView.tsx | Updated two import paths from `./settings/*` to `../settings/*`, aligning with the new canonical location of the moved components. No logic changes. |
| packages/app-core/src/components/settings/IdentitySettingsSection.tsx | Moved from `pages/settings/` to `settings/`; all relative import paths adjusted by one directory level upward. No functional changes. |
| packages/app-core/src/components/settings/RuntimeSettingsSection.tsx | Moved from `pages/settings/` to `settings/`; two relative imports updated accordingly. No functional changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SV["SettingsView.tsx\n(pages/)"]

    subgraph before["Before"]
        direction TB
        PS["pages/settings/\nIdentitySettingsSection\nRuntimeSettingsSection"]
    end

    subgraph after["After"]
        direction TB
        CS["settings/\nIdentitySettingsSection ✓\nRuntimeSettingsSection ✓\n(+ existing components)"]
    end

    SV -- "old: ./settings/*" --> PS
    SV -- "new: ../settings/*" --> CS

    style before fill:#fdd,stroke:#c00
    style after fill:#dfd,stroke:#090
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(app-core): fold pages/settings/ in..."](https://github.com/elizaos/eliza/commit/e9a4741d6a236fa74170df16dcf627f13dbc04f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30951793)</sub>

<!-- /greptile_comment -->