### PR TITLE
fix(chat): route live checks safely

### DIFF
--- a/packages/agent/src/actions/search.test.ts
+++ b/packages/agent/src/actions/search.test.ts
@@ -174,6 +174,30 @@ describe("SEARCH action", () => {
     expect(result?.values?.error).toBe("SEARCH_CATEGORY_NOT_FOUND");
   });
 
+  it("stops post-action continuation when web search service is unavailable", async () => {
+    const runtime = createRuntime();
+    await webSearchPlugin.init?.({}, runtime);
+
+    const result = await searchAction.handler(
+      runtime,
+      createMessage("what is the current BTC price?"),
+      undefined,
+      {
+        parameters: {
+          category: "web",
+          query: "current BTC price",
+        },
+      },
+    );
+
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({
+      actionName: "SEARCH",
+      category: "web",
+      suppressPostActionContinuation: true,
+    });
+  });
+
   it("validates category filters before dispatch", async () => {
     const runtime = createRuntime();
     const fetchMock = vi.fn();

--- a/packages/agent/src/actions/terminal.test.ts
+++ b/packages/agent/src/actions/terminal.test.ts
@@ -1,0 +1,31 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { terminalAction } from "./terminal";
+
+vi.mock("../security/access.js", () => ({
+  hasOwnerAccess: vi.fn(async () => false),
+}));
+
+describe("SHELL_COMMAND action", () => {
+  it("stops post-action continuation when terminal access is denied", async () => {
+    const result = await terminalAction.handler?.(
+      { agentId: "agent-id" } as IAgentRuntime,
+      {
+        agentId: "agent-id",
+        entityId: "not-owner",
+        roomId: "room-id",
+        content: {},
+      } as Memory,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      text: "Permission denied: only the owner may run terminal commands.",
+      data: {
+        actionName: "SHELL_COMMAND",
+        suppressPostActionContinuation: true,
+        terminal: { permissionDenied: true },
+      },
+    });
+  });
+});

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -287,6 +287,11 @@ export const terminalAction: Action = {
       return {
         success: false,
         text: "Permission denied: only the owner may run terminal commands.",
+        data: {
+          actionName: TERMINAL_ACTION_NAME,
+          suppressPostActionContinuation: true,
+          terminal: { permissionDenied: true },
+        },
       };
     }
 

--- a/packages/agent/src/actions/web-search.ts
+++ b/packages/agent/src/actions/web-search.ts
@@ -377,7 +377,11 @@ async function runWebSearch(
       success: false,
       text: 'Web search service is not available. Enable plugin-web-search to use category "web".',
       values: { error: "SERVICE_NOT_FOUND" },
-      data: { actionName: "SEARCH", category: "web" },
+      data: {
+        actionName: "SEARCH",
+        category: "web",
+        suppressPostActionContinuation: true,
+      },
     };
   }
 

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -184,6 +184,7 @@
     "@elizaos/core": "workspace:*",
     "@elizaos/plugin-browser-bridge": "workspace:*",
     "@elizaos/plugin-sql": "workspace:*",
+    "@elizaos/plugin-wallet": "workspace:*",
     "@elizaos/plugin-wechat": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/ui": "workspace:*",

--- a/packages/app-core/scripts/ensure-type-package-aliases.mjs
+++ b/packages/app-core/scripts/ensure-type-package-aliases.mjs
@@ -100,21 +100,65 @@ function findCachedTypePackageDir(packageName) {
   return path.join(GLOBAL_TYPES_CACHE_DIR, matches[0]);
 }
 
