### PR TITLE
feat(discord): add opt-in staleness check for slow-reasoning agents

### DIFF
--- a/plugins/plugin-discord/__tests__/staleness.test.ts
+++ b/plugins/plugin-discord/__tests__/staleness.test.ts
@@ -1,0 +1,103 @@
+import type { Content } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+	applyDiscordStalenessGuard,
+	getDiscordStalenessConfig,
+	recordDiscordChannelMessageSeen,
+} from "../staleness";
+
+function mockMessage(channelId = "channel-1") {
+	return {
+		id: "message-1",
+		channel: { id: channelId },
+	} as never;
+}
+
+describe("Discord staleness guard", () => {
+	it("is disabled by default and parses scoped settings", () => {
+		const settings = new Map<string, unknown>([
+			["DISCORD_STALENESS_BEHAVIOR", "skip"],
+			["DISCORD_STALENESS_THRESHOLD", "4"],
+		]);
+
+		expect(getDiscordStalenessConfig((key) => settings.get(key))).toEqual({
+			enabled: false,
+			behavior: "skip",
+			threshold: 4,
+		});
+
+		settings.set("DISCORD_STALENESS_ENABLED", "true");
+		expect(getDiscordStalenessConfig((key) => settings.get(key))).toEqual({
+			enabled: true,
+			behavior: "skip",
+			threshold: 4,
+		});
+	});
+
+	it("allows responses when the newer-message delta is within threshold", () => {
+		const owner = {};
+		const start = recordDiscordChannelMessageSeen(owner, "channel-1", "a");
+		recordDiscordChannelMessageSeen(owner, "channel-1", "b");
+		const content: Content = { text: "hello" };
+
+		expect(
+			applyDiscordStalenessGuard({
+				config: { enabled: true, behavior: "skip", threshold: 1 },
+				owner,
+				message: mockMessage(),
+				startSequence: start,
+				content,
+			}),
+		).toMatchObject({ shouldSend: true, stale: false });
+		expect(content.text).toBe("hello");
+	});
+
+	it("skips stale responses when configured to skip", () => {
+		const owner = {};
+		const start = recordDiscordChannelMessageSeen(owner, "channel-1", "a");
+		recordDiscordChannelMessageSeen(owner, "channel-1", "b");
+		recordDiscordChannelMessageSeen(owner, "channel-1", "c");
+		const content: Content = { text: "hello" };
+
+		expect(
+			applyDiscordStalenessGuard({
+				config: { enabled: true, behavior: "skip", threshold: 1 },
+				owner,
+				message: mockMessage(),
+				startSequence: start,
+				content,
+			}),
+		).toMatchObject({
+			shouldSend: false,
+			stale: true,
+			messagesSinceTurnStart: 2,
+		});
+	});
+
+	it("tags stale responses once when configured to tag", () => {
+		const owner = {};
+		const start = recordDiscordChannelMessageSeen(owner, "channel-1", "a");
+		recordDiscordChannelMessageSeen(owner, "channel-1", "b");
+		recordDiscordChannelMessageSeen(owner, "channel-1", "c");
+		const content: Content = { text: "hello" };
+
+		const first = applyDiscordStalenessGuard({
+			config: { enabled: true, behavior: "tag", threshold: 1 },
+			owner,
+			message: mockMessage(),
+			startSequence: start,
+			content,
+		});
+		const second = applyDiscordStalenessGuard({
+			config: { enabled: true, behavior: "tag", threshold: 1 },
+			owner,
+			message: mockMessage(),
+			startSequence: start,
+			content,
+		});
+
+		expect(first).toMatchObject({ shouldSend: true, stale: true });
+		expect(second).toMatchObject({ shouldSend: true, stale: true });
+		expect(content.text).toBe("(catching up:) hello");
+	});
+});

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -39,6 +39,7 @@ import {
 	handleAutocomplete as handleBuiltinAutocomplete,
 	handleSlashCommand as handleBuiltinSlashCommand,
 } from "./slash-commands";
+import { recordDiscordChannelMessageSeen } from "./staleness";
 import {
 	DiscordEventTypes,
 	type DiscordListenChannelPayload,
@@ -265,6 +266,14 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				"Ignoring message from bot or self",
 			);
 			return;
