### PR TITLE
fix(discord): suppress task-agent timeout placeholder

### DIFF
--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -145,6 +145,24 @@ describe("hasActiveTaskAgentWorkForMessage", () => {
 		);
 	});
 
+	it("matches blocked task-agent work by originating message id", () => {
+		const runtime = runtimeWithTasks(
+			new Map([
+				[
+					"session-1",
+					{
+						status: "blocked",
+						originMetadata: { messageId: "message-memory-id" },
+					},
+				],
+			]),
+		);
+
+		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
+			true,
+		);
+	});
+
 	it("ignores active task-agent work for a different originating message id", () => {
 		const runtime = runtimeWithTasks(
 			new Map([

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MessageManager } from "../messages";
+import { hasActiveTaskAgentWorkForMessage, MessageManager } from "../messages";
 
 function runtime(): IAgentRuntime {
 	return {
@@ -97,5 +97,51 @@ describe("MessageManager URL enrichment", () => {
 		);
 
 		expect(first.attachments[0]?.id).toBe(second.attachments[0]?.id);
+	});
+});
+
+describe("hasActiveTaskAgentWorkForMessage", () => {
+	function runtimeWithTasks(tasks: Map<string, unknown>): IAgentRuntime {
+		return {
+			getService: vi.fn((serviceType) =>
+				serviceType === "SWARM_COORDINATOR" ? { tasks } : null,
+			),
+		} as unknown as IAgentRuntime;
+	}
+
+	it("matches active task-agent work by originating message id", () => {
+		const runtime = runtimeWithTasks(
+			new Map([
+				[
+					"session-1",
+					{
+						status: "tool_running",
+						originMetadata: { messageId: "message-memory-id" },
+					},
+				],
+			]),
+		);
+
+		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
+			true,
+		);
+	});
+
+	it("ignores terminal task-agent work", () => {
+		const runtime = runtimeWithTasks(
+			new Map([
+				[
+					"session-1",
+					{
+						status: "completed",
+						originMetadata: { messageId: "message-memory-id" },
+					},
+				],
+			]),
+		);
+
+		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
+			false,
+		);
 	});
 });

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -127,6 +127,42 @@ describe("hasActiveTaskAgentWorkForMessage", () => {
 		);
 	});
 
