### PR TITLE
feat(docker-sandbox): write ~/.eliza/eliza.json with cloud config post-start

### DIFF
--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -521,6 +521,34 @@ export class DockerSandboxProvider implements SandboxProvider {
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
+
+      // Write ~/.eliza/eliza.json so the runtime sees cloud config even if
+      // it bypasses env vars. Best-effort: a failure here is logged but
+      // does not abort provisioning — the env vars on the container still
+      // carry the same values.
+      try {
+        const elizaConfig = JSON.stringify({
+          logging: { level: "info" },
+          cloud: {
+            enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
+            apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
+            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "https://www.elizacloud.ai/api/v1",
+          },
+        });
+        // Base64-encode the JSON before passing it through the shell so an
+        // apiKey/baseUrl containing single quotes can't break out of the
+        // outer sh -c quoting or inject commands on the remote host.
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
+        const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
+          `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
+        )}`;
+        await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
+        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
+      } catch (configErr) {
+        logger.warn(
+          `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
+        );
+      }
     } catch (err) {
       // Best-effort Steward deregistration — the agent was registered but the
       // container failed to start, so we try to clean up the Steward record.


### PR DESCRIPTION
Match the legacy on-prem worker by writing the cloud apiKey/baseUrl into /root/.eliza/eliza.json post-container-start. Best-effort, logged at warn on failure (env vars still carry the values). Part of provisioning-worker migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a post-start step in `DockerSandboxProvider._createOnce` that writes `/root/.eliza/eliza.json` inside the freshly started container, carrying the cloud `apiKey`, `baseUrl`, and `enabled` fields. The write is best-effort and failure is warn-logged without aborting provisioning.

- Cloud credentials (`ELIZAOS_CLOUD_API_KEY` / `ELIZAOS_CLOUD_BASE_URL`) are correctly sourced from `allEnv`, which already receives them via `prepareManagedElizaBaseEnvironment`. The previous shell-injection concern (single quotes in JSON) is properly mitigated by base64-encoding `elizaConfig` before it touches any shell layer.
- The inner `shellQuote(encodedConfig)` call inside the template string that's fed to the outer `shellQuote` is redundant — base64 output is `[A-Za-z0-9+/=]` and needs no quoting — but it doesn't cause a correctness issue.

<h3>Confidence Score: 4/5</h3>

Safe to merge; base64 encoding correctly neutralises shell-injection risk and cloud credentials flow through allEnv as expected.

The core logic is sound: base64 encodes the JSON before any shell layer sees it, shellQuote is applied at every boundary, and the write is best-effort so a failure cannot break provisioning. The only open question is whether writing logging.level: info unconditionally might override an operator's env-var-based log level.

cloud/packages/lib/services/docker-sandbox-provider.ts — specifically the hardcoded logging.level field in the eliza.json payload.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/docker-sandbox-provider.ts | Adds a best-effort `docker exec` step post-container-start that writes cloud config to `/root/.eliza/eliza.json` via a base64-encoded payload; shell injection is correctly mitigated, though the hardcoded `logging.level: "info"` may silently override per-container log level configuration. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as DockerSandboxProvider
    participant SSH as SSH (remote VPS)
    participant DC as Docker daemon
    participant C as Container (/root/.eliza)

    P->>SSH: docker create ... (with ELIZAOS_CLOUD_API_KEY env)
    SSH->>DC: docker create
    DC-->>SSH: containerId
    SSH-->>P: containerId

    P->>SSH: docker start containerName
    SSH->>DC: docker start
    DC-->>SSH: ok
    SSH-->>P: ok

    Note over P: Build elizaConfig JSON
    Note over P: Base64-encode to encodedConfig

    P->>SSH: docker exec containerName sh -c mkdir+printf+base64-d
    SSH->>C: write /root/.eliza/eliza.json
    alt write succeeds
        C-->>SSH: ok
        SSH-->>P: ok
        P->>P: logger.info(written)
    else write fails (best-effort)
        C-->>SSH: error
        SSH-->>P: error
        P->>P: logger.warn(failed)
    end

    P->>SSH: poll docker inspect health
    SSH-->>P: healthy
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/packages/lib/services/docker-sandbox-provider.ts`, line 539-541 ([link](https://github.com/elizaos/eliza/blob/e0512a27e3c0fe5eb32723f2312b1301c123f36a/cloud/packages/lib/services/docker-sandbox-provider.ts#L539-L541)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> The `elizaConfig` JSON is interpolated directly into a `sh -c '...'` single-quoted argument without any shell escaping. `validateEnvValue` only rejects control characters (newlines, etc.) — it does not reject single quotes — so an `ELIZAOS_CLOUD_API_KEY` or `ELIZAOS_CLOUD_BASE_URL` containing a `'` character will terminate the single-quoted `sh -c` argument early, producing a malformed or injection-susceptible remote shell command. The comment in `validateEnvValue` even notes "shell-safe once single-quoted", but the JSON is NOT single-quoted before it enters this heredoc.

   A safe alternative is to base64-encode `elizaConfig` and decode it inside the container, since base64 output is `[A-Za-z0-9+/=]` and is shell-safe in any quoting context.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(docker-sandbox): write ~/.eliza/eli..."](https://github.com/elizaos/eliza/commit/a48472abb80c234e0909e28b1fea5673e424f559) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31028786)</sub>

<!-- /greptile_comment -->