+		}
+
+		if (service.messageManager) {
+			recordDiscordChannelMessageSeen(
+				service.messageManager,
+				message.channel.id,
+				message.id,
+			);
 		}
 
 		if (listenCids.includes(message.channel.id) && message) {

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -38,6 +38,12 @@ import { buildDiscordWorldMetadata } from "./identity";
 import { formatInboundEnvelope } from "./inbound-envelope";
 import { stripReasoningTags } from "./reasoning-tags";
 import {
+	applyDiscordStalenessGuard,
+	type DiscordStalenessConfig,
+	getDiscordChannelMessageSequence,
+	getDiscordStalenessConfig,
+} from "./staleness";
+import {
 	createStatusReactionController,
 	type StatusReactionScope,
 	shouldShowStatusReaction,
@@ -123,6 +129,7 @@ export class MessageManager {
 	private statusReactionScope: StatusReactionScope;
 	private envelopeEnabled: boolean;
 	private draftStreamingEnabled: boolean;
+	private stalenessConfig: DiscordStalenessConfig;
 	private recentlyProcessedMessageIds = new Map<string, number>();
 	private static readonly PROCESSED_MESSAGE_TTL_MS = 2 * 60 * 1000;
 	/**
@@ -170,6 +177,9 @@ export class MessageManager {
 		) as string | undefined;
 		this.draftStreamingEnabled =
 			draftStreamSetting === "true" || draftStreamSetting === "1";
+		this.stalenessConfig = getDiscordStalenessConfig((key) =>
+			this.runtime.getSetting(key),
+		);
 	}
 
 	/**
@@ -643,6 +653,10 @@ export class MessageManager {
 			}
 
 			const messageId = newMessage.id;
+			const stalenessStartSequence = getDiscordChannelMessageSequence(
+				this,
+				message.channel.id,
+			);
 			const channel = message.channel as TextChannel;
 			const typingController = createTypingController(channel);
 			const clientUserId = this.client.user?.id;
@@ -748,6 +762,35 @@ export class MessageManager {
 						typeof content.target === "string" &&
 						content.target.toLowerCase() !== "discord"
 					) {
+						return [];
+					}
+
+					const stalenessDecision = applyDiscordStalenessGuard({
+						config: this.stalenessConfig,
+						owner: this,
+						message,
+						startSequence: stalenessStartSequence,
+						content,
+					});
+					if (stalenessDecision.stale) {
+						this.runtime.logger.warn(
+							{
+								src: "plugin:discord",
+								agentId: this.runtime.agentId,
+								channelId: message.channel.id,
+								messageId: message.id,
+								messagesSinceTurnStart:
+									stalenessDecision.messagesSinceTurnStart,
+								threshold: this.stalenessConfig.threshold,
+								behavior: stalenessDecision.behavior,
+							},
+							"Discord response completed after newer channel messages arrived",
+						);
+					}
+					if (!stalenessDecision.shouldSend) {
+						typingController.stop();
+						statusReactions?.setDone();
+						await finalizePendingDraft();
 						return [];
 					}
 

--- a/plugins/plugin-discord/staleness.ts
+++ b/plugins/plugin-discord/staleness.ts
@@ -1,0 +1,156 @@
+import type { Content } from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+
+export type DiscordStalenessBehavior = "tag" | "skip" | "ignore";
+
+export interface DiscordStalenessConfig {
+	enabled: boolean;
+	behavior: DiscordStalenessBehavior;
+	threshold: number;
+}
+
+const DEFAULT_THRESHOLD = 2;
+const channelSequences = new WeakMap<object, Map<string, number>>();
+const lastMessageIds = new WeakMap<object, Map<string, string | undefined>>();
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+	if (value === undefined || value === null) {
+		return fallback;
+	}
+	return String(value).trim().toLowerCase() === "true";
+}
+
+function parseNonNegativeInteger(value: unknown, fallback: number): number {
+	const parsed = Number.parseInt(String(value ?? ""), 10);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parseBehavior(value: unknown): DiscordStalenessBehavior {
+	const normalized = String(value ?? "tag")
+		.trim()
+		.toLowerCase();
+	return normalized === "skip" ||
+		normalized === "ignore" ||
+		normalized === "tag"
+		? normalized
+		: "tag";
+}
+
+function ensureSequenceMap(owner: object): Map<string, number> {
+	let map = channelSequences.get(owner);
+	if (!map) {
+		map = new Map<string, number>();
+		channelSequences.set(owner, map);
+	}
+	return map;
+}
+
+export function getDiscordStalenessConfig(
+	getSetting: (key: string) => unknown,
+): DiscordStalenessConfig {
+	return {
+		enabled: parseBoolean(getSetting("DISCORD_STALENESS_ENABLED"), false),
+		behavior: parseBehavior(getSetting("DISCORD_STALENESS_BEHAVIOR")),
+		threshold: parseNonNegativeInteger(
+			getSetting("DISCORD_STALENESS_THRESHOLD"),
+			DEFAULT_THRESHOLD,
+		),
+	};
+}
+
+export function recordDiscordChannelMessageSeen(
+	owner: object | undefined,
+	channelId: string | undefined,
+	messageId?: string,
+): number {
+	if (!owner || !channelId) {
+		return 0;
+	}
+	const sequences = ensureSequenceMap(owner);
+	const next = (sequences.get(channelId) ?? 0) + 1;
+	sequences.set(channelId, next);
+
+	let lastIds = lastMessageIds.get(owner);
+	if (!lastIds) {
+		lastIds = new Map<string, string | undefined>();
+		lastMessageIds.set(owner, lastIds);
+	}
+	lastIds.set(channelId, messageId);
+
+	return next;
+}
+
+export function getDiscordChannelMessageSequence(
+	owner: object | undefined,
+	channelId: string | undefined,
+): number {
+	if (!owner || !channelId) {
+		return 0;
+	}
+	return ensureSequenceMap(owner).get(channelId) ?? 0;
+}
+
+export interface DiscordStalenessDecision {
+	shouldSend: boolean;
+	stale: boolean;
+	messagesSinceTurnStart: number;
+	behavior: DiscordStalenessBehavior;
+}
+
+export function applyDiscordStalenessGuard(options: {
+	config: DiscordStalenessConfig;
+	owner: object | undefined;
+	message: DiscordMessage;
+	startSequence: number;
+	content: Content;
+}): DiscordStalenessDecision {
+	const { config, owner, message, startSequence, content } = options;
+	if (!config.enabled || config.behavior === "ignore") {
+		return {
+			shouldSend: true,
+			stale: false,
+			messagesSinceTurnStart: 0,
+			behavior: config.behavior,
+		};
+	}
+
+	const currentSequence = getDiscordChannelMessageSequence(
+		owner,
+		message.channel?.id,
+	);
+	const messagesSinceTurnStart = Math.max(0, currentSequence - startSequence);
+	const stale = messagesSinceTurnStart > config.threshold;
+	if (!stale) {
+		return {
+			shouldSend: true,
+			stale: false,
+			messagesSinceTurnStart,
+			behavior: config.behavior,
+		};
+	}
+
+	if (config.behavior === "skip") {
+		return {
+			shouldSend: false,
+			stale: true,
+			messagesSinceTurnStart,
+			behavior: config.behavior,
+		};
+	}
+
+	if (
+		config.behavior === "tag" &&
+		typeof content.text === "string" &&
+		content.text.trim().length > 0 &&
+		!/^(\s*\(catching up:\))/i.test(content.text)
+	) {
+		content.text = `(catching up:) ${content.text}`;
+	}
+
+	return {
+		shouldSend: true,
+		stale: true,
+		messagesSinceTurnStart,
+		behavior: config.behavior,
+	};
+}


### PR DESCRIPTION
## Summary

Adds an opt-in post-completion staleness guard for Discord responses. The guard tracks inbound message sequence numbers per channel and compares the channel sequence when a response callback fires against the sequence captured when the agent started handling the turn.

This helps slow-reasoning agents avoid replying into stale context after a busy channel has moved on.

## Configuration

All defaults are conservative and the feature is off unless explicitly enabled:

- `DISCORD_STALENESS_ENABLED=false`
- `DISCORD_STALENESS_BEHAVIOR=tag`
  - `tag`: send the response with a `(catching up:)` prefix when stale
  - `skip`: suppress stale responses
  - `ignore`: leave responses unchanged even if tracking is enabled
- `DISCORD_STALENESS_THRESHOLD=2`

A response is considered stale only when more than the threshold number of newer channel messages arrived since reasoning started.

## Notes / receipts

This ports the Nyx production boot patch from `/tmp/nyx-patches-extract/patch-discord-staleness-check.py` into source-level plugin-discord TypeScript, with plugin-scoped env names instead of Nyx-specific names.

## Validation

- `bun test __tests__/staleness.test.ts`
- `bunx biome check .`
- `bun run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an opt-in post-completion staleness guard for the Discord plugin that tracks per-channel message sequence numbers and suppresses or tags agent responses when the channel has moved on significantly during slow reasoning. The feature is disabled by default and controlled entirely via three `DISCORD_STALENESS_*` env vars.

- **`staleness.ts`** (new): WeakMap-based sequence tracker and `applyDiscordStalenessGuard` function with `skip`, `tag`, and `ignore` behaviours; config parsing helpers.
- **`discord-events.ts`**: Records every inbound (non-self, non-ignored-bot) message into the sequence counter inside the `messageCreate` handler.
- **`messages.ts`**: Captures `stalenessStartSequence` before callback setup and evaluates the guard on each `HandlerCallback` invocation, logging a warning and short-circuiting when stale with `behavior=skip`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that multi-chunk agent responses can produce partial messages in busy channels when behavior=skip.

The staleness guard is evaluated per callback invocation but uses a single stalenessStartSequence captured at turn start. When a slow-reasoning agent fires its callback more than once and the channel crosses the staleness threshold between invocations, the first chunk is already sent and cannot be retracted while subsequent chunks are suppressed, leaving a truncated message visible to users. Everything else — config parsing, WeakMap scoping, tag idempotency, and finalize("") silent termination of draft streams — is correct.

plugins/plugin-discord/messages.ts — the callback-level staleness evaluation interacts with multi-chunk responses in a way that can produce truncated output.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/staleness.ts | New module implementing the staleness guard: module-level WeakMaps keyed by owner object, config parsing, sequence tracking, and the guard function. Core logic is correct. |
| plugins/plugin-discord/messages.ts | Integrates staleness guard into the callback pipeline. The guard runs per-callback invocation using a shared stalenessStartSequence, which can produce partial responses for multi-chunk agents when behavior=skip and the channel becomes busy mid-response. |
| plugins/plugin-discord/discord-events.ts | Adds recordDiscordChannelMessageSeen call in the messageCreate handler, correctly placed after the self/bot early-return guard. Messages during startup before the manager initialises are silently missed. |
| plugins/plugin-discord/__tests__/staleness.test.ts | Unit tests cover config parsing, within-threshold pass-through, skip suppression, and tag idempotency. Each test uses an independent owner object so module-level WeakMap state does not leak between tests. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Discord
    participant discord-events.ts
    participant staleness.ts
    participant messages.ts

    Discord->>discord-events.ts: messageCreate (user msg)
    discord-events.ts->>staleness.ts: recordDiscordChannelMessageSeen(owner, channelId, msgId)
    Note over staleness.ts: channelSequences[owner][channelId]++

    discord-events.ts->>messages.ts: handleMessage(message)
    messages.ts->>staleness.ts: getDiscordChannelMessageSequence(this, channelId)
    Note over messages.ts: stalenessStartSequence = N

    Discord->>discord-events.ts: messageCreate (more msgs arrive)
    discord-events.ts->>staleness.ts: recordDiscordChannelMessageSeen(...)
    Note over staleness.ts: sequence advances to N+k

    messages.ts->>messages.ts: LLM generates response
    messages.ts->>staleness.ts: applyDiscordStalenessGuard({startSequence: N, ...})
    Note over staleness.ts: delta = (N+k) - N = k
    alt k <= threshold
        staleness.ts-->>messages.ts: {shouldSend:true, stale:false}
        messages.ts->>Discord: send response
    else k > threshold AND behavior=tag
        staleness.ts-->>messages.ts: {shouldSend:true, stale:true, content prefixed}
        messages.ts->>Discord: send "(catching up:) response"
    else k > threshold AND behavior=skip
        staleness.ts-->>messages.ts: {shouldSend:false, stale:true}
        messages.ts->>messages.ts: suppress response
    end
```

<sub>Reviews (2): Last reviewed commit: ["feat(discord): add opt-in staleness guar..."](https://github.com/elizaos/eliza/commit/6069e2b3e3cc08b2be6ca8703a51b8845615cc73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30970298)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->