### PR TITLE
fix(steward): mint agent tokens with explicit 365d expiry

### DIFF
--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -230,7 +230,7 @@ if status not in (200, 201, 202, 400, 409):
     raise SystemExit(f"Steward agent registration failed with status {status}")
 # 400/409 = agent already exists, continue to token minting
 
-status, body = post(f"/agents/{agent_id}/token", {"name": tenant_id})
+status, body = post(f"/agents/{agent_id}/token", {"expiresIn": "365d"})
 if status not in (200, 201):
     print(body, file=sys.stderr)
     raise SystemExit(f"Steward token mint failed with status {status}")


### PR DESCRIPTION
Steward's token endpoint reads expiresIn from the body. The new code was sending {name: tenantId} (a field Steward ignores), so the endpoint fell back to AGENT_TOKEN_EXPIRY=30d. The legacy on-prem worker explicitly passed expiresIn=365d. Match that contract — newly provisioned agents would otherwise lose Steward auth after 30 days. Verified against /opt/steward/packages/api/src/routes/agents.ts (line 91) and services/context.ts (line 48). Part of provisioning-worker migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a one-line bug in the embedded Python script that calls the Steward token-mint endpoint. The old code sent `{"name": tenant_id}`, a field Steward ignores, causing the endpoint to fall back to its 30-day default expiry. The fix sends `{"expiresIn": "365d"}`, matching the legacy on-prem worker contract and restoring the intended 365-day token lifetime for newly provisioned agents.

- Replaces the ignored `{"name": tenant_id}` payload with `{"expiresIn": "365d"}` in the POST to `/agents/{agent_id}/token` (line 233).
- No other logic is changed; all existing error handling, retry paths, and token extraction remain intact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-justified bug fix with no side effects on surrounding logic.

The diff is a single-line substitution in an embedded Python script, correcting the request body sent to the Steward token endpoint. The old field (name) was documented as ignored by Steward, so dropping it carries no risk. The replacement value (expiresIn: 365d) matches the legacy on-prem worker contract described in the PR. All existing error handling, token extraction, and retry paths are untouched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/docker-sandbox-provider.ts | Single-line fix in the embedded Python script: replaces the ignored {"name": tenant_id} payload with the correct {"expiresIn": "365d"} body, aligning the token mint call with the Steward API contract and restoring 365-day token lifetime. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TS as DockerSandboxProvider (TS)
    participant SSH as DockerSSHClient (SSH)
    participant PY as Python script (remote)
    participant ST as Steward API

    TS->>SSH: exec(registerAgentWithSteward script)
    SSH->>PY: run embedded Python
    PY->>ST: POST /agents {id, name}
    ST-->>PY: 200/201/400/409
    Note over PY,ST: 400/409 = already exists, continue

    PY->>ST: POST /agents/{agent_id}/token {"expiresIn": "365d"} FIXED
    ST-->>PY: 200/201 {token: ...}
    PY-->>SSH: print(body)
    SSH-->>TS: rawToken string
    TS->>TS: extractStewardToken(rawToken)
    Note over TS: Token valid for 365 days (was 30d default)
```

<sub>Reviews (1): Last reviewed commit: ["fix(steward): mint agent tokens with exp..."](https://github.com/elizaos/eliza/commit/62d6486989e29403371d0d69e00991ad44eec989) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31032774)</sub>

<!-- /greptile_comment -->