### PR TITLE
fix(chat): dedupe visible reply actions

### DIFF
--- a/packages/agent/src/api/chat-routes-usage.test.ts
+++ b/packages/agent/src/api/chat-routes-usage.test.ts
@@ -1,0 +1,150 @@
+import {
+  type AgentRuntime,
+  ChannelType,
+  createMessageMemory,
+  EventType,
+  ModelType,
+  stringToUuid,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { estimateTokenCount } from "../runtime/prompt-optimization.js";
+import { generateChatResponse } from "./chat-routes.js";
+
+type RuntimeOverrides = Partial<AgentRuntime> & {
+  messageService?: NonNullable<AgentRuntime["messageService"]>;
+};
+
+function createRuntime(overrides: RuntimeOverrides = {}): AgentRuntime {
+  const runtime = {
+    agentId: stringToUuid("chat-agent"),
+    character: {
+      name: "Chat Agent",
+      system: "System prompt",
+      settings: {
+        model: "test/chat-model",
+      },
+    },
+    actions: [],
+    plugins: [],
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    emitEvent: vi.fn(async () => undefined),
+    getService: vi.fn(() => null),
+    getServicesByType: vi.fn(() => []),
+    ...overrides,
+  } satisfies Partial<AgentRuntime>;
+
+  return runtime as AgentRuntime;
+}
+
+function createChatMessage(text: string) {
+  return createMessageMemory({
+    id: stringToUuid(`message-${text}`),
+    roomId: stringToUuid("room"),
+    entityId: stringToUuid("user"),
+    content: {
+      text,
+      channelType: ChannelType.DM,
+    },
+  });
+}
+
+describe("generateChatResponse usage reporting", () => {
+  it("returns actual provider usage when a provider event is emitted", async () => {
+    let runtime: AgentRuntime;
+    runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async () => {
+          await runtime.emitEvent(EventType.MODEL_USED, {
+            runtime,
+            source: "test-provider",
+            provider: "test-provider",
+            type: ModelType.TEXT_LARGE,
+            tokens: {
+              prompt: 42,
+              completion: 11,
+              total: 53,
+            },
+          });
+          return {
+            didRespond: true,
+            responseContent: { text: "provider reply" },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result.usage).toMatchObject({
+      promptTokens: 42,
+      completionTokens: 11,
+      totalTokens: 53,
+      provider: "test-provider",
+      isEstimated: false,
+      llmCalls: 1,
+    });
+  });
+
+  it("marks route token counts as estimates when no provider event is emitted", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async () => ({
+          didRespond: true,
+          responseContent: { text: "estimated reply" },
+          responseMessages: [],
+        })),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+    const message = createChatMessage("count this prompt");
+
+    const result = await generateChatResponse(runtime, message, "Chat Agent", {
+      timeoutDuration: 5_000,
+    });
+
+    expect(result.usage).toMatchObject({
+      promptTokens: estimateTokenCount("count this prompt"),
+      completionTokens: estimateTokenCount("estimated reply"),
+      isEstimated: true,
+      llmCalls: 0,
+    });
+  });
+
+  it("marks visible action callbacks even when handlers only set actions", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({ text: "callback reply", actions: ["REPLY"] });
+          return {
+            didRespond: true,
+            responseContent: { actions: ["REPLY"], text: "callback reply" },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result).toMatchObject({
+      text: "callback reply",
+      usedActionCallbacks: true,
+      actionCallbackHistory: ["callback reply"],
+    });
+  });
+});

--- a/packages/agent/src/api/chat-routes-usage.test.ts
+++ b/packages/agent/src/api/chat-routes-usage.test.ts
@@ -147,4 +147,32 @@ describe("generateChatResponse usage reporting", () => {
       actionCallbackHistory: ["callback reply"],
     });
   });
