### PR TITLE
feat(discord): add opt-in message coalescing for high-traffic channels

### DIFF
--- a/plugins/plugin-discord/__tests__/message-coalesce.test.ts
+++ b/plugins/plugin-discord/__tests__/message-coalesce.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMessageDebouncer } from "../debouncer";
+import {
+	getDiscordMessageCoalesceConfig,
+	makeCoalescedDiscordMessage,
+} from "../message-coalesce";
+
+function mockMessage(id: string, content: string, authorId = "user-1") {
+	return {
+		id,
+		content,
+		createdTimestamp: Number(id.replace(/\D/g, "")) || Date.now(),
+		channel: { id: "channel-1" },
+		author: {
+			id: authorId,
+			username: `user-${authorId}`,
+			displayName: `User ${authorId}`,
+		},
+		member: { displayName: `Member ${authorId}` },
+		attachments: { size: 0 },
+		stickers: { size: 0 },
+	} as never;
+}
+
+describe("Discord message coalescing", () => {
+	it("is disabled by default and parses scoped env-style settings", () => {
+		const settings = new Map<string, unknown>([
+			["DISCORD_MESSAGE_COALESCE_WINDOW_MS", "1200"],
+			["DISCORD_MESSAGE_COALESCE_MAX_BATCH", "3"],
+		]);
+
+		expect(getDiscordMessageCoalesceConfig((key) => settings.get(key))).toEqual(
+			{
+				enabled: false,
+				windowMs: 8000,
+				maxBatch: 3,
+			},
+		);
+
+		settings.set("DISCORD_MESSAGE_COALESCE_ENABLED", "true");
+		expect(getDiscordMessageCoalesceConfig((key) => settings.get(key))).toEqual(
+			{
+				enabled: true,
+				windowMs: 1200,
+				maxBatch: 3,
+			},
+		);
+	});
+
+	it("formats multiple messages into one annotated Discord message", () => {
+		const combined = makeCoalescedDiscordMessage(
+			[mockMessage("1", "first"), mockMessage("2", "second")],
+			undefined,
+			{ enabled: true, maxBatch: 5 },
+		) as never as {
+			content: string;
+			__discordCoalescedMessageIds: string[];
+		};
+
+		expect(combined.content).toContain(
+			"[Discord message 1/2 id=1 author=Member user-1",
+		);
+		expect(combined.content).toContain("first");
+		expect(combined.content).toContain("second");
+		expect(combined.__discordCoalescedMessageIds).toEqual(["1", "2"]);
+	});
+
+	it("flushes the receive window when max-batch is reached", () => {
+		vi.useFakeTimers();
+		try {
+			const flushed: unknown[][] = [];
+			const debouncer = createMessageDebouncer(
+				(messages) => flushed.push([...messages]),
+				8000,
+				{ maxBatch: 2 },
+			);
+
+			debouncer.enqueue(mockMessage("1", "first"));
+			expect(flushed).toHaveLength(0);
+
+			debouncer.enqueue(mockMessage("2", "second"));
+			expect(flushed).toHaveLength(1);
+			expect(flushed[0]).toHaveLength(2);
+			expect(debouncer.pendingCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("flushes after the coalescing window expires", () => {
+		vi.useFakeTimers();
+		try {
+			const flushed: unknown[][] = [];
+			const debouncer = createMessageDebouncer(
+				(messages) => flushed.push([...messages]),
+				8000,
+				{ maxBatch: 5 },
+			);
+
+			debouncer.enqueue(mockMessage("1", "first"));
+			debouncer.enqueue(mockMessage("2", "second"));
+			expect(flushed).toHaveLength(0);
+
+			vi.advanceTimersByTime(7999);
+			expect(flushed).toHaveLength(0);
+
+			vi.advanceTimersByTime(1);
+			expect(flushed).toHaveLength(1);
+			expect(flushed[0]).toHaveLength(2);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -35,6 +35,8 @@ export interface ChannelDebouncerOptions {
 	botUserId?: string;
 	getBotUserId?: () => string | undefined;
 	botName?: string;
+	coalesceEnabled?: boolean;
+	maxBatch?: number;
 }
 
 export interface ChannelDebouncer {
@@ -56,6 +58,8 @@ export function createChannelDebouncer(
 ): ChannelDebouncer {
 	const debounceMs = options.debounceMs ?? DEFAULT_CHANNEL_DEBOUNCE_MS;
 	const responseCooldownMs = options.responseCooldownMs ?? 30_000;
+	const coalesceEnabled = options.coalesceEnabled === true;
+	const maxBatch = Math.max(1, options.maxBatch ?? Number.POSITIVE_INFINITY);
 	const botName = options.botName?.trim();
 	const botNameRegex =
 		botName && botName.length >= 2
@@ -108,7 +112,8 @@ export function createChannelDebouncer(
 
 	const enqueue = (message: DiscordMessage) => {
 		const channelId = message.channel.id;
-		if (isBotTargeted(message)) {
+		const targeted = isBotTargeted(message);
+		if (targeted && !coalesceEnabled) {
 			const entry = pending.get(channelId);
 			if (entry) {
 				clearTimeout(entry.timer);
@@ -121,7 +126,7 @@ export function createChannelDebouncer(
 			return;
 		}
 
-		if (isInCooldown(channelId)) {
+		if (isInCooldown(channelId) && !targeted) {
 			return;
 		}
 
@@ -134,6 +139,10 @@ export function createChannelDebouncer(
 		if (existing) {
 			clearTimeout(existing.timer);
 			existing.messages.push(message);
+			if (coalesceEnabled && existing.messages.length >= maxBatch) {
+				flush(channelId);
+				return;
+			}
 			existing.timer = setTimeout(() => flush(channelId), debounceMs);
 			return;
 		}
@@ -168,8 +177,10 @@ export function createChannelDebouncer(
 export function createMessageDebouncer(
 	onFlush: DebouncerFlushCallback,
 	debounceMs: number = DEFAULT_DEBOUNCE_MS,
+	options: { maxBatch?: number } = {},
 ): MessageDebouncer {
 	const pending = new Map<string, PendingEntry>();
+	const maxBatch = Math.max(1, options.maxBatch ?? Number.POSITIVE_INFINITY);
 
 	const makeKey = (message: DiscordMessage) =>
 		`${message.channel.id}:${message.author.id}`;
@@ -213,6 +224,10 @@ export function createMessageDebouncer(
 		if (existing) {
 			clearTimeout(existing.timer);
 			existing.messages.push(message);
+			if (existing.messages.length >= maxBatch) {
+				flush(key);
+				return;
+			}
 			existing.timer = setTimeout(() => flush(key), debounceMs);
 			return;
 		}

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -29,6 +29,10 @@ import {
 	type MessageDebouncer,
 } from "./debouncer";
 import {
+	getDiscordMessageCoalesceConfig,
+	makeCoalescedDiscordMessage,
+} from "./message-coalesce";
+import {
 	diffMemberRoles,
 	diffOverwrites,
 	diffRolePermissions,
@@ -164,25 +168,65 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 } {
 	const { listenCids, debounceMs, channelDebounceMs, responseCooldownMs } =
 		parseEventListenerConfig(service);
+	const messageCoalesce = getDiscordMessageCoalesceConfig((key) =>
+		service.runtime.getSetting(key),
+	);
+	const effectiveDebounceMs = messageCoalesce.enabled
+		? messageCoalesce.windowMs
+		: debounceMs;
+	const effectiveChannelDebounceMs = messageCoalesce.enabled
+		? messageCoalesce.windowMs
+		: channelDebounceMs;
 
 	// ── Message debouncer ──────────────────────────────────────────────
-	const messageDebouncer = createMessageDebouncer((messages) => {
-		if (!service.messageManager || messages.length === 0) {
-			return;
-		}
+	const messageDebouncer = createMessageDebouncer(
+		(messages) => {
+			if (!service.messageManager || messages.length === 0) {
+				return;
+			}
 
-		if (messages.length === 1) {
-			void service.messageManager.handleMessage(messages[0]);
-			return;
-		}
+			const anchor = messages[0];
+			if (messageCoalesce.enabled) {
+				const combined = makeCoalescedDiscordMessage(
+					messages,
+					anchor,
+					messageCoalesce,
+				);
+				if (messages.length > 1) {
+					service.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: service.runtime.agentId,
+							channelId: messages[0]?.channel?.id,
+							messageIds: messages.map((message) => message.id),
+							count: messages.length,
+							path: "messageDebouncer",
+						},
+						"Coalesced inbound Discord messages",
+					);
+				}
+				void service.messageManager.handleMessage(combined as Message);
+				return;
+			}
 
-		const anchor = messages[0];
-		const combinedText = messages.map((message) => message.content).join("\n");
-		const combined = Object.create(anchor, {
-			content: { value: combinedText, writable: true, enumerable: true },
-		});
-		void service.messageManager.handleMessage(combined as Message);
-	}, debounceMs);
+			if (messages.length === 1) {
+				void service.messageManager.handleMessage(anchor);
+				return;
+			}
+
+			const combinedText = messages
+				.map((message) => message.content)
+				.join("\n");
+			const combined = Object.create(anchor, {
+				content: { value: combinedText, writable: true, enumerable: true },
+			});
+			void service.messageManager.handleMessage(combined as Message);
+		},
+		effectiveDebounceMs,
+		{
+			maxBatch: messageCoalesce.enabled ? messageCoalesce.maxBatch : undefined,
+		},
+	);
 
 	// ── Channel debouncer ──────────────────────────────────────────────
 	const channelDebouncer = createChannelDebouncer(
@@ -216,7 +260,27 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			}
 
 			anchor ??= messages[messages.length - 1];
-			if (messages.length === 1) {
+			if (messageCoalesce.enabled) {
+				const combined = makeCoalescedDiscordMessage(
+					messages,
+					anchor,
+					messageCoalesce,
+				);
+				if (messages.length > 1) {
+					service.runtime.logger.info(
+						{
+							src: "plugin:discord",
+							agentId: service.runtime.agentId,
+							channelId: messages[0]?.channel?.id,
+							messageIds: messages.map((message) => message.id),
+							count: messages.length,
+							path: "channelDebouncer",
+						},
+						"Coalesced inbound Discord messages",
+					);
+				}
+				void service.messageManager.handleMessage(combined as Message);
+			} else if (messages.length === 1) {
 				void service.messageManager.handleMessage(anchor);
 			} else {
 				const contextLines = messages
@@ -238,10 +302,12 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			channelDebouncer?.markResponded(messages[0].channel.id);
 		},
 		{
-			debounceMs: channelDebounceMs,
+			debounceMs: effectiveChannelDebounceMs,
 			responseCooldownMs,
 			getBotUserId: () => service.client?.user?.id,
 			botName: service.character?.name,
+			coalesceEnabled: messageCoalesce.enabled,
+			maxBatch: messageCoalesce.maxBatch,
 		},
 	);
 

--- a/plugins/plugin-discord/message-coalesce.ts
+++ b/plugins/plugin-discord/message-coalesce.ts
@@ -1,0 +1,148 @@
+import type { Message as DiscordMessage } from "discord.js";
+
+export interface DiscordMessageCoalesceConfig {
+	enabled: boolean;
+	windowMs: number;
+	maxBatch: number;
+}
+
+export interface CoalescedDiscordMessageMeta {
+	id?: string;
+	channelId?: string;
+	authorId?: string;
+	username?: string;
+	displayName?: string;
+	createdTimestamp?: number;
+	contentPreview: string;
+}
+
+export type DiscordMessageWithCoalescedMetadata = DiscordMessage & {
+	__discordCoalescedMessages?: CoalescedDiscordMessageMeta[];
+	__discordCoalescedMessageIds?: string[];
+};
+
+const DEFAULT_WINDOW_MS = 8_000;
+const DEFAULT_MAX_BATCH = 5;
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+	if (value === undefined || value === null) {
+		return fallback;
+	}
+	return String(value).trim().toLowerCase() === "true";
+}
+
+function parsePositiveInteger(value: unknown, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getDiscordMessageCoalesceConfig(
+	getSetting: (key: string) => unknown,
+): DiscordMessageCoalesceConfig {
+	const enabled = parseBoolean(
+		getSetting("DISCORD_MESSAGE_COALESCE_ENABLED"),
+		false,
+	);
+
+	return {
+		enabled,
+		windowMs: enabled
+			? parsePositiveInteger(
+					getSetting("DISCORD_MESSAGE_COALESCE_WINDOW_MS"),
+					DEFAULT_WINDOW_MS,
+				)
+			: DEFAULT_WINDOW_MS,
+		maxBatch: parsePositiveInteger(
+			getSetting("DISCORD_MESSAGE_COALESCE_MAX_BATCH"),
+			DEFAULT_MAX_BATCH,
+		),
+	};
+}
+
+export function getDiscordMessageMeta(
+	message: DiscordMessage,
+): CoalescedDiscordMessageMeta {
+	return {
+		id: message.id,
+		channelId: message.channel?.id,
+		authorId: message.author?.id,
+		username: message.author?.username,
+		displayName:
+			message.member?.displayName ??
+			message.author?.globalName ??
+			message.author?.displayName ??
+			message.author?.username,
+		createdTimestamp: message.createdTimestamp,
+		contentPreview: String(message.content || "").slice(0, 300),
+	};
+}
+
+export function formatCoalescedDiscordMessages(
+	messages: DiscordMessage[],
+): string {
+	return messages
+		.map((message, index) => {
+			const meta = getDiscordMessageMeta(message);
+			const label =
+				meta.displayName || meta.username || meta.authorId || "unknown";
+			const ordinal = index + 1;
+			return `[Discord message ${ordinal}/${messages.length} id=${meta.id || "unknown"} author=${label} author_id=${meta.authorId || "unknown"} at=${meta.createdTimestamp || "unknown"}]\n${message.content || ""}\n[/Discord message ${ordinal}/${messages.length} id=${meta.id || "unknown"}]`;
+		})
+		.join("\n\n");
+}
+
+export function makeCoalescedDiscordMessage(
+	messages: DiscordMessage[],
+	anchor?: DiscordMessage,
+	config: Pick<DiscordMessageCoalesceConfig, "enabled" | "maxBatch"> = {
+		enabled: false,
+		maxBatch: DEFAULT_MAX_BATCH,
+	},
+): DiscordMessage {
+	if (!config.enabled || messages.length <= 1) {
+		return anchor ?? messages[0];
+	}
+
+	const capped = messages.slice(0, config.maxBatch);
+	const base = anchor ?? capped[capped.length - 1] ?? messages[0];
+	const meta = capped.map(getDiscordMessageMeta);
+	return Object.create(base, {
+		content: {
+			value: formatCoalescedDiscordMessages(capped),
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		},
+		__discordCoalescedMessages: {
+			value: meta,
+			writable: false,
+			enumerable: false,
+			configurable: true,
+		},
+		__discordCoalescedMessageIds: {
+			value: meta.map((entry) => entry.id).filter(Boolean),
+			writable: false,
+			enumerable: false,
+			configurable: true,
+		},
+	});
+}
+
+export function appendCoalescedDiscordMetadata(
+	message: DiscordMessage,
+	extraMetadata: Record<string, unknown> = {},
+): any {
+	const coalesced = message as DiscordMessageWithCoalescedMetadata;
+	const ids = coalesced.__discordCoalescedMessageIds;
+	const messages = coalesced.__discordCoalescedMessages;
+	if (!Array.isArray(ids) || ids.length <= 1) {
+		return extraMetadata;
+	}
+
+	return {
+		...extraMetadata,
+		coalescedDiscordMessageIds: ids,
+		coalescedDiscordMessages: Array.isArray(messages) ? messages : undefined,
+		coalescedDiscordMessageCount: ids.length,
+	};
+}

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -36,6 +36,7 @@ import { createDraftStreamController } from "./draft-stream";
 import { getDiscordSettings } from "./environment";
 import { buildDiscordWorldMetadata } from "./identity";
 import { formatInboundEnvelope } from "./inbound-envelope";
+import { appendCoalescedDiscordMetadata } from "./message-coalesce";
 import { stripReasoningTags } from "./reasoning-tags";
 import {
 	createStatusReactionController,
@@ -513,7 +514,7 @@ export class MessageManager {
 										: "none",
 						},
 					},
-					extraMetadata: {
+					extraMetadata: appendCoalescedDiscordMetadata(message, {
 						// Reply attribution for cross-agent filtering
 						// WHY: When user replies to another bot's message, we need to know
 						// so other agents can ignore it (only the replied-to agent should respond)
@@ -536,7 +537,7 @@ export class MessageManager {
 							message.mentions.repliedUser?.globalName ??
 							message.mentions.repliedUser?.username,
 						replyToSenderUserName: message.mentions.repliedUser?.username,
-					},
+					}),
 				},
 			);
 


### PR DESCRIPTION
## Summary

Adds an opt-in receive-side Discord message coalescing mode for high-traffic channels. When enabled, multiple inbound Discord messages received inside a short window are presented to the agent as one annotated message, preserving per-message ids, authors, timestamps, and metadata.

This is useful for agents backed by rate-limited or slower models, busy Discord channels where users send several short messages in quick succession, and deployments that prefer batching context before the agent starts reasoning.

## Configuration

All defaults are conservative and the feature is off unless explicitly enabled:

- `DISCORD_MESSAGE_COALESCE_ENABLED=false`
- `DISCORD_MESSAGE_COALESCE_WINDOW_MS=8000`
- `DISCORD_MESSAGE_COALESCE_MAX_BATCH=5`

When disabled, existing debouncer behavior is preserved.

## Notes / receipts

This ports the Nyx production boot patch from `/tmp/nyx-patches-extract/patch-discord-message-coalesce.py` into source-level plugin-discord TypeScript, with plugin-scoped env names instead of Nyx-specific names.

## Validation

- `bun test __tests__/message-coalesce.test.ts`
- `bunx biome check .`
- `bun run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in Discord message coalescing mode (`DISCORD_MESSAGE_COALESCE_ENABLED`) that batches multiple inbound messages within a configurable time window (`windowMs`) and/or up to a max count (`maxBatch`) before presenting them as a single annotated message to the agent.

- **`message-coalesce.ts`** — new module with config parsing, the `[Discord message N/M ...]` formatter, and `appendCoalescedDiscordMetadata` for threading coalesced IDs into memory-event payloads.
- **`debouncer.ts`** — both `createChannelDebouncer` and `createMessageDebouncer` gain `maxBatch` support; when coalescing is enabled, targeted (bot-mention) messages no longer bypass the debounce window — they are batched like any other message.
- **`discord-events.ts`** — routes both debouncers through `makeCoalescedDiscordMessage` when enabled, replacing the old inline `Object.create` merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the feature is off by default and does not affect existing flows unless explicitly opted in.

All changes are gated behind DISCORD_MESSAGE_COALESCE_ENABLED=false by default. The new module is self-contained and existing debounce paths are preserved unchanged when the flag is off. The observations noted are non-blocking quality concerns that do not affect correctness in the default configuration.

The changed createChannelDebouncer logic in debouncer.ts — specifically the batch-limit flush and the targeted-message cooldown bypass when coalescing is on — has no corresponding test cases and is worth a second look before wider deployment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/message-coalesce.ts | New module providing the coalescing config parser, message formatter, and metadata utilities; `appendCoalescedDiscordMetadata` returns `any` (existing thread), and `windowMs`/`maxBatch` have asymmetric env-var read semantics when the feature is disabled. |
| plugins/plugin-discord/debouncer.ts | Adds `coalesceEnabled`/`maxBatch` options to both debouncers; targeted (bot-mention) messages no longer flush immediately when coalescing is enabled — they wait the full window — which silently changes the UX contract for direct mentions. |
| plugins/plugin-discord/discord-events.ts | Wires the coalesce config into both message and channel debouncers; replaces the old inline `Object.create` merge with `makeCoalescedDiscordMessage`; the `maxBatch` option is passed inconsistently (always set for channel debouncer, conditionally for message debouncer) but is harmless at runtime. |
| plugins/plugin-discord/messages.ts | Single change: wraps `extraMetadata` literal with `appendCoalescedDiscordMetadata`, threading coalesced-message IDs into the memory event payload when a batch is processed. |
| plugins/plugin-discord/__tests__/message-coalesce.test.ts | New test file covering `getDiscordMessageCoalesceConfig`, `makeCoalescedDiscordMessage`, and `createMessageDebouncer` batch/timer flush paths; the changed `createChannelDebouncer` coalescing path (batch-limit flush, cooldown bypass) is not covered. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Discord as Discord Gateway
    participant Listener as messageCreate listener
    participant CD as ChannelDebouncer / MessageDebouncer
    participant Coal as makeCoalescedDiscordMessage
    participant MM as MessageManager.handleMessage

    Discord->>Listener: message 1
    Listener->>CD: enqueue(msg1)
    CD-->>CD: start windowMs timer

    Discord->>Listener: message 2
    Listener->>CD: enqueue(msg2)
    CD-->>CD: reset timer

    alt maxBatch reached
        CD->>Coal: messages[0..maxBatch]
    else windowMs expires
        CD->>Coal: messages accumulated so far
    end

    Coal->>Coal: Object.create(anchor) with formatted content + __discordCoalescedMessageIds
    Coal-->>CD: combined DiscordMessage

    CD->>MM: handleMessage(combined)
    MM->>MM: appendCoalescedDiscordMetadata adds coalescedDiscordMessageIds to extraMetadata
```

<sub>Reviews (2): Last reviewed commit: ["feat(discord): add opt-in message coales..."](https://github.com/elizaos/eliza/commit/b6a0c0661f453822b1f753295d6ec3b93fa14f2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30970296)</sub>

<!-- /greptile_comment -->