+function ensureRealDirectory(dir) {
+  let shouldRecreate = false;
+
+  try {
+    const stat = lstatSync(dir);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      shouldRecreate = true;
+    } else {
+      try {
+        readlinkSync(dir);
+        shouldRecreate = true;
+      } catch {
+        // A normal directory is already usable.
+      }
+    }
+  } catch {
+    // Missing or broken paths are recreated below.
+  }
+
+  if (shouldRecreate) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  mkdirSync(dir, { recursive: true });
+}
+
 function materializeTypePackage(targetTypesDir, packageName) {
   const sourceDir = findCachedTypePackageDir(packageName);
   if (!sourceDir) {
     return false;
   }
 
+  ensureRealDirectory(targetTypesDir);
   const targetDir = path.join(targetTypesDir, packageName);
   rmSync(targetDir, { recursive: true, force: true });
-  mkdirSync(targetTypesDir, { recursive: true });
   cpSync(sourceDir, targetDir, {
     recursive: true,
     force: true,
   });
   ensureTypeEntryPoint(targetDir, packageName);
   return true;
+}
+
+function ensureChildDirectory(parentDir, childName) {
+  ensureRealDirectory(parentDir);
+  const childDir = path.join(parentDir, childName);
+
+  try {
+    mkdirSync(childDir, { recursive: true });
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+
+    rmSync(parentDir, { recursive: true, force: true });
+    mkdirSync(parentDir, { recursive: true });
+    mkdirSync(childDir, { recursive: true });
+  }
+
+  return childDir;
 }
 
 function ensureTypeEntryPoint(targetDir, packageName) {
@@ -140,9 +184,7 @@ function ensureTypeEntryPoint(targetDir, packageName) {
 }
 
 function ensureBunTypesAlias(targetTypesDir) {
-  mkdirSync(targetTypesDir, { recursive: true });
-  const bunTypesDir = path.join(targetTypesDir, "bun");
-  mkdirSync(bunTypesDir, { recursive: true });
+  const bunTypesDir = ensureChildDirectory(targetTypesDir, "bun");
   writeFileSync(
     path.join(bunTypesDir, "index.d.ts"),
     '/// <reference types="bun-types" />\n',
@@ -173,6 +215,7 @@ function main() {
   ].sort();
 
   for (const targetTypesDir of TYPE_ROOTS) {
+    ensureBunTypesAlias(targetTypesDir);
     for (const packageName of packageNames) {
       if (materializeTypePackage(targetTypesDir, packageName)) {
         materializedCount++;

--- a/packages/app-core/scripts/ensure-type-package-aliases.mjs
+++ b/packages/app-core/scripts/ensure-type-package-aliases.mjs
@@ -140,6 +140,7 @@ function ensureTypeEntryPoint(targetDir, packageName) {
 }
 
 function ensureBunTypesAlias(targetTypesDir) {
+  mkdirSync(targetTypesDir, { recursive: true });
   const bunTypesDir = path.join(targetTypesDir, "bun");
   mkdirSync(bunTypesDir, { recursive: true });
   writeFileSync(

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -97,7 +97,6 @@ function resolveSystemApkStagingDir() {
   };
 }
 const systemApkStaging = resolveSystemApkStagingDir();
-const elizaOsVendorDir = systemApkStaging.vendorDir;
 const elizaOsApkDir = systemApkStaging.apkDir;
 const elizaOsApkName = systemApkStaging.apkName;
 const platformsDir = path.join(appCoreRoot, "platforms");
@@ -511,18 +510,18 @@ async function buildWeb(platform) {
       : platform === "ios-overlay"
         ? "ios"
         : platform;
-  await run(
-    process.execPath,
-    [path.join(repoRoot, "scripts/run-app-web-build.mjs")],
-    {
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        ELIZA_CAPACITOR_BUILD_TARGET: capacitorTarget,
-        MILADY_CAPACITOR_BUILD_TARGET: capacitorTarget,
-      },
+  const hostBuildScript = path.join(repoRoot, "scripts/run-app-web-build.mjs");
+  const buildScript = fs.existsSync(hostBuildScript)
+    ? hostBuildScript
+    : path.join(appCoreRoot, "scripts/build-capacitor-app.mjs");
+  await run(process.execPath, [buildScript], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ELIZA_CAPACITOR_BUILD_TARGET: capacitorTarget,
+      MILADY_CAPACITOR_BUILD_TARGET: capacitorTarget,
     },
-  );
+  });
 }
 
 // ── Phase 3: Capacitor sync ────────────────────────────────────────────

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -2362,19 +2362,42 @@ function hasSimulatorSlice(xcframeworkDir) {
 }
 
 function patchLlamaCppCapacitorPodspecForXcframework(packageDir) {
-  const podspecPath = path.join(packageDir, "LlamaCppCapacitor.podspec");
-  if (!fs.existsSync(podspecPath)) return;
-  const current = fs.readFileSync(podspecPath, "utf8");
-  const patched = current.replace(
-    "s.vendored_frameworks = 'ios/Frameworks/llama-cpp.framework'",
-    "s.vendored_frameworks = 'ios/Frameworks/llama-cpp.xcframework'",
-  );
-  if (patched !== current) {
-    fs.writeFileSync(podspecPath, patched, "utf8");
-    console.log(
-      "[mobile-build] Patched llama-cpp-capacitor podspec for xcframework.",
-    );
+  for (const podspecName of ["LlamaCppCapacitor.podspec", "LlamaCpp.podspec"]) {
+    const podspecPath = path.join(packageDir, podspecName);
+    if (!fs.existsSync(podspecPath)) continue;
+
+    const current = fs.readFileSync(podspecPath, "utf8");
+    const patched = current
+      .replace(
+        /s\.vendored_frameworks\s*=\s*['"]ios\/Frameworks\/llama-cpp\.framework['"]/,
+        "s.vendored_frameworks = 'ios/Frameworks/llama-cpp.xcframework'",
+      )
+      .replace(
+        /\n\s*s\.pod_target_xcconfig\s*=\s*\{\s*\n\s*['"]FRAMEWORK_SEARCH_PATHS['"]\s*=>\s*[^\n]*ios\/Frameworks[^\n]*\n\s*\}/,
+        "",
+      );
+    if (patched !== current) {
+      fs.writeFileSync(podspecPath, patched, "utf8");
+      console.log(
+        `[mobile-build] Patched ${podspecName} for simulator xcframework.`,
+      );
+    }
   }
+}
+
+function moveDeviceOnlyLlamaCppFrameworkForSimulator(frameworksDir) {
+  const deviceFramework = path.join(frameworksDir, "llama-cpp.framework");
+  if (!fs.existsSync(deviceFramework)) return;
+
+  const archivedFramework = path.join(
+    frameworksDir,
+    "llama-cpp-device.framework",
+  );
+  fs.rmSync(archivedFramework, { recursive: true, force: true });
+  fs.renameSync(deviceFramework, archivedFramework);
+  console.log(
+    "[mobile-build] Moved device-only llama.cpp framework out of simulator framework search path.",
+  );
 }
 
 async function buildIosLlamaCppSimulatorFramework(packageDir) {
@@ -2440,6 +2463,7 @@ async function ensureIosLlamaCppVendoredFramework({ buildTarget }) {
   patchLlamaCppCapacitorPodspecForXcframework(packageDir);
 
   if (hasSimulatorSlice(xcframeworkDir)) {
+    moveDeviceOnlyLlamaCppFrameworkForSimulator(frameworksDir);
     return;
   }
 
@@ -2461,6 +2485,7 @@ async function ensureIosLlamaCppVendoredFramework({ buildTarget }) {
   await run("xcodebuild", [...createArgs, "-output", xcframeworkDir], {
     cwd: packageDir,
   });
+  moveDeviceOnlyLlamaCppFrameworkForSimulator(frameworksDir);
   console.log(
     "[mobile-build] Prepared llama.cpp xcframework for iOS simulator.",
   );

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -59,6 +59,19 @@ describe("live routing regressions", () => {
 				"check git status in /home/alice/project and tell me the branch",
 			),
 		).toContain("git -C '/home/alice/project' status --short --branch");
+		expect(
+			inferLocalShellCommandFromMessageText(
+				"explain how df -h checks disk space on this VPS",
+			),
+		).toBeNull();
+		expect(
+			inferLocalShellCommandFromMessageText(
+				"explain how to run df -h on this VPS",
+			),
+		).toBeNull();
+		expect(inferLocalShellCommandFromMessageText("run df -h on this VPS")).toBe(
+			"df -h",
+		);
 	});
 
 	it("recognizes current-info requests as web search without spawning work", () => {
@@ -121,6 +134,54 @@ describe("live routing regressions", () => {
 					secondBestScore: 0,
 					reasons: ["metadata:keyword-overlap"],
 				},
+			),
+		).toBe(false);
+	});
+
+	it("does not promote explanation-only shell questions into execution", () => {
+		const runtime = {
+			actions: [
+				{
+					name: "SHELL_COMMAND",
+					description: "Run local shell commands",
+				},
+			],
+		} as unknown as Pick<IAgentRuntime, "actions">;
+		const text = "explain how df -h checks disk space on this VPS";
+		const howToRunText = "explain how to run df -h on this VPS";
+
+		expect(
+			suggestOwnedActionFromMetadata(runtime, {
+				content: { text },
+			}),
+		).toBeNull();
+		expect(
+			suggestOwnedActionFromMetadata(runtime, {
+				content: { text: howToRunText },
+			}),
+		).toBeNull();
+		expect(
+			shouldPromoteExplicitReplyToOwnedAction(
+				{ actions: ["REPLY"] },
+				{
+					actionName: "SHELL_COMMAND",
+					score: 100,
+					secondBestScore: 0,
+					reasons: ["direct:local-shell-check"],
+				},
+				text,
+			),
+		).toBe(false);
+		expect(
+			shouldPromoteExplicitReplyToOwnedAction(
+				{ actions: ["REPLY"] },
+				{
+					actionName: "SHELL_COMMAND",
+					score: 100,
+					secondBestScore: 0,
+					reasons: ["direct:local-shell-check"],
+				},
+				howToRunText,
 			),
 		).toBe(false);
 	});

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -5,6 +5,7 @@ import {
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
+	shouldPromoteExplicitReplyToOwnedAction,
 	shouldSkipDocumentProviderRescue,
 	stripReplyWhenActionOwnsTurn,
 	suggestOwnedActionFromMetadata,
@@ -86,6 +87,42 @@ describe("live routing regressions", () => {
 				"what is the current BTC price in USD? answer briefly.",
 			),
 		).toBe("current BTC price in USD");
+	});
+
+	it("promotes explicit reply to direct shell/search action aliases", () => {
+		expect(
+			shouldPromoteExplicitReplyToOwnedAction(
+				{ actions: ["REPLY"] },
+				{
+					actionName: "TERMINAL",
+					score: 1,
+					secondBestScore: 0,
+					reasons: ["direct:local-shell-check"],
+				},
+			),
+		).toBe(true);
+		expect(
+			shouldPromoteExplicitReplyToOwnedAction(
+				{ actions: ["REPLY"] },
+				{
+					actionName: "BRAVE_SEARCH",
+					score: 1,
+					secondBestScore: 0,
+					reasons: ["direct:web-search"],
+				},
+			),
+		).toBe(true);
+		expect(
+			shouldPromoteExplicitReplyToOwnedAction(
+				{ actions: ["REPLY"] },
+				{
+					actionName: "MANAGE_ISSUES",
+					score: 1,
+					secondBestScore: 0,
+					reasons: ["metadata:keyword-overlap"],
+				},
+			),
+		).toBe(false);
 	});
 
 	it("does not route generic current status questions to web search", () => {

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActionResult, IAgentRuntime } from "../index";
+import {
+	actionResultsSuppressPostActionContinuation,
+	inferLocalShellCommandFromMessageText,
+	inferWebSearchQueryFromMessageText,
+	looksLikeSelfPolicyExplanationRequest,
+	stripReplyWhenActionOwnsTurn,
+	suggestOwnedActionFromMetadata,
+} from "../services/message";
+
+const logger = {
+	info: vi.fn(),
+	debug: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+};
+
+describe("live routing regressions", () => {
+	it("collapses duplicate visible REPLY planner actions", () => {
+		expect(
+			stripReplyWhenActionOwnsTurn(
+				{ actions: [], logger } as unknown as Pick<
+					IAgentRuntime,
+					"actions" | "logger"
+				>,
+				["REPLY", "REPLY"],
+			),
+		).toEqual(["REPLY"]);
+	});
+
+	it("dedupes aliases against registered canonical action names", () => {
+		expect(
+			stripReplyWhenActionOwnsTurn(
+				{
+					actions: [{ name: "REPLY", similes: ["RESPOND"] }],
+					logger,
+				} as unknown as Pick<IAgentRuntime, "actions" | "logger">,
+				["RESPOND", "REPLY"],
+			),
+		).toEqual(["RESPOND"]);
+	});
+
+	it("infers safe params for explicit local shell checks", () => {
+		expect(
+			inferLocalShellCommandFromMessageText(
+				"check disk space on this VPS with df -h",
+			),
+		).toBe("df -h");
+		expect(
+			inferLocalShellCommandFromMessageText(
+				"which folder is live read-only? answer paths only. do not run commands.",
+			),
+		).toBeNull();
+	});
+
+	it("recognizes current-info requests as web search without spawning work", () => {
+		const runtime = {
+			actions: [
+				{
+					name: "SEARCH",
+					similes: ["WEB_SEARCH", "SEARCH_WEB"],
+					description: "Search the web or other registered backends",
+				},
+			],
+		} as unknown as Pick<IAgentRuntime, "actions">;
+
+		const suggestion = suggestOwnedActionFromMetadata(runtime, {
+			content: {
+				text: "what is the current BTC price in USD? answer briefly.",
+			},
+		});
+
+		expect(suggestion).toMatchObject({
+			actionName: "SEARCH",
+			reasons: ["direct:web-search"],
+		});
+		expect(
+			inferWebSearchQueryFromMessageText(
+				"what is the current BTC price in USD? answer briefly.",
+			),
+		).toBe("current BTC price in USD");
+	});
+
+	it("does not rescue self-policy explanation questions into task actions", () => {
+		expect(
+			looksLikeSelfPolicyExplanationRequest({
+				content: {
+					text: "for a new monetized ai chat app, what workflow, example app, and sdk should you use? answer in one short sentence. do not build anything.",
+				},
+			}),
+		).toBe(true);
+	});
+
+	it("stops continuation when an action result blocks the turn", () => {
+		expect(
+			actionResultsSuppressPostActionContinuation([
+				{
+					success: false,
+					text: "Permission denied",
+					data: {
+						actionName: "SHELL_COMMAND",
+						terminal: { permissionDenied: true },
+					},
+				} as ActionResult,
+			]),
+		).toBe(true);
+		expect(
+			actionResultsSuppressPostActionContinuation([
+				{ success: true, text: "done", data: { actionName: "SEARCH" } },
+			] as ActionResult[]),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -133,6 +133,16 @@ describe("live routing regressions", () => {
 		).toBe(false);
 	});
 
+	it("does not skip document rescue for self-policy questions about documents", () => {
+		expect(
+			shouldSkipDocumentProviderRescue({
+				content: {
+					text: "what workflow should you use for processing documents in your knowledge base?",
+				},
+			} as unknown as Parameters<typeof shouldSkipDocumentProviderRescue>[0]),
+		).toBe(false);
+	});
+
 	it("stops continuation when an action result blocks the turn", () => {
 		expect(
 			actionResultsSuppressPostActionContinuation([

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -5,6 +5,7 @@ import {
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
+	shouldSkipDocumentProviderRescue,
 	stripReplyWhenActionOwnsTurn,
 	suggestOwnedActionFromMetadata,
 } from "../services/message";
@@ -52,6 +53,11 @@ describe("live routing regressions", () => {
 				"which folder is live read-only? answer paths only. do not run commands.",
 			),
 		).toBeNull();
+		expect(
+			inferLocalShellCommandFromMessageText(
+				"check git status in /home/alice/project and tell me the branch",
+			),
+		).toContain("git -C '/home/alice/project' status --short --branch");
 	});
 
 	it("recognizes current-info requests as web search without spawning work", () => {
@@ -82,6 +88,31 @@ describe("live routing regressions", () => {
 		).toBe("current BTC price in USD");
 	});
 
+	it("does not route generic current status questions to web search", () => {
+		const runtime = {
+			actions: [
+				{
+					name: "SEARCH",
+					similes: ["WEB_SEARCH", "SEARCH_WEB"],
+					description: "Search the web or other registered backends",
+				},
+			],
+		} as unknown as Pick<IAgentRuntime, "actions">;
+
+		expect(
+			suggestOwnedActionFromMetadata(runtime, {
+				content: {
+					text: "what is the current status of the build?",
+				},
+			}),
+		).toBeNull();
+		expect(
+			inferWebSearchQueryFromMessageText(
+				"what is the current status of the build?",
+			),
+		).toBeNull();
+	});
+
 	it("does not rescue self-policy explanation questions into task actions", () => {
 		expect(
 			looksLikeSelfPolicyExplanationRequest({
@@ -90,6 +121,16 @@ describe("live routing regressions", () => {
 				},
 			}),
 		).toBe(true);
+	});
+
+	it("does not skip document rescue for ordinary second-person questions", () => {
+		expect(
+			shouldSkipDocumentProviderRescue({
+				content: {
+					text: "can you explain the uploaded document?",
+				},
+			} as unknown as Parameters<typeof shouldSkipDocumentProviderRescue>[0]),
+		).toBe(false);
 	});
 
 	it("stops continuation when an action result blocks the turn", () => {

--- a/packages/core/src/features/basic-capabilities/actions/reply.test.ts
+++ b/packages/core/src/features/basic-capabilities/actions/reply.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../../../index";
+import { ModelType } from "../../../index";
+import { replyAction } from "./reply";
+
+function createRuntime(modelResponse: string): IAgentRuntime {
+	return {
+		agentId: "agent-id",
+		character: { templates: {} },
+		composeState: vi.fn(async () => ({ values: {}, data: {} }) as State),
+		useModel: vi.fn(async (modelType: ModelType) => {
+			expect(modelType).toBe(ModelType.TEXT_LARGE);
+			return modelResponse;
+		}),
+	} as unknown as IAgentRuntime;
+}
+
+function createMessage(): Memory {
+	return {
+		id: "message-id",
+		agentId: "agent-id",
+		entityId: "user-id",
+		roomId: "room-id",
+		content: { text: "hello" },
+	} as unknown as Memory;
+}
+
+describe("REPLY action", () => {
+	it("falls back to planner text when the reply model returns empty structured text", async () => {
+		const runtime = createRuntime("thought: empty\ntext:");
+		const callback = vi.fn();
+
+		const result = await replyAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+			undefined,
+			callback,
+			[
+				{
+					content: { text: "planner already had a reply" },
+				} as Memory,
+			],
+		);
+
+		expect(result?.text).toBe("planner already had a reply");
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "planner already had a reply" }),
+		);
+	});
+
+	it("falls back to non-structured raw model text", async () => {
+		const runtime = createRuntime("plain reply");
+
+		const result = await replyAction.handler?.(
+			runtime,
+			createMessage(),
+			undefined,
+		);
+
+		expect(result?.text).toBe("plain reply");
+	});
+});

--- a/packages/core/src/features/basic-capabilities/actions/reply.ts
+++ b/packages/core/src/features/basic-capabilities/actions/reply.ts
@@ -17,6 +17,17 @@ import { composePromptFromState, parseToonKeyValue } from "../../../utils.ts";
 // Get text content from centralized specs
 const spec = requireActionSpec("REPLY");
 
+function getPlannerReplyFallback(responses?: Memory[]): string {
+	for (const response of responses ?? []) {
+		const text = response.content?.text;
+		if (typeof text === "string" && text.trim().length > 0) {
+			return text.trim();
+		}
+	}
+
+	return "";
+}
+
 export const replyAction = {
 	name: spec.name,
 	similes: spec.similes ? [...spec.similes] : [],
@@ -68,16 +79,39 @@ export const replyAction = {
 			template: runtime.character.templates?.replyTemplate || replyTemplate,
 		});
 
-		const response = await runtime.useModel(ModelType.TEXT_LARGE, {
-			prompt,
-		});
+		const plannerReplyFallback = getPlannerReplyFallback(responses);
+		let response: string;
+		try {
+			response = await runtime.useModel(ModelType.TEXT_LARGE, {
+				prompt,
+			});
+		} catch (error) {
+			if (plannerReplyFallback) {
+				logger.warn(
+					{
+						src: "plugin:basic-capabilities:action:reply",
+						agentId: runtime.agentId,
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"Reply model failed; using planner reply fallback",
+				);
+				response = "";
+			} else {
+				throw error;
+			}
+		}
 
 		const parsedToon = parseToonKeyValue(response);
 		const thoughtValue = parsedToon?.thought;
 		const textValue = parsedToon?.text;
 		const thought: string =
 			typeof thoughtValue === "string" ? thoughtValue : "";
-		const text: string = typeof textValue === "string" ? textValue : "";
+		const parsedText = typeof textValue === "string" ? textValue.trim() : "";
+		const rawText = response.trim();
+		const text =
+			parsedText ||
+			plannerReplyFallback ||
+			(rawText.startsWith("<") ? "" : rawText);
 
 		const responseContent = {
 			thought,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1907,7 +1907,7 @@ function looksLikeWebSearchRequest(text: string): boolean {
 			normalized,
 		);
 	const mentionsMarketOrNews =
-		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather|score|scores|status)\b/iu.test(
+		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather)\b/iu.test(
 			normalized,
 		);
 
@@ -1920,7 +1920,7 @@ function quoteShellArg(value: string): string {
 
 function extractLocalShellPath(text: string): string | null {
 	const match = text.match(
-		/(?:^|[\s`'"])(\/home\/milady\/[A-Za-z0-9._~+/-]+)/u,
+		/(?:^|[\s`'"])(\/(?:home|Users|workspace|workspaces|tmp|var\/tmp|opt|srv)\/[A-Za-z0-9._~+/@:-]+)/u,
 	);
 	if (!match?.[1]) {
 		return null;
@@ -2528,9 +2528,9 @@ export function shouldSkipDocumentProviderRescue(message: Memory): boolean {
 	}
 
 	const asksSelfPolicy =
-		/\b(your|you|configured|routing|workflow|workflows?|folders?|repos?|repositories|source|workspace|workspaces|skills?|sdk|example app|read-only|pr work)\b/.test(
+		/\b(?:configured|routing|workflow|workflows?|folders?|repos?|repositories|source|workspace|workspaces|skills?|sdk|example app|read-only|pr work)\b/.test(
 			text,
-		);
+		) && /\b(?:you|your|agent|nubilio|codex|task agent|subagent)\b/.test(text);
 	const asksDocumentOrKnowledge =
 		/\b(uploaded|upload|attachment|attached|document|documents?|file|files?|knowledge base|kb)\b/.test(
 			text,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1521,6 +1521,8 @@ Examples:
 	- "for important meetings, remind me an hour before, ten minutes before, and at start on my Mac and phone" -> OWNER_DEVICE_INTENT
 	- "if missing this could trigger a cancellation fee, warn me clearly and offer to handle it now" -> OWNER_DEVICE_INTENT
 	- "if you get stuck in the browser or on my computer, call me" -> OWNER_VOICE_CALL
+	- "check disk space on this VPS with df -h" -> SHELL_COMMAND
+	- "what is the current BTC price in USD?" -> SEARCH
 
 ${draftSection}Return TOON only:
 thought: short reasoning
@@ -1763,6 +1765,48 @@ function findDirectOwnedActionSuggestion(
 	runtime: Pick<IAgentRuntime, "actions">,
 	messageText: string,
 ): ActionOwnershipSuggestion | null {
+	if (looksLikeLocalShellRequest(messageText)) {
+		const shellAction = findRuntimeActionByNames(runtime, [
+			"SHELL_COMMAND",
+			"RUN_IN_TERMINAL",
+			"RUN_COMMAND",
+			"EXECUTE_COMMAND",
+			"TERMINAL",
+			"SHELL",
+			"RUN_SHELL",
+			"EXEC",
+		]);
+		if (shellAction) {
+			return {
+				actionName: shellAction.name,
+				score: 100,
+				secondBestScore: 0,
+				reasons: ["direct:local-shell-check"],
+			};
+		}
+	}
+
+	if (looksLikeWebSearchRequest(messageText)) {
+		const searchAction = findRuntimeActionByNames(runtime, [
+			"SEARCH",
+			"WEB_SEARCH",
+			"SEARCH_WEB",
+			"BRAVE_SEARCH",
+			"INTERNET_SEARCH",
+			"SEARCH_INTERNET",
+			"LOOKUP_WEB",
+			"GOOGLE",
+		]);
+		if (searchAction) {
+			return {
+				actionName: searchAction.name,
+				score: 100,
+				secondBestScore: 0,
+				reasons: ["direct:web-search"],
+			};
+		}
+	}
+
 	if (
 		/\b(?:no calls? between|sleep window|blackout|preferred hours?|travel buffer|unless i explicitly say|unless i say it'?s okay)\b/iu.test(
 			messageText,
@@ -1796,17 +1840,251 @@ function findDirectOwnedActionSuggestion(
 	return null;
 }
 
+function findRuntimeActionByNames(
+	runtime: Pick<IAgentRuntime, "actions">,
+	names: string[],
+): Action | undefined {
+	const wanted = new Set(names.map(normalizeActionIdentifier));
+	return (runtime.actions ?? []).find((action) => {
+		const candidates = [action.name, ...(action.similes ?? [])]
+			.filter((value): value is string => typeof value === "string")
+			.map(normalizeActionIdentifier);
+		return candidates.some((candidate) => wanted.has(candidate));
+	});
+}
+
+function looksLikeLocalShellRequest(text: string): boolean {
+	const normalized = text.toLowerCase();
+	if (!normalized.trim()) {
+		return false;
+	}
+
+	if (
+		/\b(?:do not|don't|dont|without)\s+(?:run|execute|use)\s+(?:commands?|shell|terminal)\b/iu.test(
+			normalized,
+		)
+	) {
+		return false;
+	}
+
+	const mentionsCommand =
+		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh)\b/iu.test(
+			normalized,
+		);
+	const asksToInspect =
+		/\b(?:run|execute|check|inspect|show|list|print|tail|look(?:\s+at)?|read|verify)\b/iu.test(
+			normalized,
+		);
+	const mentionsLocalSurface =
+		/(?:^|\s)(?:\/home\/|~\/|\.\/|\.\.\/)/u.test(normalized) ||
+		/\b(?:this vps|local(?:ly)?|workspace|worktree|repo|repository|branch|head|origin\/(?:develop|main|master)|git status|disk space|logs?|service|systemd)\b/iu.test(
+			normalized,
+		);
+
+	return mentionsCommand && asksToInspect && mentionsLocalSurface;
+}
+
+function looksLikeWebSearchRequest(text: string): boolean {
+	const normalized = text.toLowerCase();
+	if (!normalized.trim()) {
+		return false;
+	}
+
+	if (
+		/\b(?:do not|don't|dont|without)\s+(?:browse|search|google|look\s+up|use)\s+(?:the\s+)?(?:web|internet|live prices?|current prices?)\b/iu.test(
+			normalized,
+		)
+	) {
+		return false;
+	}
+
+	const explicitlyAsksSearch =
+		/\b(?:search\s+(?:the\s+)?web|web\s+search|search\s+online|look\s+up|lookup|google|browse\s+(?:the\s+)?web|search\s+(?:the\s+)?internet)\b/iu.test(
+			normalized,
+		);
+	const asksCurrentInfo =
+		/\b(?:current|currently|latest|live|real[- ]?time|right now|today|now|up[- ]?to[- ]?date)\b/iu.test(
+			normalized,
+		);
+	const mentionsMarketOrNews =
+		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather|score|scores|status)\b/iu.test(
+			normalized,
+		);
+
+	return explicitlyAsksSearch || (asksCurrentInfo && mentionsMarketOrNews);
+}
+
+function quoteShellArg(value: string): string {
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function extractLocalShellPath(text: string): string | null {
+	const match = text.match(
+		/(?:^|[\s`'"])(\/home\/milady\/[A-Za-z0-9._~+/-]+)/u,
+	);
+	if (!match?.[1]) {
+		return null;
+	}
+	return match[1].replace(/[),.;:]+$/u, "");
+}
+
+export function inferLocalShellCommandFromMessageText(
+	messageText: string,
+): string | null {
+	const text = messageText.toLowerCase();
+	if (!looksLikeLocalShellRequest(messageText)) {
+		return null;
+	}
+
+	if (/\bdf\s+-h\b/iu.test(messageText) || /\bdisk space\b/iu.test(text)) {
+		return "df -h";
+	}
+
+	if (/\bgit\b/iu.test(text)) {
+		const localPath = extractLocalShellPath(messageText);
+		if (!localPath) {
+			if (/\bgit\s+status\b/iu.test(messageText)) {
+				return "git status --short --branch";
+			}
+			return null;
+		}
+		const repo = quoteShellArg(localPath);
+		const commands = [`git -C ${repo} status --short --branch`];
+		if (
+			/\b(?:branch|head|sha|origin\/(?:develop|main|master)|latest|author config|commit author|user\.name|user\.email)\b/iu.test(
+				messageText,
+			)
+		) {
+			commands.push(
+				`git -C ${repo} branch --show-current`,
+				`git -C ${repo} rev-parse --short HEAD`,
+				`(git -C ${repo} rev-parse --short origin/develop 2>/dev/null || git -C ${repo} rev-parse --short origin/main 2>/dev/null || true)`,
+				`git -C ${repo} config user.name`,
+				`git -C ${repo} config user.email`,
+			);
+		}
+		return commands.join(" && ");
+	}
+
+	return null;
+}
+
+export function inferWebSearchQueryFromMessageText(
+	messageText: string,
+): string | null {
+	if (!looksLikeWebSearchRequest(messageText)) {
+		return null;
+	}
+
+	const query = messageText
+		.replace(/<@!?\d+>/gu, " ")
+		.replace(
+			/\banswer\s+(?:briefly|in\s+one\s+short\s+sentence|with\s+the\s+price\s+only)\b.*$/iu,
+			" ",
+		)
+		.replace(
+			/\band\s+mention\s+if\s+you\s+cannot\s+browse\s+live\s+prices\b.*$/iu,
+			" ",
+		)
+		.replace(
+			/\b(?:search\s+(?:the\s+)?web\s+(?:for|about)?|web\s+search|search\s+online|look\s+up|lookup|google|browse\s+(?:the\s+)?web|search\s+(?:the\s+)?internet)\b/iu,
+			" ",
+		)
+		.replace(/\bwhat\s+is\s+the\b/iu, " ")
+		.replace(/[?.!]+/gu, " ")
+		.trim()
+		.replace(/\s+/gu, " ");
+
+	return query.length > 0 ? query : messageText.trim();
+}
+
+function hasSelectedShellCommandAction(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+): boolean {
+	return (
+		responseContent?.actions?.some(
+			(actionName) =>
+				typeof actionName === "string" &&
+				normalizeActionIdentifier(actionName) ===
+					normalizeActionIdentifier("SHELL_COMMAND"),
+		) ?? false
+	);
+}
+
+function hasSelectedSearchAction(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+): boolean {
+	return (
+		responseContent?.actions?.some((actionName) => {
+			if (typeof actionName !== "string") {
+				return false;
+			}
+			const normalized = normalizeActionIdentifier(actionName);
+			return (
+				normalized === normalizeActionIdentifier("SEARCH") ||
+				normalized === normalizeActionIdentifier("WEB_SEARCH")
+			);
+		}) ?? false
+	);
+}
+
+function mergeLocalShellCommandParams(
+	existingParams: Content["params"],
+	command: string,
+): Content["params"] {
+	if (
+		existingParams &&
+		typeof existingParams === "object" &&
+		!Array.isArray(existingParams)
+	) {
+		return {
+			...(existingParams as Record<string, unknown>),
+			SHELL_COMMAND: {
+				...(((existingParams as Record<string, unknown>).SHELL_COMMAND as
+					| Record<string, unknown>
+					| undefined) ?? {}),
+				command,
+			},
+		} as Content["params"];
+	}
+
+	return {
+		SHELL_COMMAND: { command },
+	} as Content["params"];
+}
+
+function mergeWebSearchQueryParams(
+	existingParams: Content["params"],
+	query: string,
+): Content["params"] {
+	if (
+		existingParams &&
+		typeof existingParams === "object" &&
+		!Array.isArray(existingParams)
+	) {
+		return {
+			...(existingParams as Record<string, unknown>),
+			SEARCH: {
+				...(((existingParams as Record<string, unknown>).SEARCH as
+					| Record<string, unknown>
+					| undefined) ?? {}),
+				category: "web",
+				query,
+			},
+		} as Content["params"];
+	}
+
+	return {
+		SEARCH: { category: "web", query },
+	} as Content["params"];
+}
+
 export function suggestOwnedActionFromMetadata(
 	runtime: Pick<IAgentRuntime, "actions">,
 	message: Pick<Memory, "content">,
 ): ActionOwnershipSuggestion | null {
 	const messageText = getUserMessageText(message);
-	if (
-		messageText.length === 0 ||
-		!ACTION_OWNERSHIP_TRIGGER_PATTERNS.some((pattern) =>
-			pattern.test(messageText),
-		)
-	) {
+	if (messageText.length === 0) {
 		return null;
 	}
 
@@ -1816,6 +2094,14 @@ export function suggestOwnedActionFromMetadata(
 	);
 	if (directSuggestion) {
 		return directSuggestion;
+	}
+
+	if (
+		!ACTION_OWNERSHIP_TRIGGER_PATTERNS.some((pattern) =>
+			pattern.test(messageText),
+		)
+	) {
+		return null;
 	}
 
 	const ranked: ActionOwnershipCandidate[] = (runtime.actions ?? [])
@@ -1972,6 +2258,24 @@ export function shouldRunMetadataActionRescue(
 	return true;
 }
 
+function shouldPromoteExplicitReplyToOwnedAction(
+	responseContent: Pick<Content, "actions"> | null | undefined,
+	suggestion: ActionOwnershipSuggestion | null,
+): boolean {
+	if (!suggestion || !hasExplicitReplyIntent(responseContent)) {
+		return false;
+	}
+	const normalizedAction = normalizeActionIdentifier(suggestion.actionName);
+	return (
+		(normalizedAction === normalizeActionIdentifier("SHELL_COMMAND") &&
+			suggestion.reasons.includes("direct:local-shell-check")) ||
+		(normalizedAction === normalizeActionIdentifier("SEARCH") &&
+			suggestion.reasons.includes("direct:web-search")) ||
+		(normalizedAction === normalizeActionIdentifier("WEB_SEARCH") &&
+			suggestion.reasons.includes("direct:web-search"))
+	);
+}
+
 function shouldAttemptActionRescue(
 	runtime: Pick<IAgentRuntime, "actions">,
 	message: Memory,
@@ -1990,6 +2294,10 @@ function shouldAttemptActionRescue(
 	}
 
 	if (looksLikeNonActionableChatter(message)) {
+		return false;
+	}
+
+	if (looksLikeSelfPolicyExplanationRequest(message)) {
 		return false;
 	}
 
@@ -2140,8 +2448,95 @@ function shouldAttemptProviderRescue(
 	);
 }
 
+export function looksLikeSelfPolicyExplanationRequest(
+	message: Pick<Memory, "content">,
+): boolean {
+	const text =
+		typeof message.content.text === "string"
+			? message.content.text.toLowerCase()
+			: "";
+	if (!text.trim()) {
+		return false;
+	}
+
+	const hasNoWorkDirective =
+		/\b(?:do not|don't|dont|without)\s+(?:build|create|edit|change|modify|write|scaffold|run|execute|use|touch|commit|push|open|make)\b/iu.test(
+			text,
+		) ||
+		/\b(?:answer|respond)\s+(?:in|with)\s+(?:one|1|a)\s+(?:short\s+)?sentence\b/iu.test(
+			text,
+		) ||
+		/\bdo not run commands?\b/iu.test(text);
+	const asksMonetizedAppGuidance =
+		/\b(?:monetized|monetised)\b/iu.test(text) &&
+		/\b(?:workflow|skill|sdk|example app|edad[- ]?chat|build[- ]?monetized[- ]?app)\b/iu.test(
+			text,
+		);
+	const asksWorkspaceMap =
+		/\b(?:which|what|where)\b[\s\S]{0,120}\b(?:folder|folders|path|paths|repo|repos|repository|repositories|workspace|worktree|source)\b/iu.test(
+			text,
+		) &&
+		/\b(?:live|read[- ]?only|allowed|touch|edit|pr work|github|git config|default branch|latest)\b/iu.test(
+			text,
+		);
+	const asksAgentMethod =
+		/\b(?:what|which|how)\b[\s\S]{0,120}\b(?:workflow|workflows|skill|skills|sdk|example app|routing|configured|allowed|supposed to use|should you use)\b/iu.test(
+			text,
+		) &&
+		/\b(?:you|your|nubilio|agent|codex|task agent|subagent)\b/iu.test(text);
+	const asksQuestion =
+		/\?/.test(text) || /\b(?:what|which|where|how|should)\b/iu.test(text);
+	const asksActualWork =
+		/\b(?:build|create|make|implement|fix|edit|change|modify|write|scaffold|deploy|commit|push|open)\b[\s\S]{0,120}\b(?:app|code|file|files|pr|pull request|branch|repo|feature|bug)\b/iu.test(
+			text,
+		);
+
+	if (
+		hasNoWorkDirective &&
+		asksQuestion &&
+		(asksMonetizedAppGuidance || asksWorkspaceMap || asksAgentMethod)
+	) {
+		return true;
+	}
+
+	return (
+		asksQuestion &&
+		!asksActualWork &&
+		(asksWorkspaceMap || asksAgentMethod || asksMonetizedAppGuidance)
+	);
+}
+
 export function shouldSkipDocumentProviderRescue(message: Memory): boolean {
-	return (message.content.attachments?.length ?? 0) > 0;
+	if ((message.content.attachments?.length ?? 0) > 0) {
+		return true;
+	}
+
+	const text =
+		typeof message.content.text === "string"
+			? message.content.text.toLowerCase()
+			: "";
+	if (!text) {
+		return false;
+	}
+
+	if (looksLikeLocalShellRequest(text)) {
+		return true;
+	}
+
+	if (looksLikeSelfPolicyExplanationRequest(message)) {
+		return true;
+	}
+
+	const asksSelfPolicy =
+		/\b(your|you|configured|routing|workflow|workflows?|folders?|repos?|repositories|source|workspace|workspaces|skills?|sdk|example app|read-only|pr work)\b/.test(
+			text,
+		);
+	const asksDocumentOrKnowledge =
+		/\b(uploaded|upload|attachment|attached|document|documents?|file|files?|knowledge base|kb)\b/.test(
+			text,
+		);
+
+	return asksSelfPolicy && !asksDocumentOrKnowledge;
 }
 
 function buildProviderSelectionPrompt(draftReply?: string): string {
@@ -2447,6 +2842,34 @@ function suppressesPostActionContinuation(
 	return getActionContinuationDecision(runtime, responseContent).suppressed;
 }
 
+export function actionResultsSuppressPostActionContinuation(
+	actionResults: readonly ActionResult[],
+): boolean {
+	return actionResults.some((result) => {
+		const data =
+			result?.data &&
+			typeof result.data === "object" &&
+			!Array.isArray(result.data)
+				? (result.data as Record<string, unknown>)
+				: null;
+		if (!data) {
+			return false;
+		}
+
+		if (data.suppressPostActionContinuation === true) {
+			return true;
+		}
+
+		const terminal = data.terminal;
+		return (
+			terminal !== null &&
+			typeof terminal === "object" &&
+			!Array.isArray(terminal) &&
+			(terminal as Record<string, unknown>).permissionDenied === true
+		);
+	});
+}
+
 /**
  * True when the planner's `text` field should be surfaced to the user as a
  * preamble before action handlers run in actions-mode dispatch. The goal:
@@ -2504,19 +2927,51 @@ export function stripReplyWhenActionOwnsTurn(
 	runtime: Pick<IAgentRuntime, "actions" | "logger">,
 	actions: readonly string[] | null | undefined,
 ): string[] {
-	if (!actions || actions.length <= 1) {
-		return Array.isArray(actions) ? [...actions] : [];
-	}
-
-	const hasPassive = actions.some((action) =>
-		PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
-	);
-	if (!hasPassive) {
-		return [...actions];
+	if (!actions || actions.length === 0) {
+		return [];
 	}
 
 	const actionLookup = buildRuntimeActionLookup(runtime);
-	const ownedActions = actions.filter((action) => {
+	const dedupedActions: string[] = [];
+	const seenActionNames = new Set<string>();
+	for (const action of actions) {
+		const canonicalName =
+			resolveRuntimeAction(actionLookup, action)?.name ??
+			canonicalPlannerControlActionName(action) ??
+			action;
+		const normalizedName = normalizeActionIdentifier(canonicalName);
+		if (normalizedName && seenActionNames.has(normalizedName)) {
+			continue;
+		}
+		if (normalizedName) {
+			seenActionNames.add(normalizedName);
+		}
+		dedupedActions.push(action);
+	}
+
+	if (dedupedActions.length !== actions.length) {
+		runtime.logger.info(
+			{
+				src: "service:message",
+				originalActions: actions,
+				filteredActions: dedupedActions,
+			},
+			"Dropped duplicate planner actions before execution",
+		);
+	}
+
+	if (dedupedActions.length <= 1) {
+		return dedupedActions;
+	}
+
+	const hasPassive = dedupedActions.some((action) =>
+		PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
+	);
+	if (!hasPassive) {
+		return dedupedActions;
+	}
+
+	const ownedActions = dedupedActions.filter((action) => {
 		const normalized = normalizeActionIdentifier(action);
 		if (!normalized || PASSIVE_TURN_ACTIONS.has(normalized)) {
 			return false;
@@ -2527,16 +2982,16 @@ export function stripReplyWhenActionOwnsTurn(
 		);
 	});
 	if (ownedActions.length === 0) {
-		return [...actions];
+		return dedupedActions;
 	}
 
-	const filtered = actions.filter(
+	const filtered = dedupedActions.filter(
 		(action) => !PASSIVE_TURN_ACTIONS.has(normalizeActionIdentifier(action)),
 	);
 	runtime.logger.info(
 		{
 			src: "service:message",
-			originalActions: actions,
+			originalActions: dedupedActions,
 			filteredActions: filtered,
 			suppressedBy: ownedActions,
 		},
@@ -4030,11 +4485,15 @@ export class DefaultMessageService implements IMessageService {
 						{ onStreamChunk: opts.onStreamChunk },
 					);
 
+					const latestActionResults = message.id
+						? runtime.getActionResults(message.id)
+						: [];
 					if (
 						opts.continueAfterActions &&
 						message.id &&
 						shouldContinueAfterActions(runtime, responseContent) &&
-						!suppressesPostActionContinuation(runtime, responseContent)
+						!suppressesPostActionContinuation(runtime, responseContent) &&
+						!actionResultsSuppressPostActionContinuation(latestActionResults)
 					) {
 						const continuation = await this.runPostActionContinuation(
 							runtime,
@@ -4042,7 +4501,7 @@ export class DefaultMessageService implements IMessageService {
 							state,
 							callback,
 							opts,
-							runtime.getActionResults(message.id),
+							latestActionResults,
 						);
 						if (continuation.responseMessages.length > 0) {
 							responseMessages = [
@@ -5051,6 +5510,15 @@ export class DefaultMessageService implements IMessageService {
 			};
 		}
 
+		if (actionResultsSuppressPostActionContinuation(initialActionResults)) {
+			return {
+				responseContent: null,
+				responseMessages: [],
+				state,
+				mode: "none",
+			};
+		}
+
 		const traceActionResults: ActionResult[] = [...initialActionResults];
 		const responseMessages: Memory[] = [];
 		let accumulatedState = state;
@@ -5201,6 +5669,9 @@ export class DefaultMessageService implements IMessageService {
 			}
 
 			const latestActionResults = runtime.getActionResults(message.id);
+			if (actionResultsSuppressPostActionContinuation(latestActionResults)) {
+				break;
+			}
 			if (latestActionResults.length === 0) {
 				runtime.logger.warn(
 					{ src: "service:message", iteration: iterationCount + 1 },
@@ -5278,6 +5749,14 @@ export class DefaultMessageService implements IMessageService {
 		const initialActionResults = message.id
 			? runtime.getActionResults(message.id)
 			: [];
+		if (actionResultsSuppressPostActionContinuation(initialActionResults)) {
+			return {
+				responseContent: null,
+				responseMessages: [],
+				state,
+				mode: "none",
+			};
+		}
 		let accumulatedState = withTaskCompletion(
 			withActionResults(
 				await composeContinuationDecisionState(
@@ -5437,7 +5916,8 @@ export class DefaultMessageService implements IMessageService {
 		if (
 			latestActionResults.length > 0 &&
 			shouldContinueAfterActions(runtime, responseContent) &&
-			!suppressesPostActionContinuation(runtime, responseContent)
+			!suppressesPostActionContinuation(runtime, responseContent) &&
+			!actionResultsSuppressPostActionContinuation(latestActionResults)
 		) {
 			return await this.runPostActionContinuation(
 				runtime,
@@ -6057,25 +6537,27 @@ Return TOON only with the continuation in the text field, starting immediately a
 			}
 		}
 
-		if (shouldRunMetadataActionRescue(responseContent)) {
-			const metadataSuggestion = suggestOwnedActionFromMetadata(
-				runtime,
-				message,
+		const metadataSuggestion = suggestOwnedActionFromMetadata(runtime, message);
+		if (
+			metadataSuggestion &&
+			(shouldRunMetadataActionRescue(responseContent) ||
+				shouldPromoteExplicitReplyToOwnedAction(
+					responseContent,
+					metadataSuggestion,
+				))
+		) {
+			runtime.logger.info(
+				{
+					src: "service:message",
+					originalActions: responseContent.actions ?? [],
+					suggestedAction: metadataSuggestion.actionName,
+					score: metadataSuggestion.score,
+					secondBestScore: metadataSuggestion.secondBestScore,
+					reasons: metadataSuggestion.reasons,
+				},
+				"Recovered primary action from action metadata after passive reply draft",
 			);
-			if (metadataSuggestion) {
-				runtime.logger.info(
-					{
-						src: "service:message",
-						originalActions: responseContent.actions ?? [],
-						suggestedAction: metadataSuggestion.actionName,
-						score: metadataSuggestion.score,
-						secondBestScore: metadataSuggestion.secondBestScore,
-						reasons: metadataSuggestion.reasons,
-					},
-					"Recovered primary action from action metadata after passive reply draft",
-				);
-				responseContent.actions = [metadataSuggestion.actionName];
-			}
+			responseContent.actions = [metadataSuggestion.actionName];
 		}
 
 		// Action parameter repair (Python parity):
@@ -6086,6 +6568,70 @@ Return TOON only with the continuation in the text field, starting immediately a
 			const normalizedName = action.name.trim().toUpperCase();
 			if (normalizedName) {
 				actionByName.set(normalizedName, action);
+			}
+		}
+
+		if (hasSelectedShellCommandAction(responseContent)) {
+			const existingShellParams = parseActionParams(responseContent.params).get(
+				"SHELL_COMMAND",
+			);
+			if (
+				typeof existingShellParams?.command !== "string" ||
+				existingShellParams.command.trim().length === 0
+			) {
+				const inferredCommand = inferLocalShellCommandFromMessageText(
+					getUserMessageText(message),
+				);
+				if (inferredCommand) {
+					runtime.logger.info(
+						{
+							src: "service:message",
+							action: "SHELL_COMMAND",
+							command: inferredCommand,
+						},
+						"Filled SHELL_COMMAND params for explicit local shell check",
+					);
+					responseContent.params = mergeLocalShellCommandParams(
+						responseContent.params,
+						inferredCommand,
+					);
+				}
+			}
+		}
+
+		if (hasSelectedSearchAction(responseContent)) {
+			const existingSearchParams =
+				parseActionParams(responseContent.params).get("SEARCH") ??
+				parseActionParams(responseContent.params).get("WEB_SEARCH");
+			const existingCategory =
+				typeof existingSearchParams?.category === "string"
+					? existingSearchParams.category.trim().toLowerCase()
+					: "";
+			const missingWebQuery =
+				typeof existingSearchParams?.query !== "string" ||
+				existingSearchParams.query.trim().length === 0;
+			if (
+				(existingCategory === "" || existingCategory === "web") &&
+				(missingWebQuery || existingCategory === "")
+			) {
+				const inferredQuery = inferWebSearchQueryFromMessageText(
+					getUserMessageText(message),
+				);
+				if (inferredQuery) {
+					runtime.logger.info(
+						{
+							src: "service:message",
+							action: "SEARCH",
+							category: "web",
+							query: inferredQuery,
+						},
+						"Filled SEARCH params for explicit current-info request",
+					);
+					responseContent.params = mergeWebSearchQueryParams(
+						responseContent.params,
+						inferredQuery,
+					);
+				}
 			}
 		}
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2469,7 +2469,7 @@ export function looksLikeSelfPolicyExplanationRequest(
 		/\bdo not run commands?\b/iu.test(text);
 	const asksMonetizedAppGuidance =
 		/\b(?:monetized|monetised)\b/iu.test(text) &&
-		/\b(?:workflow|skill|sdk|example app|edad[- ]?chat|build[- ]?monetized[- ]?app)\b/iu.test(
+		/\b(?:workflow|skill|sdk|example app|reference app|build[- ]?monetized[- ]?app)\b/iu.test(
 			text,
 		);
 	const asksWorkspaceMap =
@@ -2482,8 +2482,7 @@ export function looksLikeSelfPolicyExplanationRequest(
 	const asksAgentMethod =
 		/\b(?:what|which|how)\b[\s\S]{0,120}\b(?:workflow|workflows|skill|skills|sdk|example app|routing|configured|allowed|supposed to use|should you use)\b/iu.test(
 			text,
-		) &&
-		/\b(?:you|your|nubilio|agent|codex|task agent|subagent)\b/iu.test(text);
+		) && /\b(?:you|your|agent|codex|task agent|subagent)\b/iu.test(text);
 	const asksQuestion =
 		/\?/.test(text) || /\b(?:what|which|where|how|should)\b/iu.test(text);
 	const asksActualWork =
@@ -2523,20 +2522,24 @@ export function shouldSkipDocumentProviderRescue(message: Memory): boolean {
 		return true;
 	}
 
-	if (looksLikeSelfPolicyExplanationRequest(message)) {
-		return true;
-	}
-
 	const asksSelfPolicy =
 		/\b(?:configured|routing|workflow|workflows?|folders?|repos?|repositories|source|workspace|workspaces|skills?|sdk|example app|read-only|pr work)\b/.test(
 			text,
-		) && /\b(?:you|your|agent|nubilio|codex|task agent|subagent)\b/.test(text);
+		) && /\b(?:you|your|agent|codex|task agent|subagent)\b/.test(text);
 	const asksDocumentOrKnowledge =
 		/\b(uploaded|upload|attachment|attached|document|documents?|file|files?|knowledge base|kb)\b/.test(
 			text,
 		);
 
-	return asksSelfPolicy && !asksDocumentOrKnowledge;
+	if (asksDocumentOrKnowledge) {
+		return false;
+	}
+
+	if (looksLikeSelfPolicyExplanationRequest(message)) {
+		return true;
+	}
+
+	return asksSelfPolicy;
 }
 
 function buildProviderSelectionPrompt(draftReply?: string): string {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1867,6 +1867,10 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		return false;
 	}
 
+	if (looksLikeActionExplanationRequest(normalized)) {
+		return false;
+	}
+
 	const mentionsCommand =
 		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh)\b/iu.test(
 			normalized,
@@ -1882,6 +1886,27 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		);
 
 	return mentionsCommand && asksToInspect && mentionsLocalSurface;
+}
+
+function looksLikeActionExplanationRequest(text: string): boolean {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	const asksForExplanation =
+		/\b(?:explain|describe|teach|walk\s+me\s+through|what\s+does|what\s+is|how\s+(?:does|do|to)|why)\b/iu.test(
+			normalized,
+		);
+	if (!asksForExplanation) {
+		return false;
+	}
+
+	const asksToExecuteAfterExplanation =
+		/\b(?:and|then|also|after(?:wards)?|next)\s+(?:please\s+)?(?:run|execute)\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:run|execute)\b.*\b(?:after|once)\s+(?:you\s+)?(?:explain|describe|teach|walk\s+me\s+through)\b/iu.test(
+			normalized,
+		);
+
+	return !asksToExecuteAfterExplanation;
 }
 
 function looksLikeWebSearchRequest(text: string): boolean {
@@ -2261,8 +2286,12 @@ export function shouldRunMetadataActionRescue(
 export function shouldPromoteExplicitReplyToOwnedAction(
 	responseContent: Pick<Content, "actions"> | null | undefined,
 	suggestion: ActionOwnershipSuggestion | null,
+	messageText = "",
 ): boolean {
 	if (!suggestion || !hasExplicitReplyIntent(responseContent)) {
+		return false;
+	}
+	if (looksLikeActionExplanationRequest(messageText)) {
 		return false;
 	}
 	return (
@@ -6542,6 +6571,7 @@ Return TOON only with the continuation in the text field, starting immediately a
 				shouldPromoteExplicitReplyToOwnedAction(
 					responseContent,
 					metadataSuggestion,
+					getUserMessageText(message),
 				))
 		) {
 			runtime.logger.info(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1599,7 +1599,7 @@ const ACTION_OWNERSHIP_TRIGGER_PATTERNS = [
 const ACTION_METADATA_FUTURE_HINTS =
 	/\b(?:standing|future|workflow|policy|approval|delegate|gated|queued?|queue|intervention|nudge|warning|upload|portal|browser|device|follow[- ]?up)\b/iu;
 
-type ActionOwnershipSuggestion = {
+export type ActionOwnershipSuggestion = {
 	actionName: string;
 	score: number;
 	secondBestScore: number;
@@ -2258,21 +2258,16 @@ export function shouldRunMetadataActionRescue(
 	return true;
 }
 
-function shouldPromoteExplicitReplyToOwnedAction(
+export function shouldPromoteExplicitReplyToOwnedAction(
 	responseContent: Pick<Content, "actions"> | null | undefined,
 	suggestion: ActionOwnershipSuggestion | null,
 ): boolean {
 	if (!suggestion || !hasExplicitReplyIntent(responseContent)) {
 		return false;
 	}
-	const normalizedAction = normalizeActionIdentifier(suggestion.actionName);
 	return (
-		(normalizedAction === normalizeActionIdentifier("SHELL_COMMAND") &&
-			suggestion.reasons.includes("direct:local-shell-check")) ||
-		(normalizedAction === normalizeActionIdentifier("SEARCH") &&
-			suggestion.reasons.includes("direct:web-search")) ||
-		(normalizedAction === normalizeActionIdentifier("WEB_SEARCH") &&
-			suggestion.reasons.includes("direct:web-search"))
+		suggestion.reasons.includes("direct:local-shell-check") ||
+		suggestion.reasons.includes("direct:web-search")
 	);
 }
 

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import {
 	__setKnowledgeUrlFetchImplForTests,
 	ContentType,
@@ -8,7 +6,7 @@ import {
 } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MessageManager } from "../messages";
+import { MessageManager, resolveGenerationTimeoutMs } from "../messages";
 
 function runtime(): IAgentRuntime {
 	return {
@@ -103,14 +101,10 @@ describe("MessageManager URL enrichment", () => {
 });
 
 describe("MessageManager generation timeout config", () => {
-	it("allows env-configured timeout disablement", async () => {
-		const source = await readFile(
-			path.resolve(import.meta.dirname, "../messages.ts"),
-			"utf8",
-		);
-
-		expect(source).toContain("process.env.DISCORD_GENERATION_TIMEOUT_MS");
-		expect(source).toContain("process.env.MESSAGE_TIMEOUT_MS");
-		expect(source).toContain("generationTimeoutMs === null");
+	it("allows env-configured timeout disablement", () => {
+		expect(resolveGenerationTimeoutMs("0", "120000")).toBeNull();
+		expect(resolveGenerationTimeoutMs(undefined, "0")).toBeNull();
+		expect(resolveGenerationTimeoutMs("1000", undefined)).toBe(30_000);
+		expect(resolveGenerationTimeoutMs(undefined, "45000")).toBe(45_000);
 	});
 });

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import {
 	__setKnowledgeUrlFetchImplForTests,
 	ContentType,
@@ -97,5 +99,18 @@ describe("MessageManager URL enrichment", () => {
 		);
 
 		expect(first.attachments[0]?.id).toBe(second.attachments[0]?.id);
+	});
+});
+
+describe("MessageManager generation timeout config", () => {
+	it("allows env-configured timeout disablement", async () => {
+		const source = await readFile(
+			path.resolve(import.meta.dirname, "../messages.ts"),
+			"utf8",
+		);
+
+		expect(source).toContain("process.env.DISCORD_GENERATION_TIMEOUT_MS");
+		expect(source).toContain("process.env.MESSAGE_TIMEOUT_MS");
+		expect(source).toContain("generationTimeoutMs === null");
 	});
 });

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -106,5 +106,6 @@ describe("MessageManager generation timeout config", () => {
 		expect(resolveGenerationTimeoutMs(undefined, "0")).toBeNull();
 		expect(resolveGenerationTimeoutMs("1000", undefined)).toBe(30_000);
 		expect(resolveGenerationTimeoutMs(undefined, "45000")).toBe(45_000);
+		expect(resolveGenerationTimeoutMs("disabled", undefined)).toBe(120_000);
 	});
 });

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -54,6 +54,19 @@ import {
 	sendMessageInChunks,
 } from "./utils";
 
+export function resolveGenerationTimeoutMs(
+	timeoutSetting: unknown,
+	fallbackSetting: unknown,
+): number | null {
+	const parsed = Number.parseInt(
+		String(timeoutSetting ?? fallbackSetting ?? "120000"),
+		10,
+	);
+	return Number.isFinite(parsed) && parsed > 0
+		? Math.max(30_000, parsed)
+		: null;
+}
+
 function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -671,21 +684,12 @@ export class MessageManager {
 			let typingStarted = false;
 			let responseEmitted = false;
 			let generationTimedOut = false;
-			const generationTimeoutSetting = Number.parseInt(
-				String(
-					this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
-						process.env.DISCORD_GENERATION_TIMEOUT_MS ??
-						this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
-						process.env.MESSAGE_TIMEOUT_MS ??
-						"120000",
-				),
-				10,
+			const generationTimeoutMs = resolveGenerationTimeoutMs(
+				this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
+					process.env.DISCORD_GENERATION_TIMEOUT_MS,
+				this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
+					process.env.MESSAGE_TIMEOUT_MS,
 			);
-			const generationTimeoutMs =
-				Number.isFinite(generationTimeoutSetting) &&
-				generationTimeoutSetting > 0
-					? Math.max(30_000, generationTimeoutSetting)
-					: null;
 
 			const finalizePendingDraft = async () => {
 				if (draftStream?.isStarted() && !draftStream.isDone()) {

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -62,9 +62,10 @@ export function resolveGenerationTimeoutMs(
 		String(timeoutSetting ?? fallbackSetting ?? "120000"),
 		10,
 	);
-	return Number.isFinite(parsed) && parsed > 0
-		? Math.max(30_000, parsed)
-		: null;
+	if (!Number.isFinite(parsed)) {
+		return 120_000;
+	}
+	return parsed > 0 ? Math.max(30_000, parsed) : null;
 }
 
 function escapeRegex(value: string): string {

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -671,17 +671,21 @@ export class MessageManager {
 			let typingStarted = false;
 			let responseEmitted = false;
 			let generationTimedOut = false;
-			const generationTimeoutMs = Math.max(
-				30_000,
-				Number.parseInt(
-					String(
-						this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
-							this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
-							"120000",
-					),
-					10,
-				) || 120_000,
+			const generationTimeoutSetting = Number.parseInt(
+				String(
+					this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
+						process.env.DISCORD_GENERATION_TIMEOUT_MS ??
+						this.runtime.getSetting("MESSAGE_TIMEOUT_MS") ??
+						process.env.MESSAGE_TIMEOUT_MS ??
+						"120000",
+				),
+				10,
 			);
+			const generationTimeoutMs =
+				Number.isFinite(generationTimeoutSetting) &&
+				generationTimeoutSetting > 0
+					? Math.max(30_000, generationTimeoutSetting)
+					: null;
 
 			const finalizePendingDraft = async () => {
 				if (draftStream?.isStarted() && !draftStream.isDone()) {
@@ -992,19 +996,23 @@ export class MessageManager {
 					}
 				})();
 
-				const timeoutPromise = new Promise<never>((_, reject) => {
-					generationTimeoutHandle = setTimeout(() => {
-						generationTimedOut = true;
-						reject(
-							new Error(
-								`Discord generation timeout after ${generationTimeoutMs}ms`,
-							),
-						);
-					}, generationTimeoutMs);
-				});
-
 				generationPromise.catch(() => {});
-				await Promise.race([generationPromise, timeoutPromise]);
+				if (generationTimeoutMs === null) {
+					await generationPromise;
+				} else {
+					const timeoutPromise = new Promise<never>((_, reject) => {
+						generationTimeoutHandle = setTimeout(() => {
+							generationTimedOut = true;
+							reject(
+								new Error(
+									`Discord generation timeout after ${generationTimeoutMs}ms`,
+								),
+							);
+						}, generationTimeoutMs);
+					});
+
+					await Promise.race([generationPromise, timeoutPromise]);
+				}
 			} catch (generationError) {
 				this.runtime.logger.error(
 					{


### PR DESCRIPTION
## Summary

- Collapse duplicate visible `REPLY` planner actions and make reply actions fall back to planner text when the secondary reply generation is empty.
- Route explicit local shell and web-search requests directly to their owned actions, suppress duplicate post-action continuation, and keep explanation-only prompts conversational.
- Let Discord generation timeouts be disabled with `DISCORD_GENERATION_TIMEOUT_MS=0`, with tests covering the disabled timeout path.
- Add the app-core CI support fixes needed for this branch's required checks: wallet shim dependency, bundled Capacitor web build fallback, Windows type-package root creation, and llama simulator framework prep.

## Validation

- `./node_modules/.bin/biome check ...` on touched core, agent, Discord, and app-core files
- `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts packages/core/src/__tests__/message-routing-live-regression.test.ts packages/core/src/features/basic-capabilities/actions/reply.test.ts`
- `./node_modules/.bin/vitest run --config packages/agent/vitest.config.ts packages/agent/src/actions/search.test.ts packages/agent/src/actions/terminal.test.ts`
- `./node_modules/.bin/vitest run --config plugins/plugin-discord/vitest.config.ts plugins/plugin-discord/__tests__/messages-url.test.ts`
- `bun run --cwd packages/core build:node`
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd plugins/plugin-discord typecheck`
- `bun run --cwd packages/app-core build:dist`
- `node --check packages/app-core/scripts/run-mobile-build.mjs`
- `node --check packages/app-core/scripts/ensure-type-package-aliases.mjs`
- `node packages/app-core/scripts/ensure-type-package-aliases.mjs`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens message-routing logic in the core `message.ts` service so that explicit shell-check and live-price queries are dispatched to the owning action instead of being answered conversationally, and prevents post-action continuation when terminal permission or web-search service failures block the turn. It also allows Discord generation timeouts to be disabled via `DISCORD_GENERATION_TIMEOUT_MS=0`, collapses duplicate planner actions before execution, and adds a fallback in the REPLY action handler for empty/malformed model output.

- **Shell and web-search routing** — introduces `looksLikeLocalShellRequest`, `looksLikeWebSearchRequest`, `looksLikeActionExplanationRequest`, and `findDirectOwnedActionSuggestion` to give direct ownership to shell and search actions while guarding explanatory questions from execution.
- **Post-action continuation suppression** — `actionResultsSuppressPostActionContinuation` now detects `suppressPostActionContinuation` flags in action results and halts follow-on agent turns.
- **CI / build fixes** — updates app-core wallet shim, mobile build fallback, iOS llama framework prep, and Windows `@types` root repair.

<h3>Confidence Score: 3/5</h3>

Several routing-correctness issues flagged in prior rounds remain unresolved in the new core heuristics, making merge to develop risky without follow-up fixes.

The PR fixes a meaningful set of real problems — status/score false-positive web routing, hardcoded home path, the run/execute explanation guard, and Discord timeout test quality — but the param-inference path still silently skips command and query injection when the promoted action uses an alias name (TERMINAL or BRAVE_SEARCH instead of SHELL_COMMAND or SEARCH), and looksLikeWebSearchRequest still triggers false-positive search suggestions via the action-rescue path for common programming terms like hash lookup or DNS lookup. Both holes are in the hot path that runs on every incoming message in all deployments.

packages/core/src/services/message.ts — the param-inference helpers (hasSelectedShellCommandAction, hasSelectedSearchAction) and the looksLikeWebSearchRequest function warrant the most scrutiny before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Largest change — adds shell/search routing heuristics, action promotion logic, param-inference helpers, and continuation-suppression; several routing issues from prior rounds remain unfixed (lookup false-positive, alias param-inference gap, overly broad you/your predicate). |
| plugins/plugin-discord/messages.ts | Extracts resolveGenerationTimeoutMs as a testable helper; correctly returns 120 000 for non-numeric env strings, returns null only for explicit 0, and enforces a 30 s floor — behavior is sound. |
| packages/core/src/features/basic-capabilities/actions/reply.ts | Adds plannerReplyFallback so empty/malformed model text surfaces the planner's own text; model errors with a fallback are swallowed to a warn log, which the downstream parsedText fallback chain handles gracefully. |
| packages/agent/src/actions/terminal.ts | Permission-denied path now returns suppressPostActionContinuation:true in action result data; success path retains suppressVisibleCallback:true and allows normal continuation. |
| packages/agent/src/actions/web-search.ts | SERVICE_NOT_FOUND path now emits suppressPostActionContinuation:true so unavailable search results do not spawn follow-on task-agent turns. |
| packages/core/src/__tests__/message-routing-live-regression.test.ts | New regression suite covers duplicate-action collapse, param inference, search routing, explanation-only shell guard, self-policy bypass, document rescue, and continuation suppression — good behavioral coverage. |
| plugins/plugin-discord/__tests__/messages-url.test.ts | Replaced source-string assertions with direct resolveGenerationTimeoutMs behavior tests; now verifies actual runtime semantics (null for 0, 120 000 for non-numeric, 30 000 floor, numeric passthrough). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Message] --> B{suggestOwnedActionFromMetadata}
    B --> C{findDirectOwnedActionSuggestion}
    C --> D{looksLikeLocalShellRequest?}
    D -->|yes and not explanation| E[Shell Action Suggestion]
    D -->|no| F{looksLikeWebSearchRequest?}
    F -->|yes| G[Search Action Suggestion]
    F -->|no| H[Score-based ownership ranking]
    E --> L{Model chose explicit REPLY?}
    G --> L
    L -->|yes - direct reason| M{looksLikeActionExplanationRequest?}
    M -->|yes| N[Keep REPLY]
    M -->|no| O[Promote to owned action]
    L -->|no - rescue path| P{shouldRunMetadataActionRescue?}
    P -->|yes| O
    O --> Q{hasSelectedShellCommandAction or hasSelectedSearchAction?}
    Q -->|yes - exact name| R[Infer and fill params]
    Q -->|no - alias name| S[Action runs with NO inferred params]
    O --> T[Execute action]
    T --> U{actionResultsSuppressPostActionContinuation?}
    U -->|true| V[Stop continuation]
    U -->|false| W[Normal continuation]
```

<sub>Reviews (10): Last reviewed commit: ["fix(chat): keep explanatory shell prompt..."](https://github.com/elizaos/eliza/commit/4d776758f14865dcf6be719add59a6579ec61e9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31002378)</sub>

<!-- /greptile_comment -->