### PR TITLE
feat(docker-sandbox): persist /root/.milady and /root/.eliza across recreations

### DIFF
--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -434,7 +434,10 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Ensure volume directory exists
-      await ssh.exec(`mkdir -p ${shellQuote(volumePath)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `mkdir -p ${shellQuote(volumePath)} ${shellQuote(`${volumePath}/milady`)} ${shellQuote(`${volumePath}/eliza`)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
 
       // Pull image (may take a while on first run)
       logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
@@ -505,6 +508,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-retries 6",
         ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
+        `-v ${shellQuote(`${volumePath}/milady`)}:/root/.milady`,
+        `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 2139).
         // Publish both externally allocated host ports to that live listener so
         // nginx can reach /api/* via bridge_url and the UI via web_ui_port.


### PR DESCRIPTION
## Summary

The agent image keeps PGLite state, runtime config, and exec-approvals under \`/root/.milady\` and \`/root/.eliza\`. The current \`DockerSandboxProvider.create\` only mounts \`\${volumePath}:/app/data\`, so every container recreation throws away that state — agents lose their local DB rows, exec-approval history, and any runtime config the image writes there.

The legacy on-prem worker (\`0xSolace/milady-cloud/provisioning-worker/provisioning-worker.ts:940-942\`) mounts all three. This brings the new provider to parity.

## Change

\`cloud/packages/lib/services/docker-sandbox-provider.ts\`:

1. **\`mkdir -p\`** (around line 437) — create the two extra subdirs alongside \`volumePath\` so the bind mounts have a host-side target.

2. **\`docker create\` args** (around line 510) — add two \`-v\` flags:
   \`\`\`
   -v \${volumePath}/milady:/root/.milady
   -v \${volumePath}/eliza:/root/.eliza
   \`\`\`

## Why this is safe

- **Additive only**: existing \`/app/data\` mount unchanged. No envvar, port, or network change.
- **Existing containers unaffected**: mounts apply at \`docker create\`. Already-running agents don't get re-created.
- **First-launch cost**: 2 extra empty directories per agent. Negligible disk.
- **No existing unit test for \`DockerSandboxProvider.create()\`**: the path has no mock-SSH harness in the repo. Building one is a larger separate effort. Validation will come from the parallel-run phase against \`agent_provision\` jobs alongside the legacy \`milady_provision\` flow.

## Context

Part of the on-prem provisioning-worker migration from \`0xSolace/milady-cloud\` (legacy 1316-line worker) to \`cloud/packages/lib/services/provisioning-jobs.ts\` + \`cloud/packages/scripts/provisioning-worker.ts\` in this repo. Audit identified this as one of six gaps — without these mounts, agent state is lost and users would notice the difference once the new worker replaces the legacy one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two new bind mounts (`/root/.milady` and `/root/.eliza`) to container creation so that PGLite state, exec-approval history, and runtime config written by the agent image are persisted across container recreations, bringing the new provisioning worker to parity with the legacy `milady_provision` flow.

- **`mkdir -p` expansion** (line 437–440): the single `mkdir -p` call is widened to also pre-create `${volumePath}/milady` and `${volumePath}/eliza` on the host before `docker create` runs; ordering is left-to-right so the parent directory is always guaranteed to exist first.
- **New `-v` flags** (lines 511–512): the two subdirectories are bind-mounted at `/root/.milady` and `/root/.eliza` using the same `shellQuote` pattern as the existing `/app/data` mount; because the host directories sit under `${volumePath}`, their contents are also reachable from `/app/data/milady` and `/app/data/eliza` within the container.

<h3>Confidence Score: 4/5</h3>

Safe to merge — additive only, no existing mounts or env vars are modified, and the change is isolated to container creation.

The change is small and well-scoped: two extra host directories are pre-created with `mkdir -p` and two matching bind mounts are added to `docker create`. Both follow the exact same `shellQuote` and volume-flag patterns already in production for `/app/data`. The only gap is the lack of automated tests for `DockerSandboxProvider.create()`, which the PR author acknowledges and defers to a parallel integration run — a risk that exists in the baseline code as well. No logic that affects running containers is touched.

No files require special attention; the single changed file makes a narrow, consistent addition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/docker-sandbox-provider.ts | Adds pre-creation of two host subdirectories (`milady`, `eliza`) via mkdir -p and maps them as bind mounts into the container at `/root/.milady` and `/root/.eliza`, following the same shellQuote/volume patterns as the existing `/app/data` mount. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as DockerSandboxProvider.create()
    participant SSH as SSH Client (remote host)
    participant Docker as Docker Daemon

    Caller->>SSH: mkdir -p volumePath volumePath/milady volumePath/eliza
    SSH-->>Caller: directories created

    Caller->>SSH: docker pull image
    SSH-->>Caller: image ready

    Caller->>SSH: docker create\n  -v volumePath:/app/data\n  -v volumePath/milady:/root/.milady (NEW)\n  -v volumePath/eliza:/root/.eliza   (NEW)\n  ...other flags...
    SSH->>Docker: create container with bind mounts
    Docker-->>SSH: container ID
    SSH-->>Caller: container ID

    Caller->>SSH: docker start container
    SSH->>Docker: start
    Docker-->>SSH: running
```

<sub>Reviews (1): Last reviewed commit: ["feat(docker-sandbox): persist /root/.mil..."](https://github.com/elizaos/eliza/commit/5ef4952ab7699a5ad93e76369611cdbe34cdf715) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31028560)</sub>

<!-- /greptile_comment -->