+	it("matches queued active task-agent work by originating message id", () => {
+		const runtime = runtimeWithTasks(
+			new Map([
+				[
+					"session-1",
+					{
+						status: "active",
+						originMetadata: { messageId: "message-memory-id" },
+					},
+				],
+			]),
+		);
+
+		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
+			true,
+		);
+	});
+
+	it("ignores active task-agent work for a different originating message id", () => {
+		const runtime = runtimeWithTasks(
+			new Map([
+				[
+					"session-1",
+					{
+						status: "tool_running",
+						originMetadata: { messageId: "other-message-memory-id" },
+					},
+				],
+			]),
+		);
+
+		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
+			false,
+		);
+	});
+
 	it("ignores terminal task-agent work", () => {
 		const runtime = runtimeWithTasks(
 			new Map([

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1073,7 +1073,7 @@ export class MessageManager {
 				typingController.stop();
 				if (activeTaskAgentWork) {
 					statusReactions?.setDone();
-					await finalizePendingDraft();
+					await abortPendingDraft();
 					this.runtime.logger.warn(
 						{
 							src: "plugin:discord",

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -109,7 +109,11 @@ function webpageAttachmentId(url: string): string {
 	return `webpage-${createHash("sha256").update(url).digest("hex").slice(0, 24)}`;
 }
 
-const ACTIVE_TASK_AGENT_STATUSES = new Set(["active", "tool_running"]);
+const ACTIVE_TASK_AGENT_STATUSES = new Set([
+	"active",
+	"blocked",
+	"tool_running",
+]);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
 	return value && typeof value === "object" && !Array.isArray(value)

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -109,6 +109,53 @@ function webpageAttachmentId(url: string): string {
 	return `webpage-${createHash("sha256").update(url).digest("hex").slice(0, 24)}`;
 }
 
+const ACTIVE_TASK_AGENT_STATUSES = new Set(["active", "tool_running"]);
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function stringField(
+	record: Record<string, unknown> | null,
+	field: string,
+): string | undefined {
+	const value = record?.[field];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function hasActiveTaskAgentWorkForMessage(
+	runtime: Pick<IAgentRuntime, "getService">,
+	messageId: string,
+): boolean {
+	try {
+		const coordinator = asRecord(runtime.getService("SWARM_COORDINATOR"));
+		const tasks = coordinator?.tasks;
+		if (!(tasks instanceof Map)) {
+			return false;
+		}
+
+		for (const taskValue of tasks.values()) {
+			const task = asRecord(taskValue);
+			const status = stringField(task, "status");
+			if (!status || !ACTIVE_TASK_AGENT_STATUSES.has(status)) {
+				continue;
+			}
+
+			const metadata = asRecord(task?.originMetadata);
+			const originMessageId = stringField(metadata, "messageId");
+			if (originMessageId === messageId) {
+				return true;
+			}
+		}
+	} catch {
+		return false;
+	}
+
+	return false;
+}
+
 /**
  * Class representing a Message Manager for handling Discord messages.
  */
@@ -1006,12 +1053,16 @@ export class MessageManager {
 				generationPromise.catch(() => {});
 				await Promise.race([generationPromise, timeoutPromise]);
 			} catch (generationError) {
+				const activeTaskAgentWork =
+					generationTimedOut &&
+					hasActiveTaskAgentWorkForMessage(this.runtime, messageId);
 				this.runtime.logger.error(
 					{
 						src: "plugin:discord",
 						agentId: this.runtime.agentId,
 						messageId: message.id,
 						timeoutMs: generationTimeoutMs,
+						activeTaskAgentWork,
 						error:
 							generationError instanceof Error
 								? generationError.message
@@ -1020,6 +1071,23 @@ export class MessageManager {
 					"Discord generation failed or timed out",
 				);
 				typingController.stop();
+				if (activeTaskAgentWork) {
+					statusReactions?.setDone();
+					await finalizePendingDraft();
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							messageId: message.id,
+							memoryId: messageId,
+							roomId,
+							timeoutMs: generationTimeoutMs,
+						},
+						"Suppressing Discord timeout reply while task-agent work is still active",
+					);
+					return;
+				}
+
 				statusReactions?.setError();
 				await abortPendingDraft();
 


### PR DESCRIPTION
## Summary
- suppress the Discord timeout placeholder when the timed-out turn still has active task-agent work tied to the same originating message
- abort any in-progress Discord draft on the suppression path so partial streamed text is not posted before the task-agent result
- treat `active`, `blocked`, and `tool_running` task-agent states as live work for timeout suppression
- keep normal timeout/provider failure replies for turns with no active task-agent work
- add focused coverage for active/task-running/blocked status handling and mismatched originating message IDs

## Validation
- live VPS Discord E2E in test channel: `check disk space on this VPS with df -h...` replied once after ~69s with the disk verdict and no timeout placeholder
- live health: `/api/health` ready with runtime/database/coordinator ok and Discord configured
- `bun install --ignore-scripts --frozen-lockfile`
- `bun run generate:types`
- `bun run --cwd packages/core build:node`
- `./node_modules/.bin/biome check plugins/plugin-discord/messages.ts plugins/plugin-discord/__tests__/messages-url.test.ts`
- `cd plugins/plugin-discord && ../../node_modules/.bin/vitest run --config vitest.config.ts __tests__/messages-url.test.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR suppresses the Discord timeout-placeholder reply when the timed-out generation turn has active task-agent work still in flight for the same originating message, preventing the duplicate-reply scenario where users see an error notice followed by the real task-agent answer.

- Introduces `hasActiveTaskAgentWorkForMessage` (exported for testing), which inspects the `SWARM_COORDINATOR` service's task map for any entry in `\"active\"`, `\"blocked\"`, or `\"tool_running\"` state whose `originMetadata.messageId` matches the Eliza memory ID of the current message.
- In the generation-timeout catch block, when an active task is found, calls `abortPendingDraft()` to discard any partial streamed draft and returns without sending the timeout placeholder; the normal error path is left unchanged for provider failures and turns with no active task-agent work.
- Adds five unit tests covering all three active statuses, a mismatched origin ID (false-positive guard), and a terminal `\"completed\"` status (false-negative guard).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the suppression logic is gated behind both a timeout flag and a coordinator lookup, so no reply is silently dropped unless a matching active task is confirmed.

The change is narrowly scoped: it only suppresses the timeout placeholder when the coordinator explicitly reports live task-agent work for the originating message. All three previously flagged concerns have been addressed. The defensive helpers and try/catch wrapper prevent coordinator shape changes from breaking the normal error path.

No files require special attention; messages.ts is the only substantive change and the new code path is exercised by the added tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/messages.ts | Adds `hasActiveTaskAgentWorkForMessage` and suppression logic in the generation-timeout catch block; correctly uses `abortPendingDraft()` and includes `"blocked"` in active statuses. |
| plugins/plugin-discord/__tests__/messages-url.test.ts | Adds five focused unit tests covering all three active statuses, a mismatched origin message ID, and a terminal status — addresses previously flagged coverage gaps. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Discord
    participant MessageManager
    participant TaskCoordinator
    participant TaskAgent

    User->>Discord: sends message
    Discord->>MessageManager: handleMessage()
    MessageManager->>MessageManager: start generationPromise + timeoutPromise
    MessageManager->>TaskAgent: (via messageService/emitEvent)
    TaskAgent->>TaskCoordinator: register task (status: active → tool_running)

    Note over MessageManager: generationTimeoutMs elapses
    MessageManager->>MessageManager: generationTimedOut = true
    MessageManager->>MessageManager: catch(generationError)
    MessageManager->>TaskCoordinator: hasActiveTaskAgentWorkForMessage(messageId)
    TaskCoordinator-->>MessageManager: true (task still running)
    MessageManager->>MessageManager: abortPendingDraft()
    MessageManager->>Discord: statusReactions.setDone() — no timeout placeholder sent
    Note over MessageManager: returns silently

    TaskAgent-->>MessageManager: eventually delivers real response
    MessageManager->>Discord: posts task-agent result message
    Discord-->>User: single reply with the actual answer
```

<sub>Reviews (3): Last reviewed commit: ["fix(discord): treat blocked task-agent w..."](https://github.com/elizaos/eliza/commit/f2c15ce890bf79683b26e15bb14cbca50926120d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30977551)</sub>

<!-- /greptile_comment -->