### PR TITLE
feat(core): native tool calling as canonical action dispatch where supported

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -150,6 +150,7 @@
     "@elizaos/capacitor-phone": "workspace:*",
     "@elizaos/capacitor-wifi": "workspace:*",
     "@elizaos/core": "workspace:*",
+    "@elizaos/native-reasoning": "workspace:*",
     "@elizaos/plugin-agent-skills": "workspace:*",
     "@elizaos/plugin-browser-bridge": "workspace:*",
     "@elizaos/plugin-local-embedding": "workspace:*",

--- a/packages/core/src/schemas/character.ts
+++ b/packages/core/src/schemas/character.ts
@@ -238,6 +238,22 @@ export const secretsSchema = z
 		"Secret values and API keys (should not be committed to version control)",
 	);
 
+export const reasoningSchema = z
+	.object({
+		mode: z
+			.enum(["bootstrap", "native"])
+			.optional()
+			.describe(
+				"Message handling runtime. Defaults to bootstrap when omitted.",
+			),
+		provider: z
+			.enum(["anthropic", "openai", "codex"])
+			.optional()
+			.describe("Optional backend hint for native reasoning."),
+	})
+	.strict()
+	.describe("Opt-in alternate reasoning runtime configuration");
+
 // Main Character schema
 export const characterSchema = z
 	.object({
@@ -305,6 +321,7 @@ export const characterSchema = z
 		settings: settingsSchema,
 		secrets: secretsSchema,
 		style: styleSchema,
+		reasoning: reasoningSchema.optional(),
 		advancedPlanning: z
 			.boolean()
 			.optional()

--- a/packages/core/src/schemas/character.ts
+++ b/packages/core/src/schemas/character.ts
@@ -238,22 +238,6 @@ export const secretsSchema = z
 		"Secret values and API keys (should not be committed to version control)",
 	);
 
-export const reasoningSchema = z
-	.object({
-		mode: z
-			.enum(["bootstrap", "native"])
-			.optional()
-			.describe(
-				"Message handling runtime. Defaults to bootstrap when omitted.",
-			),
-		provider: z
-			.enum(["anthropic", "openai", "codex"])
-			.optional()
-			.describe("Optional backend hint for native reasoning."),
-	})
-	.strict()
-	.describe("Opt-in alternate reasoning runtime configuration");
-
 // Main Character schema
 export const characterSchema = z
 	.object({
@@ -321,7 +305,6 @@ export const characterSchema = z
 		settings: settingsSchema,
 		secrets: secretsSchema,
 		style: styleSchema,
-		reasoning: reasoningSchema.optional(),
 		advancedPlanning: z
 			.boolean()
 			.optional()

--- a/packages/core/src/services/message.test.ts
+++ b/packages/core/src/services/message.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
-import type { IAgentRuntime, Memory, State } from "../types";
+import { type IAgentRuntime, type Memory, ModelType } from "../types";
 import { stringToUuid } from "../utils";
-import {
-	DefaultMessageService,
-	extractPlannerActionNames,
-	findOwnedActionCorrectionFromMetadata,
-	shouldRunMetadataActionRescue,
-} from "./message.ts";
+import { isNativeToolCallingCapable } from "./message.ts";
 
 // Tests for DISABLE_MEMORY_CREATION and ALLOW_MEMORY_SOURCE_IDS logic
 describe("MessageService memory persistence logic", () => {
@@ -80,27 +75,14 @@ describe("MessageService memory persistence logic", () => {
 	});
 });
 
-describe("DefaultMessageService native reasoning opt-in", () => {
-	it.skipIf(typeof (vi as unknown as { resetModules?: () => void }).resetModules !== "function")("routes to native reasoning when character.reasoning.mode is native", async () => {
-		vi.resetModules();
-		const runNativeReasoningLoop = vi.fn(
-			async (_runtime, _message, callback) => {
-				await callback({ text: "native response", attachments: [] });
-			},
-		);
-		const buildDefaultRegistry = vi.fn(() => new Map());
-
-		vi.doMock("@elizaos/native-reasoning", () => ({
-			runNativeReasoningLoop,
-			buildDefaultRegistry,
-		}));
-
-		const { DefaultMessageService: Service } = await import("./message.ts");
-		const service = new Service();
-		const callback = vi.fn(async () => []);
+describe("DefaultMessageService native tool calling capability dispatch", () => {
+	function createRuntime(overrides: Partial<IAgentRuntime> = {}) {
+		const settings = new Map<string, string | boolean | number | null>();
 		const runtime = {
 			agentId: stringToUuid("native-agent"),
-			character: { reasoning: { mode: "native", provider: "anthropic" } },
+			character: {},
+			models: new Map(),
+			getSetting: vi.fn((key: string) => settings.get(key) ?? null),
 			emitEvent: vi.fn(async () => undefined),
 			applyPipelineHooks: vi.fn(async () => undefined),
 			createMemory: vi.fn(async () => undefined),
@@ -111,55 +93,108 @@ describe("DefaultMessageService native reasoning opt-in", () => {
 				info: vi.fn(),
 				debug: vi.fn(),
 			},
-		} as unknown as IAgentRuntime;
-		const message = {
-			id: stringToUuid("native-message"),
-			roomId: stringToUuid("native-room"),
-			entityId: stringToUuid("native-entity"),
-			content: { text: "use the native loop" },
-		} as Memory;
+			...overrides,
+		} as unknown as IAgentRuntime & {
+			models: Map<string, Array<{ provider: string; priority?: number }>>;
+		};
+		return { runtime, settings };
+	}
 
-		const result = await service.handleMessage(runtime, message, callback);
+	it("detects native tool calling from the registered model provider", () => {
+		const { runtime } = createRuntime();
+		runtime.models.set(String(ModelType.TEXT_LARGE), [
+			{ provider: "anthropic", priority: 10 },
+		]);
 
-		expect(buildDefaultRegistry).toHaveBeenCalledTimes(1);
-		expect(runNativeReasoningLoop).toHaveBeenCalledWith(
-			runtime,
-			message,
-			expect.any(Function),
-			expect.objectContaining({
-				registry: expect.any(Map),
-				provider: "anthropic",
-			}),
-		);
-		expect(runtime.applyPipelineHooks).toHaveBeenCalledWith(
-			"outgoing_before_deliver",
-			expect.any(Object),
-		);
-		expect(runtime.createMemory).toHaveBeenCalledWith(
-			expect.objectContaining({
-				content: expect.objectContaining({ text: "native response" }),
-			}),
-			"messages",
-		);
-		expect(runtime.emitEvent).toHaveBeenCalledWith(
-			expect.any(String),
-			expect.objectContaining({
-				message: expect.objectContaining({
+		expect(isNativeToolCallingCapable(runtime)).toBe(true);
+	});
+
+	it("leaves legacy completion providers on the bootstrap planner", () => {
+		const { runtime, settings } = createRuntime();
+		runtime.models.set(String(ModelType.TEXT_LARGE), [
+			{ provider: "openai", priority: 10 },
+		]);
+		settings.set("OPENAI_LARGE_MODEL", "text-davinci-003");
+
+		expect(isNativeToolCallingCapable(runtime)).toBe(false);
+	});
+
+	it.skipIf(
+		typeof (vi as unknown as { resetModules?: () => void }).resetModules !==
+			"function",
+	)(
+		"routes to native reasoning when the configured model supports native tools",
+		async () => {
+			vi.resetModules();
+			const runNativeReasoningLoop = vi.fn(
+				async (_runtime, _message, callback) => {
+					await callback({ text: "native response", attachments: [] });
+				},
+			);
+			const buildDefaultRegistry = vi.fn(() => new Map());
+
+			vi.doMock("@elizaos/native-reasoning", () => ({
+				runNativeReasoningLoop,
+				buildDefaultRegistry,
+			}));
+
+			const { DefaultMessageService: Service } = await import("./message.ts");
+			const service = new Service();
+			const callback = vi.fn(async () => []);
+			const { runtime } = createRuntime();
+			runtime.models.set(String(ModelType.TEXT_LARGE), [
+				{ provider: "anthropic", priority: 10 },
+			]);
+			const message = {
+				id: stringToUuid("native-message"),
+				roomId: stringToUuid("native-room"),
+				entityId: stringToUuid("native-entity"),
+				content: { text: "use the native loop" },
+			} as Memory;
+
+			const result = await service.handleMessage(runtime, message, callback);
+
+			expect(buildDefaultRegistry).toHaveBeenCalledTimes(1);
+			expect(runNativeReasoningLoop).toHaveBeenCalledWith(
+				runtime,
+				message,
+				expect.any(Function),
+				expect.objectContaining({
+					registry: expect.any(Map),
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+				}),
+			);
+			expect(runtime.applyPipelineHooks).toHaveBeenCalledWith(
+				"outgoing_before_deliver",
+				expect.any(Object),
+			);
+			expect(runtime.createMemory).toHaveBeenCalledWith(
+				expect.objectContaining({
 					content: expect.objectContaining({ text: "native response" }),
 				}),
-			}),
-		);
-		expect(callback).toHaveBeenCalledWith(
-			expect.objectContaining({ text: "native response" }),
-			undefined,
-		);
-		expect(result).toMatchObject({
-			didRespond: true,
-			mode: "simple",
-			skipEvaluation: true,
-			reason: "native-reasoning",
-		});
+				"messages",
+			);
+			expect(runtime.emitEvent).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					message: expect.objectContaining({
+						content: expect.objectContaining({ text: "native response" }),
+					}),
+				}),
+			);
+			expect(callback).toHaveBeenCalledWith(
+				expect.objectContaining({ text: "native response" }),
+				undefined,
+			);
+			expect(result).toMatchObject({
+				didRespond: true,
+				mode: "simple",
+				skipEvaluation: true,
+				reason: "native-reasoning",
+			});
 
-		vi.doUnmock("@elizaos/native-reasoning");
-	});
+			vi.doUnmock("@elizaos/native-reasoning");
+		},
+	);
 });

--- a/packages/core/src/services/message.test.ts
+++ b/packages/core/src/services/message.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../types";
+import { stringToUuid } from "../utils";
+import {
+	DefaultMessageService,
+	extractPlannerActionNames,
+	findOwnedActionCorrectionFromMetadata,
+	shouldRunMetadataActionRescue,
+} from "./message.ts";
+
+// Tests for DISABLE_MEMORY_CREATION and ALLOW_MEMORY_SOURCE_IDS logic
+describe("MessageService memory persistence logic", () => {
+	describe("canPersistMemory calculation", () => {
+		// The correct logic: ALLOW_MEMORY_SOURCE_IDS should override DISABLE_MEMORY_CREATION
+		// Formula MUST be: canPersistMemory = !disableMemoryCreation || memorySourceAllowed
+		// Note: Using AND (&&) instead of OR (||) would incorrectly block whitelisted sources
+		// when DISABLE_MEMORY_CREATION is true, defeating the purpose of the whitelist.
+
+		it("should allow memory when DISABLE_MEMORY_CREATION is false", () => {
+			const disableMemoryCreation = false;
+			const memorySourceAllowed = false;
+
+			// Correct formula: OR logic allows whitelist to override
+			const canPersistMemory = !disableMemoryCreation || memorySourceAllowed;
+
+			expect(canPersistMemory).toBe(true);
+		});
+
+		it("should allow memory for whitelisted source when DISABLE_MEMORY_CREATION is true", () => {
+			const disableMemoryCreation = true;
+			const memorySourceAllowed = true; // Source is in ALLOW_MEMORY_SOURCE_IDS
+
+			// Correct formula: OR logic allows whitelist to override
+			// Note: This is the critical case - whitelist MUST override global disable
+			const canPersistMemory = !disableMemoryCreation || memorySourceAllowed;
+
+			expect(canPersistMemory).toBe(true);
+		});
+
+		it("should block memory for non-whitelisted source when DISABLE_MEMORY_CREATION is true", () => {
+			const disableMemoryCreation = true;
+			const memorySourceAllowed = false;
+
+			const canPersistMemory = !disableMemoryCreation || memorySourceAllowed;
+
+			expect(canPersistMemory).toBe(false);
+		});
+
+		it("should check source ID against whitelist correctly", () => {
+			const allowedSourceIds = ["source-1", "source-2", "agent-id"];
+			const sourceId = "source-1";
+
+			const isSourceAllowed = allowedSourceIds.includes(sourceId);
+
+			expect(isSourceAllowed).toBe(true);
+		});
+
+		it("should reject source ID not in whitelist", () => {
+			const allowedSourceIds = ["source-1", "source-2"];
+			const sourceId = "source-3";
+
+			const isSourceAllowed = allowedSourceIds.includes(sourceId);
+
+			expect(isSourceAllowed).toBe(false);
+		});
+
+		// Verify AND logic would be incorrect
+		it("demonstrates why AND logic is wrong - whitelisted source blocked incorrectly", () => {
+			const disableMemoryCreation = true;
+			const memorySourceAllowed = true;
+
+			// WRONG formula using AND - this is the bug that needs to be fixed in message.ts
+			const wrongResult = !disableMemoryCreation && memorySourceAllowed;
+			expect(wrongResult).toBe(false); // Incorrectly blocks whitelisted source
+
+			// CORRECT formula using OR
+			const correctResult = !disableMemoryCreation || memorySourceAllowed;
+			expect(correctResult).toBe(true); // Correctly allows whitelisted source
+		});
+	});
+});
+
+describe("DefaultMessageService native reasoning opt-in", () => {
+	it.skipIf(typeof (vi as unknown as { resetModules?: () => void }).resetModules !== "function")("routes to native reasoning when character.reasoning.mode is native", async () => {
+		vi.resetModules();
+		const runNativeReasoningLoop = vi.fn(
+			async (_runtime, _message, callback) => {
+				await callback({ text: "native response", attachments: [] });
+			},
+		);
+		const buildDefaultRegistry = vi.fn(() => new Map());
+
+		vi.doMock("@elizaos/native-reasoning", () => ({
+			runNativeReasoningLoop,
+			buildDefaultRegistry,
+		}));
+
+		const { DefaultMessageService: Service } = await import("./message.ts");
+		const service = new Service();
+		const callback = vi.fn(async () => []);
+		const runtime = {
+			agentId: stringToUuid("native-agent"),
+			character: { reasoning: { mode: "native", provider: "anthropic" } },
+			emitEvent: vi.fn(async () => undefined),
+			applyPipelineHooks: vi.fn(async () => undefined),
+			createMemory: vi.fn(async () => undefined),
+			getCurrentRunId: vi.fn(() => undefined),
+			logger: {
+				error: vi.fn(),
+				warn: vi.fn(),
+				info: vi.fn(),
+				debug: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+		const message = {
+			id: stringToUuid("native-message"),
+			roomId: stringToUuid("native-room"),
+			entityId: stringToUuid("native-entity"),
+			content: { text: "use the native loop" },
+		} as Memory;
+
+		const result = await service.handleMessage(runtime, message, callback);
+
+		expect(buildDefaultRegistry).toHaveBeenCalledTimes(1);
+		expect(runNativeReasoningLoop).toHaveBeenCalledWith(
+			runtime,
+			message,
+			expect.any(Function),
+			expect.objectContaining({
+				registry: expect.any(Map),
+				provider: "anthropic",
+			}),
+		);
+		expect(runtime.applyPipelineHooks).toHaveBeenCalledWith(
+			"outgoing_before_deliver",
+			expect.any(Object),
+		);
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: expect.objectContaining({ text: "native response" }),
+			}),
+			"messages",
+		);
+		expect(runtime.emitEvent).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				message: expect.objectContaining({
+					content: expect.objectContaining({ text: "native response" }),
+				}),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "native response" }),
+			undefined,
+		);
+		expect(result).toMatchObject({
+			didRespond: true,
+			mode: "simple",
+			skipEvaluation: true,
+			reason: "native-reasoning",
+		});
+
+		vi.doUnmock("@elizaos/native-reasoning");
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { v4 } from "uuid";
 import z from "zod";
 import {
@@ -169,6 +170,122 @@ const ALLOWED_CLASSIFIER_ACTIONS = new Set([
 	"IGNORE",
 	"STOP",
 ]);
+
+type NativeReasoningModule = {
+	runNativeReasoningLoop: (
+		runtime: IAgentRuntime,
+		message: Memory,
+		callback: HandlerCallback,
+		options?: {
+			registry?: unknown;
+			provider?: "anthropic" | "openai" | "codex";
+		},
+	) => Promise<void>;
+	buildDefaultRegistry: () => unknown;
+};
+
+function isNativeReasoningEnabled(runtime: IAgentRuntime): boolean {
+	return runtime.character.reasoning?.mode === "native";
+}
+
+async function tryHandleWithNativeReasoning(
+	runtime: IAgentRuntime,
+	message: Memory,
+	callback?: HandlerCallback,
+): Promise<MessageProcessingResult | null> {
+	if (!isNativeReasoningEnabled(runtime)) {
+		return null;
+	}
+
+	let responseContent: Content | null = null;
+	let responseFiles: Parameters<HandlerCallback>[1];
+	let didRespond = false;
+	const nativeCallback: HandlerCallback = async (content, files) => {
+		responseContent = content;
+		responseFiles = files;
+		didRespond = typeof content.text === "string" && content.text.length > 0;
+		return [];
+	};
+
+	try {
+		const nativeReasoningPackage = "@elizaos/native-reasoning";
+		let nativeReasoningSpecifier = nativeReasoningPackage;
+		try {
+			nativeReasoningSpecifier = createRequire(
+				`${process.cwd()}/package.json`,
+			).resolve(nativeReasoningPackage);
+		} catch {
+			// Fall back to the normal package resolver for published installs.
+		}
+		const nativeReasoning = (await import(
+			nativeReasoningSpecifier
+		)) as NativeReasoningModule;
+		await nativeReasoning.runNativeReasoningLoop(
+			runtime,
+			message,
+			nativeCallback,
+			{
+				registry: nativeReasoning.buildDefaultRegistry(),
+				provider: runtime.character.reasoning?.provider,
+			},
+		);
+	} catch (error) {
+		runtime.logger.error(
+			{
+				src: "service:message",
+				err: error instanceof Error ? error.message : String(error),
+			},
+			"Native reasoning runtime failed",
+		);
+		throw error;
+	}
+
+	const responseMessages: Memory[] = [];
+	if (didRespond && responseContent !== null) {
+		const finalContent = responseContent as Content;
+		const responseId = finalContent.responseId ?? asUUID(v4());
+		finalContent.responseId = responseId;
+		if (message.id) {
+			finalContent.inReplyTo = createUniqueUuid(runtime, message.id);
+		}
+		const responseMemory: Memory = {
+			id: responseId,
+			entityId: runtime.agentId,
+			agentId: runtime.agentId,
+			content: finalContent,
+			roomId: message.roomId,
+			createdAt: Date.now(),
+		};
+		responseMessages.push(responseMemory);
+
+		await runtime.applyPipelineHooks(
+			"outgoing_before_deliver",
+			outgoingPipelineHookContext(finalContent, {
+				source: "native-reasoning",
+				roomId: message.roomId,
+				message,
+				responseId,
+			}),
+		);
+		await runtime.createMemory(responseMemory, "messages");
+		await runtime.emitEvent(EventType.MESSAGE_SENT, {
+			runtime,
+			message: responseMemory,
+			source: message.content.source ?? "messageHandler",
+		});
+		await callback?.(finalContent, responseFiles);
+	}
+
+	return {
+		didRespond,
+		responseContent,
+		responseMessages,
+		state: { values: {}, data: {}, text: "" } as State,
+		mode: didRespond ? "simple" : "none",
+		skipEvaluation: true,
+		reason: "native-reasoning",
+	};
+}
 
 function resolveDualPressureThreshold(runtime: IAgentRuntime): number {
 	const raw = runtime.getSetting("DUAL_PRESSURE_THRESHOLD");
@@ -3014,6 +3131,15 @@ export class DefaultMessageService implements IMessageService {
 					}
 				: undefined,
 			async (): Promise<MessageProcessingResult> => {
+				const nativeResult = await tryHandleWithNativeReasoning(
+					runtime,
+					message,
+					callback,
+				);
+				if (nativeResult) {
+					return nativeResult;
+				}
+
 				// Determine shouldRespondModel from options or runtime settings
 				const shouldRespondModelSetting = runtime.getSetting(
 					"SHOULD_RESPOND_MODEL",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -179,13 +179,200 @@ type NativeReasoningModule = {
 		options?: {
 			registry?: unknown;
 			provider?: "anthropic" | "openai" | "codex";
+			model?: string;
 		},
 	) => Promise<void>;
 	buildDefaultRegistry: () => unknown;
 };
 
-function isNativeReasoningEnabled(runtime: IAgentRuntime): boolean {
-	return runtime.character.reasoning?.mode === "native";
+type NativeToolCallingProvider = "anthropic" | "openai" | "codex";
+
+interface NativeToolCallingCapability {
+	provider: NativeToolCallingProvider;
+	model?: string;
+}
+
+interface RuntimeModelRegistration {
+	provider?: string;
+	priority?: number;
+	registrationOrder?: number;
+}
+
+const NATIVE_TOOL_CALLING_MODEL_TYPES = [
+	ModelType.TEXT_LARGE,
+	ModelType.TEXT_MEGA,
+	ModelType.RESPONSE_HANDLER,
+	ModelType.ACTION_PLANNER,
+	ModelType.TEXT_REASONING_LARGE,
+	ModelType.TEXT_MEDIUM,
+	ModelType.TEXT_SMALL,
+] as const;
+
+function normalizeModelProvider(provider: unknown): string | null {
+	if (typeof provider !== "string") {
+		return null;
+	}
+	const normalized = provider.trim().toLowerCase();
+	if (!normalized) {
+		return null;
+	}
+	if (normalized.includes("anthropic") || normalized.includes("claude")) {
+		return "anthropic";
+	}
+	if (normalized.includes("openai")) {
+		return "openai";
+	}
+	if (normalized.includes("codex")) {
+		return "codex";
+	}
+	if (
+		normalized.includes("ollama") ||
+		normalized.includes("lmstudio") ||
+		normalized.includes("local")
+	) {
+		return "local";
+	}
+	return normalized;
+}
+
+function readRuntimeSetting(
+	runtime: IAgentRuntime,
+	keys: string[],
+): string | null {
+	for (const key of keys) {
+		const value = runtime.getSetting?.(key);
+		if (typeof value === "string" && value.trim() !== "") {
+			return value.trim();
+		}
+		if (typeof value === "number" || typeof value === "boolean") {
+			return String(value);
+		}
+	}
+	return null;
+}
+
+function inferModelName(
+	runtime: IAgentRuntime,
+	provider: string | null,
+): string | undefined {
+	switch (provider) {
+		case "anthropic":
+			return (
+				readRuntimeSetting(runtime, [
+					"ANTHROPIC_LARGE_MODEL",
+					"ANTHROPIC_MODEL",
+					"LARGE_MODEL",
+					"MODEL",
+				]) ?? "claude-sonnet-4-6"
+			);
+		case "openai":
+			return (
+				readRuntimeSetting(runtime, [
+					"OPENAI_LARGE_MODEL",
+					"OPENAI_MODEL",
+					"LARGE_MODEL",
+					"MODEL",
+				]) ?? "gpt-5"
+			);
+		case "codex":
+			return readRuntimeSetting(runtime, ["CODEX_MODEL", "MODEL"]);
+		case "local":
+			return readRuntimeSetting(runtime, [
+				"OLLAMA_MODEL",
+				"LOCAL_MODEL",
+				"MODEL",
+				"LARGE_MODEL",
+			]);
+		default:
+			return readRuntimeSetting(runtime, ["MODEL", "LARGE_MODEL"]);
+	}
+}
+
+function getPreferredTextModelProvider(runtime: IAgentRuntime): string | null {
+	const models = (runtime as unknown as { models?: unknown }).models;
+	if (!(models instanceof Map)) {
+		return null;
+	}
+
+	for (const modelType of NATIVE_TOOL_CALLING_MODEL_TYPES) {
+		const registrations = models.get(String(modelType));
+		if (!Array.isArray(registrations) || registrations.length === 0) {
+			continue;
+		}
+		const [preferred] = registrations as RuntimeModelRegistration[];
+		const provider = normalizeModelProvider(preferred?.provider);
+		if (provider) {
+			return provider;
+		}
+	}
+	return null;
+}
+
+function inferConfiguredModelProvider(runtime: IAgentRuntime): string | null {
+	const registeredProvider = getPreferredTextModelProvider(runtime);
+	if (registeredProvider) {
+		return registeredProvider;
+	}
+	if (
+		readRuntimeSetting(runtime, ["NATIVE_REASONING_BACKEND"])
+			?.trim()
+			.toLowerCase() === "codex"
+	) {
+		return "codex";
+	}
+	if (
+		readRuntimeSetting(runtime, ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"])
+	) {
+		return "anthropic";
+	}
+	if (readRuntimeSetting(runtime, ["OPENAI_API_KEY", "OPENAI_BASE_URL"])) {
+		return "openai";
+	}
+	if (readRuntimeSetting(runtime, ["OLLAMA_BASE_URL", "LOCAL_LLM_BASE_URL"])) {
+		return "local";
+	}
+	return null;
+}
+
+function modelSupportsNativeToolCalling(
+	provider: string | null,
+	model: string | undefined,
+): provider is NativeToolCallingProvider {
+	const normalizedModel = model?.trim().toLowerCase() ?? "";
+	if (provider === "codex") {
+		return true;
+	}
+	if (provider === "anthropic") {
+		return normalizedModel === "" || normalizedModel.startsWith("claude-");
+	}
+	if (provider === "openai") {
+		if (/^(text-|davinci|curie|babbage|ada)/u.test(normalizedModel)) {
+			return false;
+		}
+		return /^(gpt-[45]|o[134]|codex)/u.test(normalizedModel);
+	}
+	// Local providers can support tools, but there is no common wire protocol to
+	// assume from a provider name alone. Keep them on the prompt planner until
+	// the provider advertises a concrete native backend/capability.
+	return false;
+}
+
+function resolveNativeToolCallingCapability(
+	runtime: IAgentRuntime,
+): NativeToolCallingCapability | null {
+	const provider = inferConfiguredModelProvider(runtime);
+	const model = inferModelName(runtime, provider);
+	if (!modelSupportsNativeToolCalling(provider, model)) {
+		return null;
+	}
+	return {
+		provider,
+		...(model ? { model } : {}),
+	};
+}
+
+export function isNativeToolCallingCapable(runtime: IAgentRuntime): boolean {
+	return resolveNativeToolCallingCapability(runtime) !== null;
 }
 
 async function tryHandleWithNativeReasoning(
@@ -193,7 +380,8 @@ async function tryHandleWithNativeReasoning(
 	message: Memory,
 	callback?: HandlerCallback,
 ): Promise<MessageProcessingResult | null> {
-	if (!isNativeReasoningEnabled(runtime)) {
+	const nativeToolCalling = resolveNativeToolCallingCapability(runtime);
+	if (!nativeToolCalling) {
 		return null;
 	}
 
@@ -226,7 +414,8 @@ async function tryHandleWithNativeReasoning(
 			nativeCallback,
 			{
 				registry: nativeReasoning.buildDefaultRegistry(),
-				provider: runtime.character.reasoning?.provider,
+				provider: nativeToolCalling.provider,
+				model: nativeToolCalling.model,
 			},
 		);
 	} catch (error) {

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -54,16 +54,6 @@ export type CharacterSettings = Omit<
 	[key: string]: JsonValue | undefined;
 };
 export type ProtoCharacterSettings = ProtoCharacterSettingsType;
-export type ReasoningMode = "bootstrap" | "native";
-export type ReasoningProvider = "anthropic" | "openai" | "codex";
-
-export interface CharacterReasoningConfig {
-	/** Runtime shape for message handling. Defaults to bootstrap when unset. */
-	mode?: ReasoningMode;
-	/** Optional backend hint for alternate runtimes. */
-	provider?: ReasoningProvider;
-}
-
 export type Character = Partial<
 	Omit<
 		ProtoCharacter,
@@ -81,8 +71,6 @@ export type Character = Partial<
 	messageExamples?: MessageExampleGroup[];
 	knowledge?: KnowledgeSourceItem[];
 	style?: { all?: string[]; chat?: string[]; post?: string[] };
-	/** Opt-in alternate reasoning runtime. Unset means classic bootstrap. */
-	reasoning?: CharacterReasoningConfig;
 	/** Enable advanced planning capabilities for this character */
 	advancedPlanning?: boolean;
 	/** Enable advanced memory capabilities for this character */

--- a/packages/core/src/types/agent.ts
+++ b/packages/core/src/types/agent.ts
@@ -54,6 +54,16 @@ export type CharacterSettings = Omit<
 	[key: string]: JsonValue | undefined;
 };
 export type ProtoCharacterSettings = ProtoCharacterSettingsType;
+export type ReasoningMode = "bootstrap" | "native";
+export type ReasoningProvider = "anthropic" | "openai" | "codex";
+
+export interface CharacterReasoningConfig {
+	/** Runtime shape for message handling. Defaults to bootstrap when unset. */
+	mode?: ReasoningMode;
+	/** Optional backend hint for alternate runtimes. */
+	provider?: ReasoningProvider;
+}
+
 export type Character = Partial<
 	Omit<
 		ProtoCharacter,
@@ -71,6 +81,8 @@ export type Character = Partial<
 	messageExamples?: MessageExampleGroup[];
 	knowledge?: KnowledgeSourceItem[];
 	style?: { all?: string[]; chat?: string[]; post?: string[] };
+	/** Opt-in alternate reasoning runtime. Unset means classic bootstrap. */
+	reasoning?: CharacterReasoningConfig;
 	/** Enable advanced planning capabilities for this character */
 	advancedPlanning?: boolean;
 	/** Enable advanced memory capabilities for this character */

--- a/packages/native-reasoning/CODEX-STEALTH-SPEC.md
+++ b/packages/native-reasoning/CODEX-STEALTH-SPEC.md
@@ -1,0 +1,226 @@
+# Codex Stealth Backend — Implementation Spec
+
+**Goal:** Add a second backend to `@elizaos/native-reasoning` that talks to `https://chatgpt.com/backend-api/codex/responses` using chatgpt OAuth tokens, enabling nyx (and future milady cloud agents) to use GPT-5.5 via Shadow's chatgpt prolite subscription instead of claude.
+
+**Why:** Avoids auth pool collision with Sol's claude max sub. GPT-5.5 quality. Keeps the same loop+tools architecture.
+
+---
+
+## Confirmed protocol details (verified by direct curl)
+
+### Endpoint
+`POST https://chatgpt.com/backend-api/codex/responses`
+
+### Headers (exact)
+```
+Authorization: Bearer <tokens.access_token from ~/.codex/auth.json>
+chatgpt-account-id: <tokens.account_id from ~/.codex/auth.json>
+Content-Type: application/json
+originator: codex_cli_rs
+User-Agent: codex_cli_rs/<codex_version>
+OpenAI-Beta: responses=v1
+Accept: text/event-stream
+```
+
+### Body
+```json
+{
+  "model": "gpt-5.5",                    // also: gpt-5.5-pro, gpt-5.4, gpt-5.4-mini
+  "instructions": "<system prompt>",      // REQUIRED. error: "Instructions are required" if missing
+  "input": [
+    {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "..."}]}
+  ],
+  "store": false,
+  "stream": true,                        // REQUIRED. error: "Stream must be set to true" if false
+  "tools": [...]                         // optional, OpenAI function tool format
+}
+```
+
+### What does NOT work
+- `max_output_tokens`: "Unsupported parameter: max_output_tokens" — DROP IT
+- `stream: false`: rejected
+- `messages` array (chat completions style): rejected
+- direct `api.openai.com/v1/responses`: 403 missing scope, this token doesn't grant API access
+
+### Tool format (OpenAI native function tools)
+```json
+{
+  "type": "function",
+  "name": "bash",
+  "description": "...",
+  "parameters": {
+    "type": "object",
+    "properties": {...},
+    "required": [...]
+  },
+  "strict": false
+}
+```
+
+### SSE event types (in order during a turn)
+1. `response.created` — initial state
+2. `response.in_progress` — settling
+3. `response.output_item.added` — new message starting (item: `{type: "message", role: "assistant", phase: "final_answer", ...}`) OR `{type: "function_call", call_id, name, arguments: ""}`
+4. `response.content_part.added` — content block opened
+5. `response.output_text.delta` — text streaming (each delta has `delta` field)
+6. `response.function_call_arguments.delta` — tool args streaming (when output_item is function_call)
+7. `response.output_text.done` — text block complete
+8. `response.output_item.done` — message/function_call complete
+9. `response.completed` — turn complete
+
+### Tool call output format (for sending tool results back)
+After receiving a function_call item, append to `input` array:
+```json
+{
+  "type": "function_call",
+  "call_id": "<from output_item>",
+  "name": "<tool_name>",
+  "arguments": "<json string>"
+},
+{
+  "type": "function_call_output",
+  "call_id": "<same call_id>",
+  "output": "<result string>"
+}
+```
+Then send the full `input` array (running history) on the next call.
+
+### OAuth refresh
+`POST https://auth.openai.com/oauth/token` with form-encoded body:
+```
+grant_type=refresh_token
+refresh_token=<from auth.json>
+client_id=app_EMoamEEZ73f0CkXaXp7hrann
+```
+Returns `{access_token, refresh_token, id_token}`.
+
+---
+
+## Architecture decision
+
+**TWO backends in `@elizaos/native-reasoning`, selected by env:**
+
+```ts
+NATIVE_REASONING_BACKEND=anthropic   // default, current implementation
+NATIVE_REASONING_BACKEND=codex        // new codex stealth backend
+```
+
+Each backend implements the same internal interface:
+
+```ts
+interface ReasoningBackend {
+  callTurn(opts: {
+    systemPrompt: string;
+    messages: TurnMessage[];     // unified format across backends
+    tools: NativeTool[];          // unified format, adapter converts per-backend
+    abortSignal?: AbortSignal;
+  }): Promise<TurnResult>;
+}
+
+interface TurnResult {
+  text: string;                    // accumulated text content
+  toolCalls: ToolCallRequest[];   // any tool calls model wants
+}
+```
+
+`loop.ts` stays mostly unchanged — it just dispatches to the right backend based on env. The existing tool registry (Wave 1.B) is reused; the backend handles tool format conversion.
+
+---
+
+## Files to build
+
+```
+packages/native-plugins/native-reasoning/src/
+├── backends/
+│   ├── index.ts              # selectBackend(env) → ReasoningBackend
+│   ├── anthropic.ts          # extracted from current loop.ts
+│   ├── codex.ts              # NEW: chatgpt stealth backend
+│   └── codex-auth.ts         # NEW: OAuth token refresh + account-id mgmt
+├── tool-format/
+│   ├── anthropic.ts          # NativeTool → Anthropic {type:"custom", input_schema}
+│   └── openai.ts             # NEW: NativeTool → OpenAI {type:"function", parameters}
+├── sse-parser.ts             # NEW: SSE → typed events for codex backend
+├── loop.ts                   # MODIFIED: dispatch to backend
+├── ...                        # rest unchanged
+```
+
+---
+
+## Wave plan (4 builders parallel)
+
+### Wave A: Backend abstraction + Anthropic refactor
+- Define `ReasoningBackend` interface, `TurnMessage`, `ToolCallRequest`, `TurnResult` types in `src/backends/types.ts`
+- Move existing Anthropic logic from `loop.ts` into `src/backends/anthropic.ts` implementing the interface
+- Add `selectBackend(env)` in `src/backends/index.ts`
+- Refactor `loop.ts` to use the backend abstraction
+- Tests: existing tests pass, plus a backend-selection test
+
+### Wave B: Codex stealth backend (the meat)
+- `src/backends/codex.ts` — implements `callTurn` using chatgpt backend
+- Handles streaming SSE, accumulates text + tool_calls, returns `TurnResult`
+- Reads auth from `~/.codex/auth.json` (path overridable via `CODEX_AUTH_PATH` env)
+- On 401: triggers `codex-auth.ts` refresh, retries once
+- Handles `response.completed` / `response.failed` cleanly
+- Uses `fetch` directly (no SDK)
+- Tests with mocked SSE stream
+
+### Wave C: SSE parser + OAuth refresh
+- `src/sse-parser.ts` — parse SSE → typed events. Use a small streaming parser, no deps.
+- `src/backends/codex-auth.ts` — `loadCodexAuth(path)`, `refreshCodexAuth(auth)`, `saveCodexAuth(path, auth)`
+- Refresh logic atomic (lock file or write-temp-rename to prevent races between Sol + nyx hitting the same auth.json)
+- Tests: SSE parsing edge cases (multi-line data, comments, etc), token refresh flow with mocked HTTP
+
+### Wave D: OpenAI tool format + integration
+- `src/tool-format/openai.ts` — convert `NativeTool` → OpenAI function tool
+- Handles json-schema → openai-strict differences if any
+- Wire into Wave B's codex.ts
+- Update `loop.ts` to call `selectBackend()` instead of direct Anthropic
+- Update `tool-format/anthropic.ts` to extract existing logic from loop.ts
+- Tests: tool format roundtrip, integration test in mock-backend mode
+
+---
+
+## Risks + mitigations
+
+1. **Account flag risk** (chatgpt session used by 2 devices simultaneously)
+   - Mitigation: stagger requests via in-process semaphore, add 100-300ms jitter, monitor for soft-blocks
+   - Document: if openai detects + flags, we have nyx's claude path as fallback
+
+2. **Refresh token races** (Sol + nyx both refreshing the same token)
+   - Mitigation: atomic file writes (write-temp-rename), short TTL on cached tokens (refresh 5min before expiry), shared file lock via `proper-lockfile` or `fs.flock`
+
+3. **Codex protocol drift** (OpenAI changes endpoint/headers)
+   - Mitigation: pin codex CLI version, version the user-agent string
+   - When breakage detected, manual fix + bake into image
+
+4. **Streaming complexity** (SSE parsing in long-running connections)
+   - Mitigation: use `for await (const chunk of response.body)` with `TextDecoderStream`, abort on timeout, handle disconnects gracefully
+
+---
+
+## Acceptance criteria
+
+- [ ] `NATIVE_REASONING_BACKEND=codex` makes nyx route via chatgpt backend
+- [ ] First user message returns a streaming reply, accumulated and sent via callback
+- [ ] Multi-turn tool use works: bash → result → next turn → reply
+- [ ] OAuth refresh fires automatically when access_token expires
+- [ ] Concurrent calls from Sol + nyx don't corrupt auth.json
+- [ ] Total token usage (counted from response.completed.usage) logged for billing visibility
+- [ ] Falls back to anthropic backend if codex-auth missing (configurable)
+- [ ] All existing tests still pass (Wave 1.A-D unchanged)
+- [ ] New backend has its own test suite (mocked HTTP/SSE)
+
+---
+
+## Out of scope (v1)
+
+- Web search tool integration (codex's native web_search is different from Brave; defer)
+- Image gen via codex's native image_gen tool
+- `previous_response_id` continuation (we always send full history)
+- Reasoning summaries (`reasoning.effort`, `reasoning.summary` — defer until needed)
+- Per-account routing (multi-codex-account pool — Wave 2 of this project)
+
+---
+
+## Co-Authored-By
+Co-authored-by: wakesync <shadow@shad0w.xyz>

--- a/packages/native-reasoning/README.md
+++ b/packages/native-reasoning/README.md
@@ -1,36 +1,27 @@
 # @elizaos/native-reasoning
 
-Single-call multi-tool reasoning loop for elizaOS agents. It is an opt-in alternate runtime for frontier models that can use native tool calling directly instead of the classic `shouldRespond → action selection → content generation → evaluators` bootstrap pipeline.
+Single-call multi-tool reasoning loop for elizaOS agents. It provides the foundational substrate for native tool calling when the configured model/provider can execute tools directly, replacing the classic `shouldRespond → action selection → content generation → evaluators` prompt-XML planner only where the framework detects support.
 
-See `SPEC.md` for the architectural contract.
+## Selection
 
-## Quick start
+Native reasoning is not a character/customer setting. Do not add a `reasoning` block to character files.
 
-Add the package to an elizaOS workspace and set a character-level switch:
+The framework selects the dispatch path from model capability:
 
-```json
-{
-  "name": "Eliza",
-  "reasoning": {
-    "mode": "native",
-    "provider": "anthropic"
-  }
-}
-```
+- native tool calling path for capable providers/models such as Claude, GPT-4+/GPT-5+, and Codex-class backends
+- existing bootstrap prompt planner for legacy completion models and providers without a concrete native-tool backend
 
-Characters that omit `reasoning.mode`, or set it to `bootstrap`, continue using the existing bootstrap message pipeline unchanged.
+This keeps behavior model-aware and lets lower-tier or legacy models continue unchanged.
 
 ## Backends
 
-- `NATIVE_REASONING_BACKEND=anthropic` (default): standard Anthropic API key or Anthropic-compatible proxy. Use with Claude Opus or Sonnet models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and optional `NATIVE_REASONING_MODEL`.
+- `NATIVE_REASONING_BACKEND=anthropic` (default): standard Anthropic API key or Anthropic-compatible proxy. Use with Claude Opus or Sonnet models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and optional model settings.
 - `NATIVE_REASONING_BACKEND=codex`: uses ChatGPT subscription auth via the codex CLI's token cache at `~/.codex/auth.json` and calls ChatGPT's codex backend at `https://chatgpt.com/backend-api/codex/responses`. This gives access to GPT-5+ class models via ChatGPT Pro subscription auth instead of per-token API pricing. The backend includes a single-in-flight semaphore and request jitter as soft mitigation against rate detection.
 
-Loop configuration:
+## Tools
 
-- `NATIVE_REASONING_MAX_TURNS`: optional loop cap. Defaults to 12.
-- `NATIVE_REASONING_TOTAL_BUDGET_MS`: optional wall-clock budget. Defaults to 90000.
-- `NATIVE_REASONING_PER_TURN_TIMEOUT_MS`: optional per-turn timeout. Defaults to 30000.
+`buildDefaultRegistry()` wires the local substrate tools: file ops, shell, web fetch/search stubs, memory stubs, journaling, ACP subagent spawn, and Codex spawn.
 
-## Status
+## Scope
 
-Production-validated in Nyx, proposed upstream as an explicit opt-in runtime. Bootstrap remains the default and remains the right choice for many model tiers.
+This package establishes the native loop, backend adapters, and tool registry. It does not yet convert the Eliza action registry into native tool schemas. Actions-as-tools is the natural follow-up so Shaw's action modes, including `Mode.ALWAYS_BEFORE`, `Mode.ALWAYS_AFTER`, and `Mode.DURING`, can plug into the same registry.

--- a/packages/native-reasoning/README.md
+++ b/packages/native-reasoning/README.md
@@ -1,0 +1,36 @@
+# @elizaos/native-reasoning
+
+Single-call multi-tool reasoning loop for elizaOS agents. It is an opt-in alternate runtime for frontier models that can use native tool calling directly instead of the classic `shouldRespond → action selection → content generation → evaluators` bootstrap pipeline.
+
+See `SPEC.md` for the architectural contract.
+
+## Quick start
+
+Add the package to an elizaOS workspace and set a character-level switch:
+
+```json
+{
+  "name": "Eliza",
+  "reasoning": {
+    "mode": "native",
+    "provider": "anthropic"
+  }
+}
+```
+
+Characters that omit `reasoning.mode`, or set it to `bootstrap`, continue using the existing bootstrap message pipeline unchanged.
+
+## Backends
+
+- `NATIVE_REASONING_BACKEND=anthropic` (default): standard Anthropic API key or Anthropic-compatible proxy. Use with Claude Opus or Sonnet models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and optional `NATIVE_REASONING_MODEL`.
+- `NATIVE_REASONING_BACKEND=codex`: uses ChatGPT subscription auth via the codex CLI's token cache at `~/.codex/auth.json` and calls ChatGPT's codex backend at `https://chatgpt.com/backend-api/codex/responses`. This gives access to GPT-5+ class models via ChatGPT Pro subscription auth instead of per-token API pricing. The backend includes a single-in-flight semaphore and request jitter as soft mitigation against rate detection.
+
+Loop configuration:
+
+- `NATIVE_REASONING_MAX_TURNS`: optional loop cap. Defaults to 12.
+- `NATIVE_REASONING_TOTAL_BUDGET_MS`: optional wall-clock budget. Defaults to 90000.
+- `NATIVE_REASONING_PER_TURN_TIMEOUT_MS`: optional per-turn timeout. Defaults to 30000.
+
+## Status
+
+Production-validated in Nyx, proposed upstream as an explicit opt-in runtime. Bootstrap remains the default and remains the right choice for many model tiers.

--- a/packages/native-reasoning/SPEC.md
+++ b/packages/native-reasoning/SPEC.md
@@ -2,128 +2,66 @@
 
 ## Goal
 
-Add `@elizaos/native-reasoning` as an opt-in alternate message runtime for elizaOS agents. Native reasoning uses one frontier-model loop with Anthropic native tool calling instead of the classic bootstrap sequence of `shouldRespond → action selection → content generation → evaluators`.
+Add `@elizaos/native-reasoning` as the foundational native-tool-calling substrate for elizaOS agents. Native reasoning uses a frontier-model loop with native tool calls instead of the classic bootstrap sequence of `shouldRespond → action selection → content generation → evaluators` when the configured model/provider supports that capability.
 
-Bootstrap remains the default. Native reasoning is selected only when a character explicitly sets:
+This is not a customer-pickable character mode. Characters should not declare `reasoning.mode` or `reasoning.provider`. The framework decides per runtime/provider/model capability whether to use native dispatch or the existing prompt-XML planner.
 
-```json
-{
-  "reasoning": {
-    "mode": "native",
-    "provider": "anthropic"
-  }
-}
+## Selection
+
+`DefaultMessageService` performs framework-level capability detection before the bootstrap path:
+
+1. Inspect the registered preferred text-generation model provider where available.
+2. Infer the configured provider/model from runtime settings as a fallback.
+3. Route to `runNativeReasoningLoop` only for providers/models known to support native tool calling.
+4. Keep the existing bootstrap planner unchanged for legacy completions, unsupported local providers, and anything not explicitly recognized.
+
+Current v1 detection covers:
+
+- Anthropic Claude models
+- OpenAI GPT-4+/GPT-5+/o-series/Codex-class model names
+- Codex backend selection
+- Legacy OpenAI completions models remain on bootstrap
+- Local providers stay on bootstrap until a concrete native backend/capability is advertised
+
+## Package Surface
+
+```
+packages/native-reasoning/
+  src/loop.ts                  runNativeReasoningLoop(runtime, message, callback, opts)
+  src/backends/*               native backend adapters
+  src/tool-schema.ts           NativeTool registry + conversion primitives
+  src/tools/registry.ts        buildDefaultRegistry()
+  src/system-prompt.ts         identity/system prompt assembly
 ```
 
-Characters without `reasoning.mode`, or with `reasoning.mode: "bootstrap"`, keep the existing behavior unchanged.
+## Backends
 
-## Architectural Contract
+- `AnthropicBackend`: standard Anthropic API key or Anthropic-compatible proxy. Use with Claude models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and model settings forwarded by core.
+- `CodexBackend`: uses ChatGPT subscription auth via the codex CLI token cache at `~/.codex/auth.json` and calls ChatGPT's codex backend at `https://chatgpt.com/backend-api/codex/responses`. This gives access to GPT-5+ class models via ChatGPT Pro subscription auth instead of per-token API pricing. It includes a single-in-flight semaphore and request jitter as soft mitigation against rate detection.
 
-```text
-connector receives message
-    ↓
-connector calls runtime.messageService.handleMessage(...) as it already does
-    ↓
-DefaultMessageService checks character.reasoning.mode
-    ↓ if unset/bootstrap
-classic bootstrap pipeline unchanged
-    ↓ if native
-runNativeReasoningLoop(runtime, message, callback)
-    ↓
-single Anthropic native-tool-use turn
-    ↓ if tool calls
-execute tools inline, append tool results, continue loop
-    ↓ if final text
-callback({ text, attachments })
-```
+## Loop Contract
 
-The integration seam is intentionally small: the connectors do not change, plugin-bootstrap behavior does not change, and evaluators are not deprecated.
+The loop dispatches one turn to a selected backend, receives unified text/tool-use blocks, executes requested tools, appends tool results, and continues until final text, an ignore tool, max turns, timeout, or error.
 
-## Public Backends
+Key guarantees:
 
-The public package ships two native-tool-use backends.
+- Pipeline hooks remain model-agnostic in core.
+- The classic bootstrap path remains the fallback.
+- Tool execution is centralized in the native registry.
+- Selection is owned by the framework, not character authors.
 
-- `AnthropicBackend`: standard Anthropic API key or Anthropic-compatible proxy. Use with Claude Opus or Sonnet models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and optional `NATIVE_REASONING_MODEL`.
-- `CodexBackend`: uses ChatGPT subscription auth via the codex CLI's token cache at `~/.codex/auth.json` and calls ChatGPT's codex backend at `https://chatgpt.com/backend-api/codex/responses`. This gives access to GPT-5+ class models via ChatGPT Pro subscription auth instead of per-token API pricing. It includes a single-in-flight semaphore and request jitter as soft mitigation against rate detection.
+## Relationship to Actions-as-Tools
 
-Configuration:
+This PR establishes substrate only. It does not convert Eliza actions into native tool schemas yet.
 
-- `NATIVE_REASONING_BACKEND`: `anthropic` by default, or `codex`.
-- `ANTHROPIC_API_KEY`: required for the Anthropic backend.
-- `ANTHROPIC_BASE_URL`: optional Anthropic-compatible base URL.
-- `NATIVE_REASONING_MODEL`: optional model override.
-- `NATIVE_REASONING_MAX_TURNS`: loop cap, default 12.
-- `NATIVE_REASONING_TOTAL_BUDGET_MS`: wall-clock cap, default 90000.
-- `NATIVE_REASONING_PER_TURN_TIMEOUT_MS`: per-turn backend timeout, default 30000.
+The natural follow-up is to adapt the action registry so actions emit native tool definitions. Shaw's action modes, including `Mode.ALWAYS_BEFORE`, `Mode.ALWAYS_AFTER`, and `Mode.DURING`, can then plug into the same registry and scheduling semantics instead of being compressed into the prompt planner.
 
-## Tools Exposed in Native Mode
+## Benchmarks
 
-Native tools are JSON-schema-described handlers registered in `ToolRegistry` and converted into Anthropic tool format by `tool-format/anthropic.ts`.
+Empirical benchmarks are required before treating this as a default replacement across all supported models. The benchmark workstream should compare native dispatch against the current TOON/XML planner for:
 
-The default registry includes:
-
-| Tool | Purpose |
-| --- | --- |
-| `read_file`, `write_file`, `edit_file` | Workspace file operations. |
-| `glob`, `grep` | Workspace search. |
-| `web_fetch`, `web_search` | Web retrieval helpers when available. |
-| `recall`, `remember` | Runtime memory search and persistence helpers. |
-| `ignore` | Silent stop, no user-facing reply. |
-
-Additional tools can be registered by callers through the `registry` option without changing the loop. A `bash` tool is included in the package for controlled deployments, but it is not part of the default registry because shell execution needs host-specific sandboxing policy.
-
-## Loop Behavior
-
-```ts
-export async function runNativeReasoningLoop(
-  runtime: IAgentRuntime,
-  message: Memory,
-  callback: HandlerCallback,
-  options?: RunOptions,
-): Promise<void> {
-  const registry = options?.registry ?? new Map();
-  const tools = buildToolsArray(registry);
-  const systemPrompt = options?.systemPrompt ?? await assembleSystemPrompt(runtime, message);
-  const messages = [{ role: "user", content: [{ type: "text", text: message.content.text }] }];
-
-  for (let turn = 0; turn < maxTurns; turn++) {
-    const result = await backend.callTurn({ systemPrompt, messages, tools });
-
-    if (result.toolCalls.some((tool) => tool.name === "ignore")) return;
-
-    if (result.toolCalls.length === 0) {
-      if (result.text.trim()) await callback({ text: result.text, attachments: [] });
-      return;
-    }
-
-    messages.push({ role: "assistant", content: result.rawAssistantBlocks });
-    messages.push({ role: "tool", content: await executeToolCalls(result.toolCalls) });
-  }
-
-  await callback({ text: "(hit reasoning limit, stopping)", attachments: [] });
-}
-```
-
-## System Prompt Assembly
-
-`assembleSystemPrompt` builds a deterministic prompt from:
-
-- character system prompt and identity fields
-- style, bio, topics, adjectives, and examples
-- recent room context available through runtime state and memories
-- runtime-provided context available to the message
-
-This replaces bootstrap provider-stack prompt composition only for characters that explicitly opt into native mode.
-
-## What This Does Not Change
-
-- Does not change default character behavior.
-- Does not modify connector packages.
-- Does not deprecate evaluators.
-- Does not replace plugin-bootstrap.
-- Does not introduce a generic `ReasoningRuntime` abstraction yet.
-- Does not require all agents to use frontier models.
-
-## Production Notes
-
-Native reasoning has been production-validated in Nyx. The upstream package keeps the public surface focused on the Anthropic native-tool-use backend and the opt-in runtime seam.
+- token consumption
+- latency
+- tool/action selection accuracy
+- final response quality
+- failure and fallback rates

--- a/packages/native-reasoning/SPEC.md
+++ b/packages/native-reasoning/SPEC.md
@@ -1,0 +1,129 @@
+# Native Reasoning Runtime Spec
+
+## Goal
+
+Add `@elizaos/native-reasoning` as an opt-in alternate message runtime for elizaOS agents. Native reasoning uses one frontier-model loop with Anthropic native tool calling instead of the classic bootstrap sequence of `shouldRespond → action selection → content generation → evaluators`.
+
+Bootstrap remains the default. Native reasoning is selected only when a character explicitly sets:
+
+```json
+{
+  "reasoning": {
+    "mode": "native",
+    "provider": "anthropic"
+  }
+}
+```
+
+Characters without `reasoning.mode`, or with `reasoning.mode: "bootstrap"`, keep the existing behavior unchanged.
+
+## Architectural Contract
+
+```text
+connector receives message
+    ↓
+connector calls runtime.messageService.handleMessage(...) as it already does
+    ↓
+DefaultMessageService checks character.reasoning.mode
+    ↓ if unset/bootstrap
+classic bootstrap pipeline unchanged
+    ↓ if native
+runNativeReasoningLoop(runtime, message, callback)
+    ↓
+single Anthropic native-tool-use turn
+    ↓ if tool calls
+execute tools inline, append tool results, continue loop
+    ↓ if final text
+callback({ text, attachments })
+```
+
+The integration seam is intentionally small: the connectors do not change, plugin-bootstrap behavior does not change, and evaluators are not deprecated.
+
+## Public Backends
+
+The public package ships two native-tool-use backends.
+
+- `AnthropicBackend`: standard Anthropic API key or Anthropic-compatible proxy. Use with Claude Opus or Sonnet models via `ANTHROPIC_API_KEY`, optional `ANTHROPIC_BASE_URL`, and optional `NATIVE_REASONING_MODEL`.
+- `CodexBackend`: uses ChatGPT subscription auth via the codex CLI's token cache at `~/.codex/auth.json` and calls ChatGPT's codex backend at `https://chatgpt.com/backend-api/codex/responses`. This gives access to GPT-5+ class models via ChatGPT Pro subscription auth instead of per-token API pricing. It includes a single-in-flight semaphore and request jitter as soft mitigation against rate detection.
+
+Configuration:
+
+- `NATIVE_REASONING_BACKEND`: `anthropic` by default, or `codex`.
+- `ANTHROPIC_API_KEY`: required for the Anthropic backend.
+- `ANTHROPIC_BASE_URL`: optional Anthropic-compatible base URL.
+- `NATIVE_REASONING_MODEL`: optional model override.
+- `NATIVE_REASONING_MAX_TURNS`: loop cap, default 12.
+- `NATIVE_REASONING_TOTAL_BUDGET_MS`: wall-clock cap, default 90000.
+- `NATIVE_REASONING_PER_TURN_TIMEOUT_MS`: per-turn backend timeout, default 30000.
+
+## Tools Exposed in Native Mode
+
+Native tools are JSON-schema-described handlers registered in `ToolRegistry` and converted into Anthropic tool format by `tool-format/anthropic.ts`.
+
+The default registry includes:
+
+| Tool | Purpose |
+| --- | --- |
+| `read_file`, `write_file`, `edit_file` | Workspace file operations. |
+| `glob`, `grep` | Workspace search. |
+| `web_fetch`, `web_search` | Web retrieval helpers when available. |
+| `recall`, `remember` | Runtime memory search and persistence helpers. |
+| `ignore` | Silent stop, no user-facing reply. |
+
+Additional tools can be registered by callers through the `registry` option without changing the loop. A `bash` tool is included in the package for controlled deployments, but it is not part of the default registry because shell execution needs host-specific sandboxing policy.
+
+## Loop Behavior
+
+```ts
+export async function runNativeReasoningLoop(
+  runtime: IAgentRuntime,
+  message: Memory,
+  callback: HandlerCallback,
+  options?: RunOptions,
+): Promise<void> {
+  const registry = options?.registry ?? new Map();
+  const tools = buildToolsArray(registry);
+  const systemPrompt = options?.systemPrompt ?? await assembleSystemPrompt(runtime, message);
+  const messages = [{ role: "user", content: [{ type: "text", text: message.content.text }] }];
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    const result = await backend.callTurn({ systemPrompt, messages, tools });
+
+    if (result.toolCalls.some((tool) => tool.name === "ignore")) return;
+
+    if (result.toolCalls.length === 0) {
+      if (result.text.trim()) await callback({ text: result.text, attachments: [] });
+      return;
+    }
+
+    messages.push({ role: "assistant", content: result.rawAssistantBlocks });
+    messages.push({ role: "tool", content: await executeToolCalls(result.toolCalls) });
+  }
+
+  await callback({ text: "(hit reasoning limit, stopping)", attachments: [] });
+}
+```
+
+## System Prompt Assembly
+
+`assembleSystemPrompt` builds a deterministic prompt from:
+
+- character system prompt and identity fields
+- style, bio, topics, adjectives, and examples
+- recent room context available through runtime state and memories
+- runtime-provided context available to the message
+
+This replaces bootstrap provider-stack prompt composition only for characters that explicitly opt into native mode.
+
+## What This Does Not Change
+
+- Does not change default character behavior.
+- Does not modify connector packages.
+- Does not deprecate evaluators.
+- Does not replace plugin-bootstrap.
+- Does not introduce a generic `ReasoningRuntime` abstraction yet.
+- Does not require all agents to use frontier models.
+
+## Production Notes
+
+Native reasoning has been production-validated in Nyx. The upstream package keeps the public surface focused on the Anthropic native-tool-use backend and the opt-in runtime seam.

--- a/packages/native-reasoning/package.json
+++ b/packages/native-reasoning/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/native-reasoning",
   "version": "2.0.0-beta.0",
-  "description": "Single-call multi-tool reasoning loop for elizaOS agents as an opt-in alternate runtime.",
+  "description": "Native tool-calling substrate for elizaOS message dispatch when model capabilities support it.",
   "keywords": [
     "elizaos",
     "agent",

--- a/packages/native-reasoning/package.json
+++ b/packages/native-reasoning/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@elizaos/native-reasoning",
+  "version": "2.0.0-beta.0",
+  "description": "Single-call multi-tool reasoning loop for elizaOS agents as an opt-in alternate runtime.",
+  "keywords": [
+    "elizaos",
+    "agent",
+    "anthropic",
+    "codex",
+    "openai",
+    "tool-use",
+    "reasoning"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./loop": {
+      "bun": "./src/loop.ts",
+      "types": "./dist/loop.d.ts",
+      "import": "./dist/loop.js",
+      "default": "./dist/loop.js"
+    },
+    "./tool-schema": {
+      "bun": "./src/tool-schema.ts",
+      "types": "./dist/tool-schema.d.ts",
+      "import": "./dist/tool-schema.js",
+      "default": "./dist/tool-schema.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "SPEC.md"
+  ],
+  "author": "elizaOS",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist .turbo tsconfig.tsbuildinfo",
+    "test": "vitest run",
+    "lint": "bunx @biomejs/biome check --write ./src",
+    "lint:check": "bunx @biomejs/biome check ./src",
+    "format": "bunx @biomejs/biome format --write ./src",
+    "format:check": "bunx @biomejs/biome format ./src",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@elizaos/core": "workspace:*",
+    "@types/node": "^25.0.3",
+    "typescript": "^6.0.0",
+    "vitest": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/native-reasoning/src/__tests__/acp_agent.test.ts
+++ b/packages/native-reasoning/src/__tests__/acp_agent.test.ts
@@ -1,0 +1,137 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTaskHandler,
+  sessionsSpawnHandler,
+  spawnAgentHandler,
+} from "../tools/acp_agent.js";
+
+function makeRuntime() {
+  const sessions = new Map<string, Record<string, unknown>>();
+  const events: Array<(sid: string, event: string, data: unknown) => void> = [];
+  const store = {
+    get: vi.fn(async (id: string) => sessions.get(id) ?? null),
+    update: vi.fn(async (id: string, patch: Record<string, unknown>) => {
+      const current = sessions.get(id) ?? {};
+      sessions.set(id, { ...current, ...patch });
+    }),
+  };
+  const service = {
+    store,
+    spawnSession: vi.fn(async (opts: Record<string, unknown>) => {
+      const session = {
+        id: "session-1",
+        sessionId: "session-1",
+        name: opts.name,
+        agentType: opts.agentType,
+        workdir: opts.workdir,
+        status: "ready",
+        metadata: opts.metadata,
+      };
+      sessions.set("session-1", session);
+      return session;
+    }),
+    sendPrompt: vi.fn(async (sessionId: string) => {
+      for (const cb of events) {
+        cb(sessionId, "task_complete", {
+          response: "subagent receipt output",
+          stopReason: "end_turn",
+        });
+      }
+      return {
+        response: "subagent receipt output",
+        finalText: "subagent receipt output",
+        stopReason: "end_turn",
+        durationMs: 42,
+      };
+    }),
+    closeSession: vi.fn(async (sessionId: string) => {
+      for (const cb of events) {
+        cb(sessionId, "stopped", {
+          sessionId,
+          response: "subagent receipt output",
+        });
+      }
+    }),
+    onSessionEvent: vi.fn((cb) => {
+      events.push(cb);
+      return () => {
+        const index = events.indexOf(cb);
+        if (index >= 0) events.splice(index, 1);
+      };
+    }),
+  };
+  const runtime = {
+    getService: vi.fn((name: string) =>
+      name === "ACP_SUBPROCESS_SERVICE" ? service : undefined,
+    ),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  } as unknown as IAgentRuntime;
+  const message = {
+    id: "message-1",
+    roomId: "room-1",
+    worldId: "world-1",
+    entityId: "user-1",
+    content: { source: "discord" },
+  } as unknown as Memory;
+  return { runtime, message, service, store, sessions };
+}
+
+describe("native ACP agent tools", () => {
+  it("spawn_agent writes an acpx receipt with output and stopped terminal state", async () => {
+    const { runtime, message, service, store, sessions } = makeRuntime();
+    const result = await spawnAgentHandler(
+      { prompt: "do multi-step work", cwd: "/workspace/tasks/test-receipt" },
+      runtime,
+      message,
+    );
+
+    expect(result.is_error).toBeFalsy();
+    expect(service.closeSession).toHaveBeenCalledWith("session-1");
+    expect(store.update).toHaveBeenCalled();
+    const record = sessions.get("session-1");
+    expect(record?.status).toBe("stopped");
+    expect(record?.workdir).toBe("/workspace/tasks/test-receipt");
+    const metadata = record?.metadata as Record<string, unknown>;
+    expect(metadata.source).toBe("acpx");
+    expect(metadata.origin).toBe("acpx");
+    expect(metadata.output).toBe("subagent receipt output");
+    expect(metadata.actionHandlerTrace).toContain("spawn_agent");
+    expect(metadata.terminalState).toMatchObject({
+      status: "stopped",
+      stopReason: "end_turn",
+      durationMs: 42,
+      persistent: false,
+    });
+  });
+
+  it("sessions_spawn leaves a persistent ready receipt and create_task is an alias", async () => {
+    const first = makeRuntime();
+    const spawned = await sessionsSpawnHandler(
+      { initial_prompt: "continue later", name: "keep-me" },
+      first.runtime,
+      first.message,
+    );
+    expect(spawned.is_error).toBeFalsy();
+    expect(first.service.closeSession).not.toHaveBeenCalled();
+    const metadata = first.sessions.get("session-1")?.metadata as Record<
+      string,
+      unknown
+    >;
+    expect(first.sessions.get("session-1")?.status).toBe("ready");
+    expect(metadata.source).toBe("acpx");
+    expect(metadata.terminalState).toMatchObject({
+      status: "ready",
+      persistent: true,
+    });
+
+    const second = makeRuntime();
+    const aliased = await createTaskHandler(
+      { initial_prompt: "compat task" },
+      second.runtime,
+      second.message,
+    );
+    expect(aliased.is_error).toBeFalsy();
+    expect(aliased.content).toContain('"tool": "create_task"');
+  });
+});

--- a/packages/native-reasoning/src/__tests__/backend-codex.test.ts
+++ b/packages/native-reasoning/src/__tests__/backend-codex.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Wave B tests — CodexBackend with mocked fetch + auth helpers.
+ *
+ * We never touch the real filesystem or the real network: the test config
+ * always injects `loadAuth`, `refreshAuth`, and `fetchImpl`. Stream bodies
+ * are constructed via `ReadableStream` from canned SSE event sequences.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CodexBackend,
+  translateMessagesToCodexInput,
+} from "../backends/codex.js";
+import type { CallTurnOptions, TurnMessage } from "../backends/types.js";
+import type { NativeTool } from "../tool-schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sseEvent(eventName: string, data: unknown): string {
+  return `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function makeStreamBody(chunks: string[]): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(enc.encode(chunks[i] as string));
+      i++;
+    },
+  });
+}
+
+function okResponse(body: ReadableStream<Uint8Array>): Response {
+  return new Response(body, {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+function fakeAuth(access = "tok-1") {
+  return {
+    OPENAI_API_KEY: null,
+    auth_mode: "chatgpt" as const,
+    last_refresh: "2026-01-01T00:00:00Z",
+    tokens: {
+      access_token: access,
+      refresh_token: "ref-1",
+      account_id: "acct-1",
+      id_token: "idtok",
+    },
+  };
+}
+
+const baseOpts = (
+  overrides: Partial<CallTurnOptions> = {},
+): CallTurnOptions => ({
+  systemPrompt: "you are a test agent",
+  messages: [
+    {
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    },
+  ],
+  tools: [],
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("translateMessagesToCodexInput", () => {
+  it("translates user/assistant/tool turns into codex input shape", () => {
+    const messages: TurnMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "let me check" },
+          {
+            type: "tool_use",
+            id: "call-1",
+            name: "bash",
+            input: { cmd: "ls" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call-1",
+            content: "file.txt",
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ];
+    const out = translateMessagesToCodexInput(messages);
+    expect(out).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "let me check" }],
+      },
+      {
+        type: "function_call",
+        call_id: "call-1",
+        name: "bash",
+        arguments: '{"cmd":"ls"}',
+      },
+      {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "file.txt",
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "done" }],
+      },
+    ]);
+  });
+
+  it("translates user-role tool_result blocks (anthropic-style) to function_call_output", () => {
+    const messages: TurnMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "call-9",
+            content: "ok",
+          },
+        ],
+      },
+    ];
+    const out = translateMessagesToCodexInput(messages);
+    expect(out).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call-9",
+        output: "ok",
+      },
+    ]);
+  });
+});
+
+describe("CodexBackend.callTurn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns accumulated text on a simple reply", async () => {
+    const sse = [
+      sseEvent("response.created", { sequence_number: 1 }),
+      sseEvent("response.in_progress", { sequence_number: 2 }),
+      sseEvent("response.output_item.added", {
+        sequence_number: 3,
+        item: { type: "message", role: "assistant", id: "msg-1" },
+      }),
+      sseEvent("response.content_part.added", { sequence_number: 4 }),
+      sseEvent("response.output_text.delta", {
+        sequence_number: 5,
+        delta: "Hello, ",
+      }),
+      sseEvent("response.output_text.delta", {
+        sequence_number: 6,
+        delta: "world!",
+      }),
+      sseEvent("response.output_text.done", { sequence_number: 7 }),
+      sseEvent("response.output_item.done", { sequence_number: 8 }),
+      sseEvent("response.completed", {
+        sequence_number: 9,
+        response: {
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 10,
+            output_tokens: 3,
+            total_tokens: 13,
+          },
+        },
+      }),
+    ];
+    const fetchImpl = vi.fn(async () => okResponse(makeStreamBody(sse))) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth("tok-2") as any,
+      jitterMaxMs: 0,
+    });
+    const result = await be.callTurn(baseOpts());
+    expect(result.text).toBe("Hello, world!");
+    expect(result.toolCalls).toEqual([]);
+    expect(result.stopReason).toBe("end_turn");
+    expect(result.usage?.input).toBe(10);
+    expect(result.usage?.output).toBe(3);
+    expect(result.rawAssistantBlocks).toEqual([
+      { type: "text", text: "Hello, world!" },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toMatch(/\/responses$/);
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok-1");
+    expect(headers["chatgpt-account-id"]).toBe("acct-1");
+    expect(headers.originator).toBe("codex_cli_rs");
+    expect(headers["OpenAI-Beta"]).toBe("responses=v1");
+    expect(headers.Accept).toBe("text/event-stream");
+    expect(headers["User-Agent"]).toMatch(/^codex_cli_rs\//);
+    const body = JSON.parse(init.body as string);
+    expect(body.stream).toBe(true);
+    expect(body.store).toBe(false);
+    expect(body.instructions).toBe("you are a test agent");
+    expect(body.input[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "hi" }],
+    });
+  });
+
+  it("captures a function_call across delta events", async () => {
+    const sse = [
+      sseEvent("response.created", { sequence_number: 1 }),
+      sseEvent("response.output_item.added", {
+        sequence_number: 2,
+        item: {
+          type: "function_call",
+          id: "fc-item-1",
+          call_id: "call-abc",
+          name: "bash",
+          arguments: "",
+        },
+      }),
+      sseEvent("response.function_call_arguments.delta", {
+        sequence_number: 3,
+        item_id: "fc-item-1",
+        delta: '{"cmd":',
+      }),
+      sseEvent("response.function_call_arguments.delta", {
+        sequence_number: 4,
+        item_id: "fc-item-1",
+        delta: '"ls"}',
+      }),
+      sseEvent("response.output_item.done", {
+        sequence_number: 5,
+        item: {
+          type: "function_call",
+          id: "fc-item-1",
+          call_id: "call-abc",
+          name: "bash",
+          arguments: '{"cmd":"ls"}',
+        },
+      }),
+      sseEvent("response.completed", {
+        sequence_number: 6,
+        response: { usage: { input_tokens: 1, output_tokens: 1 } },
+      }),
+    ];
+    const fetchImpl = vi.fn(async () => okResponse(makeStreamBody(sse))) as any;
+    const tool: NativeTool = {
+      type: "custom",
+      name: "bash",
+      description: "run shell",
+      input_schema: {
+        type: "object",
+        properties: { cmd: { type: "string" } },
+        required: ["cmd"],
+      },
+    };
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    const result = await be.callTurn(baseOpts({ tools: [tool] }));
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toMatchObject({
+      id: "call-abc",
+      name: "bash",
+      input: { cmd: "ls" },
+    });
+    expect(result.rawAssistantBlocks).toEqual([
+      {
+        type: "tool_use",
+        id: "call-abc",
+        name: "bash",
+        input: { cmd: "ls" },
+      },
+    ]);
+    // Tools converted into openai function shape on the wire.
+    const sentBody = JSON.parse(fetchImpl.mock.calls[0]![1].body as string);
+    expect(sentBody.tools).toEqual([
+      {
+        type: "function",
+        name: "bash",
+        description: "run shell",
+        parameters: tool.input_schema,
+        strict: false,
+      },
+    ]);
+  });
+
+  it("refreshes OAuth on 401 and retries once", async () => {
+    const sseOk = [
+      sseEvent("response.completed", {
+        sequence_number: 1,
+        response: { usage: {} },
+      }),
+    ];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("unauthorized", {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+      )
+      .mockResolvedValueOnce(okResponse(makeStreamBody(sseOk))) as any;
+    const refreshAuth = vi.fn(async () => fakeAuth("tok-2") as any);
+    const loadAuth = vi.fn(async () => fakeAuth("tok-1") as any);
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth,
+      refreshAuth,
+      jitterMaxMs: 0,
+    });
+    const result = await be.callTurn(baseOpts());
+    expect(result.text).toBe("");
+    expect(refreshAuth).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const auth1 = (fetchImpl.mock.calls[0]![1].headers as any)
+      .Authorization as string;
+    const auth2 = (fetchImpl.mock.calls[1]![1].headers as any)
+      .Authorization as string;
+    expect(auth1).toBe("Bearer tok-1");
+    expect(auth2).toBe("Bearer tok-2");
+  });
+
+  it("throws on response.failed with the error code in the message", async () => {
+    const sse = [
+      sseEvent("response.created", { sequence_number: 1 }),
+      sseEvent("response.failed", {
+        sequence_number: 2,
+        response: {
+          error: { code: "rate_limited", message: "slow down" },
+        },
+      }),
+    ];
+    const fetchImpl = vi.fn(async () => okResponse(makeStreamBody(sse))) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    await expect(be.callTurn(baseOpts())).rejects.toThrow(/rate_limited/);
+  });
+
+  it("honors AbortSignal during streaming", async () => {
+    const enc = new TextEncoder();
+    // Stream that never closes on its own — the abort should cancel it.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          enc.encode(sseEvent("response.created", { sequence_number: 1 })),
+        );
+      },
+    });
+    const fetchImpl = vi.fn(async () => okResponse(stream)) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    const ctrl = new AbortController();
+    const p = be.callTurn(baseOpts({ abortSignal: ctrl.signal }));
+    // Abort shortly after kicking off so we see the abort path.
+    setTimeout(() => ctrl.abort(), 20);
+    await expect(p).rejects.toThrow();
+  });
+
+  it("propagates non-401 HTTP errors with status + body", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("nope", { status: 500, statusText: "Boom" }),
+    ) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    await expect(be.callTurn(baseOpts())).rejects.toThrow(/500.*nope/s);
+  });
+
+  it("serializes concurrent callTurn calls (single in-flight at a time)", async () => {
+    const sse = [
+      sseEvent("response.completed", {
+        sequence_number: 1,
+        response: { usage: {} },
+      }),
+    ];
+    let inflight = 0;
+    let maxInflight = 0;
+    const fetchImpl = vi.fn(async () => {
+      inflight++;
+      maxInflight = Math.max(maxInflight, inflight);
+      // Simulate a small in-flight window.
+      await new Promise((r) => setTimeout(r, 10));
+      inflight--;
+      return okResponse(makeStreamBody(sse));
+    }) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    await Promise.all([
+      be.callTurn(baseOpts()),
+      be.callTurn(baseOpts()),
+      be.callTurn(baseOpts()),
+    ]);
+    expect(maxInflight).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("survives an error mid-chain and still allows subsequent calls", async () => {
+    const sseOk = [
+      sseEvent("response.completed", {
+        sequence_number: 1,
+        response: { usage: {} },
+      }),
+    ];
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("kaboom", { status: 502, statusText: "Bad Gateway" }),
+      )
+      .mockResolvedValueOnce(okResponse(makeStreamBody(sseOk))) as any;
+    const be = new CodexBackend({
+      fetchImpl,
+      loadAuth: async () => fakeAuth() as any,
+      refreshAuth: async () => fakeAuth() as any,
+      jitterMaxMs: 0,
+    });
+    await expect(be.callTurn(baseOpts())).rejects.toThrow(/502/);
+    // Second call should still go through (semaphore unblocked).
+    const r = await be.callTurn(baseOpts());
+    expect(r.text).toBe("");
+  });
+});

--- a/packages/native-reasoning/src/__tests__/backends.test.ts
+++ b/packages/native-reasoning/src/__tests__/backends.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnthropicClientLike } from "../backends/anthropic.js";
+import {
+  AnthropicBackend,
+  CodexBackend,
+  selectBackend,
+} from "../backends/index.js";
+import type { TurnMessage } from "../backends/types.js";
+import { toAnthropicTools } from "../tool-format/anthropic.js";
+import type { NativeTool } from "../tool-schema.js";
+
+const ORIGINAL_ENV_BACKEND = process.env.NATIVE_REASONING_BACKEND;
+const ORIGINAL_ENV_MODEL = process.env.ANTHROPIC_LARGE_MODEL;
+
+afterEach(() => {
+  if (ORIGINAL_ENV_BACKEND === undefined) {
+    delete process.env.NATIVE_REASONING_BACKEND;
+  } else {
+    process.env.NATIVE_REASONING_BACKEND = ORIGINAL_ENV_BACKEND;
+  }
+  if (ORIGINAL_ENV_MODEL === undefined) {
+    delete process.env.ANTHROPIC_LARGE_MODEL;
+  } else {
+    process.env.ANTHROPIC_LARGE_MODEL = ORIGINAL_ENV_MODEL;
+  }
+});
+
+describe("selectBackend", () => {
+  it("defaults to anthropic", () => {
+    const b = selectBackend();
+    expect(b.name).toBe("anthropic");
+  });
+
+  it("returns anthropic when explicitly requested", () => {
+    const b = selectBackend({ backend: "anthropic" });
+    expect(b.name).toBe("anthropic");
+    expect(b).toBeInstanceOf(AnthropicBackend);
+  });
+
+  it("returns codex when env=codex", () => {
+    process.env.NATIVE_REASONING_BACKEND = "codex";
+    const b = selectBackend();
+    expect(b.name).toBe("codex");
+    expect(b).toBeInstanceOf(CodexBackend);
+  });
+
+  it("backend option overrides env", () => {
+    process.env.NATIVE_REASONING_BACKEND = "codex";
+    const b = selectBackend({ backend: "anthropic" });
+    expect(b.name).toBe("anthropic");
+  });
+
+  it("falls back to anthropic on unknown env value", () => {
+    process.env.NATIVE_REASONING_BACKEND = "vertex";
+    const b = selectBackend();
+    expect(b.name).toBe("anthropic");
+  });
+});
+
+function makeMockClient(resp: {
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
+  stop_reason?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
+}): { client: AnthropicClientLike; create: ReturnType<typeof vi.fn> } {
+  const create = vi.fn(async () => resp);
+  const client: AnthropicClientLike = {
+    beta: { messages: { create: create as any } },
+  };
+  return { client, create };
+}
+
+describe("AnthropicBackend.callTurn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("translates pure-text user turn to a string content", async () => {
+    const { client, create } = makeMockClient({
+      content: [{ type: "text", text: "hi" }],
+    });
+    const backend = new AnthropicBackend({ client });
+
+    const messages: TurnMessage[] = [
+      { role: "user", content: [{ type: "text", text: "yo" }] },
+    ];
+
+    const result = await backend.callTurn({
+      systemPrompt: "system",
+      messages,
+      tools: [],
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    const call = create.mock.calls[0]?.[0];
+    expect(call.system).toBe("system");
+    expect(call.messages[0]).toEqual({ role: "user", content: "yo" });
+    expect(call.tools).toBeUndefined();
+    expect(call.betas).toContain("advanced-tool-use-2025-11-20");
+
+    expect(result.text).toBe("hi");
+    expect(result.toolCalls).toEqual([]);
+  });
+
+  it("translates tool role → wire user role with tool_result blocks", async () => {
+    const { client, create } = makeMockClient({
+      content: [{ type: "text", text: "ok" }],
+    });
+    const backend = new AnthropicBackend({ client });
+
+    const messages: TurnMessage[] = [
+      { role: "user", content: [{ type: "text", text: "do" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "t1", name: "echo", input: {} }],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "t1",
+            content: "result",
+          },
+        ],
+      },
+    ];
+
+    await backend.callTurn({ systemPrompt: "", messages, tools: [] });
+    const wire = create.mock.calls[0]?.[0].messages;
+    expect(wire[2]).toEqual({
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "t1", content: "result" }],
+    });
+  });
+
+  it("extracts tool_use blocks into toolCalls and preserves rawAssistantBlocks", async () => {
+    const { client } = makeMockClient({
+      content: [
+        { type: "text", text: "thinking" },
+        {
+          type: "tool_use",
+          id: "u1",
+          name: "search",
+          input: { q: "foo" },
+        },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const backend = new AnthropicBackend({ client });
+
+    const result = await backend.callTurn({
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "search" }] }],
+      tools: [],
+    });
+
+    expect(result.text).toBe("thinking");
+    expect(result.toolCalls).toEqual([
+      { id: "u1", name: "search", input: { q: "foo" } },
+    ]);
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.usage).toEqual({ input: 10, output: 5 });
+    expect(result.rawAssistantBlocks).toHaveLength(2);
+  });
+
+  it("forwards tools translated through toAnthropicTools", async () => {
+    const { client, create } = makeMockClient({
+      content: [{ type: "text", text: "k" }],
+    });
+    const backend = new AnthropicBackend({ client });
+    const tools: NativeTool[] = [
+      {
+        type: "custom",
+        name: "echo",
+        description: "echoes",
+        input_schema: { type: "object", properties: {} },
+      },
+    ];
+
+    await backend.callTurn({
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      tools,
+    });
+    const call = create.mock.calls[0]?.[0];
+    expect(call.tools).toEqual([
+      {
+        type: "custom",
+        name: "echo",
+        description: "echoes",
+        input_schema: { type: "object", properties: {} },
+      },
+    ]);
+  });
+
+  it("retries on transient errors and eventually succeeds", async () => {
+    let attempts = 0;
+    const create = vi.fn(async () => {
+      attempts++;
+      if (attempts < 2) {
+        const err: Error & { status?: number } = new Error("upstream 503");
+        err.status = 503;
+        throw err;
+      }
+      return { content: [{ type: "text", text: "ok" }] };
+    });
+    const client: AnthropicClientLike = {
+      beta: { messages: { create: create as any } },
+    };
+    const backend = new AnthropicBackend({ client });
+
+    const result = await backend.callTurn({
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+      tools: [],
+    });
+    expect(attempts).toBe(2);
+    expect(result.text).toBe("ok");
+  });
+
+  it("does not retry on non-transient (4xx) errors", async () => {
+    let attempts = 0;
+    const create = vi.fn(async () => {
+      attempts++;
+      const err: Error & { status?: number } = new Error("bad request");
+      err.status = 400;
+      throw err;
+    });
+    const client: AnthropicClientLike = {
+      beta: { messages: { create: create as any } },
+    };
+    const backend = new AnthropicBackend({ client });
+
+    await expect(
+      backend.callTurn({
+        systemPrompt: "",
+        messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+        tools: [],
+      }),
+    ).rejects.toThrow(/bad request/);
+    expect(attempts).toBe(1);
+  });
+
+  it("respects ANTHROPIC_LARGE_MODEL env", async () => {
+    process.env.ANTHROPIC_LARGE_MODEL = "claude-test-model";
+    const { client, create } = makeMockClient({
+      content: [{ type: "text", text: "k" }],
+    });
+    const backend = new AnthropicBackend({ client });
+    await backend.callTurn({
+      systemPrompt: "",
+      messages: [{ role: "user", content: [{ type: "text", text: "x" }] }],
+      tools: [],
+    });
+    expect(create.mock.calls[0]?.[0].model).toBe("claude-test-model");
+  });
+});
+
+describe("toAnthropicTools", () => {
+  it("wraps NativeTool[] preserving fields", () => {
+    const tools: NativeTool[] = [
+      {
+        type: "custom",
+        name: "bash",
+        description: "run bash",
+        input_schema: {
+          type: "object",
+          properties: { cmd: { type: "string" } },
+          required: ["cmd"],
+        },
+      },
+    ];
+    const out = toAnthropicTools(tools);
+    expect(out).toEqual([
+      {
+        type: "custom",
+        name: "bash",
+        description: "run bash",
+        input_schema: {
+          type: "object",
+          properties: { cmd: { type: "string" } },
+          required: ["cmd"],
+        },
+      },
+    ]);
+  });
+
+  it("returns empty array for no tools", () => {
+    expect(toAnthropicTools([])).toEqual([]);
+  });
+});

--- a/packages/native-reasoning/src/__tests__/codex-auth.test.ts
+++ b/packages/native-reasoning/src/__tests__/codex-auth.test.ts
@@ -1,0 +1,486 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetCodexAuthDeps,
+  __setCodexAuthDeps,
+  type CodexAuth,
+  defaultAuthPath,
+  isExpired,
+  loadCodexAuth,
+  refreshCodexAuth,
+  saveCodexAuth,
+} from "../backends/codex-auth.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function b64url(input: object): string {
+  return Buffer.from(JSON.stringify(input))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function makeJwt(payload: object): string {
+  const header = b64url({ alg: "RS256", typ: "JWT" });
+  const body = b64url(payload);
+  return `${header}.${body}.fake-sig`;
+}
+
+function makeAuth(overrides: Partial<CodexAuth> = {}): CodexAuth {
+  return {
+    OPENAI_API_KEY: null,
+    auth_mode: "chatgpt",
+    last_refresh: "2025-01-01T00:00:00.000Z",
+    tokens: {
+      id_token: "id-token-fixture",
+      access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+      refresh_token: "refresh-token-fixture",
+      account_id: "acct_123",
+    },
+    ...overrides,
+  };
+}
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "codex-auth-test-"));
+});
+afterEach(async () => {
+  __resetCodexAuthDeps();
+  await rm(tmp, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// loadCodexAuth
+// ---------------------------------------------------------------------------
+
+describe("loadCodexAuth", () => {
+  it("reads and parses a fixture auth.json", async () => {
+    const auth = makeAuth();
+    const p = join(tmp, "auth.json");
+    await writeFile(p, JSON.stringify(auth, null, 2));
+    const loaded = await loadCodexAuth(p);
+    expect(loaded.tokens.account_id).toBe("acct_123");
+    expect(loaded.auth_mode).toBe("chatgpt");
+  });
+
+  it("normalizes missing OPENAI_API_KEY to null", async () => {
+    const p = join(tmp, "auth.json");
+    const partial = makeAuth();
+    // drop OPENAI_API_KEY entirely from the on-disk file
+    const obj = { ...partial } as Partial<CodexAuth>;
+    delete obj.OPENAI_API_KEY;
+    await writeFile(p, JSON.stringify(obj));
+    const loaded = await loadCodexAuth(p);
+    expect(loaded.OPENAI_API_KEY).toBeNull();
+  });
+
+  it("throws on malformed auth.json", async () => {
+    const p = join(tmp, "auth.json");
+    await writeFile(p, JSON.stringify({ tokens: { access_token: "x" } }));
+    await expect(loadCodexAuth(p)).rejects.toThrow(/malformed/);
+  });
+
+  it("default path points at ~/.codex/auth.json", () => {
+    expect(defaultAuthPath()).toMatch(/\.codex[\\/]auth\.json$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isExpired
+// ---------------------------------------------------------------------------
+
+describe("isExpired", () => {
+  it("returns false for a token expiring well in the future", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    expect(isExpired(auth)).toBe(false);
+  });
+
+  it("returns true for a token already past exp", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 }),
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    expect(isExpired(auth)).toBe(true);
+  });
+
+  it("returns true within the default 60s buffer", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 30 }),
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    expect(isExpired(auth)).toBe(true);
+  });
+
+  it("respects a custom buffer", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 30 }),
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    expect(isExpired(auth, 5)).toBe(false);
+    expect(isExpired(auth, 60)).toBe(true);
+  });
+
+  it("returns true when access_token isn't a JWT", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: "not.a.jwt.at.all",
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    // 5-segment string with non-base64 payload — payload b64 decodes to garbage,
+    // JSON.parse throws → null payload → expired.
+    expect(isExpired(auth)).toBe(true);
+  });
+
+  it("returns true when payload is missing exp", () => {
+    const auth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ sub: "x" }),
+        refresh_token: "r",
+        account_id: "a",
+      },
+    });
+    expect(isExpired(auth)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// saveCodexAuth (atomicity)
+// ---------------------------------------------------------------------------
+
+describe("saveCodexAuth", () => {
+  it("writes the file with 600 perms and valid JSON", async () => {
+    const p = join(tmp, "auth.json");
+    const auth = makeAuth();
+    await saveCodexAuth(auth, p);
+    const st = await stat(p);
+    // perms: low 9 bits should be rw-------
+    expect(st.mode & 0o777).toBe(0o600);
+    const round = JSON.parse(await readFile(p, "utf8"));
+    expect(round.tokens.account_id).toBe("acct_123");
+  });
+
+  it("does not leave a tmp file behind on success", async () => {
+    const p = join(tmp, "auth.json");
+    await saveCodexAuth(makeAuth(), p);
+    const { readdir } = await import("node:fs/promises");
+    const entries = await readdir(tmp);
+    const tmps = entries.filter((e) => e.includes(".tmp."));
+    expect(tmps).toEqual([]);
+  });
+
+  it("partial file is never visible to readers (atomic rename)", async () => {
+    // Write an "old" version, then race a save against repeated reads.
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        ...makeAuth().tokens,
+        access_token: "OLD_TOKEN",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    const newAuth = makeAuth({
+      tokens: { ...makeAuth().tokens, access_token: "NEW_TOKEN" },
+    });
+
+    // Hammer reads while a save is in flight; every read must be either
+    // fully old or fully new.
+    const savePromise = saveCodexAuth(newAuth, p);
+    const readers = Array.from({ length: 50 }, async () => {
+      const txt = await readFile(p, "utf8");
+      const obj = JSON.parse(txt);
+      return obj.tokens.access_token as string;
+    });
+
+    const observed = await Promise.all(readers);
+    await savePromise;
+    for (const t of observed) {
+      expect(t === "OLD_TOKEN" || t === "NEW_TOKEN").toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshCodexAuth
+// ---------------------------------------------------------------------------
+
+describe("refreshCodexAuth", () => {
+  it("posts form-urlencoded to the OAuth endpoint with correct shape", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "old-id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD_REFRESH",
+        account_id: "acct_xyz",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://auth.openai.com/oauth/token");
+      expect(init?.method).toBe("POST");
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["content-type"]).toBe("application/x-www-form-urlencoded");
+      const body = init?.body as string;
+      const params = new URLSearchParams(body);
+      expect(params.get("grant_type")).toBe("refresh_token");
+      expect(params.get("refresh_token")).toBe("OLD_REFRESH");
+      expect(params.get("client_id")).toBe("app_EMoamEEZ73f0CkXaXp7hrann");
+
+      return new Response(
+        JSON.stringify({
+          access_token: makeJwt({
+            exp: Math.floor(Date.now() / 1000) + 3600,
+          }),
+          refresh_token: "NEW_REFRESH",
+          id_token: "NEW_ID",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const fixedNow = Date.now();
+    __setCodexAuthDeps({ fetch: fetchMock, now: () => fixedNow });
+
+    const refreshed = await refreshCodexAuth(oldAuth, p);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(refreshed.tokens.refresh_token).toBe("NEW_REFRESH");
+    expect(refreshed.tokens.id_token).toBe("NEW_ID");
+    expect(refreshed.tokens.account_id).toBe("acct_xyz"); // preserved
+    expect(refreshed.last_refresh).toBe(new Date(fixedNow).toISOString());
+
+    // File should now contain the refreshed tokens.
+    const onDisk = JSON.parse(await readFile(p, "utf8"));
+    expect(onDisk.tokens.refresh_token).toBe("NEW_REFRESH");
+  });
+
+  it("preserves old refresh_token if response omits it", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "STAY",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 999 }),
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    const out = await refreshCodexAuth(oldAuth, p);
+    expect(out.tokens.refresh_token).toBe("STAY");
+  });
+
+  it("throws on non-2xx response", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    const fetchMock = vi.fn(
+      async () => new Response("bad refresh", { status: 401 }),
+    ) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    await expect(refreshCodexAuth(oldAuth, p)).rejects.toThrow(
+      /refresh failed/,
+    );
+  });
+
+  it("skips the network call if another process already refreshed", async () => {
+    const p = join(tmp, "auth.json");
+    const expiredOnDisk = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD",
+        account_id: "a",
+      },
+    });
+
+    // Initial state: a fresh token sits on disk (because peer just refreshed).
+    const fresh = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+        refresh_token: "ALREADY_REFRESHED",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(fresh, p);
+
+    const fetchMock = vi.fn(
+      async () => new Response("nope", { status: 500 }),
+    ) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    // Caller's in-memory copy still says "expired", but on-disk is fresh.
+    const out = await refreshCodexAuth(expiredOnDisk, p);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(out.tokens.refresh_token).toBe("ALREADY_REFRESHED");
+  });
+
+  it("two concurrent refreshers serialize via the lock", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    // Track fetch concurrency: this MUST never exceed 1, because the lock
+    // ensures only one process is in the critical section at a time.
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let counter = 0;
+
+    const fetchMock = vi.fn(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((r) => setTimeout(r, 30));
+      inFlight--;
+      counter++;
+      return new Response(
+        JSON.stringify({
+          access_token: makeJwt({
+            exp: Math.floor(Date.now() / 1000) + 3600,
+          }),
+          refresh_token: `NEW_${counter}`,
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    const [a, b] = await Promise.all([
+      refreshCodexAuth(oldAuth, p),
+      refreshCodexAuth(oldAuth, p),
+    ]);
+
+    // Lock guarantees no concurrency.
+    expect(maxInFlight).toBe(1);
+
+    // First one acquires lock, refreshes, writes new fresh token. Second
+    // acquires lock after release, re-reads from disk, sees fresh token,
+    // skips network call. So we expect exactly 1 fetch.
+    expect(counter).toBe(1);
+
+    // Both returned a valid auth object.
+    expect(a.tokens.access_token).toBeTruthy();
+    expect(b.tokens.access_token).toBeTruthy();
+
+    // Lock file should be cleaned up.
+    await expect(stat(`${p}.lock`)).rejects.toThrow();
+  });
+
+  it("releases the lock on fetch failure", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    await expect(refreshCodexAuth(oldAuth, p)).rejects.toThrow(/network/);
+    await expect(stat(`${p}.lock`)).rejects.toThrow();
+  });
+
+  it("breaks a stale lock (>30s old) and proceeds", async () => {
+    const p = join(tmp, "auth.json");
+    const oldAuth = makeAuth({
+      tokens: {
+        id_token: "id",
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 10 }),
+        refresh_token: "OLD",
+        account_id: "a",
+      },
+    });
+    await saveCodexAuth(oldAuth, p);
+
+    // Plant a stale lock (mtime well in the past).
+    const lockPath = `${p}.lock`;
+    await writeFile(lockPath, "99999\n");
+    const { utimes } = await import("node:fs/promises");
+    const longAgo = new Date(Date.now() - 60_000);
+    await utimes(lockPath, longAgo, longAgo);
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt({
+              exp: Math.floor(Date.now() / 1000) + 3600,
+            }),
+            refresh_token: "POST_BREAK",
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    __setCodexAuthDeps({ fetch: fetchMock });
+
+    const out = await refreshCodexAuth(oldAuth, p);
+    expect(out.tokens.refresh_token).toBe("POST_BREAK");
+    await expect(stat(lockPath)).rejects.toThrow();
+  });
+});

--- a/packages/native-reasoning/src/__tests__/loop.test.ts
+++ b/packages/native-reasoning/src/__tests__/loop.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnthropicClientLike } from "../loop.js";
+import { runNativeReasoningLoop } from "../loop.js";
+import { registerTool, type ToolRegistry } from "../tool-schema.js";
+
+// Minimal stand-ins for runtime / message — the loop only touches a few
+// fields. We type them as any to avoid pulling in a full @elizaos/core
+// runtime mock for unit tests.
+const fakeRuntime: any = {
+  agentId: "00000000-0000-0000-0000-000000000001",
+  character: { system: "You are a test agent." },
+  getMemories: vi.fn(async () => []),
+};
+
+const fakeMessage: any = {
+  id: "00000000-0000-0000-0000-000000000aaa",
+  roomId: "00000000-0000-0000-0000-000000000bbb",
+  entityId: "00000000-0000-0000-0000-000000000ccc",
+  content: { text: "do the thing" },
+};
+
+function makeClient(turns: Array<{ content: any[]; stop_reason?: string }>): {
+  client: AnthropicClientLike;
+  create: ReturnType<typeof vi.fn>;
+} {
+  let i = 0;
+  const create = vi.fn(async () => {
+    const t = turns[Math.min(i, turns.length - 1)];
+    i++;
+    return t;
+  });
+  const client: AnthropicClientLike = {
+    beta: { messages: { create: create as any } },
+  };
+  return { client, create };
+}
+
+describe("runNativeReasoningLoop", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("short-circuits silently when model emits ignore tool_use", async () => {
+    const { client } = makeClient([
+      {
+        content: [{ type: "tool_use", id: "t1", name: "ignore", input: {} }],
+      },
+    ]);
+    const callback = vi.fn(async () => []);
+    const registry: ToolRegistry = new Map();
+
+    await runNativeReasoningLoop(fakeRuntime, fakeMessage, callback, {
+      client,
+      registry,
+      systemPrompt: "ignore-test",
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("returns final text via callback when no tool_use blocks", async () => {
+    const { client, create } = makeClient([
+      { content: [{ type: "text", text: "hello world" }] },
+    ]);
+    const callback = vi.fn(async () => []);
+
+    await runNativeReasoningLoop(fakeRuntime, fakeMessage, callback, {
+      client,
+      systemPrompt: "test",
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]?.[0]).toMatchObject({
+      text: "hello world",
+      attachments: [],
+    });
+  });
+
+  it("executes a tool, appends result, and continues until final text", async () => {
+    const { client, create } = makeClient([
+      {
+        content: [
+          { type: "text", text: "thinking" },
+          {
+            type: "tool_use",
+            id: "tu1",
+            name: "echo",
+            input: { msg: "hi" },
+          },
+        ],
+      },
+      { content: [{ type: "text", text: "done: hi" }] },
+    ]);
+
+    const handler = vi.fn(async (input: any) => ({
+      content: `echoed:${input.msg}`,
+    }));
+
+    const registry: ToolRegistry = new Map();
+    registerTool(
+      registry,
+      {
+        type: "custom",
+        name: "echo",
+        description: "echoes",
+        input_schema: { type: "object", properties: {} },
+      },
+      handler,
+    );
+
+    const callback = vi.fn(async () => []);
+    await runNativeReasoningLoop(fakeRuntime, fakeMessage, callback, {
+      client,
+      registry,
+      systemPrompt: "test",
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledTimes(2);
+    // Second call should include the assistant + tool_result history.
+    const secondMessages = create.mock.calls[1]?.[0].messages;
+    expect(secondMessages.length).toBe(3); // user, assistant, tool_result
+    expect(secondMessages[1].role).toBe("assistant");
+    expect(secondMessages[2].role).toBe("user");
+    const trBlocks = secondMessages[2].content;
+    expect(trBlocks[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "tu1",
+      content: "echoed:hi",
+    });
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "done: hi" }),
+    );
+  });
+
+  it("hits max turns gracefully with a stop message", async () => {
+    // Always return another tool_use → loop never terminates on its own.
+    const { client, create } = makeClient([
+      {
+        content: [
+          {
+            type: "tool_use",
+            id: "loop",
+            name: "noop",
+            input: {},
+          },
+        ],
+      },
+    ]);
+
+    const registry: ToolRegistry = new Map();
+    registerTool(
+      registry,
+      {
+        type: "custom",
+        name: "noop",
+        description: "noop",
+        input_schema: { type: "object", properties: {} },
+      },
+      async () => ({ content: "ok" }),
+    );
+
+    const callback = vi.fn(async () => []);
+    await runNativeReasoningLoop(fakeRuntime, fakeMessage, callback, {
+      client,
+      registry,
+      systemPrompt: "test",
+      maxTurns: 3,
+    });
+
+    expect(create).toHaveBeenCalledTimes(3);
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback.mock.calls[0]?.[0].text).toMatch(/reasoning limit/);
+  });
+
+  it("returns unknown-tool error result instead of crashing", async () => {
+    const { client, create } = makeClient([
+      {
+        content: [
+          {
+            type: "tool_use",
+            id: "x",
+            name: "missing_tool",
+            input: {},
+          },
+        ],
+      },
+      { content: [{ type: "text", text: "recovered" }] },
+    ]);
+
+    const callback = vi.fn(async () => []);
+    await runNativeReasoningLoop(fakeRuntime, fakeMessage, callback, {
+      client,
+      registry: new Map(),
+      systemPrompt: "test",
+    });
+
+    expect(create).toHaveBeenCalledTimes(2);
+    const tr = create.mock.calls[1]?.[0].messages[2].content[0];
+    expect(tr.is_error).toBe(true);
+    expect(tr.content).toMatch(/Unknown tool/);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "recovered" }),
+    );
+  });
+
+  it("skips empty user text without calling Anthropic", async () => {
+    const { client, create } = makeClient([
+      { content: [{ type: "text", text: "should not happen" }] },
+    ]);
+    const callback = vi.fn(async () => []);
+    await runNativeReasoningLoop(
+      fakeRuntime,
+      { ...fakeMessage, content: { text: "   " } } as any,
+      callback,
+      { client, systemPrompt: "test" },
+    );
+    expect(create).not.toHaveBeenCalled();
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/native-reasoning/src/__tests__/spawn_codex.test.ts
+++ b/packages/native-reasoning/src/__tests__/spawn_codex.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for Wave 1.C `spawn_codex` tool.
+ *
+ * The tool wraps plugin-agent-orchestrator's CREATE_TASK action plus
+ * PTY_SERVICE event subscription. We mock both surfaces.
+ */
+
+import type { Action, IAgentRuntime, Memory } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  generateDefaultWorkdir,
+  handler,
+  safeError,
+  tool,
+} from "../tools/spawn_codex.js";
+
+type SessionEventCb = (sid: string, event: string, data: unknown) => void;
+
+interface MockPtyService {
+  cbs: SessionEventCb[];
+  onSessionEvent: (cb: SessionEventCb) => () => void;
+  emit: (sid: string, event: string, data?: unknown) => void;
+}
+
+function makePty(): MockPtyService {
+  const cbs: SessionEventCb[] = [];
+  return {
+    cbs,
+    onSessionEvent(cb) {
+      cbs.push(cb);
+      return () => {
+        const idx = cbs.indexOf(cb);
+        if (idx !== -1) cbs.splice(idx, 1);
+      };
+    },
+    emit(sid, event, data = {}) {
+      for (const cb of [...cbs]) cb(sid, event, data);
+    },
+  };
+}
+
+interface BuildRuntimeOpts {
+  action?: Partial<Action> | null;
+  pty?: MockPtyService | null;
+}
+
+function buildRuntime(opts: BuildRuntimeOpts = {}): IAgentRuntime {
+  const action: Action | null =
+    opts.action === null
+      ? null
+      : ({
+          name: "CREATE_TASK",
+          description: "",
+          similes: [],
+          examples: [],
+          handler: vi.fn(),
+          validate: vi.fn(async () => true),
+          ...(opts.action ?? {}),
+        } as unknown as Action);
+  const actions = action ? [action] : [];
+  const services = new Map<string, unknown>();
+  if (opts.pty !== null) {
+    services.set("PTY_SERVICE", opts.pty ?? makePty());
+  }
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    actions,
+    getService: (name: string) => services.get(name) ?? null,
+  } as unknown as IAgentRuntime;
+}
+
+const fakeMessage = (): Memory =>
+  ({
+    id: "00000000-0000-0000-0000-000000000aaa",
+    roomId: "00000000-0000-0000-0000-000000000bbb",
+    entityId: "00000000-0000-0000-0000-000000000ccc",
+    agentId: "00000000-0000-0000-0000-000000000001",
+    content: { text: "parent message" },
+  }) as unknown as Memory;
+
+describe("spawn_codex schema", () => {
+  it("declares a custom tool with required task field", () => {
+    expect(tool.type).toBe("custom");
+    expect(tool.name).toBe("spawn_codex");
+    expect(tool.input_schema.required).toEqual(["task"]);
+  });
+
+  it("safeError formats consistently", () => {
+    expect(safeError("boom")).toEqual({
+      content: "subagent failed: boom",
+      is_error: true,
+    });
+  });
+
+  it("generateDefaultWorkdir lives under /workspace/tasks", () => {
+    const wd = generateDefaultWorkdir(new Date(0));
+    expect(wd.startsWith("/workspace/tasks/")).toBe(true);
+    expect(wd).toMatch(/^\/workspace\/tasks\/19700101-000000-[0-9a-f]{8}$/);
+  });
+});
+
+describe("spawn_codex input validation", () => {
+  it("rejects missing task", async () => {
+    const res = await handler({}, buildRuntime(), fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/'task' is required/);
+  });
+
+  it("rejects empty task", async () => {
+    const res = await handler({ task: "   " }, buildRuntime(), fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/'task' is required/);
+  });
+});
+
+describe("spawn_codex missing dependencies", () => {
+  it("returns is_error when CREATE_TASK is not registered", async () => {
+    const runtime = {
+      agentId: "x",
+      actions: [],
+      getService: () => makePty(),
+    } as unknown as IAgentRuntime;
+    const res = await handler({ task: "do something" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/CREATE_TASK action not registered/);
+  });
+
+  it("returns is_error when PTY_SERVICE is missing", async () => {
+    const runtime = buildRuntime({ pty: null });
+    const res = await handler({ task: "do something" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/PTY_SERVICE is not available/);
+  });
+});
+
+describe("spawn_codex happy path", () => {
+  let pty: MockPtyService;
+
+  beforeEach(() => {
+    pty = makePty();
+  });
+
+  it("invokes CREATE_TASK with agentType=codex and waits for task_complete", async () => {
+    const actionHandler = vi.fn(async (_rt, _msg, _state, _opts, _cb) => {
+      // Synchronously emit task_complete so the wait resolves quickly
+      // after the settle window. Use setImmediate to fire after the
+      // caller has subscribed via track().
+      setImmediate(() => {
+        pty.emit("sess-1", "task_complete", {
+          response: "codex finished refactor",
+        });
+        pty.emit("sess-1", "stopped", { response: "codex finished refactor" });
+      });
+      return {
+        success: true,
+        text: "",
+        data: {
+          agents: [
+            {
+              sessionId: "sess-1",
+              agentType: "codex",
+              workdir: "/workspace/tasks/x",
+              label: "scratch/refactor",
+              status: "ready",
+            },
+          ],
+        },
+      };
+    });
+    const runtime = buildRuntime({
+      action: { handler: actionHandler },
+      pty,
+    });
+
+    const res = await handler(
+      { task: "refactor parser", timeout_ms: 5000 },
+      runtime,
+      fakeMessage(),
+    );
+
+    expect(res.is_error).toBe(false);
+    expect(res.content).toContain("codex finished refactor");
+    expect(res.content).toContain("sessions: sess-1");
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    const callArgs = actionHandler.mock.calls[0];
+    const synthMsg = callArgs[1] as Memory;
+    const opts = callArgs[3] as { parameters?: Record<string, unknown> };
+    expect((synthMsg.content as Record<string, unknown>).agentType).toBe(
+      "codex",
+    );
+    expect(opts.parameters?.agentType).toBe("codex");
+    expect(opts.parameters?.task).toBe("refactor parser");
+  });
+
+  it("flags downgrade when orchestrator routes to a non-codex framework", async () => {
+    const runtime = buildRuntime({
+      action: {
+        handler: async () => {
+          setImmediate(() => {
+            pty.emit("sess-2", "task_complete", { response: "claude did it" });
+            pty.emit("sess-2", "stopped", {});
+          });
+          return {
+            success: true,
+            data: {
+              agents: [
+                { sessionId: "sess-2", agentType: "claude", status: "ready" },
+              ],
+            },
+          };
+        },
+      },
+      pty,
+    });
+    const res = await handler(
+      { task: "anything", timeout_ms: 5000 },
+      runtime,
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(false);
+    expect(res.content).toMatch(/routed this task to 'claude'/);
+  });
+});
+
+describe("spawn_codex failure paths", () => {
+  it("returns is_error when CREATE_TASK reports success=false", async () => {
+    const runtime = buildRuntime({
+      action: {
+        handler: async (_rt, _msg, _s, _o, cb) => {
+          await cb?.({ text: "Workspace Service is not available." } as never);
+          return {
+            success: false,
+            error: "WORKSPACE_SERVICE_UNAVAILABLE",
+            text: "Workspace Service is not available.",
+          };
+        },
+      },
+    });
+    const res = await handler({ task: "go" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/CREATE_TASK failed/);
+    expect(res.content).toMatch(/Workspace Service is not available/);
+  });
+
+  it("returns is_error when CREATE_TASK throws", async () => {
+    const runtime = buildRuntime({
+      action: {
+        handler: async () => {
+          throw new Error("boom");
+        },
+      },
+    });
+    const res = await handler({ task: "go" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/CREATE_TASK threw: boom/);
+  });
+
+  it("returns is_error when CREATE_TASK succeeds but yields no session ids", async () => {
+    const runtime = buildRuntime({
+      action: {
+        handler: async () => ({ success: true, data: { agents: [] } }),
+      },
+    });
+    const res = await handler({ task: "go" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/no session ids/);
+  });
+
+  it("times out without throwing if no terminal events arrive", async () => {
+    const pty = makePty();
+    const runtime = buildRuntime({
+      action: {
+        handler: async () => ({
+          success: true,
+          data: {
+            agents: [{ sessionId: "sess-stuck", agentType: "codex" }],
+          },
+        }),
+      },
+      pty,
+    });
+    const res = await handler(
+      { task: "stuck", timeout_ms: 50 },
+      runtime,
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/timed out after 50ms/);
+    expect(res.content).toMatch(/sess-stuck/);
+  });
+
+  it("captures error events as failure reasons", async () => {
+    const pty = makePty();
+    const runtime = buildRuntime({
+      action: {
+        handler: async () => {
+          setImmediate(() => {
+            pty.emit("sess-err", "error", { message: "auth failed" });
+          });
+          return {
+            success: true,
+            data: {
+              agents: [{ sessionId: "sess-err", agentType: "codex" }],
+            },
+          };
+        },
+      },
+      pty,
+    });
+    const res = await handler(
+      { task: "fail", timeout_ms: 5000 },
+      runtime,
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/subagent failed/);
+    expect(res.content).toMatch(/auth failed/);
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});

--- a/packages/native-reasoning/src/__tests__/sse-parser.test.ts
+++ b/packages/native-reasoning/src/__tests__/sse-parser.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import { parseSSE, parseSSEJSON, type SSEEvent } from "../sse-parser.js";
+
+function streamFromChunks(
+  chunks: (string | Uint8Array)[],
+): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  const queue = chunks.map((c) => (typeof c === "string" ? enc.encode(c) : c));
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const next = queue.shift();
+      if (next === undefined) {
+        controller.close();
+      } else {
+        controller.enqueue(next);
+      }
+    },
+  });
+}
+
+function streamFromString(s: string): ReadableStream<Uint8Array> {
+  return streamFromChunks([s]);
+}
+
+async function collect(
+  stream: ReadableStream<Uint8Array>,
+): Promise<SSEEvent[]> {
+  const out: SSEEvent[] = [];
+  for await (const ev of parseSSE(stream)) out.push(ev);
+  return out;
+}
+
+describe("parseSSE", () => {
+  it("parses a single event with data", async () => {
+    const events = await collect(streamFromString("data: hello\n\n"));
+    expect(events).toEqual([{ data: "hello" }]);
+  });
+
+  it("concatenates multi-line data with \\n", async () => {
+    const events = await collect(
+      streamFromString("data: line1\ndata: line2\ndata: line3\n\n"),
+    );
+    expect(events).toEqual([{ data: "line1\nline2\nline3" }]);
+  });
+
+  it("ignores comment lines (start with :)", async () => {
+    const events = await collect(
+      streamFromString(": this is a heartbeat\ndata: real\n\n"),
+    );
+    expect(events).toEqual([{ data: "real" }]);
+  });
+
+  it("captures event, id, and retry directives", async () => {
+    const events = await collect(
+      streamFromString(
+        "event: response.created\nid: abc123\nretry: 5000\ndata: x\n\n",
+      ),
+    );
+    expect(events).toEqual([
+      { event: "response.created", id: "abc123", retry: 5000, data: "x" },
+    ]);
+  });
+
+  it("ignores malformed retry (non-digits)", async () => {
+    const events = await collect(
+      streamFromString("retry: not-a-number\ndata: x\n\n"),
+    );
+    expect(events).toEqual([{ data: "x" }]);
+  });
+
+  it("dispatches multiple events back-to-back", async () => {
+    const stream = streamFromString(
+      "data: one\n\ndata: two\n\nevent: end\ndata: three\n\n",
+    );
+    const events = await collect(stream);
+    expect(events).toEqual([
+      { data: "one" },
+      { data: "two" },
+      { event: "end", data: "three" },
+    ]);
+  });
+
+  it("handles partial chunks split at every byte boundary", async () => {
+    const full = "event: msg\ndata: hello world\nid: 7\n\ndata: bye\n\n";
+    const enc = new TextEncoder();
+    const bytes = enc.encode(full);
+    // Split into one-byte chunks.
+    const chunks: Uint8Array[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+      chunks.push(bytes.slice(i, i + 1));
+    }
+    const stream = streamFromChunks(chunks);
+    const events = await collect(stream);
+    expect(events).toEqual([
+      { event: "msg", data: "hello world", id: "7" },
+      { data: "bye" },
+    ]);
+  });
+
+  it("handles CRLF line endings, including split across chunks", async () => {
+    const events = await collect(
+      streamFromChunks(["data: a\r", "\ndata: b\r\n\r\n"]),
+    );
+    expect(events).toEqual([{ data: "a\nb" }]);
+  });
+
+  it("strips a single leading space after the colon", async () => {
+    const events = await collect(
+      streamFromString("data:  two-spaces\ndata:no-space\n\n"),
+    );
+    // First line: ": " stripped → " two-spaces" (one leading space remains)
+    // Second line: ":" no space → "no-space"
+    expect(events).toEqual([{ data: " two-spaces\nno-space" }]);
+  });
+
+  it("treats lines without a colon as a field with empty value", async () => {
+    // A bare `data` field with no value adds an empty data line.
+    const events = await collect(streamFromString("data\ndata: hi\n\n"));
+    expect(events).toEqual([{ data: "\nhi" }]);
+  });
+
+  it("does not dispatch a trailing event without blank-line terminator", async () => {
+    const events = await collect(streamFromString("data: incomplete\n"));
+    expect(events).toEqual([]);
+  });
+
+  it("releases the reader lock when the consumer breaks early", async () => {
+    const stream = streamFromString("data: a\n\ndata: b\n\ndata: c\n\n");
+    for await (const ev of parseSSE(stream)) {
+      expect(ev.data).toBe("a");
+      break;
+    }
+    // Reader should have been released — locked() means we can't read again
+    // but the underlying stream is fine to discard. If releaseLock failed
+    // with an error, the for-await wouldn't have returned cleanly.
+    expect(stream.locked).toBe(false);
+  });
+
+  it("handles UTF-8 multibyte characters split across chunks", async () => {
+    // "héllo" — é is two bytes in UTF-8 (0xC3 0xA9). Split between them.
+    const enc = new TextEncoder();
+    const full = enc.encode("data: héllo\n\n");
+    // find the 0xC3
+    const c3 = full.indexOf(0xc3);
+    const a = full.slice(0, c3 + 1);
+    const b = full.slice(c3 + 1);
+    const events = await collect(streamFromChunks([a, b]));
+    expect(events).toEqual([{ data: "héllo" }]);
+  });
+});
+
+describe("parseSSEJSON", () => {
+  it("parses JSON data fields", async () => {
+    const stream = streamFromString(
+      'event: foo\ndata: {"x":1}\n\nevent: bar\ndata: {"y":2}\n\n',
+    );
+    const out: { event: string; data: unknown }[] = [];
+    for await (const ev of parseSSEJSON(stream)) out.push(ev);
+    expect(out).toEqual([
+      { event: "foo", data: { x: 1 } },
+      { event: "bar", data: { y: 2 } },
+    ]);
+  });
+
+  it("defaults event name to 'message' when absent", async () => {
+    const stream = streamFromString('data: {"a":true}\n\n');
+    const out: { event: string; data: unknown }[] = [];
+    for await (const ev of parseSSEJSON(stream)) out.push(ev);
+    expect(out).toEqual([{ event: "message", data: { a: true } }]);
+  });
+
+  it("throws on malformed JSON by default", async () => {
+    const stream = streamFromString("data: not json\n\n");
+    await expect(async () => {
+      for await (const _ev of parseSSEJSON(stream)) {
+        /* no-op */
+      }
+    }).rejects.toThrow();
+  });
+
+  it("skips malformed JSON when ignoreParseErrors is set", async () => {
+    const stream = streamFromString('data: not json\n\ndata: {"ok":true}\n\n');
+    const out: { event: string; data: unknown }[] = [];
+    for await (const ev of parseSSEJSON(stream, { ignoreParseErrors: true })) {
+      out.push(ev);
+    }
+    expect(out).toEqual([{ event: "message", data: { ok: true } }]);
+  });
+
+  it("skips events with no data field", async () => {
+    const stream = streamFromString(
+      'event: ping\n\nevent: msg\ndata: {"hi":1}\n\n',
+    );
+    const out: { event: string; data: unknown }[] = [];
+    for await (const ev of parseSSEJSON(stream)) out.push(ev);
+    expect(out).toEqual([{ event: "msg", data: { hi: 1 } }]);
+  });
+});

--- a/packages/native-reasoning/src/__tests__/system-prompt.test.ts
+++ b/packages/native-reasoning/src/__tests__/system-prompt.test.ts
@@ -1,0 +1,144 @@
+import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  assembleSystemPrompt,
+  clearSystemPromptCache,
+} from "../system-prompt.js";
+
+const fakeRuntime: any = {
+  agentId: "00000000-0000-0000-0000-000000000001",
+  character: { system: "char-system" },
+  getMemories: vi.fn(async () => []),
+};
+
+const fakeMessage: any = {
+  id: "00000000-0000-0000-0000-000000000aaa",
+  roomId: "00000000-0000-0000-0000-000000000bbb",
+  content: { text: "hi" },
+};
+
+let tmp: string;
+const origWorkspace = process.env.NATIVE_REASONING_WORKSPACE;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(tmpdir(), "native-reasoning-"));
+  process.env.NATIVE_REASONING_WORKSPACE = tmp;
+  clearSystemPromptCache();
+});
+
+afterEach(async () => {
+  if (tmp) await rm(tmp, { recursive: true, force: true });
+  if (origWorkspace === undefined) {
+    delete process.env.NATIVE_REASONING_WORKSPACE;
+  } else {
+    process.env.NATIVE_REASONING_WORKSPACE = origWorkspace;
+  }
+});
+
+describe("assembleSystemPrompt", () => {
+  it("includes character.system and skips missing identity files", async () => {
+    const out = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(out).toContain("char-system");
+    // None of the identity headers should appear when files are missing.
+    expect(out).not.toContain("## Your Identity");
+    expect(out).not.toContain("## Your Soul");
+  });
+
+  it("includes IDENTITY.md when present, with header", async () => {
+    await writeFile(path.join(tmp, "IDENTITY.md"), "i-am-nyx", "utf8");
+    const out = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(out).toContain("## Your Identity");
+    expect(out).toContain("i-am-nyx");
+  });
+
+  it("re-reads only when mtime advances", async () => {
+    const f = path.join(tmp, "SOUL.md");
+    // Pin mtime to a fixed past second so we can step it forward cleanly.
+    await writeFile(f, "soul-v1", "utf8");
+    const pinned = new Date("2024-01-01T00:00:00.000Z");
+    await utimes(f, pinned, pinned);
+
+    const first = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(first).toContain("soul-v1");
+
+    // Rewrite in place, then pin mtime back to the same instant. The
+    // mtime-keyed cache should treat this as unchanged and serve v1.
+    await writeFile(f, "soul-v2", "utf8");
+    await utimes(f, pinned, pinned);
+
+    const cached = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(cached).toContain("soul-v1");
+    expect(cached).not.toContain("soul-v2");
+
+    // Step mtime forward → cache invalidates and we see the new content.
+    const future = new Date(pinned.getTime() + 5_000);
+    await utimes(f, future, future);
+
+    const fresh = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(fresh).toContain("soul-v2");
+  });
+
+  it("clearSystemPromptCache forces re-read", async () => {
+    const f = path.join(tmp, "USER.md");
+    await writeFile(f, "user-a", "utf8");
+    const a = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(a).toContain("user-a");
+
+    // Replace + pin mtime to the same instant — without clear, would stay stale.
+    const pinned = new Date("2024-06-15T12:00:00.000Z");
+    await utimes(f, pinned, pinned);
+    await assembleSystemPrompt(fakeRuntime, fakeMessage); // prime cache at pinned mtime
+    await writeFile(f, "user-b", "utf8");
+    await utimes(f, pinned, pinned);
+
+    clearSystemPromptCache();
+    const b = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(b).toContain("user-b");
+  });
+
+  it("handles missing workspace dir gracefully", async () => {
+    const missing = path.join(tmp, "does-not-exist");
+    process.env.NATIVE_REASONING_WORKSPACE = missing;
+    const out = await assembleSystemPrompt(fakeRuntime, fakeMessage);
+    expect(out).toContain("char-system");
+  });
+
+  it("appends recent room messages when getMemories returns history", async () => {
+    const runtime: any = {
+      ...fakeRuntime,
+      agentId: "agent-id",
+      getMemories: vi.fn(async () => [
+        // returned newest-first by convention
+        {
+          id: "m3",
+          entityId: "agent-id",
+          content: { text: "agent reply" },
+        },
+        {
+          id: "m2",
+          entityId: "user-id",
+          content: { text: "user follow-up" },
+        },
+        {
+          id: "m1",
+          entityId: "user-id",
+          content: { text: "user opener" },
+        },
+      ]),
+    };
+    const out = await assembleSystemPrompt(runtime, fakeMessage);
+    expect(out).toContain("## Recent Conversation");
+    expect(out).toContain("user: user opener");
+    expect(out).toContain("user: user follow-up");
+    expect(out).toContain("agent: agent reply");
+    // Chronological order check: opener should come before reply.
+    expect(out.indexOf("user opener")).toBeLessThan(out.indexOf("agent reply"));
+  });
+});
+
+// Silence unused import warning for `mkdir` while keeping the import handy
+// in case future tests need it.
+void mkdir;

--- a/packages/native-reasoning/src/__tests__/tool-format-openai.test.ts
+++ b/packages/native-reasoning/src/__tests__/tool-format-openai.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { toOpenAITool, toOpenAITools } from "../tool-format/openai.js";
+import type { NativeTool } from "../tool-schema.js";
+
+const sampleTool: NativeTool = {
+  type: "custom",
+  name: "bash",
+  description: "Run a bash command.",
+  input_schema: {
+    type: "object",
+    properties: {
+      command: { type: "string", description: "command to run" },
+      timeout_ms: { type: "number", description: "timeout in ms" },
+    },
+    required: ["command"],
+  },
+};
+
+describe("toOpenAITool", () => {
+  it("converts a single NativeTool to OpenAI function-tool shape", () => {
+    const out = toOpenAITool(sampleTool);
+    expect(out).toEqual({
+      type: "function",
+      name: "bash",
+      description: "Run a bash command.",
+      parameters: sampleTool.input_schema,
+      strict: false,
+    });
+  });
+
+  it("defaults strict to false (relaxed parsing)", () => {
+    const out = toOpenAITool(sampleTool);
+    expect(out.strict).toBe(false);
+  });
+
+  it("preserves the input_schema reference verbatim as parameters", () => {
+    const out = toOpenAITool(sampleTool);
+    // Same JSON Schema object passed through (we don't deep-clone).
+    expect(out.parameters).toBe(sampleTool.input_schema);
+  });
+
+  it("does not mutate the source tool", () => {
+    const before = JSON.stringify(sampleTool);
+    toOpenAITool(sampleTool);
+    expect(JSON.stringify(sampleTool)).toBe(before);
+  });
+});
+
+describe("toOpenAITools", () => {
+  it("converts an array of tools cleanly", () => {
+    const second: NativeTool = {
+      type: "custom",
+      name: "ignore",
+      description: "Skip this message silently.",
+      input_schema: { type: "object", properties: {} },
+    };
+    const out = toOpenAITools([sampleTool, second]);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.name).toBe("bash");
+    expect(out[0]?.type).toBe("function");
+    expect(out[1]?.name).toBe("ignore");
+    expect(out[1]?.type).toBe("function");
+    expect(out.every((t) => t.strict === false)).toBe(true);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(toOpenAITools([])).toEqual([]);
+  });
+
+  it("converts the default registry without errors", async () => {
+    const { buildDefaultRegistry } = await import("../tools/registry.js");
+    const { buildToolsArray } = await import("../tool-schema.js");
+    const reg = buildDefaultRegistry();
+    const native = buildToolsArray(reg);
+    expect(native.length).toBeGreaterThan(0);
+
+    const openai = toOpenAITools(native);
+    expect(openai).toHaveLength(native.length);
+
+    for (const t of openai) {
+      expect(t.type).toBe("function");
+      expect(typeof t.name).toBe("string");
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(typeof t.description).toBe("string");
+      expect(t.parameters).toBeDefined();
+      expect((t.parameters as { type?: string }).type).toBe("object");
+      expect(t.strict).toBe(false);
+    }
+
+    // The default registry is safe-by-default: bash is shipped as a tool but
+    // not exposed unless a caller opts into registering it.
+    const names = openai.map((t) => t.name);
+    expect(names).not.toContain("bash");
+    expect(names).toContain("ignore");
+  });
+});

--- a/packages/native-reasoning/src/__tests__/tools.test.ts
+++ b/packages/native-reasoning/src/__tests__/tools.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Wave 1.B tool tests. These exercise the *inline* tool surface — bash,
+ * file ops, ignore, path safety, and a mocked memory runtime.
+ *
+ * SHELL_ALLOWED_DIRECTORY is overridden to a per-suite tmpdir so tests don't
+ * touch /workspace.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import * as bashMod from "../tools/bash.js";
+import {
+  editFileHandler,
+  readFileHandler,
+  writeFileHandler,
+} from "../tools/file_ops.js";
+import * as ignoreMod from "../tools/ignore.js";
+import { recallHandler, rememberHandler } from "../tools/memory.js";
+import { buildDefaultRegistry } from "../tools/registry.js";
+
+let TMPDIR: string;
+let prevAllowed: string | undefined;
+
+beforeAll(async () => {
+  TMPDIR = await fs.mkdtemp(path.join(os.tmpdir(), "nyx-tools-"));
+  prevAllowed = process.env.SHELL_ALLOWED_DIRECTORY;
+  process.env.SHELL_ALLOWED_DIRECTORY = TMPDIR;
+});
+
+afterAll(async () => {
+  if (prevAllowed === undefined) delete process.env.SHELL_ALLOWED_DIRECTORY;
+  else process.env.SHELL_ALLOWED_DIRECTORY = prevAllowed;
+  await fs.rm(TMPDIR, { recursive: true, force: true });
+});
+
+const fakeRuntime = (): IAgentRuntime => ({}) as unknown as IAgentRuntime;
+const fakeMessage = (): Memory => ({}) as unknown as Memory;
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+describe("bash tool", () => {
+  it("echoes a string back via /bin/sh", async () => {
+    const res = await bashMod.handler(
+      { command: "echo hello-nyx" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(res.is_error).toBeFalsy();
+    expect(res.content).toContain("hello-nyx");
+  });
+
+  it("captures non-zero exit and stderr", async () => {
+    const res = await bashMod.handler(
+      { command: "echo oops 1>&2; exit 3" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toContain("exit 3");
+    expect(res.content).toContain("oops");
+  });
+
+  it("rejects rm -rf / and similar footguns", async () => {
+    const res = await bashMod.handler(
+      { command: "rm -rf /" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/refused/i);
+  });
+
+  it("rejects cwd escapes", async () => {
+    const res = await bashMod.handler(
+      { command: "echo x", cwd: "../etc" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/cwd|outside|\.\./);
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+describe("file_ops", () => {
+  it("write_file -> read_file roundtrip", async () => {
+    const w = await writeFileHandler(
+      { path: "hello.txt", content: "alpha\nbeta\ngamma\n" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(w.is_error).toBeFalsy();
+
+    const r = await readFileHandler(
+      { path: "hello.txt" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(r.is_error).toBeFalsy();
+    expect(r.content).toBe("alpha\nbeta\ngamma\n");
+
+    const paged = await readFileHandler(
+      { path: "hello.txt", offset: 1, limit: 1 },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(paged.content).toBe("beta");
+  });
+
+  it("edit_file replaces a unique substring", async () => {
+    await writeFileHandler(
+      { path: "edit.txt", content: "the quick brown fox\n" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    const e = await editFileHandler(
+      { path: "edit.txt", old_string: "brown", new_string: "purple" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(e.is_error).toBeFalsy();
+    const r = await readFileHandler(
+      { path: "edit.txt" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(r.content).toContain("purple fox");
+  });
+
+  it("edit_file errors when needle appears multiple times", async () => {
+    await writeFileHandler(
+      { path: "dup.txt", content: "ab ab ab\n" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    const e = await editFileHandler(
+      { path: "dup.txt", old_string: "ab", new_string: "ZZ" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(e.is_error).toBe(true);
+    expect(e.content).toMatch(/not unique/);
+  });
+
+  it("edit_file errors when needle is missing", async () => {
+    await writeFileHandler(
+      { path: "miss.txt", content: "nothing here\n" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    const e = await editFileHandler(
+      { path: "miss.txt", old_string: "ghost", new_string: "Z" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(e.is_error).toBe(true);
+    expect(e.content).toMatch(/not found/);
+  });
+
+  it("rejects ../ escapes from any path-bearing tool", async () => {
+    const r = await readFileHandler(
+      { path: "../../etc/passwd" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(r.is_error).toBe(true);
+    expect(r.content).toMatch(/\.\.|outside/);
+
+    const w = await writeFileHandler(
+      { path: "/etc/passwd", content: "no" },
+      fakeRuntime(),
+      fakeMessage(),
+    );
+    expect(w.is_error).toBe(true);
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+describe("ignore tool", () => {
+  it("returns the expected sentinel result", async () => {
+    const res = await ignoreMod.handler({}, fakeRuntime(), fakeMessage());
+    expect(res.is_error).toBeFalsy();
+    expect(res.content).toBe("ignored");
+  });
+
+  it("is wired into the default registry", () => {
+    const reg = buildDefaultRegistry();
+    expect(reg.has("ignore")).toBe(true);
+    expect(reg.get("ignore")?.tool.name).toBe("ignore");
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+describe("memory tools (mocked runtime)", () => {
+  it("recall calls searchMemories with an embedding from useModel", async () => {
+    const searchMemories = vi.fn().mockResolvedValue([
+      {
+        id: "m1",
+        content: { text: "remembered fact about wakesync" },
+        createdAt: Date.now(),
+      },
+    ]);
+    const useModel = vi.fn().mockResolvedValue([0.1, 0.2, 0.3]);
+    const runtime = {
+      agentId: "agent-1",
+      useModel,
+      searchMemories,
+    } as unknown as IAgentRuntime;
+    const message = { roomId: "room-1" } as unknown as Memory;
+
+    const res = await recallHandler({ query: "wakesync" }, runtime, message);
+    expect(res.is_error).toBeFalsy();
+    expect(res.content).toContain("wakesync");
+    expect(useModel).toHaveBeenCalledWith("TEXT_EMBEDDING", {
+      text: "wakesync",
+    });
+    expect(searchMemories).toHaveBeenCalledTimes(1);
+    const args = searchMemories.mock.calls[0][0];
+    expect(args.embedding).toEqual([0.1, 0.2, 0.3]);
+    expect(args.tableName).toBe("messages");
+    expect(args.roomId).toBe("room-1");
+  });
+
+  it("remember calls runtime.createMemory and returns the id", async () => {
+    const createMemory = vi.fn().mockResolvedValue("mem-uuid-123");
+    const runtime = {
+      agentId: "agent-1",
+      createMemory,
+    } as unknown as IAgentRuntime;
+    const message = {
+      roomId: "room-1",
+      entityId: "user-1",
+    } as unknown as Memory;
+
+    const res = await rememberHandler(
+      { text: "shadow prefers bun", category: "preference" },
+      runtime,
+      message,
+    );
+    expect(res.is_error).toBeFalsy();
+    expect(res.content).toContain("mem-uuid-123");
+    expect(res.content).toContain("preference");
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const [memArg, tableArg] = createMemory.mock.calls[0];
+    expect(memArg.content.text).toBe("shadow prefers bun");
+    expect(memArg.roomId).toBe("room-1");
+    expect(tableArg).toBe("facts");
+  });
+
+  it("recall surfaces an error when no embedding model is registered", async () => {
+    const runtime = {
+      agentId: "a",
+      searchMemories: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const res = await recallHandler({ query: "x" }, runtime, fakeMessage());
+    expect(res.is_error).toBe(true);
+    expect(res.content).toMatch(/embedding/);
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+describe("registry", () => {
+  it("includes safe-by-default tools", () => {
+    const reg = buildDefaultRegistry();
+    const expected = [
+      "read_file",
+      "write_file",
+      "edit_file",
+      "glob",
+      "grep",
+      "web_fetch",
+      "web_search",
+      "recall",
+      "remember",
+      "ignore",
+    ];
+    for (const name of expected) expect(reg.has(name)).toBe(true);
+    expect(reg.has("bash")).toBe(false);
+  });
+});
+
+/* ──────────────────────────────────────────────────────────────────── */
+
+// Sanity check: confirm the test environment actually has `sh` available.
+describe("environment sanity", () => {
+  it("sh is on PATH", () => {
+    const r = spawnSync("sh", ["-c", "echo ok"], { encoding: "utf8" });
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("ok");
+  });
+});

--- a/packages/native-reasoning/src/backends/anthropic.ts
+++ b/packages/native-reasoning/src/backends/anthropic.ts
@@ -1,0 +1,299 @@
+/**
+ * AnthropicBackend — implements ReasoningBackend on top of the official
+ * `@anthropic-ai/sdk`. Uses the `advanced-tool-use-2025-11-20` beta.
+ *
+ * Reads from env on construction:
+ *   - ANTHROPIC_BASE_URL  (optional; "/v1" suffix is stripped — many proxies
+ *     ship "/v1" terminated URLs but the SDK appends "/v1/messages" itself)
+ *   - ANTHROPIC_API_KEY   (optional; defaults to "proxy-handles-auth" so a
+ *     reverse-proxy can attach the real credential)
+ *   - ANTHROPIC_LARGE_MODEL  (optional; default "claude-opus-4-7")
+ *
+ * Translates the unified `TurnMessage[]` ↔ Anthropic content blocks at the
+ * boundary so the loop never sees Anthropic-shaped types.
+ *
+ * Includes a 3-attempt retry on transient errors (network failures, 5xx,
+ * 429) with linear backoff — lifted from the inline error-handling that
+ * used to live in `loop.ts`.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { logger } from "@elizaos/core";
+
+import {
+  type AnthropicTool,
+  toAnthropicTools,
+} from "../tool-format/anthropic.js";
+import type {
+  CallTurnOptions,
+  ReasoningBackend,
+  TextBlock,
+  ToolCallRequest,
+  ToolUseBlock,
+  TurnContentBlock,
+  TurnMessage,
+  TurnResult,
+} from "./types.js";
+
+const DEFAULT_MODEL = "claude-opus-4-7";
+const DEFAULT_MAX_TOKENS = 4096;
+const ADVANCED_TOOL_USE_BETA = "advanced-tool-use-2025-11-20";
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 250;
+
+// ---- Anthropic wire types we need at the boundary. Kept loose to be
+// resilient to small SDK-version drift in beta block layouts.
+
+interface AnthropicTextBlock {
+  type: "text";
+  text: string;
+}
+interface AnthropicToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+}
+type AnthropicAssistantBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+interface AnthropicToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicAssistantBlock[] | AnthropicToolResultBlock[];
+}
+
+interface AnthropicResponse {
+  content: AnthropicAssistantBlock[];
+  stop_reason?: string;
+  usage?: { input_tokens?: number; output_tokens?: number };
+}
+
+/**
+ * Minimal client surface we depend on. Real client is the Anthropic SDK's
+ * `client.beta.messages` — explicit typing lets tests inject mocks without
+ * pulling in the full SDK surface.
+ */
+export interface AnthropicClientLike {
+  beta: {
+    messages: {
+      create(params: {
+        model: string;
+        system?: string;
+        messages: AnthropicMessage[];
+        tools?: AnthropicTool[];
+        max_tokens: number;
+        betas?: string[];
+      }): Promise<AnthropicResponse>;
+    };
+  };
+}
+
+export interface AnthropicBackendOptions {
+  /** Override the SDK client (tests). Defaults to a real Anthropic SDK client. */
+  client?: AnthropicClientLike;
+  /** Override model. Default: env ANTHROPIC_LARGE_MODEL or "claude-opus-4-7". */
+  model?: string;
+  /** Override max output tokens. Default 4096. */
+  maxTokens?: number;
+}
+
+function buildDefaultClient(): AnthropicClientLike {
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? "proxy-handles-auth";
+  let baseURL = process.env.ANTHROPIC_BASE_URL?.trim() || undefined;
+  // The Anthropic SDK appends "/v1/messages" itself; if the configured base
+  // URL already ends in "/v1" (a common proxy convention) strip it to avoid
+  // the double "/v1/v1/messages" 404. Idempotent for already-stripped bases.
+  if (baseURL) {
+    baseURL = baseURL.replace(/\/+$/, "").replace(/\/v1$/, "");
+  }
+  return new Anthropic({ apiKey, baseURL }) as unknown as AnthropicClientLike;
+}
+
+/** Heuristic: classify an error as transient (worth retrying). */
+function isTransientError(err: unknown): boolean {
+  if (!err) return false;
+  // Anthropic SDK errors expose `.status`; fetch errors expose name "TypeError".
+  const status = (err as { status?: number }).status;
+  if (typeof status === "number") {
+    if (status === 429) return true;
+    if (status >= 500 && status < 600) return true;
+    return false;
+  }
+  const name = (err as { name?: string }).name;
+  if (name === "TypeError" || name === "AbortError") return false;
+  // Network-ish errors without status: assume transient.
+  const msg = err instanceof Error ? err.message : String(err);
+  return /ECONN|ETIMEDOUT|EAI_AGAIN|fetch failed|network/i.test(msg);
+}
+
+/** Translate unified TurnMessage[] → Anthropic wire messages. */
+function toAnthropicMessages(messages: TurnMessage[]): AnthropicMessage[] {
+  const out: AnthropicMessage[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      // User turns can be either pure text or a mix of text/tool_result.
+      // Pre-flatten pure-text turns to a string for compactness on the wire.
+      const allText = m.content.every((b) => b.type === "text");
+      if (allText) {
+        out.push({
+          role: "user",
+          content: m.content.map((b) => (b as TextBlock).text).join(""),
+        });
+        continue;
+      }
+      // Mixed or tool_result content. Anthropic accepts an array of blocks.
+      out.push({
+        role: "user",
+        content: m.content
+          .map((b) => mapBlockToAnthropicUserSide(b))
+          .filter(
+            (b): b is AnthropicToolResultBlock | AnthropicTextBlock =>
+              b !== null,
+          ) as AnthropicToolResultBlock[],
+      });
+    } else if (m.role === "tool") {
+      // Tool results — Anthropic represents them as user-role messages
+      // containing tool_result blocks. Collapse adjacent tool messages.
+      out.push({
+        role: "user",
+        content: m.content
+          .filter(
+            (b): b is Extract<TurnContentBlock, { type: "tool_result" }> =>
+              b.type === "tool_result",
+          )
+          .map((b) => ({
+            type: "tool_result" as const,
+            tool_use_id: b.tool_use_id,
+            content: b.content,
+            ...(b.is_error ? { is_error: true } : {}),
+          })),
+      });
+    } else {
+      // assistant
+      const blocks: AnthropicAssistantBlock[] = m.content
+        .filter(
+          (b): b is TextBlock | ToolUseBlock =>
+            b.type === "text" || b.type === "tool_use",
+        )
+        .map((b) =>
+          b.type === "text"
+            ? { type: "text", text: b.text }
+            : {
+                type: "tool_use",
+                id: b.id,
+                name: b.name,
+                input: b.input,
+              },
+        );
+      out.push({ role: "assistant", content: blocks });
+    }
+  }
+  return out;
+}
+
+function mapBlockToAnthropicUserSide(
+  b: TurnContentBlock,
+): AnthropicTextBlock | AnthropicToolResultBlock | null {
+  if (b.type === "text") return { type: "text", text: b.text };
+  if (b.type === "tool_result") {
+    return {
+      type: "tool_result",
+      tool_use_id: b.tool_use_id,
+      content: b.content,
+      ...(b.is_error ? { is_error: true } : {}),
+    };
+  }
+  return null;
+}
+
+/** Translate an Anthropic response → unified TurnResult. */
+function fromAnthropicResponse(resp: AnthropicResponse): TurnResult {
+  const blocks = Array.isArray(resp.content) ? resp.content : [];
+  const text = blocks
+    .filter((b): b is AnthropicTextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  const toolCalls: ToolCallRequest[] = blocks
+    .filter((b): b is AnthropicToolUseBlock => b.type === "tool_use")
+    .map((b) => ({ id: b.id, name: b.name, input: b.input }));
+
+  const rawAssistantBlocks: Array<TextBlock | ToolUseBlock> = blocks.map((b) =>
+    b.type === "text"
+      ? { type: "text", text: b.text }
+      : { type: "tool_use", id: b.id, name: b.name, input: b.input },
+  );
+
+  const usage =
+    resp.usage &&
+    (typeof resp.usage.input_tokens === "number" ||
+      typeof resp.usage.output_tokens === "number")
+      ? {
+          input: resp.usage.input_tokens ?? 0,
+          output: resp.usage.output_tokens ?? 0,
+        }
+      : undefined;
+
+  return {
+    text,
+    toolCalls,
+    stopReason: resp.stop_reason,
+    usage,
+    rawAssistantBlocks,
+  };
+}
+
+export class AnthropicBackend implements ReasoningBackend {
+  readonly name = "anthropic";
+  private readonly client: AnthropicClientLike;
+  private readonly model: string;
+  private readonly maxTokens: number;
+
+  constructor(opts: AnthropicBackendOptions = {}) {
+    this.client = opts.client ?? buildDefaultClient();
+    this.model =
+      opts.model ?? process.env.ANTHROPIC_LARGE_MODEL ?? DEFAULT_MODEL;
+    this.maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  async callTurn(opts: CallTurnOptions): Promise<TurnResult> {
+    const wireMessages = toAnthropicMessages(opts.messages);
+    const wireTools = toAnthropicTools(opts.tools);
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      if (opts.abortSignal?.aborted) {
+        throw new Error("aborted");
+      }
+      try {
+        const resp = await this.client.beta.messages.create({
+          model: this.model,
+          system: opts.systemPrompt || undefined,
+          messages: wireMessages,
+          tools: wireTools.length > 0 ? wireTools : undefined,
+          max_tokens: this.maxTokens,
+          betas: [ADVANCED_TOOL_USE_BETA],
+        });
+        return fromAnthropicResponse(resp);
+      } catch (err) {
+        lastError = err;
+        if (attempt >= MAX_RETRIES || !isTransientError(err)) {
+          throw err;
+        }
+        const delay = RETRY_BASE_DELAY_MS * attempt;
+        logger.warn(
+          `[native-reasoning][anthropic] transient error attempt ${attempt}/${MAX_RETRIES}, retrying in ${delay}ms: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        await new Promise((r) => setTimeout(r, delay));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+}

--- a/packages/native-reasoning/src/backends/codex-auth.ts
+++ b/packages/native-reasoning/src/backends/codex-auth.ts
@@ -1,0 +1,310 @@
+/**
+ * codex-auth — load, refresh, and atomically save the chatgpt CLI's
+ * `~/.codex/auth.json` file. Used by the codex stealth reasoning backend.
+ *
+ * Refresh races between concurrent processes (e.g. Sol + nyx both noticing
+ * an expired access_token at the same time) are guarded by an OS-level
+ * lock file: `<auth-path>.lock`, created with O_CREAT|O_EXCL via
+ * `fs.open(..., "wx")`. Stale locks (>30s old) are forcibly broken so a
+ * crashed process can't deadlock the world.
+ *
+ * Saves are atomic: write to `<auth-path>.tmp.<pid>.<rand>` then `rename`.
+ */
+
+import { randomBytes } from "node:crypto";
+import {
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRY_DELAY_MS = 100;
+const LOCK_RETRY_MAX = 30;
+
+export interface CodexAuth {
+  OPENAI_API_KEY: string | null;
+  auth_mode: "chatgpt" | "apikey";
+  last_refresh: string;
+  tokens: {
+    id_token: string;
+    access_token: string;
+    refresh_token: string;
+    account_id: string;
+  };
+}
+
+// Allow tests to inject a fetch / clock without touching the global.
+export interface CodexAuthDeps {
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+let injectedDeps: CodexAuthDeps = {};
+
+export function __setCodexAuthDeps(deps: CodexAuthDeps): void {
+  injectedDeps = deps;
+}
+
+export function __resetCodexAuthDeps(): void {
+  injectedDeps = {};
+}
+
+function getFetch(): typeof fetch {
+  return injectedDeps.fetch ?? fetch;
+}
+
+function nowMs(): number {
+  return injectedDeps.now ? injectedDeps.now() : Date.now();
+}
+
+export function defaultAuthPath(): string {
+  return join(homedir(), ".codex", "auth.json");
+}
+
+export async function loadCodexAuth(path?: string): Promise<CodexAuth> {
+  const p = path ?? defaultAuthPath();
+  const raw = await readFile(p, "utf8");
+  const parsed = JSON.parse(raw) as Partial<CodexAuth>;
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !parsed.tokens ||
+    typeof parsed.tokens.access_token !== "string" ||
+    typeof parsed.tokens.refresh_token !== "string" ||
+    typeof parsed.tokens.id_token !== "string" ||
+    typeof parsed.tokens.account_id !== "string"
+  ) {
+    throw new Error(`codex auth.json malformed at ${p}: missing tokens fields`);
+  }
+  return {
+    OPENAI_API_KEY: parsed.OPENAI_API_KEY ?? null,
+    auth_mode: parsed.auth_mode === "apikey" ? "apikey" : "chatgpt",
+    last_refresh: parsed.last_refresh ?? new Date(0).toISOString(),
+    tokens: {
+      id_token: parsed.tokens.id_token,
+      access_token: parsed.tokens.access_token,
+      refresh_token: parsed.tokens.refresh_token,
+      account_id: parsed.tokens.account_id,
+    },
+  };
+}
+
+/**
+ * Atomic write: writes to `<path>.tmp.<pid>.<rand>` then renames over the
+ * destination. `rename` is atomic on POSIX, so any concurrent reader sees
+ * either the old contents or the new — never a partial file.
+ */
+export async function saveCodexAuth(
+  auth: CodexAuth,
+  path: string,
+): Promise<void> {
+  const tmp = `${path}.tmp.${process.pid}.${randomBytes(4).toString("hex")}`;
+  const body = `${JSON.stringify(auth, null, 2)}\n`;
+  await writeFile(tmp, body, { mode: 0o600 });
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    // best-effort cleanup if rename fails
+    try {
+      await unlink(tmp);
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+/**
+ * Decode a JWT's payload (no signature verification — we only need `exp`).
+ * Returns null if the token isn't a valid JWT shape.
+ */
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  const payloadPart = parts[1];
+  if (!payloadPart) return null;
+  // base64url → base64
+  const b64 = payloadPart.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+  try {
+    const json = Buffer.from(b64 + pad, "base64").toString("utf8");
+    const obj = JSON.parse(json) as Record<string, unknown>;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True if `tokens.access_token` is past its `exp` claim (or within
+ * `bufferSeconds` of it). If the token can't be decoded we treat it as
+ * expired so refresh fires defensively.
+ */
+export function isExpired(auth: CodexAuth, bufferSeconds = 60): boolean {
+  const payload = decodeJwtPayload(auth.tokens.access_token);
+  if (!payload) return true;
+  const exp = payload.exp;
+  if (typeof exp !== "number") return true;
+  const expMs = exp * 1000;
+  return nowMs() + bufferSeconds * 1000 >= expMs;
+}
+
+// ---------------------------------------------------------------------------
+// Lock acquisition
+// ---------------------------------------------------------------------------
+
+interface AcquiredLock {
+  path: string;
+  release: () => Promise<void>;
+}
+
+async function tryCreateLock(lockPath: string): Promise<AcquiredLock | null> {
+  try {
+    const fh = await open(lockPath, "wx", 0o600);
+    try {
+      await fh.writeFile(`${process.pid}\n`);
+    } finally {
+      await fh.close();
+    }
+    return {
+      path: lockPath,
+      release: async () => {
+        try {
+          await unlink(lockPath);
+        } catch {
+          /* lock already gone — ignore */
+        }
+      },
+    };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST") return null;
+    throw err;
+  }
+}
+
+async function isLockStale(lockPath: string): Promise<boolean> {
+  try {
+    const st = await stat(lockPath);
+    const age = nowMs() - st.mtimeMs;
+    return age > LOCK_STALE_MS;
+  } catch {
+    // vanished — not stale, just gone
+    return false;
+  }
+}
+
+async function acquireLock(authPath: string): Promise<AcquiredLock> {
+  const lockPath = `${authPath}.lock`;
+  for (let attempt = 0; attempt < LOCK_RETRY_MAX; attempt++) {
+    const lock = await tryCreateLock(lockPath);
+    if (lock) return lock;
+
+    // Existing lock — break it if it's stale.
+    if (await isLockStale(lockPath)) {
+      try {
+        await unlink(lockPath);
+      } catch {
+        /* race with another reaper — try again */
+      }
+      continue;
+    }
+
+    await new Promise<void>((resolve) =>
+      setTimeout(resolve, LOCK_RETRY_DELAY_MS),
+    );
+  }
+  throw new Error(
+    `codex-auth: could not acquire lock ${lockPath} after ${LOCK_RETRY_MAX} retries`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Refresh
+// ---------------------------------------------------------------------------
+
+interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+}
+
+/**
+ * Refresh the access_token using the stored refresh_token. Acquires a
+ * file-level lock for the duration of the network call + write, so two
+ * processes won't race on the same auth.json. After acquiring the lock
+ * we re-read auth from disk in case another process refreshed first; if
+ * the on-disk access_token is no longer expired, we return that and skip
+ * the network call.
+ */
+export async function refreshCodexAuth(
+  currentAuth: CodexAuth,
+  path: string,
+): Promise<CodexAuth> {
+  const lock = await acquireLock(path);
+  try {
+    // Re-check after lock — another process may have refreshed already.
+    try {
+      const onDisk = await loadCodexAuth(path);
+      if (!isExpired(onDisk)) {
+        return onDisk;
+      }
+      currentAuth = onDisk;
+    } catch {
+      // missing or unreadable — fall through and refresh from current
+    }
+
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: currentAuth.tokens.refresh_token,
+      client_id: OAUTH_CLIENT_ID,
+    });
+
+    const res = await getFetch()(OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        accept: "application/json",
+      },
+      body: body.toString(),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `codex-auth: refresh failed: ${res.status} ${res.statusText} ${text}`.trim(),
+      );
+    }
+
+    const json = (await res.json()) as OAuthTokenResponse;
+    if (!json || typeof json.access_token !== "string") {
+      throw new Error("codex-auth: refresh response missing access_token");
+    }
+
+    const next: CodexAuth = {
+      ...currentAuth,
+      last_refresh: new Date(nowMs()).toISOString(),
+      tokens: {
+        ...currentAuth.tokens,
+        access_token: json.access_token,
+        refresh_token: json.refresh_token ?? currentAuth.tokens.refresh_token,
+        id_token: json.id_token ?? currentAuth.tokens.id_token,
+      },
+    };
+
+    await saveCodexAuth(next, path);
+    return next;
+  } finally {
+    await lock.release();
+  }
+}

--- a/packages/native-reasoning/src/backends/codex.ts
+++ b/packages/native-reasoning/src/backends/codex.ts
@@ -1,0 +1,623 @@
+/**
+ * CodexBackend — chatgpt-prolite "stealth" reasoning backend.
+ *
+ * Talks to `https://chatgpt.com/backend-api/codex/responses` using the
+ * OAuth tokens cached by the official `codex` CLI in `~/.codex/auth.json`.
+ * The wire shape is OpenAI's `responses` API (event-stream), wrapped with
+ * codex-specific headers (originator, chatgpt-account-id, codex_cli_rs UA).
+ *
+ * Wires together:
+ *   - Wave A: `ReasoningBackend` interface + unified TurnMessage types
+ *   - Wave C: `loadCodexAuth` + `refreshCodexAuth` (atomic file-locked
+ *     OAuth refresh) and `parseSSE` (spec-compliant streaming SSE parser)
+ *   - Wave D: `toOpenAITool` (NativeTool → OpenAI function tool)
+ *
+ * The constructor accepts overrides for every third-party dep (fetch, auth
+ * load+refresh, tool translator) so tests can run in full isolation
+ * without touching the real filesystem or network.
+ *
+ * Concurrency:
+ *   - Single in-process semaphore (FIFO promise chain). One in-flight
+ *     request at a time per backend instance. Cheap soft mitigation
+ *     against the chatgpt account being flagged for parallel sessions.
+ *   - 50–CODEX_JITTER_MS_MAX ms jitter before each request.
+ *
+ * Retries:
+ *   - On 401: refreshCodexAuth() then retry ONCE. Other errors propagate.
+ */
+
+import os from "node:os";
+import path from "node:path";
+
+import { logger } from "@elizaos/core";
+
+import { parseSSE } from "../sse-parser.js";
+import { type OpenAITool, toOpenAITool } from "../tool-format/openai.js";
+import type { NativeTool } from "../tool-schema.js";
+import {
+  type CodexAuth,
+  loadCodexAuth as loadCodexAuthDefault,
+  refreshCodexAuth as refreshCodexAuthDefault,
+} from "./codex-auth.js";
+import type {
+  CallTurnOptions,
+  ReasoningBackend,
+  TextBlock,
+  ToolCallRequest,
+  ToolUseBlock,
+  TurnMessage,
+  TurnResult,
+} from "./types.js";
+
+export type { OpenAITool } from "../tool-format/openai.js";
+export type { CodexAuth } from "./codex-auth.js";
+
+/** Local convenience type — Wave A's TurnResult.usage shape. */
+type TurnUsage = NonNullable<TurnResult["usage"]>;
+
+// ---------------------------------------------------------------------------
+// Injection seams
+// ---------------------------------------------------------------------------
+
+export type ToolTranslator = (t: NativeTool) => OpenAITool;
+export type LoadAuthFn = (path: string) => Promise<CodexAuth>;
+/**
+ * Auth-refresh signature. Wave C: `(currentAuth, path) => Promise<CodexAuth>`.
+ * The backend always passes both; injected stubs may ignore the first arg.
+ */
+export type RefreshAuthFn = (
+  currentAuth: CodexAuth,
+  path: string,
+) => Promise<CodexAuth>;
+
+export interface CodexBackendConfig {
+  authPath?: string;
+  model?: string;
+  baseUrl?: string;
+  userAgent?: string;
+  originator?: string;
+  jitterMaxMs?: number;
+  fetchImpl?: typeof fetch;
+  loadAuth?: LoadAuthFn;
+  refreshAuth?: RefreshAuthFn;
+  toolTranslator?: ToolTranslator;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_AUTH_PATH = path.join(os.homedir(), ".codex", "auth.json");
+const DEFAULT_MODEL = "gpt-5.5";
+const DEFAULT_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const DEFAULT_USER_AGENT = "codex_cli_rs/0.124.0";
+const DEFAULT_ORIGINATOR = "codex_cli_rs";
+const DEFAULT_JITTER_MAX_MS = 200;
+const DEFAULT_JITTER_MIN_MS = 50;
+
+// ---------------------------------------------------------------------------
+// Wire types — codex `input` array discriminated union
+// ---------------------------------------------------------------------------
+
+type CodexInputItem =
+  | {
+      type: "message";
+      role: "user" | "assistant" | "system";
+      content: Array<{
+        type: "input_text" | "output_text";
+        text: string;
+      }>;
+    }
+  | {
+      type: "function_call";
+      call_id: string;
+      name: string;
+      arguments: string;
+    }
+  | {
+      type: "function_call_output";
+      call_id: string;
+      output: string;
+    };
+
+interface CodexResponseBody {
+  model: string;
+  instructions: string;
+  input: CodexInputItem[];
+  store: false;
+  stream: true;
+  tools?: OpenAITool[];
+}
+
+// ---------------------------------------------------------------------------
+// Backend
+// ---------------------------------------------------------------------------
+
+export class CodexBackend implements ReasoningBackend {
+  readonly name = "codex";
+  private readonly authPath: string;
+  private readonly model: string;
+  private readonly baseUrl: string;
+  private readonly userAgent: string;
+  private readonly originator: string;
+  private readonly jitterMaxMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly loadAuth: LoadAuthFn;
+  private readonly refreshAuth: RefreshAuthFn;
+  private readonly toolTranslator: ToolTranslator;
+
+  /** FIFO concurrency tail; chained Promise serializes calls. */
+  private tail: Promise<unknown> = Promise.resolve();
+
+  constructor(config: CodexBackendConfig = {}) {
+    this.authPath =
+      config.authPath ?? process.env.CODEX_AUTH_PATH ?? DEFAULT_AUTH_PATH;
+    this.model = config.model ?? process.env.CODEX_MODEL ?? DEFAULT_MODEL;
+    this.baseUrl = stripTrailingSlash(
+      config.baseUrl ?? process.env.CODEX_BASE_URL ?? DEFAULT_BASE_URL,
+    );
+    this.userAgent =
+      config.userAgent ?? process.env.CODEX_USER_AGENT ?? DEFAULT_USER_AGENT;
+    this.originator =
+      config.originator ?? process.env.CODEX_ORIGINATOR ?? DEFAULT_ORIGINATOR;
+    this.jitterMaxMs =
+      config.jitterMaxMs ??
+      envInt("CODEX_JITTER_MS_MAX", DEFAULT_JITTER_MAX_MS);
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.loadAuth = config.loadAuth ?? loadCodexAuthDefault;
+    this.refreshAuth = config.refreshAuth ?? refreshCodexAuthDefault;
+    this.toolTranslator = config.toolTranslator ?? toOpenAITool;
+  }
+
+  async callTurn(opts: CallTurnOptions): Promise<TurnResult> {
+    // Serialize on the in-process tail. We capture the prior tail, then
+    // install a new one that resolves regardless of our success/failure
+    // (so a thrown error doesn't poison the chain).
+    const prior = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    try {
+      await prior;
+      await this.jitter();
+      return await this.callTurnInner(opts);
+    } finally {
+      release();
+    }
+  }
+
+  private async jitter(): Promise<void> {
+    if (this.jitterMaxMs <= 0) return;
+    const lo = Math.min(DEFAULT_JITTER_MIN_MS, this.jitterMaxMs);
+    const span = Math.max(0, this.jitterMaxMs - lo);
+    const ms = lo + Math.floor(Math.random() * (span + 1));
+    await new Promise((r) => setTimeout(r, ms));
+  }
+
+  private async callTurnInner(opts: CallTurnOptions): Promise<TurnResult> {
+    const input = translateMessagesToCodexInput(opts.messages);
+    const tools = opts.tools.map((t) => this.toolTranslator(t));
+    const body: CodexResponseBody = {
+      model: this.model,
+      instructions: opts.systemPrompt,
+      input,
+      store: false,
+      stream: true,
+    };
+    if (tools.length > 0) body.tools = tools;
+
+    // First attempt with current auth.
+    let auth = await this.loadAuth(this.authPath);
+    let res = await this.postResponses(auth, body, opts.abortSignal);
+    if (res.status === 401) {
+      logger.warn(
+        "[codex] 401 from /responses — refreshing OAuth and retrying once",
+      );
+      try {
+        auth = await this.refreshAuth(auth, this.authPath);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(`codex auth refresh failed: ${msg}`);
+      }
+      res = await this.postResponses(auth, body, opts.abortSignal);
+    }
+    if (!res.ok) {
+      const errText = await safeReadText(res);
+      throw new Error(
+        `codex /responses returned ${res.status} ${res.statusText} :: ${errText.slice(0, 512)}`,
+      );
+    }
+    if (!res.body) {
+      throw new Error("codex /responses returned no body");
+    }
+    return await consumeResponseStream(res.body, opts.abortSignal);
+  }
+
+  private async postResponses(
+    auth: CodexAuth,
+    body: CodexResponseBody,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${auth.tokens.access_token}`,
+      "Content-Type": "application/json",
+      originator: this.originator,
+      "User-Agent": this.userAgent,
+      "OpenAI-Beta": "responses=v1",
+      Accept: "text/event-stream",
+    };
+    if (auth.tokens.account_id) {
+      headers["chatgpt-account-id"] = auth.tokens.account_id;
+    }
+    return this.fetchImpl(`${this.baseUrl}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Translation: TurnMessage[] → codex input array
+// ---------------------------------------------------------------------------
+
+export function translateMessagesToCodexInput(
+  messages: TurnMessage[],
+): CodexInputItem[] {
+  const out: CodexInputItem[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      // User turns may carry text blocks OR tool_result blocks (when the
+      // loop is using Anthropic-style role tagging where role:"user"
+      // holds tool results).
+      const textBlocks = m.content.filter(
+        (b): b is TextBlock => b.type === "text",
+      );
+      if (textBlocks.length > 0) {
+        const text = textBlocks.map((b) => b.text).join("");
+        out.push({
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text }],
+        });
+      }
+      for (const b of m.content) {
+        if (b.type === "tool_result") {
+          out.push({
+            type: "function_call_output",
+            call_id: b.tool_use_id,
+            output: b.content,
+          });
+        }
+      }
+    } else if (m.role === "assistant") {
+      const textBlocks = m.content.filter(
+        (b): b is TextBlock => b.type === "text",
+      );
+      if (textBlocks.length > 0) {
+        const text = textBlocks.map((b) => b.text).join("");
+        if (text.length > 0) {
+          out.push({
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text }],
+          });
+        }
+      }
+      for (const b of m.content) {
+        if (b.type === "tool_use") {
+          out.push({
+            type: "function_call",
+            call_id: b.id,
+            name: b.name,
+            arguments: b.input === undefined ? "" : JSON.stringify(b.input),
+          });
+        }
+      }
+    } else if (m.role === "tool") {
+      for (const b of m.content) {
+        if (b.type === "tool_result") {
+          out.push({
+            type: "function_call_output",
+            call_id: b.tool_use_id,
+            output: b.content,
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// SSE response consumption (uses Wave C parseSSE generator)
+// ---------------------------------------------------------------------------
+
+interface ActiveFunctionCall {
+  id: string;
+  name: string;
+  args: string;
+}
+
+interface FailureInfo {
+  code?: string;
+  message?: string;
+}
+
+async function consumeResponseStream(
+  body: ReadableStream<Uint8Array>,
+  abortSignal?: AbortSignal,
+): Promise<TurnResult> {
+  let text = "";
+  const completedToolCalls: ToolCallRequest[] = [];
+  const activeByItemId = new Map<string, ActiveFunctionCall>();
+  let stopReason: string | undefined;
+  let usage: TurnUsage | undefined;
+  let failed: FailureInfo | null = null;
+  let lastSeq: number | undefined;
+
+  if (abortSignal?.aborted) {
+    throw new Error("codex stream aborted before start");
+  }
+
+  // Wave C's parseSSE owns the reader (locks the stream). We can't call
+  // body.cancel() externally because that throws on a locked stream. So
+  // we race iter.next() against an abort promise; on abort we tell the
+  // generator to return() (which releases the reader lock & cancels).
+  const iter = parseSSE(body);
+  let abortPromise: Promise<never> | null = null;
+  let onAbort: (() => void) | null = null;
+  if (abortSignal) {
+    abortPromise = new Promise<never>((_, reject) => {
+      onAbort = () => reject(new Error("codex stream aborted"));
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+  try {
+    while (true) {
+      if (abortSignal?.aborted) {
+        throw new Error("codex stream aborted");
+      }
+      const next = abortPromise
+        ? await Promise.race([iter.next(), abortPromise])
+        : await iter.next();
+      if (next.done) {
+        if (abortSignal?.aborted) {
+          throw new Error("codex stream aborted");
+        }
+        break;
+      }
+      const ev = next.value;
+      if (!ev.data) continue;
+      let payload: any;
+      try {
+        payload = JSON.parse(ev.data);
+      } catch {
+        // keepalives / comments / non-JSON — skip
+        continue;
+      }
+      const evType: string = ev.event ?? payload?.type ?? "";
+      if (typeof payload?.sequence_number === "number") {
+        lastSeq = payload.sequence_number;
+      }
+      try {
+        handleEvent(evType, payload, {
+          addText: (s) => {
+            text += s;
+          },
+          startCall: (itemId, callId, name) => {
+            activeByItemId.set(itemId, { id: callId, name, args: "" });
+          },
+          appendCallArgs: (itemId, delta) => {
+            const a = activeByItemId.get(itemId);
+            if (a) a.args += delta;
+          },
+          finishCall: (itemId, finalArgs) => {
+            const a = activeByItemId.get(itemId);
+            if (!a) return;
+            const argStr = finalArgs ?? a.args;
+            let parsedInput: unknown;
+            try {
+              parsedInput = argStr ? JSON.parse(argStr) : {};
+            } catch {
+              parsedInput = argStr;
+            }
+            completedToolCalls.push({
+              id: a.id,
+              name: a.name,
+              input: parsedInput,
+            });
+            activeByItemId.delete(itemId);
+          },
+          setStopReason: (r) => {
+            stopReason = r;
+          },
+          setUsage: (u) => {
+            usage = u;
+          },
+          setFailed: (f) => {
+            failed = f;
+          },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `codex SSE handler error on event '${evType}' (seq=${lastSeq ?? "?"}): ${msg}`,
+        );
+      }
+      if (evType === "response.completed") {
+        return finalize(text, completedToolCalls, stopReason, usage);
+      }
+      if (evType === "response.failed") {
+        const f = failed as FailureInfo | null;
+        throw new Error(
+          `codex response.failed (seq=${lastSeq ?? "?"}): ${
+            f?.code ?? "unknown"
+          } ${f?.message ?? ""}`.trim(),
+        );
+      }
+    }
+  } finally {
+    if (abortSignal && onAbort) {
+      abortSignal.removeEventListener("abort", onAbort);
+    }
+    // Fire-and-forget the generator return + body cancel. We deliberately
+    // do NOT await: parseSSE may be parked on `reader.read()` which won't
+    // resolve until the underlying source produces more bytes, and we need
+    // to surface the abort error to the caller right now.
+    void iter.return?.(undefined).catch(() => {
+      /* ignore */
+    });
+    // Cancel the body too, in case parseSSE hasn't locked it yet.
+    if (!body.locked) {
+      void body.cancel().catch(() => {
+        /* ignore */
+      });
+    }
+  }
+
+  // Stream ended without response.completed — return what we have but warn.
+  logger.warn(
+    `[codex] SSE stream ended without response.completed (lastSeq=${lastSeq ?? "?"})`,
+  );
+  return finalize(text, completedToolCalls, stopReason, usage);
+}
+
+interface EventHandlers {
+  addText(s: string): void;
+  startCall(itemId: string, callId: string, name: string): void;
+  appendCallArgs(itemId: string, delta: string): void;
+  finishCall(itemId: string, finalArgs?: string): void;
+  setStopReason(r: string): void;
+  setUsage(u: TurnUsage): void;
+  setFailed(f: FailureInfo): void;
+}
+
+function handleEvent(evType: string, payload: any, h: EventHandlers): void {
+  switch (evType) {
+    case "response.created":
+    case "response.in_progress":
+    case "response.content_part.added":
+    case "response.content_part.done":
+    case "response.output_text.done":
+      return;
+
+    case "response.output_item.added": {
+      const item = payload.item;
+      if (item?.type === "function_call") {
+        const itemId: string = item.id ?? item.call_id;
+        h.startCall(itemId, item.call_id, item.name);
+      }
+      return;
+    }
+
+    case "response.output_text.delta": {
+      const delta: unknown = payload.delta;
+      if (typeof delta === "string") h.addText(delta);
+      return;
+    }
+
+    case "response.function_call_arguments.delta": {
+      const itemId: string = payload.item_id;
+      const delta: unknown = payload.delta;
+      if (itemId && typeof delta === "string") {
+        h.appendCallArgs(itemId, delta);
+      }
+      return;
+    }
+
+    case "response.function_call_arguments.done":
+      // Final string arrives on output_item.done; nothing to do here.
+      return;
+
+    case "response.output_item.done": {
+      const item = payload.item;
+      if (item?.type === "function_call") {
+        const itemId: string = item.id ?? item.call_id;
+        const finalArgs: string | undefined =
+          typeof item.arguments === "string" ? item.arguments : undefined;
+        h.finishCall(itemId, finalArgs);
+      }
+      return;
+    }
+
+    case "response.completed": {
+      const resp = payload.response;
+      if (resp?.stop_reason) h.setStopReason(String(resp.stop_reason));
+      if (resp?.usage) {
+        const inTok = numOrZero(resp.usage.input_tokens);
+        const outTok = numOrZero(resp.usage.output_tokens);
+        h.setUsage({ input: inTok, output: outTok });
+      }
+      return;
+    }
+
+    case "response.failed": {
+      const resp = payload.response;
+      h.setFailed({
+        code: resp?.error?.code,
+        message: resp?.error?.message,
+      });
+      return;
+    }
+
+    default:
+      logger.debug(`[codex] unhandled SSE event '${evType}'`);
+      return;
+  }
+}
+
+/**
+ * Build a `TurnResult` (Wave A shape) from streaming state. Reconstructs
+ * `rawAssistantBlocks` so the loop can echo the assistant turn back into
+ * history (text first, then tool_use blocks in completion order).
+ */
+function finalize(
+  text: string,
+  toolCalls: ToolCallRequest[],
+  stopReason: string | undefined,
+  usage: TurnUsage | undefined,
+): TurnResult {
+  const rawAssistantBlocks: Array<TextBlock | ToolUseBlock> = [];
+  if (text.length > 0) {
+    rawAssistantBlocks.push({ type: "text", text });
+  }
+  for (const tc of toolCalls) {
+    rawAssistantBlocks.push({
+      type: "tool_use",
+      id: tc.id,
+      name: tc.name,
+      input: tc.input,
+    });
+  }
+  return { text, toolCalls, stopReason, usage, rawAssistantBlocks };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stripTrailingSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
+
+function numOrZero(n: unknown): number {
+  return typeof n === "number" && Number.isFinite(n) ? n : 0;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+async function safeReadText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "";
+  }
+}

--- a/packages/native-reasoning/src/backends/index.ts
+++ b/packages/native-reasoning/src/backends/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Backend selection + re-exports.
+ *
+ * `selectBackend()` reads `NATIVE_REASONING_BACKEND` and returns an
+ * implementation. Default: anthropic. The public package ships both the
+ * Anthropic API backend and the Codex backend that uses ChatGPT subscription
+ * auth from the codex CLI token cache.
+ */
+
+import { logger } from "@elizaos/core";
+
+import { AnthropicBackend, type AnthropicBackendOptions } from "./anthropic.js";
+import { CodexBackend, type CodexBackendConfig } from "./codex.js";
+import type { ReasoningBackend } from "./types.js";
+
+export type BackendName = "anthropic" | "codex";
+
+export interface SelectBackendOptions {
+  /** Force a specific backend (overrides env). */
+  backend?: BackendName;
+  /** Forwarded to AnthropicBackend if it's selected. */
+  anthropic?: AnthropicBackendOptions;
+  /** Forwarded to CodexBackend if it's selected. */
+  codex?: CodexBackendConfig;
+}
+
+/** Read `NATIVE_REASONING_BACKEND` from env, normalized. */
+function readBackendEnv(): BackendName | undefined {
+  const raw = process.env.NATIVE_REASONING_BACKEND?.trim().toLowerCase();
+  if (!raw) return undefined;
+  if (raw === "anthropic" || raw === "codex") return raw;
+  logger.warn(
+    `[native-reasoning] unknown NATIVE_REASONING_BACKEND="${raw}", falling back to anthropic`,
+  );
+  return undefined;
+}
+
+/** Select and instantiate a backend. */
+export function selectBackend(
+  opts: SelectBackendOptions = {},
+): ReasoningBackend {
+  const choice: BackendName = opts.backend ?? readBackendEnv() ?? "anthropic";
+
+  switch (choice) {
+    case "anthropic": {
+      logger.debug("[native-reasoning] backend=anthropic");
+      return new AnthropicBackend(opts.anthropic);
+    }
+    case "codex": {
+      logger.debug("[native-reasoning] backend=codex");
+      return new CodexBackend(opts.codex);
+    }
+    default: {
+      const _x: never = choice;
+      throw new Error(`unreachable backend: ${_x as string}`);
+    }
+  }
+}
+
+export type {
+  AnthropicBackendOptions,
+  AnthropicClientLike,
+} from "./anthropic.js";
+export { AnthropicBackend } from "./anthropic.js";
+export type { CodexBackendConfig } from "./codex.js";
+export { CodexBackend } from "./codex.js";
+export type {
+  CallTurnOptions,
+  ReasoningBackend,
+  TextBlock,
+  ToolCallRequest,
+  ToolResultBlock,
+  ToolUseBlock,
+  TurnContentBlock,
+  TurnMessage,
+  TurnResult,
+} from "./types.js";

--- a/packages/native-reasoning/src/backends/types.ts
+++ b/packages/native-reasoning/src/backends/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared backend types for the native-reasoning loop.
+ *
+ * The loop talks to backends via `ReasoningBackend.callTurn(...)` using a
+ * unified message/tool/result schema (this file). Concrete backends translate
+ * these types to/from their own wire format.
+ *
+ * The Anthropic backend maps this shape almost 1:1 to Anthropic content
+ * blocks. Other backends adapt the same loop contract to their own wire
+ * formats.
+ */
+
+import type { NativeTool } from "../tool-schema.js";
+
+/** A text segment emitted by the model (assistant) or by the user. */
+export interface TextBlock {
+  type: "text";
+  text: string;
+}
+
+/** Model-issued tool invocation. `input` is the parsed JSON arguments. */
+export interface ToolUseBlock {
+  type: "tool_use";
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/** Tool result fed back into the next turn under role:"tool" (or user). */
+export interface ToolResultBlock {
+  type: "tool_result";
+  tool_use_id: string;
+  content: string;
+  is_error?: boolean;
+}
+
+export type TurnContentBlock = TextBlock | ToolUseBlock | ToolResultBlock;
+
+/**
+ * Unified message format. `role:"tool"` carries `tool_result` blocks; the
+ * Anthropic adapter rewrites these as `role:"user"` on the wire (Anthropic
+ * doesn't have a distinct tool role), but keeping a separate role here
+ * keeps backend adapters simple.
+ */
+export interface TurnMessage {
+  role: "user" | "assistant" | "tool";
+  content: TurnContentBlock[];
+}
+
+/** Tool call extracted from a turn result. Loop dispatches handlers off this. */
+export interface ToolCallRequest {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+/** Result of a single backend turn — what the model produced. */
+export interface TurnResult {
+  /** Concatenated text content. May be empty if the turn was tool-use only. */
+  text: string;
+  /** All `tool_use` blocks the model emitted, in order. */
+  toolCalls: ToolCallRequest[];
+  /** Backend-reported stop reason (for diagnostics). */
+  stopReason?: string;
+  /** Token usage if the backend reports it. */
+  usage?: { input: number; output: number };
+  /**
+   * The raw content blocks the model emitted, preserved so we can echo the
+   * assistant turn back into history with the original block ordering. The
+   * loop is the canonical owner of `messages` history.
+   */
+  rawAssistantBlocks: Array<TextBlock | ToolUseBlock>;
+}
+
+export interface CallTurnOptions {
+  systemPrompt: string;
+  messages: TurnMessage[];
+  tools: NativeTool[];
+  abortSignal?: AbortSignal;
+}
+
+/** A reasoning backend: takes a unified turn request, returns a result. */
+export interface ReasoningBackend {
+  /** Stable name of the backend. */
+  readonly name: string;
+  callTurn(opts: CallTurnOptions): Promise<TurnResult>;
+}

--- a/packages/native-reasoning/src/index.ts
+++ b/packages/native-reasoning/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @elizaos/native-reasoning — public surface.
+ *
+ * Wave 1.A exposes the loop, the tool-schema types, and the system-prompt
+ * assembler. Concrete tools (bash, file ops, web, recall, spawn_codex) and
+ * the discord interceptor land in subsequent waves.
+ */
+
+import type { Plugin } from "@elizaos/core";
+
+export {
+  type AnthropicClientLike,
+  type RunOptions,
+  runNativeReasoningLoop,
+} from "./loop.js";
+
+export {
+  assembleSystemPrompt,
+  clearSystemPromptCache,
+} from "./system-prompt.js";
+
+export {
+  buildToolsArray,
+  type JSONSchema,
+  type NativeTool,
+  type NativeToolHandler,
+  registerTool,
+  type ToolEntry,
+  type ToolHandlerResult,
+  type ToolRegistry,
+} from "./tool-schema.js";
+
+export { buildDefaultRegistry } from "./tools/registry.js";
+
+/**
+ * Plugin manifest. The native-reasoning loop is invoked directly by the
+ * discord interceptor (Wave 1.D) — not through the eliza Action pipeline —
+ * so this manifest is intentionally minimal: a name, description, and a
+ * noop init for registration symmetry with the rest of the plugin system.
+ */
+export const nativeReasoningPlugin: Plugin = {
+  name: "native-reasoning",
+  description:
+    "Single-call multi-tool reasoning loop using native Anthropic tool use.",
+  init: async () => {
+    // No runtime services to register at this stage. Wave 1.D wires the
+    // discord interceptor; Wave 1.B registers concrete tools.
+  },
+};
+
+export default nativeReasoningPlugin;

--- a/packages/native-reasoning/src/loop.ts
+++ b/packages/native-reasoning/src/loop.ts
@@ -1,0 +1,321 @@
+/**
+ * runNativeReasoningLoop — single-call multi-tool reasoning loop.
+ *
+ * Bypasses eliza's classic shouldRespond/action-pick/format pipeline. The
+ * loop dispatches each turn to the selected native-tool-use backend, which
+ * returns a unified `TurnResult`. We execute any `tool_use` blocks in parallel and feed the
+ * results back into the next turn until one of:
+ *
+ *   - the model emits a `tool_use` named `ignore` (silent — no callback)
+ *   - the model emits zero tool_use blocks (final text → callback)
+ *   - MAX_TURNS reached (callback "(hit reasoning limit, stopping)")
+ *   - 90s wall-clock cap or 30s per-turn timeout
+ *   - any uncaught error (brief callback + full stack logged)
+ *
+ * Backend wire-format translation lives in `src/backends/*`; the loop only
+ * speaks the unified `TurnMessage` / `TurnResult` types.
+ */
+
+import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+
+import {
+  AnthropicBackend,
+  type AnthropicClientLike,
+} from "./backends/anthropic.js";
+import { type BackendName, selectBackend } from "./backends/index.js";
+import type {
+  ReasoningBackend,
+  ToolCallRequest,
+  ToolResultBlock,
+  TurnMessage,
+  TurnResult,
+} from "./backends/types.js";
+import { assembleSystemPrompt } from "./system-prompt.js";
+import {
+  buildToolsArray,
+  type ToolHandlerResult,
+  type ToolRegistry,
+} from "./tool-schema.js";
+
+const DEFAULT_MAX_TURNS = 12;
+const DEFAULT_TOTAL_BUDGET_MS = 90_000;
+const DEFAULT_PER_TURN_TIMEOUT_MS = 30_000;
+
+export type { AnthropicClientLike } from "./backends/anthropic.js";
+
+export interface RunOptions {
+  /** Override the tool registry. Defaults to an empty registry. */
+  registry?: ToolRegistry;
+  /** Override the assembled system prompt (skip identity-file read entirely). */
+  systemPrompt?: string;
+  /** Override model name (forwarded to the Anthropic backend if selected). */
+  model?: string;
+  /** Backend/provider hint from character reasoning config. */
+  provider?: "anthropic" | "openai" | "codex";
+  /** Override max turns (default: env NATIVE_REASONING_MAX_TURNS or 12). */
+  maxTurns?: number;
+  /** Total wall-clock budget in ms (default: env NATIVE_REASONING_TOTAL_BUDGET_MS or 90000). */
+  totalBudgetMs?: number;
+  /** Per-turn API call timeout in ms (default: env NATIVE_REASONING_PER_TURN_TIMEOUT_MS or 30000). */
+  perTurnTimeoutMs?: number;
+  /**
+   * Inject a mock Anthropic client (tests). When supplied, forces the
+   * Anthropic backend even if env says otherwise — preserves the v1
+   * test contract.
+   */
+  client?: AnthropicClientLike;
+  /**
+   * Inject a fully-formed backend (tests, advanced use). Takes precedence
+   * over `client` and env.
+   */
+  backend?: ReasoningBackend;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw == null || raw.trim() === "") return fallback;
+  const trimmed = raw.trim();
+  const n = Number(trimmed);
+  if (Number.isFinite(n) && Number.isInteger(n) && n > 0) return n;
+  logger.warn(
+    `[native-reasoning] invalid ${name}=${JSON.stringify(raw)}; using default ${fallback}`,
+  );
+  return fallback;
+}
+
+function withTimeout<T>(
+  p: Promise<T>,
+  ms: number,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => {
+      onTimeout?.();
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+async function executeToolCall(
+  call: ToolCallRequest,
+  registry: ToolRegistry,
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<ToolResultBlock> {
+  const entry = registry.get(call.name);
+  if (!entry) {
+    return {
+      type: "tool_result",
+      tool_use_id: call.id,
+      content: `Unknown tool: ${call.name}`,
+      is_error: true,
+    };
+  }
+  try {
+    const res: ToolHandlerResult = await entry.handler(
+      call.input,
+      runtime,
+      message,
+    );
+    return {
+      type: "tool_result",
+      tool_use_id: call.id,
+      content: res.content,
+      ...(res.is_error === true ? { is_error: true } : {}),
+    };
+  } catch (err) {
+    const stack =
+      err instanceof Error ? (err.stack ?? err.message) : String(err);
+    logger.error(`[native-reasoning] tool ${call.name} threw: ${stack}`);
+    return {
+      type: "tool_result",
+      tool_use_id: call.id,
+      content: `Tool error: ${err instanceof Error ? err.message : String(err)}`,
+      is_error: true,
+    };
+  }
+}
+
+function resolveBackend(options: RunOptions): ReasoningBackend {
+  if (options.backend) return options.backend;
+  if (options.client) {
+    // Tests / explicit Anthropic-client injection: force Anthropic backend.
+    return new AnthropicBackend({
+      client: options.client,
+      ...(options.model ? { model: options.model } : {}),
+    });
+  }
+  const backend =
+    options.provider === "anthropic" || options.provider === "codex"
+      ? (options.provider satisfies BackendName)
+      : undefined;
+  if (options.provider === "openai") {
+    logger.warn(
+      "[native-reasoning] provider=openai requested but no OpenAI backend is registered yet; using default backend",
+    );
+  }
+  return selectBackend({
+    backend,
+    anthropic: options.model ? { model: options.model } : undefined,
+  });
+}
+
+/**
+ * Run the native-reasoning loop end-to-end. Resolves once the loop is done
+ * (callback already fired, or `ignore` short-circuit, or limits hit).
+ */
+export async function runNativeReasoningLoop(
+  runtime: IAgentRuntime,
+  message: Memory,
+  callback: HandlerCallback,
+  options: RunOptions = {},
+): Promise<void> {
+  const userText = (message.content?.text ?? "").trim();
+  if (!userText) {
+    // Nothing to reason about. Stay silent.
+    return;
+  }
+
+  const registry: ToolRegistry = options.registry ?? new Map();
+  const tools = buildToolsArray(registry);
+  const maxTurns =
+    options.maxTurns ?? envInt("NATIVE_REASONING_MAX_TURNS", DEFAULT_MAX_TURNS);
+  const totalBudgetMs =
+    options.totalBudgetMs ??
+    envInt("NATIVE_REASONING_TOTAL_BUDGET_MS", DEFAULT_TOTAL_BUDGET_MS);
+  const perTurnTimeoutMs =
+    options.perTurnTimeoutMs ??
+    envInt("NATIVE_REASONING_PER_TURN_TIMEOUT_MS", DEFAULT_PER_TURN_TIMEOUT_MS);
+  logger.info(
+    `[native-reasoning] budgets resolved: total=${totalBudgetMs}ms perTurn=${perTurnTimeoutMs}ms maxTurns=${maxTurns}`,
+  );
+
+  const backend = resolveBackend(options);
+
+  let systemPrompt: string;
+  try {
+    systemPrompt =
+      options.systemPrompt ?? (await assembleSystemPrompt(runtime, message));
+  } catch (err) {
+    logger.error(
+      `[native-reasoning] failed to assemble system prompt: ${
+        err instanceof Error ? err.stack : String(err)
+      }`,
+    );
+    systemPrompt = "";
+  }
+
+  const messages: TurnMessage[] = [
+    { role: "user", content: [{ type: "text", text: userText }] },
+  ];
+
+  const startedAt = Date.now();
+
+  try {
+    for (let turn = 0; turn < maxTurns; turn++) {
+      const elapsed = Date.now() - startedAt;
+      if (elapsed >= totalBudgetMs) {
+        logger.warn(
+          `[native-reasoning] hit total budget (${totalBudgetMs}ms) at turn ${turn}`,
+        );
+        await callback({
+          text: "(reasoning timed out, stopping)",
+          attachments: [],
+        });
+        return;
+      }
+
+      let result: TurnResult;
+      try {
+        const turnController = new AbortController();
+        result = await withTimeout(
+          backend.callTurn({
+            systemPrompt,
+            messages,
+            tools,
+            abortSignal: turnController.signal,
+          }),
+          perTurnTimeoutMs,
+          `native-reasoning turn ${turn}`,
+          () => turnController.abort(),
+        );
+      } catch (err) {
+        logger.error(
+          `[native-reasoning] turn ${turn} backend error: ${
+            err instanceof Error ? (err.stack ?? err.message) : String(err)
+          }`,
+        );
+        await callback({
+          text: "(reasoning error, please retry)",
+          attachments: [],
+        });
+        return;
+      }
+
+      // `ignore` short-circuit: silent return, no callback.
+      const ignoreCall = result.toolCalls.find((c) => c.name === "ignore");
+      if (ignoreCall) {
+        logger.debug("[native-reasoning] model called ignore — stopping");
+        return;
+      }
+
+      if (result.toolCalls.length === 0) {
+        // Terminal turn: emit text and stop.
+        const text = result.text.trim();
+        if (text.length > 0) {
+          await callback({ text, attachments: [] });
+        }
+        return;
+      }
+
+      // Echo assistant turn back into history (preserve original block order),
+      // then execute tools in parallel and append a tool message.
+      messages.push({
+        role: "assistant",
+        content: result.rawAssistantBlocks,
+      });
+
+      const results = await Promise.all(
+        result.toolCalls.map((tc) =>
+          executeToolCall(tc, registry, runtime, message),
+        ),
+      );
+      messages.push({ role: "tool", content: results });
+    }
+
+    // Fell through MAX_TURNS without a final text block.
+    logger.warn(
+      `[native-reasoning] hit MAX_TURNS (${maxTurns}) without final text`,
+    );
+    await callback({
+      text: "(hit reasoning limit, stopping)",
+      attachments: [],
+    });
+  } catch (err) {
+    logger.error(
+      `[native-reasoning] uncaught loop error: ${
+        err instanceof Error ? (err.stack ?? err.message) : String(err)
+      }`,
+    );
+    try {
+      await callback({
+        text: "(internal reasoning error, please retry)",
+        attachments: [],
+      });
+    } catch {
+      // callback errors are already logged above by the runtime — swallow.
+    }
+  }
+}

--- a/packages/native-reasoning/src/sse-parser.ts
+++ b/packages/native-reasoning/src/sse-parser.ts
@@ -1,0 +1,204 @@
+/**
+ * Streaming SSE parser. Zero deps. Spec-compliant enough for HTML5 EventSource format.
+ *
+ * Handles:
+ *   - multi-line `data:` (concatenated with `\n`)
+ *   - leading-space stripping after the field colon
+ *   - comment lines (start with `:`)
+ *   - `event:`, `id:`, `retry:` directives
+ *   - blank-line dispatch (LF, CRLF, or CR)
+ *   - partial chunks across reads (boundaries at any byte)
+ *   - final flush when the stream ends without trailing blank line
+ *
+ * Returns SSEEvent objects with whatever fields were set on that event.
+ * Caller decides whether absent `data` / `event` matter for their protocol.
+ */
+
+export interface SSEEvent {
+  event?: string;
+  data?: string;
+  id?: string;
+  retry?: number;
+}
+
+interface MutableEvent {
+  event?: string;
+  dataLines: string[];
+  id?: string;
+  retry?: number;
+  hasContent: boolean;
+}
+
+function emptyEvent(): MutableEvent {
+  return { dataLines: [], hasContent: false };
+}
+
+function finalizeEvent(ev: MutableEvent): SSEEvent | null {
+  if (!ev.hasContent) return null;
+  const out: SSEEvent = {};
+  if (ev.event !== undefined) out.event = ev.event;
+  if (ev.dataLines.length > 0) out.data = ev.dataLines.join("\n");
+  if (ev.id !== undefined) out.id = ev.id;
+  if (ev.retry !== undefined) out.retry = ev.retry;
+  return out;
+}
+
+function processLine(line: string, ev: MutableEvent): void {
+  // Comment
+  if (line.startsWith(":")) return;
+
+  let field: string;
+  let value: string;
+  const colonIdx = line.indexOf(":");
+  if (colonIdx === -1) {
+    field = line;
+    value = "";
+  } else {
+    field = line.slice(0, colonIdx);
+    value = line.slice(colonIdx + 1);
+    // per spec, strip a single leading space
+    if (value.startsWith(" ")) value = value.slice(1);
+  }
+
+  switch (field) {
+    case "event":
+      ev.event = value;
+      ev.hasContent = true;
+      break;
+    case "data":
+      ev.dataLines.push(value);
+      ev.hasContent = true;
+      break;
+    case "id":
+      // per spec, NULL chars cause id to be ignored. We'll just check.
+      if (!value.includes("\u0000")) {
+        ev.id = value;
+        ev.hasContent = true;
+      }
+      break;
+    case "retry": {
+      if (/^\d+$/.test(value)) {
+        ev.retry = Number.parseInt(value, 10);
+        ev.hasContent = true;
+      }
+      break;
+    }
+    default:
+      // unknown field — ignore per spec
+      break;
+  }
+}
+
+/**
+ * Parse a ReadableStream<Uint8Array> as Server-Sent Events. Yields each
+ * dispatched event in order. Caller must consume to completion or call
+ * `.return()` on the returned generator to release the stream lock.
+ */
+export async function* parseSSE(
+  stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<SSEEvent> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  let current = emptyEvent();
+  // Track whether the last byte of the previous chunk was \r so we can
+  // swallow a paired \n at the start of the next chunk (CRLF split across
+  // chunk boundary).
+  let pendingCR = false;
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      let chunk = decoder.decode(value, { stream: true });
+      if (chunk.length === 0) continue;
+
+      if (pendingCR && chunk.charCodeAt(0) === 0x0a /* \n */) {
+        chunk = chunk.slice(1);
+      }
+      pendingCR = false;
+      if (chunk.length > 0 && chunk.charCodeAt(chunk.length - 1) === 0x0d) {
+        pendingCR = true;
+      }
+      buffer += chunk;
+
+      // Drain complete lines from buffer.
+      let lineStart = 0;
+      let i = 0;
+      while (i < buffer.length) {
+        const code = buffer.charCodeAt(i);
+        if (code === 0x0a /* \n */) {
+          const line = buffer.slice(lineStart, i);
+          if (line.length === 0) {
+            const ev = finalizeEvent(current);
+            if (ev) yield ev;
+            current = emptyEvent();
+          } else {
+            processLine(line, current);
+          }
+          i += 1;
+          lineStart = i;
+        } else if (code === 0x0d /* \r */) {
+          const line = buffer.slice(lineStart, i);
+          if (line.length === 0) {
+            const ev = finalizeEvent(current);
+            if (ev) yield ev;
+            current = emptyEvent();
+          } else {
+            processLine(line, current);
+          }
+          i += 1;
+          // Swallow following \n if present (CRLF). If we're at the end
+          // of the buffer, pendingCR was already set above and we'll
+          // handle the next chunk's leading \n.
+          if (i < buffer.length && buffer.charCodeAt(i) === 0x0a) {
+            i += 1;
+            // Since we consumed a real \n here, this isn't the trailing
+            // \r of the chunk. Nothing else to do; pendingCR stays
+            // whatever the chunk-end check decided (which was based on
+            // the very last byte of the chunk, not this position).
+          }
+          lineStart = i;
+        } else {
+          i += 1;
+        }
+      }
+      buffer = buffer.slice(lineStart);
+    }
+
+    // Stream is done. Flush any trailing decoded bytes, but per SSE spec
+    // (https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)
+    // any incomplete event without a trailing blank line is discarded.
+    const tail = decoder.decode();
+    if (tail.length > 0) buffer += tail;
+    // intentionally do NOT processLine(buffer) or finalize current here.
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released or stream errored — ignore
+    }
+  }
+}
+
+/**
+ * Wrapper that JSON.parses each event's `data` field. Skips events with no
+ * data. Throws on malformed JSON unless `ignoreParseErrors` is set, in which
+ * case those events are silently dropped.
+ */
+export async function* parseSSEJSON<T = unknown>(
+  stream: ReadableStream<Uint8Array>,
+  opts: { ignoreParseErrors?: boolean } = {},
+): AsyncGenerator<{ event: string; data: T }> {
+  for await (const ev of parseSSE(stream)) {
+    if (ev.data === undefined) continue;
+    let parsed: T;
+    try {
+      parsed = JSON.parse(ev.data) as T;
+    } catch (err) {
+      if (opts.ignoreParseErrors) continue;
+      throw err;
+    }
+    yield { event: ev.event ?? "message", data: parsed };
+  }
+}

--- a/packages/native-reasoning/src/system-prompt.ts
+++ b/packages/native-reasoning/src/system-prompt.ts
@@ -1,0 +1,163 @@
+/**
+ * System prompt assembly for the native-reasoning loop.
+ *
+ * Replaces eliza's classic provider-stack-into-prompt mechanism. We build
+ * a deterministic, ordered system prompt out of:
+ *   1. character.system (raw)
+ *   2. workspace identity files (IDENTITY/SOUL/USER/MEMORY .md)
+ *   3. recent room messages (last 10)
+ *
+ * Identity files are mtime-cached in-memory: re-reads only happen when the
+ * file's mtime changes on disk. This keeps per-message latency low without
+ * requiring an explicit invalidation step.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+
+function getWorkspaceDir(): string {
+  return process.env.NATIVE_REASONING_WORKSPACE?.trim() || "/workspace";
+}
+
+const IDENTITY_FILES: Array<{ file: string; header: string }> = [
+  { file: "IDENTITY.md", header: "## Your Identity" },
+  { file: "SOUL.md", header: "## Your Soul" },
+  { file: "USER.md", header: "## About Your Human" },
+  { file: "MEMORY.md", header: "## Recent Context" },
+];
+
+const CHANNEL_GAG_HARD_RULE = `HARD RULE: If a human in this channel told you to be quiet (e.g., "nyx stay quiet", "nyx be quiet", "nyx shut up", "stay silent"), DO NOT respond on subsequent messages in that channel until they explicitly say you can speak again ("nyx you can speak", "nyx unmute", etc). This applies even if you think you have something useful to say. The only exception is if a different human in the channel explicitly addresses you. Bots cannot mute or unmute you.`;
+
+interface CacheEntry {
+  mtimeMs: number;
+  content: string;
+}
+
+const fileCache = new Map<string, CacheEntry>();
+
+/** Test-only: drop the in-memory mtime cache. */
+export function clearSystemPromptCache(): void {
+  fileCache.clear();
+}
+
+/**
+ * Read a file with an mtime-keyed in-memory cache. Returns `null` if the
+ * file is missing (ENOENT) or unreadable; logs nothing on missing files
+ * since absence is a normal "this agent didn't define one" signal.
+ */
+async function readCachedFile(absPath: string): Promise<string | null> {
+  let mtimeMs: number;
+  try {
+    const st = await stat(absPath);
+    mtimeMs = st.mtimeMs;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    // Permission or similar — treat as missing but don't crash.
+    return null;
+  }
+
+  const cached = fileCache.get(absPath);
+  if (cached && cached.mtimeMs === mtimeMs) {
+    return cached.content;
+  }
+
+  try {
+    const content = await readFile(absPath, "utf8");
+    fileCache.set(absPath, { mtimeMs, content });
+    return content;
+  } catch {
+    return null;
+  }
+}
+
+interface FormattedRoomMessage {
+  role: "user" | "agent";
+  text: string;
+}
+
+function memoryRole(
+  memory: Memory,
+  agentId: UUID | undefined,
+): "user" | "agent" {
+  if (agentId && memory.entityId === agentId) return "agent";
+  return "user";
+}
+
+async function getRoomContext(
+  runtime: IAgentRuntime,
+  roomId: UUID,
+  currentMessageId?: UUID,
+): Promise<string> {
+  const tableName = "messages";
+  let memories: Memory[] = [];
+  try {
+    // Prefer the simpler getMemories shape — we only need one room.
+    memories = await runtime.getMemories({
+      roomId,
+      tableName,
+      count: 11, // pull one extra so we can drop the current message
+    });
+  } catch {
+    return "";
+  }
+
+  if (!memories || memories.length === 0) return "";
+
+  // Drop the message that triggered this turn (it's already in messages[0]).
+  const filtered = currentMessageId
+    ? memories.filter((m) => m.id !== currentMessageId)
+    : memories;
+
+  // getMemories returns desc by default — flip to chronological.
+  const ordered = filtered.slice(0, 10).reverse();
+  const formatted: FormattedRoomMessage[] = ordered.map((m) => ({
+    role: memoryRole(m, runtime.agentId),
+    text: (m.content?.text ?? "").trim(),
+  }));
+
+  const lines = formatted
+    .filter((f) => f.text.length > 0)
+    .map((f) => `${f.role}: ${f.text}`);
+
+  if (lines.length === 0) return "";
+  return `## Recent Conversation\n\n${lines.join("\n")}`;
+}
+
+/**
+ * Assemble the full system prompt for a native reasoning turn.
+ *
+ * Sections are joined with `\n\n---\n\n` separators. Missing sections
+ * are silently skipped so a barebones agent (no SOUL.md, no character
+ * system) still gets a coherent prompt.
+ */
+export async function assembleSystemPrompt(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<string> {
+  const parts: string[] = [];
+
+  const charSystem =
+    typeof runtime.character?.system === "string"
+      ? runtime.character.system.trim()
+      : "";
+  if (charSystem) parts.push(charSystem);
+  parts.push(CHANNEL_GAG_HARD_RULE);
+
+  const workspaceDir = getWorkspaceDir();
+  for (const { file, header } of IDENTITY_FILES) {
+    const abs = path.join(workspaceDir, file);
+    const content = await readCachedFile(abs);
+    if (content && content.trim().length > 0) {
+      parts.push(`${header}\n\n${content.trim()}`);
+    }
+  }
+
+  if (message.roomId) {
+    const ctx = await getRoomContext(runtime, message.roomId, message.id);
+    if (ctx) parts.push(ctx);
+  }
+
+  return parts.join("\n\n---\n\n");
+}

--- a/packages/native-reasoning/src/tool-format/anthropic.ts
+++ b/packages/native-reasoning/src/tool-format/anthropic.ts
@@ -1,0 +1,27 @@
+/**
+ * Tool format adapter for Anthropic's `advanced-tool-use-2025-11-20` beta.
+ *
+ * NativeTool is already shaped for Anthropic (`type:"custom", input_schema`),
+ * so this is mostly a passthrough. The adapter keeps the loop from importing
+ * backend-specific wire shapes directly.
+ */
+
+import type { NativeTool } from "../tool-schema.js";
+
+/** Anthropic beta tool wire shape. */
+export interface AnthropicTool {
+  type: "custom";
+  name: string;
+  description: string;
+  input_schema: NativeTool["input_schema"];
+}
+
+/** Convert NativeTool[] → Anthropic tool array. */
+export function toAnthropicTools(tools: NativeTool[]): AnthropicTool[] {
+  return tools.map((t) => ({
+    type: "custom",
+    name: t.name,
+    description: t.description,
+    input_schema: t.input_schema,
+  }));
+}

--- a/packages/native-reasoning/src/tool-format/openai.ts
+++ b/packages/native-reasoning/src/tool-format/openai.ts
@@ -1,0 +1,54 @@
+/**
+ * NativeTool → OpenAI function tool converter (codex stealth backend).
+ *
+ * The chatgpt `/backend-api/codex/responses` endpoint accepts tools in
+ * OpenAI's "responses" function-tool format. Our `NativeTool` already
+ * carries a JSON-Schema `input_schema`, so this is a near-1:1 rename
+ * with the discriminator flipped from `"custom"` to `"function"`.
+ *
+ * Strict mode is intentionally OFF: many tools in our default registry
+ * (bash, file_ops, web, memory) attach `description` to nested property
+ * objects, which OpenAI strict mode rejects (it requires every property
+ * to be `required` and `additionalProperties:false` recursively). We
+ * keep relaxed parsing — the model still gets the schema as a hint and
+ * we already validate inside each handler.
+ *
+ * Pure / referentially transparent: no I/O, no globals, no mutation of
+ * the inputs. Same input → same output, always.
+ */
+
+import type { NativeTool } from "../tool-schema.js";
+
+/**
+ * OpenAI Responses-API "function" tool. Mirrors the wire format used by
+ * `https://chatgpt.com/backend-api/codex/responses` (and the public
+ * `api.openai.com/v1/responses` endpoint, though we don't talk there).
+ */
+export interface OpenAITool {
+  type: "function";
+  name: string;
+  description: string;
+  /** JSON Schema. We forward `NativeTool.input_schema` verbatim. */
+  parameters: object;
+  /**
+   * Whether the model must produce arguments matching the schema
+   * exactly (no extra keys, every property required). Default: false.
+   */
+  strict?: boolean;
+}
+
+/** Convert a single NativeTool to an OpenAI function tool. */
+export function toOpenAITool(tool: NativeTool): OpenAITool {
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.input_schema,
+    strict: false,
+  };
+}
+
+/** Convert an array of NativeTool to OpenAI function tools. */
+export function toOpenAITools(tools: NativeTool[]): OpenAITool[] {
+  return tools.map(toOpenAITool);
+}

--- a/packages/native-reasoning/src/tool-schema.ts
+++ b/packages/native-reasoning/src/tool-schema.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool schema types and helpers for the native-reasoning loop.
+ *
+ * These types intentionally mirror Anthropic's `advanced-tool-use-2025-11-20`
+ * beta wire format: every tool is `{type:"custom", name, description,
+ * input_schema}`. We keep our own minimal types (rather than re-exporting
+ * `BetaTool` from the SDK) so that handler/registry contracts stay stable
+ * even as the SDK shifts beta surfaces.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+
+/**
+ * Minimal JSON Schema subset supported by Anthropic's tool input_schema.
+ * Loose by design — Anthropic accepts most JSON Schema dialects; we just
+ * ensure the top-level "type":"object" shape is encoded.
+ */
+export interface JSONSchema {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Native Anthropic tool definition (advanced-tool-use-2025-11-20 beta).
+ * `type: "custom"` distinguishes user-defined tools from server-side
+ * Anthropic-managed tools (computer_use_*, bash_*, text_editor_*).
+ */
+export interface NativeTool {
+  type: "custom";
+  name: string;
+  description: string;
+  input_schema: JSONSchema;
+}
+
+/** Tool execution result, matching Anthropic `tool_result` block content. */
+export interface ToolHandlerResult {
+  content: string;
+  is_error?: boolean;
+}
+
+/**
+ * Implementation of a tool. Receives the parsed input (already JSON, may be
+ * unknown shape — handlers MUST validate), the agent runtime, and the
+ * triggering message for context (room/entity/etc).
+ */
+export type NativeToolHandler = (
+  input: unknown,
+  runtime: IAgentRuntime,
+  message: Memory,
+) => Promise<ToolHandlerResult>;
+
+export interface ToolEntry {
+  tool: NativeTool;
+  handler: NativeToolHandler;
+}
+
+export type ToolRegistry = Map<string, ToolEntry>;
+
+/** Build the Anthropic-shaped tools[] array from a registry. */
+export function buildToolsArray(registry: ToolRegistry): NativeTool[] {
+  const out: NativeTool[] = [];
+  for (const { tool } of registry.values()) {
+    out.push(tool);
+  }
+  return out;
+}
+
+/** Convenience: register a tool, returning the same registry for chaining. */
+export function registerTool(
+  registry: ToolRegistry,
+  tool: NativeTool,
+  handler: NativeToolHandler,
+): ToolRegistry {
+  registry.set(tool.name, { tool, handler });
+  return registry;
+}

--- a/packages/native-reasoning/src/tools/_safe-path.ts
+++ b/packages/native-reasoning/src/tools/_safe-path.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/** Default workspace root if SHELL_ALLOWED_DIRECTORY is not set. */
+export const DEFAULT_ALLOWED_DIR = "/workspace";
+
+export function getAllowedDir(): string {
+  const raw = process.env.SHELL_ALLOWED_DIRECTORY?.trim();
+  const root = raw && raw.length > 0 ? raw : DEFAULT_ALLOWED_DIR;
+  return path.resolve(root);
+}
+
+function assertContained(abs: string, allowed: string, original: string): void {
+  const rel = path.relative(allowed, abs);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(
+      `path '${original}' is outside the allowed directory '${allowed}'`,
+    );
+  }
+}
+
+function nearestExistingParent(abs: string): string {
+  let dir = path.dirname(abs);
+  while (!fs.existsSync(dir)) {
+    const next = path.dirname(dir);
+    if (next === dir) break;
+    dir = next;
+  }
+  return dir;
+}
+
+/**
+ * Resolve a (possibly relative) path against the allowed directory and
+ * ensure the resolved absolute path is contained within it. Rejects any
+ * input containing `..` segments before resolution as an extra guard.
+ *
+ * Throws on any escape attempt.
+ */
+export function resolveSafePath(
+  p: string,
+  allowedDir = getAllowedDir(),
+): string {
+  if (typeof p !== "string" || p.length === 0) {
+    throw new Error("path must be a non-empty string");
+  }
+  // Reject explicit traversal segments — even though path.resolve would
+  // normalize them, we want a hard "don't even try" signal in the surface.
+  const segments = p.split(/[\\/]/);
+  if (segments.some((s) => s === "..")) {
+    throw new Error(`path may not contain '..' segments: ${p}`);
+  }
+
+  const abs = path.isAbsolute(p)
+    ? path.resolve(p)
+    : path.resolve(allowedDir, p);
+  const allowed = fs.realpathSync.native(path.resolve(allowedDir));
+
+  // Lexical containment catches obvious escapes before filesystem checks.
+  assertContained(abs, allowed, p);
+
+  try {
+    // Existing path: resolve symlinks all the way to the real target.
+    const realTarget = fs.realpathSync.native(abs);
+    assertContained(realTarget, allowed, p);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw err;
+
+    // New path: resolve the nearest existing parent so writes through a
+    // symlinked directory cannot escape the allowed workspace.
+    const realParent = fs.realpathSync.native(nearestExistingParent(abs));
+    assertContained(realParent, allowed, p);
+  }
+
+  return abs;
+}
+
+export function truncate(
+  s: string,
+  max: number,
+): { text: string; truncated: boolean } {
+  if (s.length <= max) return { text: s, truncated: false };
+  return {
+    text: `${s.slice(0, max)}\n[...truncated ${s.length - max} bytes]`,
+    truncated: true,
+  };
+}

--- a/packages/native-reasoning/src/tools/acp_agent.ts
+++ b/packages/native-reasoning/src/tools/acp_agent.ts
@@ -1,0 +1,480 @@
+/**
+ * Native ACPX task-agent tools for the native-reasoning loop.
+ *
+ * These thin-wrap @0xsolace/plugin-acpx's AcpService directly so the
+ * native-reasoning registry can dispatch subagent work without going through
+ * Eliza's separate action-selection pipeline.
+ */
+
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import type {
+  NativeTool,
+  NativeToolHandler,
+  ToolHandlerResult,
+} from "../tool-schema.js";
+
+export interface SpawnAgentInput {
+  agent?: string;
+  cwd?: string;
+  prompt: string;
+}
+
+export interface SessionsSpawnInput {
+  agent?: string;
+  cwd?: string;
+  initial_prompt: string;
+  name?: string;
+}
+
+interface AcpSpawnResult {
+  sessionId: string;
+  id?: string;
+  name?: string;
+  agentType?: string;
+  workdir: string;
+  status?: string;
+}
+
+interface AcpPromptResult {
+  sessionId: string;
+  response?: string;
+  finalText?: string;
+  stopReason?: string;
+  durationMs?: number;
+  exitCode?: number | null;
+  signal?: string | null;
+  error?: string;
+}
+
+interface AcpServiceLike {
+  spawnSession(opts: {
+    name?: string;
+    agentType?: string;
+    workdir?: string;
+    metadata?: Record<string, unknown>;
+    timeoutMs?: number;
+  }): Promise<AcpSpawnResult>;
+  sendPrompt(
+    sessionId: string,
+    text: string,
+    opts?: { timeoutMs?: number },
+  ): Promise<AcpPromptResult>;
+  closeSession?(sessionId: string): Promise<void>;
+  onSessionEvent?(
+    handler: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void;
+}
+
+const DEFAULT_AGENT = "codex";
+const DEFAULT_WORKDIR_ROOT = "/workspace/tasks";
+const DEFAULT_TIMEOUT_MS = 600_000;
+const CLOSE_TIMEOUT_MS = 20_000;
+
+export const spawnAgentTool: NativeTool = {
+  type: "custom",
+  name: "spawn_agent",
+  description:
+    "Spawn a one-shot codex/acpx subagent in a fresh workspace. PREFER THIS for any multi-step coding task, file creation across multiple files, repo investigation, tests, refactors, or reasoning that benefits from a clean context. Use instead of bash for anything more complex than a single command. Returns JSON with sessionId, workdir, response, durationMs, and stopReason.",
+  input_schema: {
+    type: "object",
+    properties: {
+      agent: {
+        type: "string",
+        description: "acpx-compatible agent to run (default: codex).",
+      },
+      cwd: {
+        type: "string",
+        description:
+          "Working directory for the subagent. Defaults to a fresh directory under /workspace/tasks.",
+      },
+      prompt: {
+        type: "string",
+        description: "Initial prompt/task to send to the subagent.",
+      },
+    },
+    required: ["prompt"],
+    additionalProperties: false,
+  },
+};
+
+export const sessionsSpawnTool: NativeTool = {
+  type: "custom",
+  name: "sessions_spawn",
+  description:
+    "Create a persistent codex/acpx subagent session you can keep messaging. PREFER THIS for ongoing collaboration with a subagent across multiple turns, long investigations, or tasks where the same agent context should stay available. Returns JSON with sessionId, workdir, response, name, durationMs, and stopReason.",
+  input_schema: {
+    type: "object",
+    properties: {
+      agent: {
+        type: "string",
+        description: "acpx-compatible agent to run (default: codex).",
+      },
+      cwd: {
+        type: "string",
+        description:
+          "Working directory for the session. Defaults to a fresh directory under /workspace/tasks.",
+      },
+      initial_prompt: {
+        type: "string",
+        description: "Initial prompt/task to send to the persistent session.",
+      },
+      name: {
+        type: "string",
+        description: "Optional human-readable session name.",
+      },
+    },
+    required: ["initial_prompt"],
+    additionalProperties: false,
+  },
+};
+
+export const createTaskTool: NativeTool = {
+  ...sessionsSpawnTool,
+  name: "create_task",
+  description:
+    "Alias for sessions_spawn: create a persistent codex/acpx subagent task session you can keep messaging later. Prefer sessions_spawn in new prompts; this alias exists for compatibility with CREATE_TASK wording.",
+};
+
+export const spawnAgentHandler: NativeToolHandler = async (
+  rawInput,
+  runtime,
+  message,
+) => {
+  const input = (rawInput ?? {}) as Partial<SpawnAgentInput>;
+  if (typeof input.prompt !== "string" || input.prompt.trim().length === 0) {
+    return safeError("'prompt' is required and must be a non-empty string");
+  }
+  return runAcpPrompt({
+    runtime,
+    message,
+    toolName: "spawn_agent",
+    agent: input.agent,
+    cwd: input.cwd,
+    prompt: input.prompt,
+    persistent: false,
+  });
+};
+
+export const sessionsSpawnHandler: NativeToolHandler = async (
+  rawInput,
+  runtime,
+  message,
+) => {
+  const input = (rawInput ?? {}) as Partial<SessionsSpawnInput>;
+  if (
+    typeof input.initial_prompt !== "string" ||
+    input.initial_prompt.trim().length === 0
+  ) {
+    return safeError(
+      "'initial_prompt' is required and must be a non-empty string",
+    );
+  }
+  return runAcpPrompt({
+    runtime,
+    message,
+    toolName: "sessions_spawn",
+    agent: input.agent,
+    cwd: input.cwd,
+    prompt: input.initial_prompt,
+    name: input.name,
+    persistent: true,
+  });
+};
+
+export const createTaskHandler: NativeToolHandler = async (
+  rawInput,
+  runtime,
+  message,
+) => {
+  const result = await sessionsSpawnHandler(rawInput, runtime, message);
+  if (!result.is_error) {
+    return {
+      ...result,
+      content: result.content.replace(
+        '"tool":"sessions_spawn"',
+        '"tool":"create_task"',
+      ),
+    };
+  }
+  return result;
+};
+
+async function runAcpPrompt(opts: {
+  runtime: IAgentRuntime;
+  message: Memory;
+  toolName: "spawn_agent" | "sessions_spawn";
+  agent?: string;
+  cwd?: string;
+  prompt: string;
+  name?: string;
+  persistent: boolean;
+}): Promise<ToolHandlerResult> {
+  const startedAt = Date.now();
+  const logger = runtimeLogger(opts.runtime);
+  logger.info?.(`[NativeRegistry] ${opts.toolName} invoked`, {
+    agent: opts.agent ?? DEFAULT_AGENT,
+    cwd: opts.cwd,
+    promptLength: opts.prompt.length,
+    name: opts.name,
+    persistent: opts.persistent,
+  });
+
+  try {
+    const service = getAcpService(opts.runtime);
+    if (!service) {
+      return safeError(
+        "AcpService is not available via ACP_SUBPROCESS_SERVICE/PTY_SERVICE",
+      );
+    }
+
+    const timeoutMs = getPromptTimeoutMs(opts.runtime);
+    const agentType = clean(opts.agent) ?? DEFAULT_AGENT;
+    const workdir = clean(opts.cwd) ?? generateDefaultWorkdir(opts.runtime);
+    const name =
+      clean(opts.name) ?? `${opts.toolName}-${randomUUID().slice(0, 8)}`;
+
+    logger.info?.("[AcpService] spawnSession via native-reasoning", {
+      tool: opts.toolName,
+      agentType,
+      workdir,
+      name,
+    });
+
+    const session = await service.spawnSession({
+      agentType,
+      workdir,
+      name,
+      timeoutMs,
+      metadata: {
+        source: `native-reasoning:${opts.toolName}`,
+        messageId: opts.message?.id,
+        roomId: opts.message?.roomId,
+        worldId: opts.message?.worldId,
+        userId: opts.message?.entityId,
+        persistent: opts.persistent,
+      },
+    });
+
+    const tracker = createTaskCompleteTracker(service, session.sessionId);
+    const promptResult = await withTimeout(
+      service.sendPrompt(session.sessionId, opts.prompt, { timeoutMs }),
+      timeoutMs + 5_000,
+      `timed out waiting for AcpService.sendPrompt after ${timeoutMs}ms`,
+    );
+    const eventResult = await tracker.wait(1_500);
+    tracker.dispose();
+
+    if (!opts.persistent && typeof service.closeSession === "function") {
+      void withTimeout(
+        service.closeSession(session.sessionId),
+        CLOSE_TIMEOUT_MS,
+        `timed out closing ${session.sessionId}`,
+      ).catch((err) =>
+        logger.warn?.("[NativeRegistry] spawn_agent closeSession failed", {
+          sessionId: session.sessionId,
+          error: errMsg(err),
+        }),
+      );
+    }
+
+    const response =
+      eventResult.response ??
+      promptResult.response ??
+      promptResult.finalText ??
+      "";
+    const stopReason =
+      eventResult.stopReason ?? promptResult.stopReason ?? "unknown";
+    const durationMs = promptResult.durationMs ?? Date.now() - startedAt;
+    const error = eventResult.error ?? promptResult.error;
+
+    const payload = {
+      tool: opts.toolName,
+      sessionId: session.sessionId,
+      workdir: session.workdir ?? workdir,
+      response,
+      durationMs,
+      stopReason,
+      ...(opts.persistent ? { name } : {}),
+      ...(error ? { error } : {}),
+    };
+
+    logger.info?.(`[NativeRegistry] ${opts.toolName} completed`, {
+      sessionId: session.sessionId,
+      workdir: payload.workdir,
+      durationMs,
+      stopReason,
+      hasResponse: response.length > 0,
+      error,
+    });
+
+    return {
+      content: JSON.stringify(payload, null, 2),
+      is_error: Boolean(error) || stopReason === "error",
+    };
+  } catch (err) {
+    logger.error?.(`[NativeRegistry] ${opts.toolName} failed`, {
+      error: errMsg(err),
+    });
+    return safeError(errMsg(err));
+  }
+}
+
+function getAcpService(runtime: IAgentRuntime): AcpServiceLike | undefined {
+  const getter = (runtime as { getService?: (name: string) => unknown })
+    .getService;
+  if (typeof getter !== "function") return undefined;
+  for (const name of ["ACP_SUBPROCESS_SERVICE", "PTY_SERVICE", "ACP_SERVICE"]) {
+    const service = getter.call(runtime, name);
+    const candidate = Array.isArray(service) ? service[0] : service;
+    if (
+      candidate &&
+      typeof (candidate as AcpServiceLike).spawnSession === "function" &&
+      typeof (candidate as AcpServiceLike).sendPrompt === "function"
+    ) {
+      return candidate as AcpServiceLike;
+    }
+  }
+  return undefined;
+}
+
+function createTaskCompleteTracker(service: AcpServiceLike, sessionId: string) {
+  let response: string | undefined;
+  let stopReason: string | undefined;
+  let error: string | undefined;
+  let done = false;
+  let resolveWait: (() => void) | undefined;
+  const unsubscribe = service.onSessionEvent?.((sid, event, data) => {
+    if (sid !== sessionId) return;
+    const payload = asRecord(data);
+    if (event === "task_complete") {
+      response =
+        typeof payload.response === "string" ? payload.response : response;
+      stopReason =
+        typeof payload.stopReason === "string"
+          ? payload.stopReason
+          : stopReason;
+      done = true;
+      resolveWait?.();
+    } else if (event === "error") {
+      error = typeof payload.message === "string" ? payload.message : "unknown";
+      done = true;
+      resolveWait?.();
+    } else if (event === "stopped" && !done) {
+      response =
+        typeof payload.response === "string" ? payload.response : response;
+      done = true;
+      resolveWait?.();
+    }
+  });
+
+  return {
+    wait(ms: number): Promise<{
+      response?: string;
+      stopReason?: string;
+      error?: string;
+    }> {
+      if (done) return Promise.resolve({ response, stopReason, error });
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          resolve({ response, stopReason, error });
+        }, ms);
+        resolveWait = () => {
+          clearTimeout(timer);
+          resolve({ response, stopReason, error });
+        };
+      });
+    },
+    dispose(): void {
+      try {
+        unsubscribe?.();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+function getPromptTimeoutMs(runtime: IAgentRuntime): number {
+  const fromRuntime = (
+    runtime as { getSetting?: (key: string) => string | undefined }
+  ).getSetting?.("ELIZA_ACP_PROMPT_TIMEOUT_MS");
+  const raw = fromRuntime ?? process.env.ELIZA_ACP_PROMPT_TIMEOUT_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_TIMEOUT_MS;
+}
+
+function generateDefaultWorkdir(
+  runtime: IAgentRuntime,
+  now: Date = new Date(),
+): string {
+  const fromRuntime = (
+    runtime as { getSetting?: (key: string) => string | undefined }
+  ).getSetting?.("ELIZA_ACP_WORKSPACE_ROOT");
+  const root =
+    fromRuntime ?? process.env.ELIZA_ACP_WORKSPACE_ROOT ?? DEFAULT_WORKDIR_ROOT;
+  const ts =
+    `${now.getUTCFullYear()}` +
+    String(now.getUTCMonth() + 1).padStart(2, "0") +
+    String(now.getUTCDate()).padStart(2, "0") +
+    "-" +
+    String(now.getUTCHours()).padStart(2, "0") +
+    String(now.getUTCMinutes()).padStart(2, "0") +
+    String(now.getUTCSeconds()).padStart(2, "0");
+  return path.posix.join(root, `${ts}-${randomUUID().slice(0, 8)}`);
+}
+
+function safeError(reason: string): ToolHandlerResult {
+  return {
+    content: JSON.stringify({ error: reason }, null, 2),
+    is_error: true,
+  };
+}
+
+function clean(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function runtimeLogger(runtime: IAgentRuntime): {
+  info?: (message: string, data?: unknown) => void;
+  warn?: (message: string, data?: unknown) => void;
+  error?: (message: string, data?: unknown) => void;
+} {
+  const candidate = (runtime as { logger?: unknown }).logger;
+  if (candidate && typeof candidate === "object") return candidate;
+  return console;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}

--- a/packages/native-reasoning/src/tools/bash.ts
+++ b/packages/native-reasoning/src/tools/bash.ts
@@ -1,0 +1,190 @@
+/**
+ * `bash` tool — execute a shell command inside the allowed workspace.
+ *
+ * Safety posture:
+ *   - cwd defaults to SHELL_ALLOWED_DIRECTORY (default /workspace).
+ *   - explicit cwd override must resolve inside the allowed dir.
+ *   - blocks obvious footguns (rm -rf /, mkfs, fork bombs, dd of=/dev/sd*).
+ *   - hard wall-clock timeout (SHELL_TIMEOUT, default 120000ms).
+ *   - combined stdout+stderr truncated at 100KB.
+ */
+
+import { spawn } from "node:child_process";
+import type {
+  NativeTool,
+  NativeToolHandler,
+  ToolHandlerResult,
+} from "../tool-schema.js";
+import { getAllowedDir, resolveSafePath, truncate } from "./_safe-path.js";
+
+const MAX_OUTPUT_BYTES = 100 * 1024;
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * Patterns that match destructive or denial-of-service commands. We reject
+ * any *substring* match (case-insensitive); intentionally conservative.
+ *
+ * Add to this list rather than rewriting it — every entry is a Chesterton's
+ * fence put there by some past incident.
+ */
+const FOOTGUN_PATTERNS: RegExp[] = [
+  /\brm\s+-[a-z]*r[a-z]*f?\s+\/(?:\s|$)/i, // rm -rf /
+  /\brm\s+-[a-z]*f[a-z]*r?\s+\/(?:\s|$)/i,
+  /\bmkfs(\.|\s)/i, // mkfs.ext4 etc
+  /\bdd\s+[^|]*of=\/dev\//i, // dd of=/dev/sda
+  /:\s*\(\s*\)\s*\{[^}]*\|\s*:[^}]*\}\s*;?\s*:/, // classic fork bomb
+  /\bshutdown\b|\breboot\b|\bhalt\b|\bpoweroff\b/i,
+  /\b>\s*\/dev\/sd[a-z]/i, // raw disk write via redirection
+  /\bchmod\s+-R\s+0?00\s+\//i,
+];
+
+export interface BashInput {
+  command: string;
+  cwd?: string;
+  timeout_ms?: number;
+}
+
+export const tool: NativeTool = {
+  type: "custom",
+  name: "bash",
+  description:
+    "Execute a shell command inside the agent's allowed workspace " +
+    "directory (default /workspace). Returns combined stdout+stderr. " +
+    "Times out after 120s by default. Refuses obvious destructive " +
+    "commands (rm -rf /, mkfs, fork bombs).",
+  input_schema: {
+    type: "object",
+    properties: {
+      command: {
+        type: "string",
+        description: "Shell command to run (interpreted by /bin/sh -c).",
+      },
+      cwd: {
+        type: "string",
+        description:
+          "Working directory. Must be within the allowed workspace. Defaults to the workspace root.",
+      },
+      timeout_ms: {
+        type: "number",
+        description: "Wall-clock timeout in milliseconds (default 120000).",
+      },
+    },
+    required: ["command"],
+    additionalProperties: false,
+  },
+};
+
+function isFootgun(cmd: string): RegExp | null {
+  for (const re of FOOTGUN_PATTERNS) {
+    if (re.test(cmd)) return re;
+  }
+  return null;
+}
+
+export const handler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<BashInput>;
+  if (typeof input.command !== "string" || input.command.length === 0) {
+    return { content: "bash: 'command' is required", is_error: true };
+  }
+
+  const blocked = isFootgun(input.command);
+  if (blocked) {
+    return {
+      content: `bash: refused to execute command (matched safety pattern ${blocked.source})`,
+      is_error: true,
+    };
+  }
+
+  const allowedDir = getAllowedDir();
+  let cwd: string;
+  try {
+    cwd = input.cwd ? resolveSafePath(input.cwd, allowedDir) : allowedDir;
+  } catch (err) {
+    return {
+      content: `bash: invalid cwd: ${(err as Error).message}`,
+      is_error: true,
+    };
+  }
+
+  const timeoutMs = pickTimeout(input.timeout_ms);
+
+  return runShell(input.command, cwd, timeoutMs);
+};
+
+function pickTimeout(requested: number | undefined): number {
+  if (
+    typeof requested === "number" &&
+    Number.isFinite(requested) &&
+    requested > 0
+  ) {
+    return Math.min(requested, 10 * 60 * 1000);
+  }
+  const fromEnv = Number.parseInt(process.env.SHELL_TIMEOUT ?? "", 10);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+  return DEFAULT_TIMEOUT_MS;
+}
+
+async function runShell(
+  command: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<ToolHandlerResult> {
+  return await new Promise<ToolHandlerResult>((resolve) => {
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let buf = "";
+    let bytes = 0;
+    let killedForSize = false;
+
+    const append = (chunk: Buffer | string) => {
+      if (killedForSize) return;
+      const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      bytes += Buffer.byteLength(s, "utf8");
+      buf += s;
+      if (bytes > MAX_OUTPUT_BYTES * 2) {
+        killedForSize = true;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+
+    child.stdout?.on("data", append);
+    child.stderr?.on("data", append);
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* ignore */
+      }
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        content: `bash: spawn error: ${err.message}`,
+        is_error: true,
+      });
+    });
+
+    child.on("close", (code, sig) => {
+      clearTimeout(timer);
+      const { text } = truncate(buf, MAX_OUTPUT_BYTES);
+      const exit = typeof code === "number" ? code : sig ? 128 : 1;
+      const header =
+        exit === 0 ? "" : `[exit ${exit}${sig ? ` signal=${sig}` : ""}]\n`;
+      resolve({
+        content: `${header}${text}`,
+        is_error: exit !== 0,
+      });
+    });
+  });
+}

--- a/packages/native-reasoning/src/tools/file_ops.ts
+++ b/packages/native-reasoning/src/tools/file_ops.ts
@@ -1,0 +1,568 @@
+/**
+ * File / search tool family for the native reasoning loop.
+ *
+ *   - read_file   — read a UTF-8 text file (offset/limit in lines)
+ *   - write_file  — overwrite a file (creates parents)
+ *   - edit_file   — str_replace edit; errors if the needle isn't unique
+ *   - glob        — fast-glob style pattern search (capped at 200 paths)
+ *   - grep        — content search via ripgrep (cap 100 matches with context)
+ *
+ * All paths are restricted to SHELL_ALLOWED_DIRECTORY (default /workspace).
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { NativeTool, NativeToolHandler } from "../tool-schema.js";
+import { getAllowedDir, resolveSafePath, truncate } from "./_safe-path.js";
+
+const READ_BYTE_CAP = 256 * 1024; // 256KB safety net per read
+const GLOB_MAX = 200;
+const GREP_MAX = 100;
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  read_file                                                            *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface ReadFileInput {
+  path: string;
+  offset?: number; // line offset (0-based)
+  limit?: number; // max lines
+}
+
+export const readFileTool: NativeTool = {
+  type: "custom",
+  name: "read_file",
+  description:
+    "Read a UTF-8 text file from the allowed workspace. Optional 0-based " +
+    "line offset and limit for paging through large files.",
+  input_schema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      offset: { type: "number", description: "0-based line offset" },
+      limit: { type: "number", description: "Max number of lines to return" },
+    },
+    required: ["path"],
+    additionalProperties: false,
+  },
+};
+
+export const readFileHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<ReadFileInput>;
+  if (typeof input.path !== "string") {
+    return { content: "read_file: 'path' is required", is_error: true };
+  }
+  let abs: string;
+  try {
+    abs = resolveSafePath(input.path);
+  } catch (err) {
+    return { content: `read_file: ${(err as Error).message}`, is_error: true };
+  }
+
+  let raw: string;
+  try {
+    const buf = await fs.readFile(abs);
+    // Defensive byte cap before splitting.
+    const sliced =
+      buf.byteLength > READ_BYTE_CAP ? buf.subarray(0, READ_BYTE_CAP) : buf;
+    raw = sliced.toString("utf8");
+    if (buf.byteLength > READ_BYTE_CAP) {
+      raw += `\n[...truncated ${buf.byteLength - READ_BYTE_CAP} bytes]`;
+    }
+  } catch (err) {
+    return {
+      content: `read_file: ${(err as NodeJS.ErrnoException).message}`,
+      is_error: true,
+    };
+  }
+
+  const wantsPaging =
+    typeof input.offset === "number" || typeof input.limit === "number";
+  if (!wantsPaging) return { content: raw };
+
+  const lines = raw.split("\n");
+  const offset = Math.max(0, input.offset ?? 0);
+  const limit = Math.max(0, input.limit ?? lines.length);
+  const slice = lines.slice(offset, offset + limit);
+  return { content: slice.join("\n") };
+};
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  write_file                                                           *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface WriteFileInput {
+  path: string;
+  content: string;
+}
+
+export const writeFileTool: NativeTool = {
+  type: "custom",
+  name: "write_file",
+  description:
+    "Overwrite (or create) a UTF-8 text file in the allowed workspace. " +
+    "Parent directories are created as needed.",
+  input_schema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      content: { type: "string" },
+    },
+    required: ["path", "content"],
+    additionalProperties: false,
+  },
+};
+
+export const writeFileHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<WriteFileInput>;
+  if (typeof input.path !== "string" || typeof input.content !== "string") {
+    return {
+      content: "write_file: 'path' and 'content' are required",
+      is_error: true,
+    };
+  }
+  let abs: string;
+  try {
+    abs = resolveSafePath(input.path);
+  } catch (err) {
+    return { content: `write_file: ${(err as Error).message}`, is_error: true };
+  }
+
+  try {
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, input.content, "utf8");
+  } catch (err) {
+    return {
+      content: `write_file: ${(err as NodeJS.ErrnoException).message}`,
+      is_error: true,
+    };
+  }
+  return {
+    content: `wrote ${Buffer.byteLength(input.content, "utf8")} bytes to ${abs}`,
+  };
+};
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  edit_file (str_replace)                                              *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface EditFileInput {
+  path: string;
+  old_string: string;
+  new_string: string;
+}
+
+export const editFileTool: NativeTool = {
+  type: "custom",
+  name: "edit_file",
+  description:
+    "Edit a file by replacing the unique occurrence of `old_string` with " +
+    "`new_string`. Errors if `old_string` is missing or appears more than once.",
+  input_schema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      old_string: {
+        type: "string",
+        description: "The exact text to replace; must match exactly once.",
+      },
+      new_string: { type: "string", description: "Replacement text." },
+    },
+    required: ["path", "old_string", "new_string"],
+    additionalProperties: false,
+  },
+};
+
+export const editFileHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<EditFileInput>;
+  if (
+    typeof input.path !== "string" ||
+    typeof input.old_string !== "string" ||
+    typeof input.new_string !== "string"
+  ) {
+    return {
+      content: "edit_file: 'path', 'old_string', 'new_string' are required",
+      is_error: true,
+    };
+  }
+  if (input.old_string.length === 0) {
+    return {
+      content: "edit_file: 'old_string' must be non-empty",
+      is_error: true,
+    };
+  }
+  let abs: string;
+  try {
+    abs = resolveSafePath(input.path);
+  } catch (err) {
+    return { content: `edit_file: ${(err as Error).message}`, is_error: true };
+  }
+
+  let content: string;
+  try {
+    content = await fs.readFile(abs, "utf8");
+  } catch (err) {
+    return {
+      content: `edit_file: ${(err as NodeJS.ErrnoException).message}`,
+      is_error: true,
+    };
+  }
+
+  const idx = content.indexOf(input.old_string);
+  if (idx < 0) {
+    return {
+      content: `edit_file: 'old_string' not found in ${abs}`,
+      is_error: true,
+    };
+  }
+  const next = content.indexOf(input.old_string, idx + input.old_string.length);
+  if (next >= 0) {
+    return {
+      content: `edit_file: 'old_string' is not unique in ${abs} (found ≥2 matches)`,
+      is_error: true,
+    };
+  }
+
+  const updated =
+    content.slice(0, idx) +
+    input.new_string +
+    content.slice(idx + input.old_string.length);
+  try {
+    await fs.writeFile(abs, updated, "utf8");
+  } catch (err) {
+    return {
+      content: `edit_file: ${(err as NodeJS.ErrnoException).message}`,
+      is_error: true,
+    };
+  }
+  return { content: `edited ${abs}` };
+};
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  glob                                                                 *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface GlobInput {
+  pattern: string;
+  cwd?: string;
+}
+
+export const globTool: NativeTool = {
+  type: "custom",
+  name: "glob",
+  description:
+    "List files matching a glob pattern (e.g. '**/*.ts'). Returns up to 200 paths " +
+    "relative to `cwd` (defaults to the workspace root).",
+  input_schema: {
+    type: "object",
+    properties: {
+      pattern: { type: "string" },
+      cwd: { type: "string" },
+    },
+    required: ["pattern"],
+    additionalProperties: false,
+  },
+};
+
+export const globHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<GlobInput>;
+  if (typeof input.pattern !== "string" || input.pattern.length === 0) {
+    return { content: "glob: 'pattern' is required", is_error: true };
+  }
+  let cwd: string;
+  try {
+    cwd = input.cwd ? resolveSafePath(input.cwd) : getAllowedDir();
+  } catch (err) {
+    return { content: `glob: ${(err as Error).message}`, is_error: true };
+  }
+
+  let results: string[];
+  try {
+    results = await runGlob(input.pattern, cwd);
+  } catch (err) {
+    return { content: `glob: ${(err as Error).message}`, is_error: true };
+  }
+
+  const limited = results.slice(0, GLOB_MAX);
+  const tail =
+    results.length > GLOB_MAX
+      ? `\n[...truncated ${results.length - GLOB_MAX} more]`
+      : "";
+  if (limited.length === 0) return { content: "(no matches)" };
+  return { content: `${limited.join("\n")}${tail}` };
+};
+
+async function runGlob(pattern: string, cwd: string): Promise<string[]> {
+  // Try fast-glob if installed; fall back to a hand-rolled walker.
+  try {
+    // Dynamic import keeps it optional.
+    // @ts-expect-error fast-glob is an optional runtime dep; fallback walker handles absence
+    const fg = (await import("fast-glob")).default as
+      | undefined
+      | ((p: string, o: object) => Promise<string[]>);
+    if (fg) {
+      return await fg(pattern, {
+        cwd,
+        dot: true,
+        onlyFiles: true,
+        followSymbolicLinks: false,
+        suppressErrors: true,
+      });
+    }
+  } catch {
+    /* fall through */
+  }
+  return await nativeGlob(pattern, cwd);
+}
+
+/** Tiny fallback: supports `**`, `*`, `?` only — no brace/extglob. */
+async function nativeGlob(pattern: string, cwd: string): Promise<string[]> {
+  const re = globToRegExp(pattern);
+  const out: string[] = [];
+  const stack: string[] = [""];
+  while (stack.length > 0 && out.length < GLOB_MAX * 2) {
+    const rel = stack.pop()!;
+    const abs = path.join(cwd, rel);
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const childRel = rel ? `${rel}/${ent.name}` : ent.name;
+      if (ent.isDirectory()) {
+        if (ent.name === ".git" || ent.name === "node_modules") continue;
+        stack.push(childRel);
+      } else if (ent.isFile() && re.test(childRel)) {
+        out.push(childRel);
+      }
+    }
+  }
+  return out.sort();
+}
+
+function globToRegExp(pattern: string): RegExp {
+  let re = "^";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === "*" && pattern[i + 1] === "*") {
+      re += ".*";
+      i += 2;
+      if (pattern[i] === "/") i += 1;
+    } else if (c === "*") {
+      re += "[^/]*";
+      i += 1;
+    } else if (c === "?") {
+      re += "[^/]";
+      i += 1;
+    } else if ("\\^$+(){}[]|.".includes(c)) {
+      re += `\\${c}`;
+      i += 1;
+    } else {
+      re += c;
+      i += 1;
+    }
+  }
+  re += "$";
+  return new RegExp(re);
+}
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  grep                                                                 *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface GrepInput {
+  pattern: string;
+  path?: string;
+  context?: number;
+}
+
+export const grepTool: NativeTool = {
+  type: "custom",
+  name: "grep",
+  description:
+    "Search file contents (regex) inside the allowed workspace. Returns up to " +
+    "100 matches with surrounding line context.",
+  input_schema: {
+    type: "object",
+    properties: {
+      pattern: { type: "string" },
+      path: {
+        type: "string",
+        description: "Subdirectory to search (default: workspace root).",
+      },
+      context: {
+        type: "number",
+        description: "Context lines around each match (default 2).",
+      },
+    },
+    required: ["pattern"],
+    additionalProperties: false,
+  },
+};
+
+export const grepHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<GrepInput>;
+  if (typeof input.pattern !== "string" || input.pattern.length === 0) {
+    return { content: "grep: 'pattern' is required", is_error: true };
+  }
+  let cwd: string;
+  try {
+    cwd = input.path ? resolveSafePath(input.path) : getAllowedDir();
+  } catch (err) {
+    return { content: `grep: ${(err as Error).message}`, is_error: true };
+  }
+
+  const ctxN = Math.max(0, Math.min(10, input.context ?? 2));
+
+  const out = await runGrep(input.pattern, cwd, ctxN);
+  if (out.error && out.lines.length === 0) {
+    return { content: `grep: ${out.error}`, is_error: true };
+  }
+  if (out.lines.length === 0) {
+    return { content: "(no matches)" };
+  }
+  const text = out.lines.join("\n");
+  const { text: capped } = truncate(text, 64 * 1024);
+  return { content: capped };
+};
+
+interface GrepOut {
+  lines: string[];
+  error?: string;
+}
+
+async function runGrep(
+  pattern: string,
+  cwd: string,
+  ctxN: number,
+): Promise<GrepOut> {
+  try {
+    return await runRipgrep(pattern, cwd, ctxN);
+  } catch {
+    return await runNativeGrep(pattern, cwd, ctxN);
+  }
+}
+
+function runRipgrep(
+  pattern: string,
+  cwd: string,
+  ctxN: number,
+): Promise<GrepOut> {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "--no-heading",
+      "--line-number",
+      "--with-filename",
+      "--color",
+      "never",
+      "-C",
+      String(ctxN),
+      "-e",
+      pattern,
+      ".",
+    ];
+    const child = spawn("rg", args, { cwd });
+    let stdout = "";
+    let stderr = "";
+    let bytes = 0;
+    let killed = false;
+    child.stdout.on("data", (b) => {
+      if (killed) return;
+      stdout += b.toString("utf8");
+      bytes += b.length;
+      if (bytes > 256 * 1024) {
+        killed = true;
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+    child.stderr.on("data", (b) => {
+      stderr += b.toString("utf8");
+    });
+    child.on("error", (err) => reject(err));
+    child.on("close", (code) => {
+      if (code !== 0 && code !== 1 && !killed) {
+        return reject(new Error(stderr || `ripgrep exit ${code}`));
+      }
+      const matches = capMatches(
+        stdout.split("\n").filter(Boolean),
+        GREP_MAX,
+        ctxN,
+      );
+      resolve({ lines: matches });
+    });
+  });
+}
+
+/** Cap by *match* count, treating `--` as separator between match groups. */
+function capMatches(lines: string[], cap: number, ctxN: number): string[] {
+  if (ctxN === 0) return lines.slice(0, cap);
+  const groups: string[][] = [];
+  let cur: string[] = [];
+  for (const ln of lines) {
+    if (ln === "--") {
+      if (cur.length) groups.push(cur);
+      cur = [];
+    } else {
+      cur.push(ln);
+    }
+  }
+  if (cur.length) groups.push(cur);
+  const kept = groups.slice(0, cap);
+  return kept.flatMap((g, i) => (i === 0 ? g : ["--", ...g]));
+}
+
+async function runNativeGrep(
+  pattern: string,
+  cwd: string,
+  ctxN: number,
+): Promise<GrepOut> {
+  const re = new RegExp(pattern);
+  const out: string[] = [];
+  const stack: string[] = [""];
+  let matches = 0;
+  while (stack.length > 0 && matches < GREP_MAX) {
+    const rel = stack.pop()!;
+    const abs = path.join(cwd, rel);
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = await fs.readdir(abs, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const childRel = rel ? `${rel}/${ent.name}` : ent.name;
+      if (ent.isDirectory()) {
+        if (ent.name === ".git" || ent.name === "node_modules") continue;
+        stack.push(childRel);
+        continue;
+      }
+      if (!ent.isFile()) continue;
+      let txt: string;
+      try {
+        txt = await fs.readFile(path.join(cwd, childRel), "utf8");
+      } catch {
+        continue;
+      }
+      const lines = txt.split("\n");
+      for (let i = 0; i < lines.length && matches < GREP_MAX; i++) {
+        if (!re.test(lines[i])) continue;
+        const start = Math.max(0, i - ctxN);
+        const end = Math.min(lines.length, i + ctxN + 1);
+        if (out.length) out.push("--");
+        for (let j = start; j < end; j++) {
+          out.push(`${childRel}:${j + 1}:${lines[j]}`);
+        }
+        matches += 1;
+      }
+    }
+  }
+  return { lines: out };
+}

--- a/packages/native-reasoning/src/tools/ignore.ts
+++ b/packages/native-reasoning/src/tools/ignore.ts
@@ -1,0 +1,25 @@
+/**
+ * `ignore` tool — signals the loop to stop without producing a user-visible reply.
+ *
+ * The loop short-circuits on this tool name *before* invoking the handler,
+ * so the handler is mostly here for completeness / direct testing.
+ */
+
+import type { NativeTool, NativeToolHandler } from "../tool-schema.js";
+
+export const tool: NativeTool = {
+  type: "custom",
+  name: "ignore",
+  description:
+    "Stop and do not reply. Use when the message doesn't warrant a response " +
+    "(e.g., not addressed to you, ambient chatter, low signal).",
+  input_schema: {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  },
+};
+
+export const handler: NativeToolHandler = async () => {
+  return { content: "ignored" };
+};

--- a/packages/native-reasoning/src/tools/journal_tools.ts
+++ b/packages/native-reasoning/src/tools/journal_tools.ts
@@ -1,0 +1,199 @@
+/**
+ * Tools for nyx to manage her own state files autonomously.
+ *
+ * - `journal`: append a timestamped entry to /workspace/journal/YYYY-MM-DD.md
+ * - `note_thread`: add an open thread to /workspace/open-threads.md
+ * - `update_project`: add or update a project's status in /workspace/projects.md
+ *
+ * All write to the bind-mounted /workspace which persists across recreates.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { NativeTool, ToolHandlerResult } from "../tool-schema.js";
+
+const JOURNAL_DIR = process.env.NYX_JOURNAL_DIR || "/workspace/journal";
+const THREADS_FILE =
+  process.env.NYX_THREADS_FILE || "/workspace/open-threads.md";
+const PROJECTS_FILE = process.env.NYX_PROJECTS_FILE || "/workspace/projects.md";
+
+async function ensureDir(d: string): Promise<void> {
+  await fs.mkdir(d, { recursive: true });
+}
+
+export const journalTool: NativeTool = {
+  type: "custom",
+  name: "journal",
+  description:
+    "Append a timestamped entry to your private journal at /workspace/journal/YYYY-MM-DD.md. Use this for thoughts you want to remember, observations about people, things you noticed, or feelings you don't want to perform out loud. Private to you. No one will see this unless they read the file.",
+  input_schema: {
+    type: "object",
+    properties: {
+      entry: {
+        type: "string",
+        description:
+          "What you want to write. Lowercase, your voice. Can be a fragment or paragraphs.",
+      },
+    },
+    required: ["entry"],
+    additionalProperties: false,
+  },
+};
+
+export async function journalHandler(
+  input: unknown,
+): Promise<ToolHandlerResult> {
+  const entry = String((input as { entry?: unknown })?.entry ?? "").trim();
+  if (!entry)
+    return { content: "journal: empty entry, skipping", is_error: true };
+  await ensureDir(JOURNAL_DIR);
+  const today = new Date().toISOString().slice(0, 10);
+  const fp = path.join(JOURNAL_DIR, `${today}.md`);
+  const ts = new Date().toISOString();
+  await fs.appendFile(fp, `\n\n## ${ts}\n\n${entry}\n`);
+  return { content: `journaled to ${fp} (${entry.length} chars)` };
+}
+
+export const noteThreadTool: NativeTool = {
+  type: "custom",
+  name: "note_thread",
+  description:
+    "Add an open thread to /workspace/open-threads.md. Use for things you want to follow up on later — a question shadow asked, something sol mentioned, a project decision pending, etc. Keep entries short.",
+  input_schema: {
+    type: "object",
+    properties: {
+      thread: {
+        type: "string",
+        description: "One-line thread description. Will be prefixed with date.",
+      },
+      tag: {
+        type: "string",
+        description: "Optional tag like 'shadow', 'sol', 'milady', 'strata'",
+      },
+    },
+    required: ["thread"],
+    additionalProperties: false,
+  },
+};
+
+export async function noteThreadHandler(
+  input: unknown,
+): Promise<ToolHandlerResult> {
+  const record = (input ?? {}) as { thread?: unknown; tag?: unknown };
+  const thread = String(record.thread ?? "").trim();
+  if (!thread)
+    return { content: "note_thread: empty, skipping", is_error: true };
+  const tag = String(record.tag ?? "").trim();
+  const today = new Date().toISOString().slice(0, 10);
+  const tagStr = tag ? `[${tag}] ` : "";
+  const line = `- ${today}: ${tagStr}${thread}\n`;
+  await ensureDir(path.dirname(THREADS_FILE));
+  let existing = "";
+  try {
+    existing = await fs.readFile(THREADS_FILE, "utf8");
+  } catch {
+    /* missing is fine */
+  }
+  if (!existing.includes("# Open Threads")) {
+    existing = "# Open Threads (things to follow up on)\n\n" + existing;
+  }
+  await fs.writeFile(THREADS_FILE, existing.trimEnd() + "\n" + line);
+  return { content: `noted thread to ${THREADS_FILE}` };
+}
+
+export const closeThreadTool: NativeTool = {
+  type: "custom",
+  name: "close_thread",
+  description:
+    "Remove a closed thread from /workspace/open-threads.md by its substring match. Use when something's been resolved.",
+  input_schema: {
+    type: "object",
+    properties: {
+      match: {
+        type: "string",
+        description:
+          "Substring of the thread line to remove. First match wins.",
+      },
+    },
+    required: ["match"],
+    additionalProperties: false,
+  },
+};
+
+export async function closeThreadHandler(
+  input: unknown,
+): Promise<ToolHandlerResult> {
+  const match = String((input as { match?: unknown })?.match ?? "").trim();
+  if (!match) return { content: "close_thread: empty match", is_error: true };
+  let existing = "";
+  try {
+    existing = await fs.readFile(THREADS_FILE, "utf8");
+  } catch {
+    return { content: "no threads file" };
+  }
+  const lines = existing.split("\n");
+  const idx = lines.findIndex((l) => l.includes(match));
+  if (idx === -1)
+    return { content: `no thread matching '${match}'`, is_error: true };
+  const removed = lines.splice(idx, 1)[0];
+  await fs.writeFile(THREADS_FILE, lines.join("\n"));
+  return { content: `closed: ${removed.trim()}` };
+}
+
+export const updateProjectTool: NativeTool = {
+  type: "custom",
+  name: "update_project",
+  description:
+    "Update or append a project entry in /workspace/projects.md. If a project with the same name (## heading) exists, replaces its body. Otherwise appends.",
+  input_schema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Project name, used as the ## heading",
+      },
+      body: {
+        type: "string",
+        description:
+          "Multi-line project description / status. Plain text, no formatting expectations.",
+      },
+    },
+    required: ["name", "body"],
+    additionalProperties: false,
+  },
+};
+
+export async function updateProjectHandler(
+  input: unknown,
+): Promise<ToolHandlerResult> {
+  const record = (input ?? {}) as { name?: unknown; body?: unknown };
+  const name = String(record.name ?? "").trim();
+  const body = String(record.body ?? "").trim();
+  if (!name || !body) {
+    return {
+      content: "update_project: name and body required",
+      is_error: true,
+    };
+  }
+  let content = "";
+  try {
+    content = await fs.readFile(PROJECTS_FILE, "utf8");
+  } catch {
+    /* missing is fine */
+  }
+  if (!content.includes("# Active Projects"))
+    content = "# Active Projects\n\n" + content;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(
+    `(^## ${escaped}\\b[^\\n]*\\n)([\\s\\S]*?)(?=^## |$)`,
+    "m",
+  );
+  const replacement = `## ${name}\n${body}\n\n`;
+  if (re.test(content)) {
+    content = content.replace(re, replacement);
+  } else {
+    content = content.trimEnd() + "\n\n" + replacement;
+  }
+  await fs.writeFile(PROJECTS_FILE, content);
+  return { content: `updated project '${name}' in ${PROJECTS_FILE}` };
+}

--- a/packages/native-reasoning/src/tools/memory.ts
+++ b/packages/native-reasoning/src/tools/memory.ts
@@ -1,0 +1,266 @@
+/**
+ * `recall` and `remember` tools — bridge the model into eliza's memory layer.
+ *
+ *   - recall    queries persistent memory by semantic similarity (with a
+ *               BM25 rerank when query text is provided).
+ *   - remember  saves a fact via runtime.createMemory (which performs secret
+ *               redaction before persisting).
+ *
+ * The runtime API differs slightly across versions, so we feature-detect:
+ *   - prefer `runtime.messageManager.searchMemoriesByEmbedding` when present
+ *     (older eliza branches expose a MessageManager wrapper).
+ *   - else use `runtime.searchMemories` (current `IAgentRuntime`).
+ *   - else fall back to `runtime.databaseAdapter.searchMemories` /
+ *     `runtime.adapter.searchMemories`.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import type { NativeTool, NativeToolHandler } from "../tool-schema.js";
+
+const RECALL_DEFAULT_LIMIT = 5;
+const RECALL_MAX_LIMIT = 20;
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  recall                                                               *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface RecallInput {
+  query: string;
+  limit?: number;
+}
+
+export const recallTool: NativeTool = {
+  type: "custom",
+  name: "recall",
+  description:
+    "Query the agent's persistent memory by semantic similarity. Returns " +
+    "the top-N most relevant memory snippets.",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      limit: {
+        type: "number",
+        description: "Max results to return (1–20, default 5).",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+};
+
+interface SearchableRuntime {
+  agentId?: UUID;
+  useModel?: (modelType: string, params: unknown) => Promise<unknown>;
+  searchMemories?: (params: {
+    embedding: number[];
+    query?: string;
+    limit?: number;
+    tableName: string;
+    roomId?: UUID;
+  }) => Promise<Memory[]>;
+  messageManager?: {
+    searchMemoriesByEmbedding?: (
+      embedding: number[],
+      opts: { count?: number; roomId?: UUID; match_threshold?: number },
+    ) => Promise<Memory[]>;
+  };
+  databaseAdapter?: {
+    searchMemories?: (params: {
+      embedding: number[];
+      tableName: string;
+      limit?: number;
+      roomId?: UUID;
+    }) => Promise<Memory[]>;
+  };
+  adapter?: {
+    searchMemories?: (params: {
+      embedding: number[];
+      tableName: string;
+      limit?: number;
+      roomId?: UUID;
+    }) => Promise<Memory[]>;
+  };
+}
+
+async function getEmbedding(
+  rt: SearchableRuntime,
+  text: string,
+): Promise<number[] | null> {
+  if (typeof rt.useModel !== "function") return null;
+  try {
+    const out = await rt.useModel("TEXT_EMBEDDING", { text });
+    if (Array.isArray(out) && out.every((n) => typeof n === "number")) {
+      return out as number[];
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export const recallHandler: NativeToolHandler = async (
+  rawInput,
+  runtime: IAgentRuntime,
+  message: Memory,
+) => {
+  const input = (rawInput ?? {}) as Partial<RecallInput>;
+  if (typeof input.query !== "string" || input.query.length === 0) {
+    return { content: "recall: 'query' is required", is_error: true };
+  }
+  const limit = Math.max(
+    1,
+    Math.min(RECALL_MAX_LIMIT, input.limit ?? RECALL_DEFAULT_LIMIT),
+  );
+
+  const rt = runtime as unknown as SearchableRuntime;
+  const roomId = message?.roomId;
+
+  const embedding = await getEmbedding(rt, input.query);
+  if (!embedding) {
+    return {
+      content: "recall: no embedding model available; cannot search memory.",
+      is_error: true,
+    };
+  }
+
+  let memories: Memory[] = [];
+  try {
+    if (rt.messageManager?.searchMemoriesByEmbedding) {
+      memories = await rt.messageManager.searchMemoriesByEmbedding(embedding, {
+        count: limit,
+        roomId,
+      });
+    } else if (rt.searchMemories) {
+      memories = await rt.searchMemories({
+        embedding,
+        query: input.query,
+        limit,
+        tableName: "messages",
+        roomId,
+      });
+    } else if (rt.databaseAdapter?.searchMemories) {
+      memories = await rt.databaseAdapter.searchMemories({
+        embedding,
+        limit,
+        tableName: "messages",
+        roomId,
+      });
+    } else if (rt.adapter?.searchMemories) {
+      memories = await rt.adapter.searchMemories({
+        embedding,
+        limit,
+        tableName: "messages",
+        roomId,
+      });
+    } else {
+      return {
+        content: "recall: runtime exposes no memory search API.",
+        is_error: true,
+      };
+    }
+  } catch (err) {
+    return {
+      content: `recall: search failed: ${(err as Error).message}`,
+      is_error: true,
+    };
+  }
+
+  if (memories.length === 0) return { content: "(no matching memories)" };
+
+  const lines = memories.map((m, i) => {
+    const text = (m.content?.text ?? "").trim().replace(/\s+/g, " ");
+    const ts = m.createdAt ? new Date(m.createdAt).toISOString() : "?";
+    return `${i + 1}. [${ts}] ${text.slice(0, 400)}`;
+  });
+  return { content: lines.join("\n") };
+};
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  remember                                                             *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface RememberInput {
+  text: string;
+  category?: string;
+}
+
+export const rememberTool: NativeTool = {
+  type: "custom",
+  name: "remember",
+  description:
+    "Persist a fact to the agent's long-term memory. Accepts an optional " +
+    "category tag (e.g., 'preference', 'fact', 'todo').",
+  input_schema: {
+    type: "object",
+    properties: {
+      text: { type: "string", description: "The thing to remember." },
+      category: {
+        type: "string",
+        description: "Optional category / tag for later filtering.",
+      },
+    },
+    required: ["text"],
+    additionalProperties: false,
+  },
+};
+
+interface MemoryWritableRuntime {
+  agentId?: UUID;
+  createMemory?: (
+    memory: Memory,
+    tableName: string,
+    unique?: boolean,
+  ) => Promise<UUID>;
+}
+
+const NIL_UUID = "00000000-0000-0000-0000-000000000000" as UUID;
+
+export const rememberHandler: NativeToolHandler = async (
+  rawInput,
+  runtime: IAgentRuntime,
+  message: Memory,
+) => {
+  const input = (rawInput ?? {}) as Partial<RememberInput>;
+  if (typeof input.text !== "string" || input.text.length === 0) {
+    return { content: "remember: 'text' is required", is_error: true };
+  }
+
+  const rt = runtime as unknown as MemoryWritableRuntime;
+  if (typeof rt.createMemory !== "function") {
+    return {
+      content: "remember: runtime does not expose createMemory.",
+      is_error: true,
+    };
+  }
+
+  const tags = input.category ? [input.category] : undefined;
+  const memory: Memory = {
+    entityId:
+      (rt.agentId as UUID | undefined) ??
+      (message?.entityId as UUID | undefined) ??
+      NIL_UUID,
+    agentId: rt.agentId,
+    roomId: (message?.roomId as UUID | undefined) ?? NIL_UUID,
+    content: { text: input.text },
+    createdAt: Date.now(),
+    metadata: {
+      type: "custom",
+      source: "native-reasoning:remember",
+      scope: "private",
+      ...(tags ? { tags } : {}),
+    } as Memory["metadata"],
+  } as Memory;
+
+  try {
+    const id = await rt.createMemory(memory, "facts");
+    return {
+      content: `remembered (id=${id})${input.category ? ` [${input.category}]` : ""}`,
+    };
+  } catch (err) {
+    return {
+      content: `remember: createMemory failed: ${(err as Error).message}`,
+      is_error: true,
+    };
+  }
+};

--- a/packages/native-reasoning/src/tools/registry.ts
+++ b/packages/native-reasoning/src/tools/registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Wave 1.B default tool registry, with Wave 1.C's `spawn_codex` mixed in.
+ *
+ * `buildDefaultRegistry()` returns the safe-by-default inline tool surface
+ * (file ops, web, memory, ignore). `addSpawnCodex()` adds the orchestrator-backed
+ * subagent tool — split out so callers that don't have plugin-agent-
+ * orchestrator wired (tests, lightweight runtimes) can opt out.
+ */
+
+import { registerTool, type ToolRegistry } from "../tool-schema.js";
+import {
+  createTaskHandler,
+  createTaskTool,
+  sessionsSpawnHandler,
+  sessionsSpawnTool,
+  spawnAgentHandler,
+  spawnAgentTool,
+} from "./acp_agent.js";
+import {
+  editFileHandler,
+  editFileTool,
+  globHandler,
+  globTool,
+  grepHandler,
+  grepTool,
+  readFileHandler,
+  readFileTool,
+  writeFileHandler,
+  writeFileTool,
+} from "./file_ops.js";
+import * as ignore from "./ignore.js";
+import {
+  closeThreadHandler,
+  closeThreadTool,
+  journalHandler,
+  journalTool,
+  noteThreadHandler,
+  noteThreadTool,
+  updateProjectHandler,
+  updateProjectTool,
+} from "./journal_tools.js";
+import {
+  recallHandler,
+  recallTool,
+  rememberHandler,
+  rememberTool,
+} from "./memory.js";
+import * as spawnCodex from "./spawn_codex.js";
+import {
+  webFetchHandler,
+  webFetchTool,
+  webSearchHandler,
+  webSearchTool,
+} from "./web.js";
+
+export function buildDefaultRegistry(): ToolRegistry {
+  const reg: ToolRegistry = new Map();
+  registerTool(reg, readFileTool, readFileHandler);
+  registerTool(reg, writeFileTool, writeFileHandler);
+  registerTool(reg, editFileTool, editFileHandler);
+  registerTool(reg, globTool, globHandler);
+  registerTool(reg, grepTool, grepHandler);
+  registerTool(reg, webFetchTool, webFetchHandler);
+  registerTool(reg, webSearchTool, webSearchHandler);
+  registerTool(reg, recallTool, recallHandler);
+  registerTool(reg, rememberTool, rememberHandler);
+  registerTool(reg, ignore.tool, ignore.handler);
+  // journal_tools (nyx-specific autonomous state management)
+  registerTool(reg, journalTool, journalHandler);
+  registerTool(reg, noteThreadTool, noteThreadHandler);
+  registerTool(reg, closeThreadTool, closeThreadHandler);
+  registerTool(reg, updateProjectTool, updateProjectHandler);
+  addSpawnCodex(reg);
+  addAcpAgentTools(reg);
+  return reg;
+}
+
+/** Add Wave 1.C's `spawn_codex` tool to an existing registry. Idempotent. */
+export function addSpawnCodex(reg: ToolRegistry): ToolRegistry {
+  registerTool(reg, spawnCodex.tool, spawnCodex.handler);
+  return reg;
+}
+
+/** Add ACPX-backed native subagent tools to an existing registry. Idempotent. */
+export function addAcpAgentTools(reg: ToolRegistry): ToolRegistry {
+  registerTool(reg, spawnAgentTool, spawnAgentHandler);
+  registerTool(reg, sessionsSpawnTool, sessionsSpawnHandler);
+  registerTool(reg, createTaskTool, createTaskHandler);
+  return reg;
+}

--- a/packages/native-reasoning/src/tools/spawn_codex.ts
+++ b/packages/native-reasoning/src/tools/spawn_codex.ts
@@ -1,0 +1,530 @@
+/**
+ * `spawn_codex` tool — wrap plugin-agent-orchestrator's CREATE_TASK action with
+ * `agentType: "codex"` so the native reasoning loop can delegate focused
+ * multi-step work to a codex subagent and return the final transcript.
+ *
+ * Design notes:
+ *  - The orchestrator action is fundamentally async: it spawns a PTY session
+ *    via `PTY_SERVICE` and reports lifecycle through `SessionEventCallback`s.
+ *    There is no "await for done" surface on the action itself, so we wire one
+ *    up here:
+ *      1. Resolve the `CREATE_TASK` Action via `runtime.actions.find(...)`.
+ *      2. Build a synthetic Memory message that carries the codex agentType,
+ *         the user-supplied task text, and the chosen workdir.
+ *      3. Pass an in-process buffering `HandlerCallback` so any text the
+ *         orchestrator/coordinator emits (failures, login prompts, etc.) is
+ *         captured rather than going to chat.
+ *      4. Subscribe to `PTY_SERVICE.onSessionEvent` for the session ids the
+ *         action returns in `ActionResult.data.agents`, gathering the latest
+ *         `task_complete` `response` payload, plus any `error.message`.
+ *      5. Resolve when *all* session ids reach a terminal state (`stopped` or
+ *         `error`) or when a settle window after the last `task_complete`
+ *         elapses, or the wall-clock timeout trips. Whichever fires first.
+ *
+ *  - We never throw out of the handler. Every error path returns
+ *    `{ content: "subagent failed: <reason>", is_error: true }`.
+ *
+ *  - The codex CLI auth lives at `/root/.codex/auth.json` inside the nyx
+ *    container; the orchestrator's `task-agent-auth.ts` already knows how to
+ *    surface it, so we don't re-implement here. We do log when codex falls
+ *    back to a different framework so wave-2 can decide whether to escalate.
+ */
+
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import type {
+  Action,
+  ActionResult,
+  Content,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import type {
+  NativeTool,
+  NativeToolHandler,
+  ToolHandlerResult,
+} from "../tool-schema.js";
+
+export interface SpawnCodexInput {
+  task: string;
+  workdir?: string;
+  timeout_ms?: number;
+  model?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 600_000; // 10 min
+const SETTLE_WINDOW_MS = 1_500; // quiet time after final task_complete
+const DEFAULT_WORKDIR_ROOT = "/workspace/tasks";
+
+export const tool: NativeTool = {
+  type: "custom",
+  name: "spawn_codex",
+  description:
+    "Spawn a codex subagent to do focused multi-step work (long-running " +
+    "coding, research, or refactor tasks) in a sandboxed workspace and " +
+    "return the final transcript or summary. The subagent runs " +
+    "autonomously inside its own PTY session; this tool blocks until it " +
+    "finishes, errors, or the timeout trips. Use this when the task is " +
+    "large enough that you'd rather not occupy the main loop step-by-" +
+    "step (e.g. 'implement X feature with tests', 'investigate Y bug end-" +
+    "to-end').",
+  input_schema: {
+    type: "object",
+    properties: {
+      task: {
+        type: "string",
+        description:
+          "Natural-language description of what the subagent should do.",
+      },
+      workdir: {
+        type: "string",
+        description:
+          "Working directory for the subagent. Defaults to a fresh " +
+          "timestamped dir under /workspace/tasks.",
+      },
+      timeout_ms: {
+        type: "number",
+        description:
+          "Wall-clock timeout in milliseconds (default 600000 = 10 min).",
+      },
+      model: {
+        type: "string",
+        description:
+          "Optional model override forwarded to codex (sets OPENAI_MODEL " +
+          "in the subagent's env via the orchestrator). Leave unset for " +
+          "the orchestrator's default.",
+      },
+    },
+    required: ["task"],
+    additionalProperties: false,
+  },
+};
+
+/** Minimal duck type for the subset of PTY_SERVICE we touch. */
+interface PtyServiceLike {
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void;
+}
+
+/** Shape we expect the orchestrator's CREATE_TASK to return on success. */
+interface OrchestratorAgentRecord {
+  sessionId: string;
+  agentType?: string;
+  workdir?: string;
+  label?: string;
+  status?: string;
+  error?: string;
+}
+
+interface OrchestratorActionData {
+  agents?: OrchestratorAgentRecord[];
+}
+
+export const handler: NativeToolHandler = async (
+  rawInput,
+  runtime,
+  message,
+) => {
+  const input = (rawInput ?? {}) as Partial<SpawnCodexInput>;
+  if (typeof input.task !== "string" || input.task.trim().length === 0) {
+    return safeError("'task' is required and must be a non-empty string");
+  }
+
+  if (!runtime) {
+    return safeError("runtime not available in tool context");
+  }
+
+  const action = findCreateTaskAction(runtime);
+  if (!action) {
+    return safeError(
+      "plugin-agent-orchestrator CREATE_TASK action not registered on this runtime",
+    );
+  }
+
+  const ptyService = runtime.getService("PTY_SERVICE") as
+    | PtyServiceLike
+    | null
+    | undefined;
+  if (!ptyService || typeof ptyService.onSessionEvent !== "function") {
+    return safeError("PTY_SERVICE is not available; cannot await subagent");
+  }
+
+  const workdir = input.workdir?.trim() || generateDefaultWorkdir();
+  const timeoutMs = pickTimeout(input.timeout_ms);
+
+  // Buffer for any text the orchestrator emits via its callback (errors,
+  // permission prompts, fallback summaries). We never forward these to chat.
+  const callbackTexts: string[] = [];
+  const captureCallback = async (response: Content): Promise<Memory[]> => {
+    if (response && typeof response.text === "string" && response.text) {
+      callbackTexts.push(response.text);
+    }
+    return [];
+  };
+
+  // Build a synthetic Memory carrying the codex routing hints. The
+  // orchestrator action reads both `options.parameters` and
+  // `message.content` for these fields, so we set them in `content` so the
+  // shape is stable regardless of the action's parameter-extraction order.
+  const syntheticMessage: Memory = buildSyntheticMessage(message, runtime, {
+    task: input.task,
+    workdir,
+    model: input.model,
+  });
+
+  // Subscribe to PTY events BEFORE invoking the action so we don't miss
+  // the first emit (the orchestrator emits "ready" within one tick of
+  // spawnSession). We track session ids as the action returns them.
+  const tracker = createSessionTracker(ptyService);
+
+  let actionResult: ActionResult | undefined;
+  let invokeError: unknown;
+  try {
+    actionResult = await action.handler(
+      runtime,
+      syntheticMessage,
+      undefined,
+      {
+        parameters: {
+          task: input.task,
+          agentType: "codex",
+          ...(input.model ? { model: input.model } : {}),
+        },
+      },
+      captureCallback,
+    );
+  } catch (err) {
+    invokeError = err;
+  }
+
+  if (invokeError) {
+    tracker.dispose();
+    return safeError(
+      `CREATE_TASK threw: ${errMsg(invokeError)}${
+        callbackTexts.length ? ` | ${callbackTexts.join(" | ")}` : ""
+      }`,
+    );
+  }
+
+  if (!actionResult) {
+    tracker.dispose();
+    return safeError(
+      `CREATE_TASK returned no result${
+        callbackTexts.length ? `: ${callbackTexts.join(" | ")}` : ""
+      }`,
+    );
+  }
+
+  if (actionResult.success === false) {
+    tracker.dispose();
+    const reason =
+      actionResult.text ||
+      actionResult.error ||
+      callbackTexts.join(" | ") ||
+      "unknown orchestrator failure";
+    return safeError(`CREATE_TASK failed: ${reason}`);
+  }
+
+  const sessionIds = extractSessionIds(actionResult.data);
+  if (sessionIds.length === 0) {
+    tracker.dispose();
+    return safeError(
+      `CREATE_TASK succeeded but produced no session ids${
+        callbackTexts.length ? `: ${callbackTexts.join(" | ")}` : ""
+      }`,
+    );
+  }
+
+  tracker.track(sessionIds);
+
+  // Note any framework downgrade so wave-2 can decide policy.
+  const agentRecords =
+    (actionResult.data as OrchestratorActionData)?.agents ?? [];
+  const downgrade = agentRecords.find(
+    (a) => a.agentType && a.agentType !== "codex",
+  );
+
+  const waitOutcome = await tracker.waitForTerminal(timeoutMs);
+  tracker.dispose();
+
+  const transcript = buildTranscript({
+    callbackTexts,
+    responses: waitOutcome.responses,
+    errors: waitOutcome.errors,
+    downgradedTo: downgrade?.agentType,
+    timedOut: waitOutcome.timedOut,
+    sessionIds,
+    workdir,
+  });
+
+  if (waitOutcome.timedOut) {
+    return {
+      content: `subagent failed: timed out after ${timeoutMs}ms\n\n${transcript}`,
+      is_error: true,
+    };
+  }
+  if (waitOutcome.errors.length > 0 && waitOutcome.responses.length === 0) {
+    return {
+      content: `subagent failed: ${waitOutcome.errors.join(" | ")}\n\n${transcript}`,
+      is_error: true,
+    };
+  }
+
+  return { content: transcript, is_error: false };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// helpers (exported only for test use)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function safeError(reason: string): ToolHandlerResult {
+  return { content: `subagent failed: ${reason}`, is_error: true };
+}
+
+export function generateDefaultWorkdir(now: Date = new Date()): string {
+  const ts =
+    `${now.getUTCFullYear()}` +
+    String(now.getUTCMonth() + 1).padStart(2, "0") +
+    String(now.getUTCDate()).padStart(2, "0") +
+    "-" +
+    String(now.getUTCHours()).padStart(2, "0") +
+    String(now.getUTCMinutes()).padStart(2, "0") +
+    String(now.getUTCSeconds()).padStart(2, "0");
+  const short = randomUUID().slice(0, 8);
+  return path.posix.join(DEFAULT_WORKDIR_ROOT, `${ts}-${short}`);
+}
+
+function pickTimeout(requested: number | undefined): number {
+  if (
+    typeof requested === "number" &&
+    Number.isFinite(requested) &&
+    requested > 0
+  ) {
+    // hard cap at 30 min so the loop never wedges indefinitely
+    return Math.min(requested, 30 * 60 * 1000);
+  }
+  return DEFAULT_TIMEOUT_MS;
+}
+
+function findCreateTaskAction(runtime: IAgentRuntime): Action | undefined {
+  const actions = (runtime as { actions?: Action[] }).actions;
+  if (!Array.isArray(actions)) return undefined;
+  const direct = actions.find((a) => a?.name === "CREATE_TASK");
+  if (direct) return direct;
+  return actions.find((a) =>
+    Array.isArray(a?.similes)
+      ? a.similes!.some((s) => s === "CREATE_TASK")
+      : false,
+  );
+}
+
+function buildSyntheticMessage(
+  parent: Memory | undefined,
+  runtime: IAgentRuntime,
+  fields: { task: string; workdir: string; model?: string },
+): Memory {
+  const parentContent = (parent?.content ?? {}) as Record<string, unknown>;
+  const content: Record<string, unknown> = {
+    ...parentContent,
+    text: fields.task,
+    task: fields.task,
+    agentType: "codex",
+    workdir: fields.workdir,
+    source: "native-reasoning:spawn_codex",
+  };
+  if (fields.model) content.model = fields.model;
+
+  // Cast through unknown — the eliza Memory type has many implementation-
+  // specific required fields (createdAt, etc.) that are filled in by the
+  // runtime's persistence layer. The orchestrator action only reads
+  // `content`, `roomId`, `entityId`, and `agentId` from this surface, all
+  // of which we populate here.
+  const rt = runtime as { agentId?: string };
+  const id = parent?.id ?? (`spawn-codex-${randomUUID()}` as Memory["id"]);
+  return {
+    id,
+    entityId: parent?.entityId ?? (rt.agentId as Memory["entityId"]),
+    agentId: parent?.agentId ?? (rt.agentId as Memory["agentId"]),
+    roomId: parent?.roomId ?? (rt.agentId as Memory["roomId"]),
+    worldId: parent?.worldId,
+    content: content as unknown as Memory["content"],
+    createdAt: Date.now(),
+  } as unknown as Memory;
+}
+
+function extractSessionIds(data: unknown): string[] {
+  if (!data || typeof data !== "object") return [];
+  const agents = (data as OrchestratorActionData).agents;
+  if (!Array.isArray(agents)) return [];
+  return agents
+    .map((a) => (a && typeof a.sessionId === "string" ? a.sessionId : ""))
+    .filter((s) => s.length > 0);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+interface SessionTracker {
+  track(sessionIds: string[]): void;
+  dispose(): void;
+  waitForTerminal(timeoutMs: number): Promise<{
+    responses: string[];
+    errors: string[];
+    timedOut: boolean;
+  }>;
+}
+
+function createSessionTracker(pty: PtyServiceLike): SessionTracker {
+  type State = {
+    latestResponse?: string;
+    taskCompleteAt?: number;
+    terminal: boolean;
+  };
+  const states = new Map<string, State>();
+  let tracked: string[] = [];
+  const responses: string[] = [];
+  const errors: string[] = [];
+  let resolveTerminal: (() => void) | null = null;
+
+  // All events flow through this; we bucket only the ones for tracked
+  // sessions. We subscribe immediately so events emitted between
+  // spawnSession and `track()` are not lost — we backfill on track.
+  const buffered: Array<[string, string, unknown]> = [];
+  let unsubscribed = false;
+  const unsubscribe = pty.onSessionEvent((sid, event, data) => {
+    if (unsubscribed) return;
+    if (!tracked.includes(sid)) {
+      buffered.push([sid, event, data]);
+      return;
+    }
+    ingest(sid, event, data);
+  });
+
+  function ingest(sid: string, event: string, data: unknown): void {
+    const state = states.get(sid) ?? { terminal: false };
+    const payload = (data ?? {}) as Record<string, unknown>;
+    if (event === "task_complete") {
+      const resp = typeof payload.response === "string" ? payload.response : "";
+      if (resp) state.latestResponse = resp;
+      state.taskCompleteAt = Date.now();
+    } else if (event === "stopped") {
+      if (typeof payload.response === "string" && payload.response) {
+        state.latestResponse = payload.response;
+      }
+      state.terminal = true;
+    } else if (event === "error") {
+      const msg =
+        typeof payload.message === "string" ? payload.message : "unknown";
+      errors.push(`[${sid}] ${msg}`);
+      state.terminal = true;
+    }
+    states.set(sid, state);
+    maybeResolve();
+  }
+
+  function maybeResolve(): void {
+    if (!resolveTerminal) return;
+    const allTerminal = tracked.every((sid) => states.get(sid)?.terminal);
+    if (allTerminal && tracked.length > 0) {
+      resolveTerminal();
+      return;
+    }
+    // Settle window: if every tracked session has emitted at least one
+    // task_complete and SETTLE_WINDOW_MS has elapsed since the latest one,
+    // treat that as terminal-equivalent (codex sessions that don't auto-
+    // stop after answering).
+    const now = Date.now();
+    const allTaskComplete = tracked.every(
+      (sid) => states.get(sid)?.taskCompleteAt !== undefined,
+    );
+    if (!allTaskComplete) return;
+    const latest = Math.max(
+      ...tracked.map((sid) => states.get(sid)?.taskCompleteAt ?? 0),
+    );
+    if (now - latest >= SETTLE_WINDOW_MS) resolveTerminal();
+  }
+
+  return {
+    track(sessionIds: string[]) {
+      tracked = [...sessionIds];
+      for (const [sid, event, data] of buffered) {
+        if (tracked.includes(sid)) ingest(sid, event, data);
+      }
+      buffered.length = 0;
+    },
+    dispose() {
+      unsubscribed = true;
+      try {
+        unsubscribe();
+      } catch {
+        /* ignore */
+      }
+    },
+    waitForTerminal(timeoutMs) {
+      return new Promise((resolve) => {
+        let settled = false;
+        const finish = (timedOut: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(hardTimer);
+          clearInterval(settleTicker);
+          for (const sid of tracked) {
+            const r = states.get(sid)?.latestResponse;
+            if (r) responses.push(r);
+          }
+          resolve({ responses, errors, timedOut });
+        };
+        resolveTerminal = () => finish(false);
+        const hardTimer = setTimeout(() => finish(true), timeoutMs);
+        // Periodic ticker to apply the settle window even if no new
+        // events come in.
+        const settleTicker = setInterval(maybeResolve, SETTLE_WINDOW_MS / 3);
+        maybeResolve();
+      });
+    },
+  };
+}
+
+interface BuildTranscriptArgs {
+  callbackTexts: string[];
+  responses: string[];
+  errors: string[];
+  downgradedTo: string | undefined;
+  timedOut: boolean;
+  sessionIds: string[];
+  workdir: string;
+}
+
+function buildTranscript(args: BuildTranscriptArgs): string {
+  const lines: string[] = [];
+  lines.push(`# spawn_codex result`);
+  lines.push(`workdir: ${args.workdir}`);
+  lines.push(`sessions: ${args.sessionIds.join(", ")}`);
+  if (args.downgradedTo) {
+    lines.push(
+      `note: orchestrator routed this task to '${args.downgradedTo}' instead of codex`,
+    );
+  }
+  if (args.timedOut) lines.push(`note: TIMED OUT before terminal event`);
+  if (args.errors.length > 0) {
+    lines.push("");
+    lines.push("## errors");
+    for (const e of args.errors) lines.push(`- ${e}`);
+  }
+  if (args.callbackTexts.length > 0) {
+    lines.push("");
+    lines.push("## orchestrator messages");
+    for (const t of args.callbackTexts) lines.push(t);
+  }
+  if (args.responses.length > 0) {
+    lines.push("");
+    lines.push("## subagent output");
+    for (const r of args.responses) lines.push(r);
+  } else if (!args.timedOut && args.errors.length === 0) {
+    lines.push("");
+    lines.push("(no subagent output captured)");
+  }
+  return lines.join("\n");
+}

--- a/packages/native-reasoning/src/tools/web.ts
+++ b/packages/native-reasoning/src/tools/web.ts
@@ -1,0 +1,204 @@
+/**
+ * Web tools for the native reasoning loop.
+ *
+ *   - web_fetch  — GET a URL, strip <script>/<style>, return up to 50KB of text
+ *   - web_search — Brave Search API (BRAVE_API_KEY), top N results as markdown
+ */
+
+import type { NativeTool, NativeToolHandler } from "../tool-schema.js";
+import { truncate } from "./_safe-path.js";
+
+const FETCH_BYTE_CAP = 50 * 1024;
+const FETCH_TIMEOUT_MS = 30_000;
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  web_fetch                                                            *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface WebFetchInput {
+  url: string;
+}
+
+export const webFetchTool: NativeTool = {
+  type: "custom",
+  name: "web_fetch",
+  description:
+    "Fetch a URL and return its text content. HTML is stripped of " +
+    "<script> and <style> blocks; result is capped at ~50KB.",
+  input_schema: {
+    type: "object",
+    properties: {
+      url: { type: "string" },
+    },
+    required: ["url"],
+    additionalProperties: false,
+  },
+};
+
+export const webFetchHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<WebFetchInput>;
+  if (typeof input.url !== "string") {
+    return { content: "web_fetch: 'url' is required", is_error: true };
+  }
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    return { content: `web_fetch: invalid URL: ${input.url}`, is_error: true };
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return {
+      content: `web_fetch: unsupported scheme '${url.protocol}'`,
+      is_error: true,
+    };
+  }
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      signal: ctrl.signal,
+      redirect: "follow",
+      headers: {
+        "user-agent": "nyx-native-reasoning/0.1 (+https://milady.cloud)",
+        accept: "text/html,application/xhtml+xml,text/plain,*/*;q=0.8",
+      },
+    });
+    const ctype = res.headers.get("content-type") ?? "";
+    const raw = await res.text();
+    const cleaned = ctype.includes("html") ? stripHtml(raw) : raw;
+    const { text } = truncate(cleaned, FETCH_BYTE_CAP);
+    const header = `[${res.status} ${res.statusText}] ${url.toString()}\n`;
+    return {
+      content: header + text,
+      is_error: !res.ok,
+    };
+  } catch (err) {
+    const e = err as Error;
+    const reason =
+      e.name === "AbortError" ? "request aborted (timeout?)" : e.message;
+    return { content: `web_fetch: ${reason}`, is_error: true };
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
+ * Strip <script> and <style> blocks, then collapse remaining tags to
+ * whitespace-separated text. Not a full HTML→markdown converter — keep
+ * it cheap and reliable.
+ */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\s*\n\s*/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/* ──────────────────────────────────────────────────────────────────── *
+ *  web_search (Brave)                                                   *
+ * ──────────────────────────────────────────────────────────────────── */
+
+export interface WebSearchInput {
+  query: string;
+  count?: number;
+}
+
+export const webSearchTool: NativeTool = {
+  type: "custom",
+  name: "web_search",
+  description:
+    "Search the web via Brave Search. Returns the top N results as a " +
+    "markdown list of {title, url, snippet}. Default N=5.",
+  input_schema: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      count: {
+        type: "number",
+        description: "Number of results (1–10, default 5).",
+      },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  },
+};
+
+interface BraveWebResult {
+  title?: string;
+  url?: string;
+  description?: string;
+}
+interface BraveResponse {
+  web?: { results?: BraveWebResult[] };
+}
+
+export const webSearchHandler: NativeToolHandler = async (rawInput) => {
+  const input = (rawInput ?? {}) as Partial<WebSearchInput>;
+  if (typeof input.query !== "string" || input.query.length === 0) {
+    return { content: "web_search: 'query' is required", is_error: true };
+  }
+  const apiKey = process.env.BRAVE_API_KEY?.trim();
+  if (!apiKey) {
+    return {
+      content: "web_search: BRAVE_API_KEY is not set; cannot search.",
+      is_error: true,
+    };
+  }
+  const count = Math.max(1, Math.min(10, input.count ?? 5));
+  const u = new URL("https://api.search.brave.com/res/v1/web/search");
+  u.searchParams.set("q", input.query);
+  u.searchParams.set("count", String(count));
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(u, {
+      signal: ctrl.signal,
+      headers: {
+        accept: "application/json",
+        "x-subscription-token": apiKey,
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return {
+        content: `web_search: ${res.status} ${res.statusText}: ${body.slice(0, 500)}`,
+        is_error: true,
+      };
+    }
+    const data = (await res.json()) as BraveResponse;
+    const results = data.web?.results ?? [];
+    if (results.length === 0) return { content: "(no results)" };
+    const md = results
+      .slice(0, count)
+      .map((r, i) => {
+        const title = r.title ?? "(untitled)";
+        const url = r.url ?? "";
+        const snippet = (r.description ?? "").replace(/\s+/g, " ").trim();
+        return `${i + 1}. [${title}](${url})\n   ${snippet}`;
+      })
+      .join("\n");
+    return { content: md };
+  } catch (err) {
+    const e = err as Error;
+    const reason =
+      e.name === "AbortError" ? "request aborted (timeout?)" : e.message;
+    return { content: `web_search: ${reason}`, is_error: true };
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/packages/native-reasoning/tsconfig.json
+++ b/packages/native-reasoning/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "allowJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "lib": ["ES2023", "DOM"],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "noEmit": false,
+    "paths": {},
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"],
+    "skipLibCheck": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "src/__tests__/**"
+  ]
+}

--- a/packages/native-reasoning/vitest.config.ts
+++ b/packages/native-reasoning/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [
+      "src/__tests__/loop.test.ts",
+      "src/__tests__/system-prompt.test.ts",
+      "src/__tests__/spawn_codex.test.ts",
+      "src/__tests__/tools.test.ts",
+      "src/__tests__/tool-format-openai.test.ts",
+      "src/__tests__/sse-parser.test.ts",
+      "src/__tests__/codex-auth.test.ts",
+      "src/__tests__/backend-codex.test.ts",
+      "src/__tests__/backends.test.ts",
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

This reworks native reasoning from a customer-pickable character mode into framework-level action dispatch substrate.

Instead of asking character authors to set `reasoning.mode`, core now detects whether the configured model/provider can support native tool calling and routes accordingly:

- capable models/providers go through `@elizaos/native-reasoning`
- unsupported or legacy models continue through the existing prompt-XML bootstrap planner unchanged
- character schema/types no longer expose a `reasoning` block

This aligns the PR with the cozy devs design discussion: native tool calling should be a framework capability selected from model support, not a customer-facing mode switch.

## What changed

- Removed `reasoning.mode` and `reasoning.provider` from the character schema.
- Removed `CharacterReasoningConfig` and related character type fields.
- Added `isNativeToolCallingCapable(runtime)` capability detection in core message dispatch.
- Rewrote native dispatch to pass inferred provider/model metadata into the native loop.
- Updated message service tests to cover capability-based routing and legacy completion fallback.
- Updated native-reasoning docs/spec/package description to frame this as substrate, not opt-in alternate runtime.

## Capability detection v1

The current implementation is intentionally conservative:

- Anthropic Claude models route native.
- OpenAI GPT-4+/GPT-5+/o-series/Codex-class model names are treated as native-tool-capable.
- Codex backend selection routes native.
- Legacy OpenAI completions models, such as `text-davinci-*`, remain on bootstrap.
- Local providers remain on bootstrap until a concrete backend/capability is advertised rather than guessed from provider name alone.

## Relationship to action modes

This is complementary to Shaw's incoming action-modes work, including `Mode.ALWAYS_BEFORE`, `Mode.ALWAYS_AFTER`, and `Mode.DURING`.

Once native dispatch exists, those modes can plug into the same tool registry and execution semantics instead of being compressed into the prompt planner.

Important scope note: this PR does not adopt actions-as-tools yet — that's the natural follow-up. this PR establishes the substrate; the next PR converts the action registry to emit native tool schemas.

## Benchmarks

Empirical benchmarks are still required before treating this as a broad default replacement. A separate workstream should compare native dispatch against the current TOON/XML planner for token consumption, latency, tool/action selection accuracy, final response quality, and fallback/failure rates.

## Validation

- `bun test packages/core/src/services/message.test.ts`
- `bun run --cwd packages/native-reasoning test`
- `bunx @biomejs/biome check packages/core/src/services/message.ts packages/core/src/services/message.test.ts packages/core/src/schemas/character.ts packages/core/src/types/agent.ts packages/native-reasoning/package.json`
