### PR TITLE
feat(provisioning-worker): heartbeat running sandboxes each cycle

### DIFF
--- a/cloud/packages/db/repositories/agent-sandboxes.ts
+++ b/cloud/packages/db/repositories/agent-sandboxes.ts
@@ -149,6 +149,16 @@ export class AgentSandboxesRepository {
       );
   }
 
+  async listRunning(): Promise<Array<{ id: string; organization_id: string }>> {
+    return dbRead
+      .select({
+        id: agentSandboxes.id,
+        organization_id: agentSandboxes.organization_id,
+      })
+      .from(agentSandboxes)
+      .where(eq(agentSandboxes.status, "running"));
+  }
+
   async findRunningSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
     // Use dbWrite (primary) instead of dbRead (replica) to ensure fresh data.
     // The VPS worker writes bridge_url/status to primary, and read replicas

--- a/cloud/packages/lib/services/provisioning-jobs.ts
+++ b/cloud/packages/lib/services/provisioning-jobs.ts
@@ -371,6 +371,42 @@ export class ProvisioningJobService {
     });
   }
 
+  /**
+   * Drive heartbeats for every running sandbox. The on-prem worker calls this
+   * each cycle so last_heartbeat_at stays fresh and unreachable agents flip
+   * to disconnected. Heartbeats are HTTP fetches over the Headscale tunnel,
+   * so this only runs from the Node sidecar (not from the Cloudflare Worker).
+   */
+  async processRunningHeartbeats(concurrency = 5): Promise<HeartbeatResult> {
+    const running = await agentSandboxesRepository.listRunning();
+    const total = running.length;
+    if (total === 0) return { total: 0, succeeded: 0, failed: 0 };
+
+    let succeeded = 0;
+    let failed = 0;
+    const queue = [...running];
+    const workers = Array.from({ length: Math.min(concurrency, total) }, async () => {
+      while (true) {
+        const r = queue.shift();
+        if (!r) break;
+        const ok = await elizaSandboxService
+          .heartbeat(r.id, r.organization_id)
+          .catch((error: unknown) => {
+            logger.warn("[provisioning-jobs] heartbeat threw", {
+              agentId: r.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return false;
+          });
+        if (ok) succeeded += 1;
+        else failed += 1;
+      }
+    });
+    await Promise.all(workers);
+
+    return { total, succeeded, failed };
+  }
+
   private async recoverStaleJobs(): Promise<number> {
     let totalRecovered = 0;
 
@@ -435,6 +471,12 @@ export class ProvisioningJobService {
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
+
+export interface HeartbeatResult {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
 
 export interface ProcessingResult {
   claimed: number;

--- a/cloud/packages/scripts/provisioning-worker.ts
+++ b/cloud/packages/scripts/provisioning-worker.ts
@@ -15,7 +15,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ProcessingResult } from "../lib/services/provisioning-jobs";
+import type { HeartbeatResult, ProcessingResult } from "../lib/services/provisioning-jobs";
 
 type WorkerLogger = typeof import("../lib/utils/logger").logger;
 type WorkerService = typeof import("../lib/services/provisioning-jobs").provisioningJobService;
@@ -118,6 +118,11 @@ export async function processProvisioningWorkerCycle(
   return provisioningJobService.processPendingJobs(batchSize);
 }
 
+export async function processHeartbeatCycle(concurrency = 5): Promise<HeartbeatResult> {
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.processRunningHeartbeats(concurrency);
+}
+
 let running = true;
 
 async function sleep(ms: number): Promise<void> {
@@ -132,6 +137,21 @@ async function pollCycle(logger: WorkerLogger, config: ProvisioningWorkerConfig)
     }
   } catch (error) {
     logger.error("[provisioning-worker] cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const heartbeats = await processHeartbeatCycle();
+    if (heartbeats.total > 0) {
+      logger.info("[provisioning-worker] heartbeat cycle complete", {
+        total: heartbeats.total,
+        succeeded: heartbeats.succeeded,
+        failed: heartbeats.failed,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] heartbeat cycle failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/cloud/packages/tests/unit/provisioning-jobs-heartbeat.test.ts
+++ b/cloud/packages/tests/unit/provisioning-jobs-heartbeat.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface RunningRow {
+  id: string;
+  organization_id: string;
+}
+
+const state: {
+  running: RunningRow[];
+  heartbeatCalls: Array<{ agentId: string; orgId: string }>;
+  heartbeatResults: Map<string, boolean | Error>;
+} = {
+  running: [],
+  heartbeatCalls: [],
+  heartbeatResults: new Map(),
+};
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    listRunning: async (): Promise<RunningRow[]> => state.running,
+  },
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    heartbeat: async (agentId: string, orgId: string): Promise<boolean> => {
+      state.heartbeatCalls.push({ agentId, orgId });
+      const result = state.heartbeatResults.get(agentId);
+      if (result instanceof Error) throw result;
+      return result ?? true;
+    },
+  },
+}));
+
+const { provisioningJobService } = await import("@/lib/services/provisioning-jobs");
+
+describe("ProvisioningJobService.processRunningHeartbeats", () => {
+  beforeEach(() => {
+    state.running = [];
+    state.heartbeatCalls = [];
+    state.heartbeatResults = new Map();
+  });
+
+  afterEach(() => {
+    state.running = [];
+    state.heartbeatCalls = [];
+    state.heartbeatResults = new Map();
+  });
+
+  test("returns zeros when no running sandboxes", async () => {
+    const result = await provisioningJobService.processRunningHeartbeats();
+    expect(result).toEqual({ total: 0, succeeded: 0, failed: 0 });
+    expect(state.heartbeatCalls).toEqual([]);
+  });
+
+  test("calls heartbeat for every running sandbox and counts successes", async () => {
+    state.running = [
+      { id: "a-1", organization_id: "org-1" },
+      { id: "a-2", organization_id: "org-2" },
+      { id: "a-3", organization_id: "org-1" },
+    ];
+    state.heartbeatResults.set("a-1", true);
+    state.heartbeatResults.set("a-2", true);
+    state.heartbeatResults.set("a-3", true);
+
+    const result = await provisioningJobService.processRunningHeartbeats();
+
+    expect(result).toEqual({ total: 3, succeeded: 3, failed: 0 });
+    expect(state.heartbeatCalls).toHaveLength(3);
+    expect(state.heartbeatCalls.map((c) => c.agentId).sort()).toEqual(["a-1", "a-2", "a-3"]);
+    expect(state.heartbeatCalls.find((c) => c.agentId === "a-2")?.orgId).toBe("org-2");
+  });
+
+  test("counts heartbeat=false as failed without crashing", async () => {
+    state.running = [
+      { id: "ok", organization_id: "org-1" },
+      { id: "down", organization_id: "org-1" },
+    ];
+    state.heartbeatResults.set("ok", true);
+    state.heartbeatResults.set("down", false);
+
+    const result = await provisioningJobService.processRunningHeartbeats();
+
+    expect(result).toEqual({ total: 2, succeeded: 1, failed: 1 });
+  });
+
+  test("treats thrown errors as failed and continues processing the rest", async () => {
+    state.running = [
+      { id: "boom", organization_id: "org-1" },
+      { id: "ok", organization_id: "org-1" },
+    ];
+    state.heartbeatResults.set("boom", new Error("network down"));
+    state.heartbeatResults.set("ok", true);
+
+    const result = await provisioningJobService.processRunningHeartbeats();
+
+    expect(result).toEqual({ total: 2, succeeded: 1, failed: 1 });
+    expect(state.heartbeatCalls.map((c) => c.agentId).sort()).toEqual(["boom", "ok"]);
+  });
+
+  test("respects concurrency upper bound", async () => {
+    state.running = Array.from({ length: 12 }, (_, i) => ({
+      id: `agent-${i}`,
+      organization_id: "org-1",
+    }));
+    for (const r of state.running) state.heartbeatResults.set(r.id, true);
+
+    const result = await provisioningJobService.processRunningHeartbeats(3);
+
+    expect(result.total).toBe(12);
+    expect(result.succeeded).toBe(12);
+    expect(result.failed).toBe(0);
+    expect(state.heartbeatCalls).toHaveLength(12);
+  });
+});


### PR DESCRIPTION
## Summary

\`elizaSandboxService.heartbeat()\` exists and writes \`last_heartbeat_at\`, but nothing iterates running sandboxes to call it. Admin staleness signals (\`admin-infrastructure\` dashboard, container UI) read \`last_heartbeat_at\` and would never see it move under the new worker once the legacy on-prem worker is retired.

## Change

### `cloud/packages/db/repositories/agent-sandboxes.ts`
New \`listRunning()\` returning minimal \`(id, organization_id)\` tuples needed to drive heartbeats across orgs. Returns from \`dbRead\` (replica is fine for liveness; staleness fixes itself on next cycle).

### `cloud/packages/lib/services/provisioning-jobs.ts`
New \`processRunningHeartbeats(concurrency = 5)\` and \`HeartbeatResult\` type. Fans out \`heartbeat()\` with a small worker pool. Thrown errors are logged at warn level and counted as failed without aborting the cycle, so one bad agent doesn't block the others.

### `cloud/packages/scripts/provisioning-worker.ts`
\`pollCycle\` now calls \`processHeartbeatCycle()\` after \`processProvisioningWorkerCycle()\`. Independent try/catch — a heartbeat-cycle failure cannot take down job processing.

### Why not a /cron route

Heartbeats are HTTP fetches over the Headscale tunnel (see \`elizaSandboxService.heartbeat\`). Cloudflare Workers can't reach Headscale, so the cron-route shape used elsewhere in \`cloud/apps/api/cron/\` would not work for heartbeats. The on-prem Node sidecar already has Headscale access, so the loop lives there.

## Tests

\`cloud/packages/tests/unit/provisioning-jobs-heartbeat.test.ts\` — 5 cases:
1. Empty list returns zeros, no calls.
2. All-success: every running sandbox is called, counts match, orgId passed through.
3. \`heartbeat=false\` counts as failed without crashing.
4. Thrown error treated as failed; cycle continues for the rest.
5. Concurrency upper bound: 12 sandboxes with concurrency=3 still processes all 12.

\`\`\`
$ bun test packages/tests/unit/provisioning-jobs-heartbeat.test.ts
 5 pass
 0 fail
 13 expect() calls
\`\`\`

## Context

Part of the on-prem provisioning-worker migration from \`0xSolace/milady-cloud\` (legacy) to \`cloud/packages/lib/services/provisioning-jobs.ts\` + \`cloud/packages/scripts/provisioning-worker.ts\`. Audit identified the missing heartbeat loop as a blocker — the new worker as it stood would silently degrade the admin dashboard once it replaced the legacy one. Closes that gap so the staged port-then-cutover can proceed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a gap in the new provisioning worker by adding a heartbeat loop that iterates all running sandboxes each poll cycle and calls `elizaSandboxService.heartbeat()` to keep `last_heartbeat_at` fresh — a capability the legacy on-prem worker had but the new worker was missing.

- **`listRunning()`** (`agent-sandboxes.ts`): new repo method returns minimal `(id, organization_id)` tuples from the read replica, feeding the heartbeat fan-out.
- **`processRunningHeartbeats()`** (`provisioning-jobs.ts`): concurrent worker-pool (default concurrency 5) drains a shared queue; individual failures are caught, logged at warn, and counted without aborting the batch.
- **`pollCycle` integration** (`provisioning-worker.ts`): heartbeat cycle runs after the job cycle under its own try/catch, so a full heartbeat failure cannot interrupt job processing. A new unit-test file covers 5 scenarios including the concurrency cap.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and well-isolated, with independent error handling for both the heartbeat cycle and the underlying worker pool.

The heartbeat fan-out is gated behind a dedicated try/catch in pollCycle, so a broken DB replica or complete Headscale failure cannot disrupt provisioning-job processing. Individual heartbeat throws are caught, logged, and counted without aborting the batch. The underlying elizaSandboxService.heartbeat uses AbortSignal.timeout(10_000) so no worker slot can hang indefinitely. The shared mutable counters in the worker pool are safe under JavaScript's cooperative concurrency model. No production data path is removed or altered.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/db/repositories/agent-sandboxes.ts | Adds listRunning() returning (id, organization_id) tuples from the read replica; straightforward and correct, but performs an unbounded full-table scan (pre-existing P2 comment). |
| cloud/packages/lib/services/provisioning-jobs.ts | Adds processRunningHeartbeats() with a shared-queue concurrent worker pool; error isolation is correct, JavaScript single-thread model makes the shared mutable counters safe, and the underlying heartbeat has a 10s AbortSignal timeout. |
| cloud/packages/scripts/provisioning-worker.ts | Wires processHeartbeatCycle() into pollCycle() behind an independent try/catch; hardcoded concurrency=5 not threaded through from config (pre-existing P2 comment). |
| cloud/packages/tests/unit/provisioning-jobs-heartbeat.test.ts | Good unit test coverage: empty list, all-success, false return, thrown error, and concurrency cap — all 5 cases exercise the contract correctly. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `cloud/packages/db/repositories/agent-sandboxes.ts`, line 154-162 ([link](https://github.com/elizaos/eliza/blob/59848f15ee46bb4b2c06b2ab1978902e92f2415b/cloud/packages/db/repositories/agent-sandboxes.ts#L154-L162)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No row limit on cross-org scan**

   `listRunning()` performs an unbounded full-table scan across all organisations. On a large deployment with thousands of running sandboxes this query returns every row into memory before the worker pool fans out. Consider adding a reasonable upper bound (e.g. `.limit(500)`) and logging when the cap is hit, or paginating, so a single oversized response can't stall or OOM the worker process.

2. `cloud/packages/scripts/provisioning-worker.ts`, line 128-133 ([link](https://github.com/elizaos/eliza/blob/59848f15ee46bb4b2c06b2ab1978902e92f2415b/cloud/packages/scripts/provisioning-worker.ts#L128-L133)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The heartbeat concurrency is hardcoded at `5` here while `batchSize` and `pollIntervalMs` are already configurable via env vars. Adding a `WORKER_HEARTBEAT_CONCURRENCY` env var would let operators tune this for deployments with many running sandboxes without redeploying code.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat(provisioning-worker): heartbeat run..."](https://github.com/elizaos/eliza/commit/645aa4618229451b937f059caa31f984c401fc89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31027349)</sub>

<!-- /greptile_comment -->