### PR TITLE
fix(core): scale attachment answer budget

### DIFF
--- a/packages/core/src/__tests__/read-attachment-action.test.ts
+++ b/packages/core/src/__tests__/read-attachment-action.test.ts
@@ -208,6 +208,28 @@ describe("READ_ATTACHMENT", () => {
 		expect(runtime.useModel).not.toHaveBeenCalled();
 	});
 
+	it("sizes answer token budget from attachment content length", async () => {
+		const longContent = "alpha beta gamma delta ".repeat(600);
+		const { result, runtime } = await runReadAttachment({
+			responder: "summary",
+			request: "summarize this document",
+			attachments: [
+				attachment({
+					text: longContent,
+					source: "Plaintext",
+				}),
+			],
+		});
+
+		expect(result?.text).toBe("summary");
+		expect(runtime.useModel).toHaveBeenCalledWith(
+			ModelType.TEXT_SMALL,
+			expect.objectContaining({
+				maxTokens: Math.ceil(longContent.length / 4),
+			}),
+		);
+	});
+
 	it("answers image requests from generated image descriptions", async () => {
 		const imageAttachment = attachment({
 			id: "image-1",

--- a/packages/core/src/__tests__/read-attachment-action.test.ts
+++ b/packages/core/src/__tests__/read-attachment-action.test.ts
@@ -222,10 +222,14 @@ describe("READ_ATTACHMENT", () => {
 		});
 
 		expect(result?.text).toBe("summary");
+		const expectedTokens = Math.min(
+			Math.max(Math.ceil(longContent.length / 4), 1024),
+			4096,
+		);
 		expect(runtime.useModel).toHaveBeenCalledWith(
 			ModelType.TEXT_SMALL,
 			expect.objectContaining({
-				maxTokens: Math.ceil(longContent.length / 4),
+				maxTokens: expectedTokens,
 			}),
 		);
 	});

--- a/packages/core/src/features/advanced-capabilities/clipboard/actions/read-attachment.ts
+++ b/packages/core/src/features/advanced-capabilities/clipboard/actions/read-attachment.ts
@@ -17,6 +17,8 @@ import {
 import { maybeStoreTaskClipboardItem } from "../services/taskClipboardPersistence.ts";
 
 const MAX_ATTACHMENT_ANSWER_CHARS = 32_000;
+const MIN_ATTACHMENT_ANSWER_TOKENS = 1024;
+const MAX_ATTACHMENT_ANSWER_TOKENS = 4096;
 const ATTACHMENT_REQUEST_PATTERN =
 	/\b(?:attachment|file|document|doc|pdf|image|screenshot|picture|photo|audio|voice|recording|song|video|media|transcript|url|link|webpage|website|page|article)\b/i;
 type AttachmentRecord = Awaited<
@@ -34,6 +36,14 @@ function attachmentContentForAnswering(content: string): string {
 		return content;
 	}
 	return `${content.slice(0, MAX_ATTACHMENT_ANSWER_CHARS)}\n\n[Attachment content truncated before answering because it exceeded ${MAX_ATTACHMENT_ANSWER_CHARS} characters.]`;
+}
+
+function attachmentAnswerTokenBudget(content: string): number {
+	const estimatedTokens = Math.ceil(content.length / 4);
+	return Math.min(
+		Math.max(estimatedTokens, MIN_ATTACHMENT_ANSWER_TOKENS),
+		MAX_ATTACHMENT_ANSWER_TOKENS,
+	);
 }
 
 function missingReadableContentMessage(records: AttachmentRecord[]): string {
@@ -151,7 +161,7 @@ async function answerAttachmentRequest(params: {
 	const response = await params.runtime.useModel(ModelType.TEXT_SMALL, {
 		prompt,
 		temperature: 0,
-		maxTokens: 512,
+		maxTokens: attachmentAnswerTokenBudget(params.content),
 	});
 	const text = String(response).trim();
 	return text || params.content;


### PR DESCRIPTION
## Summary
- size READ_ATTACHMENT answer `maxTokens` from readable attachment content length
- keep the budget bounded between 1024 and 4096 tokens
- add a focused regression test for long attachment content

## Why
READ_ATTACHMENT was capped at 512 output tokens even when the action had enough readable document content to summarize. This could truncate useful answers for larger PDFs, documents, and extracted page content. The new budget remains bounded, but scales with the amount of available content.

## Validation
- `./node_modules/.bin/biome check --write packages/core/src/features/advanced-capabilities/clipboard/actions/read-attachment.ts packages/core/src/__tests__/read-attachment-action.test.ts`
- `./node_modules/.bin/biome check packages/core/src/features/advanced-capabilities/clipboard/actions/read-attachment.ts packages/core/src/__tests__/read-attachment-action.test.ts`
- `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts packages/core/src/__tests__/read-attachment-action.test.ts`