+
+  it("counts action-only callbacks without adding visible callback history", async () => {
+    const runtime = createRuntime({
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback?.({ actions: ["SEARCHING"] });
+          return {
+            didRespond: true,
+            responseContent: { text: "final reply" },
+            responseMessages: [],
+          };
+        }),
+      } as NonNullable<AgentRuntime["messageService"]>,
+    });
+
+    const result = await generateChatResponse(
+      runtime,
+      createChatMessage("hello"),
+      "Chat Agent",
+      { timeoutDuration: 5_000 },
+    );
+
+    expect(result).toMatchObject({
+      text: "final reply",
+      usedActionCallbacks: true,
+    });
+    expect(result.actionCallbackHistory).toBeUndefined();
+  });
 });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1438,9 +1438,10 @@ export async function generateChatResponse(
                 }
 
                 const chunk = extractCompatTextContent(content);
-                if (chunk) {
-                  recordActionCallback(extractCallbackActionTag(content), true);
-                }
+                recordActionCallback(
+                  extractCallbackActionTag(content),
+                  Boolean(chunk),
+                );
                 if (!chunk) return [];
                 if (!claimStreamSource("callback")) return [];
                 applyCallbackTextUpdate(content, chunk);

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -1284,15 +1284,32 @@ export async function generateChatResponse(
       hasText: boolean,
     ): void => {
       actionCallbacksSeen += 1;
-      seenActionTags.add(actionTag.toUpperCase());
+      const normalizedActionTag = normalizeActionName(actionTag);
+      if (normalizedActionTag) {
+        seenActionTags.add(normalizedActionTag);
+      }
       runtime.logger?.info(
         {
           src: "eliza-api",
-          action: actionTag,
+          action: normalizedActionTag || actionTag,
           hasText,
         },
-        `[eliza-api] Action callback fired: ${actionTag}`,
+        `[eliza-api] Action callback fired: ${normalizedActionTag || actionTag}`,
       );
+    };
+    const extractCallbackActionTag = (content: Content): string => {
+      const record = content as Record<string, unknown>;
+      if (typeof record.action === "string" && record.action.length > 0) {
+        return record.action;
+      }
+      if (Array.isArray(record.actions)) {
+        const firstAction = record.actions.find(
+          (action): action is string =>
+            typeof action === "string" && action.trim().length > 0,
+        );
+        if (firstAction) return firstAction;
+      }
+      return "VISIBLE_CALLBACK";
     };
 
     const generationCapture = await withModelUsageCapture(runtime, () =>
@@ -1420,15 +1437,10 @@ export async function generateChatResponse(
                   throw createChatGenerationTimeoutError(generationTimeoutMs);
                 }
 
-                const actionTag = (content as Record<string, unknown>)?.action;
-                if (typeof actionTag === "string" && actionTag.length > 0) {
-                  recordActionCallback(
-                    actionTag,
-                    Boolean(extractCompatTextContent(content)),
-                  );
-                }
-
                 const chunk = extractCompatTextContent(content);
+                if (chunk) {
+                  recordActionCallback(extractCallbackActionTag(content), true);
+                }
                 if (!chunk) return [];
                 if (!claimStreamSource("callback")) return [];
                 applyCallbackTextUpdate(content, chunk);

--- a/packages/core/src/__tests__/message-action-dedupe.test.ts
+++ b/packages/core/src/__tests__/message-action-dedupe.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { stripReplyWhenActionOwnsTurn } from "../services/message.ts";
+import type { IAgentRuntime } from "../types/runtime";
+
+function runtime(
+	actions: Array<{ name: string; similes?: string[] }> = [],
+): Pick<IAgentRuntime, "actions" | "logger"> {
+	return {
+		actions,
+		logger: {
+			info: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	} as unknown as Pick<IAgentRuntime, "actions" | "logger">;
+}
+
+describe("stripReplyWhenActionOwnsTurn", () => {
+	it("collapses duplicate REPLY planner actions before execution", () => {
+		expect(stripReplyWhenActionOwnsTurn(runtime(), ["REPLY", "REPLY"])).toEqual(
+			["REPLY"],
+		);
+	});
+
+	it("dedupes aliases against the registered canonical action name", () => {
+		expect(
+			stripReplyWhenActionOwnsTurn(
+				runtime([{ name: "REPLY", similes: ["RESPOND"] }]),
+				["RESPOND", "REPLY"],
+			),
+		).toEqual(["RESPOND"]);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2504,19 +2504,51 @@ export function stripReplyWhenActionOwnsTurn(
 	runtime: Pick<IAgentRuntime, "actions" | "logger">,
 	actions: readonly string[] | null | undefined,
 ): string[] {
-	if (!actions || actions.length <= 1) {
-		return Array.isArray(actions) ? [...actions] : [];
-	}
-
-	const hasPassive = actions.some((action) =>
-		PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
-	);
-	if (!hasPassive) {
-		return [...actions];
+	if (!actions || actions.length === 0) {
+		return [];
 	}
 
 	const actionLookup = buildRuntimeActionLookup(runtime);
-	const ownedActions = actions.filter((action) => {
+	const dedupedActions: string[] = [];
+	const seenActionNames = new Set<string>();
+	for (const action of actions) {
+		const canonicalName =
+			resolveRuntimeAction(actionLookup, action)?.name ??
+			canonicalPlannerControlActionName(action) ??
+			action;
+		const normalizedName = normalizeActionIdentifier(canonicalName);
+		if (normalizedName && seenActionNames.has(normalizedName)) {
+			continue;
+		}
+		if (normalizedName) {
+			seenActionNames.add(normalizedName);
+		}
+		dedupedActions.push(action);
+	}
+
+	if (dedupedActions.length !== actions.length) {
+		runtime.logger.info(
+			{
+				src: "service:message",
+				originalActions: actions,
+				filteredActions: dedupedActions,
+			},
+			"Dropped duplicate planner actions before execution",
+		);
+	}
+
+	if (dedupedActions.length <= 1) {
+		return dedupedActions;
+	}
+
+	const hasPassive = dedupedActions.some((action) =>
+		PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
+	);
+	if (!hasPassive) {
+		return dedupedActions;
+	}
+
+	const ownedActions = dedupedActions.filter((action) => {
 		const normalized = normalizeActionIdentifier(action);
 		if (!normalized || PASSIVE_TURN_ACTIONS.has(normalized)) {
 			return false;
@@ -2527,16 +2559,16 @@ export function stripReplyWhenActionOwnsTurn(
 		);
 	});
 	if (ownedActions.length === 0) {
-		return [...actions];
+		return dedupedActions;
 	}
 
-	const filtered = actions.filter(
+	const filtered = dedupedActions.filter(
 		(action) => !PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
 	);
 	runtime.logger.info(
 		{
 			src: "service:message",
-			originalActions: actions,
+			originalActions: dedupedActions,
 			filteredActions: filtered,
 			suppressedBy: ownedActions,
 		},

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2507,6 +2507,9 @@ export function stripReplyWhenActionOwnsTurn(
 	if (!actions || actions.length === 0) {
 		return [];
 	}
+	if (actions.length <= 1) {
+		return [...actions];
+	}
 
 	const actionLookup = buildRuntimeActionLookup(runtime);
 	const dedupedActions: string[] = [];


### PR DESCRIPTION
## Summary
- dedupe repeated planner actions by canonical runtime action name before action execution
- mark visible chat action callbacks as callback-driven even when handlers only provide `actions: ["REPLY"]`
- add focused core and agent tests for duplicate REPLY handling and callback accounting

## Why
Codex-backed chat can emit planner actions like `actions=["REPLY","REPLY"]`. The live remote backend showed two visible assistant rows for one user message. The backend should make visible reply persistence idempotent per turn instead of relying on prompts or client-side filtering.

## Validation
- `bunx --bun @biomejs/biome@2.4.14 check --write packages/core/src/services/message.ts packages/core/src/__tests__/message-action-dedupe.test.ts packages/agent/src/api/chat-routes.ts packages/agent/src/api/chat-routes-usage.test.ts`
- `bunx --bun @biomejs/biome@2.4.14 check packages/core/src/services/message.ts packages/core/src/__tests__/message-action-dedupe.test.ts packages/agent/src/api/chat-routes.ts packages/agent/src/api/chat-routes-usage.test.ts`
- `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts packages/core/src/__tests__/message-action-dedupe.test.ts`
- `./node_modules/.bin/vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/chat-routes-usage.test.ts`
- live VPS smoke test: loopback pair-code OK, public pair-code 403, spoofed X-Forwarded-For pair-code 403, pairing token exchange OK, one API chat turn produced exactly one assistant row