### PR TITLE
[codex] fix openrouter provider switching

### DIFF
--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -109,6 +109,7 @@ const SUPPORTED_PROVIDER_IDS = [
   "openai-codex",
   "anthropic-api",
   "openai-api",
+  "openrouter-api",
   "deepseek-api",
   "zai-api",
   "moonshot-api",
@@ -117,6 +118,7 @@ const SUPPORTED_PROVIDER_IDS = [
 const DIRECT_PROVIDER_IDS = new Set<LinkedAccountProviderId>([
   "anthropic-api",
   "openai-api",
+  "openrouter-api",
   "deepseek-api",
   "zai-api",
   "moonshot-api",
@@ -385,6 +387,11 @@ function directProviderBaseUrl(providerId: DirectAccountProvider): string {
       );
     case "openai-api":
       return process.env.OPENAI_BASE_URL?.trim() || "https://api.openai.com/v1";
+    case "openrouter-api":
+      return (
+        process.env.OPENROUTER_BASE_URL?.trim() ||
+        "https://openrouter.ai/api/v1"
+      );
     case "deepseek-api":
       return (
         process.env.DEEPSEEK_BASE_URL?.trim() || "https://api.deepseek.com"

--- a/packages/agent/src/api/model-provider-helpers.test.ts
+++ b/packages/agent/src/api/model-provider-helpers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchOpenRouterModels,
+  paramKeyToCategory,
+} from "./model-provider-helpers.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("OpenRouter model discovery", () => {
+  it("buckets text, free, embeddings, vision, and image generation from the models endpoint", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url !== "https://openrouter.ai/api/v1/models?output_modalities=all") {
+        return new Response("not found", { status: 404 });
+      }
+      return Response.json({
+        data: [
+          {
+            id: "openai/gpt-5.5",
+            name: "GPT-5.5",
+            architecture: {
+              input_modalities: ["text"],
+              output_modalities: ["text"],
+              modality: "text->text",
+            },
+          },
+          {
+            id: "meta-llama/llama-3.3-70b-instruct:free",
+            name: "Llama 3.3 70B Free",
+            architecture: {
+              input_modalities: ["text"],
+              output_modalities: ["text"],
+              modality: "text->text",
+            },
+          },
+          {
+            id: "openai/text-embedding-3-small",
+            name: "Text Embedding 3 Small",
+            architecture: {
+              input_modalities: ["text"],
+              output_modalities: ["embeddings"],
+              modality: "text->embeddings",
+            },
+          },
+          {
+            id: "openai/gpt-4o",
+            name: "GPT-4o",
+            architecture: {
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+              modality: "text+image->text",
+            },
+          },
+          {
+            id: "google/gemini-2.5-flash-image-preview",
+            name: "Gemini 2.5 Flash Image",
+            architecture: {
+              input_modalities: ["text"],
+              output_modalities: ["text", "image"],
+              modality: "text->image",
+            },
+          },
+        ],
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const models = await fetchOpenRouterModels("sk-or-test");
+    const byIdAndCategory = new Set(
+      models.map((model) => `${model.id}:${model.category}`),
+    );
+
+    expect(byIdAndCategory).toContain("openai/gpt-5.5:chat");
+    expect(byIdAndCategory).toContain(
+      "meta-llama/llama-3.3-70b-instruct:free:free",
+    );
+    expect(byIdAndCategory).toContain(
+      "openai/text-embedding-3-small:embedding",
+    );
+    expect(byIdAndCategory).toContain("openai/gpt-4o:chat");
+    expect(byIdAndCategory).toContain("openai/gpt-4o:vision");
+    expect(byIdAndCategory).toContain(
+      "google/gemini-2.5-flash-image-preview:imageGeneration",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps image model fields to vision and generation buckets separately", () => {
+    expect(paramKeyToCategory("OPENROUTER_IMAGE_MODEL")).toBe("vision");
+    expect(paramKeyToCategory("OPENROUTER_IMAGE_GENERATION_MODEL")).toBe(
+      "imageGeneration",
+    );
+    expect(paramKeyToCategory("AI_GATEWAY_IMAGE_MODEL")).toBe(
+      "imageGeneration",
+    );
+    expect(paramKeyToCategory("OPENROUTER_EMBEDDING_MODEL")).toBe("embedding");
+    expect(paramKeyToCategory("OPENROUTER_SMALL_MODEL")).toBe("chat");
+  });
+});

--- a/packages/agent/src/api/model-provider-helpers.ts
+++ b/packages/agent/src/api/model-provider-helpers.ts
@@ -193,8 +193,11 @@ export function getModelOptions(): {
 
 export type ModelCategory =
   | "chat"
+  | "free"
   | "embedding"
   | "image"
+  | "vision"
+  | "imageGeneration"
   | "tts"
   | "stt"
   | "other";
@@ -214,7 +217,9 @@ export interface ProviderCache {
 
 export function classifyModel(modelId: string): ModelCategory {
   const id = modelId.toLowerCase();
+  if (id.endsWith(":free")) return "free";
   if (id.includes("embed") || id.includes("text-embedding")) return "embedding";
+  if (id.includes("vision")) return "vision";
   if (
     id.includes("dall-e") ||
     id.includes("dalle") ||
@@ -223,7 +228,7 @@ export function classifyModel(modelId: string): ModelCategory {
     id.includes("midjourney") ||
     id.includes("flux")
   )
-    return "image";
+    return "imageGeneration";
   if (
     id.includes("tts") ||
     id.includes("text-to-speech") ||
@@ -245,7 +250,13 @@ export function classifyModel(modelId: string): ModelCategory {
 export function paramKeyToCategory(paramKey: string): ModelCategory {
   const k = paramKey.toUpperCase();
   if (k.includes("EMBEDDING")) return "embedding";
-  if (k.includes("IMAGE")) return "image";
+  if (
+    k.includes("IMAGE_GENERATION") ||
+    k === "AI_GATEWAY_IMAGE_MODEL" ||
+    k === "OPENAI_IMAGE_MODEL"
+  )
+    return "imageGeneration";
+  if (k.includes("IMAGE") || k.includes("VISION")) return "vision";
   if (k.includes("TTS")) return "tts";
   if (k.includes("STT") || k.includes("TRANSCRIPTION")) return "stt";
   return "chat";
@@ -359,7 +370,8 @@ export async function fetchModelsREST(
 export function restTypeToCategory(type: string): ModelCategory {
   const t = type.toLowerCase();
   if (t.includes("embed")) return "embedding";
-  if (t === "image" || t.includes("image-generation")) return "image";
+  if (t.includes("vision")) return "vision";
+  if (t === "image" || t.includes("image-generation")) return "imageGeneration";
   if (t.includes("tts") || t.includes("speech")) return "tts";
   if (t.includes("stt") || t.includes("transcription") || t.includes("whisper"))
     return "stt";
@@ -449,7 +461,6 @@ export async function fetchOllamaModels(
   }
 }
 
-/** Fetch ALL OpenRouter models: chat (/api/v1/models) + embeddings (/api/v1/embeddings/models). */
 export async function fetchOpenRouterModels(
   apiKey: string,
 ): Promise<CachedModel[]> {
@@ -459,59 +470,107 @@ export async function fetchOpenRouterModels(
   interface ORModel {
     id: string;
     name?: string;
-    architecture?: { modality?: string; output_modalities?: string[] };
+    architecture?: {
+      modality?: string;
+      input_modalities?: string[];
+      output_modalities?: string[];
+    };
+    pricing?: Record<string, string | number | null | undefined>;
   }
 
-  // Fetch chat/text models and embedding models in parallel
-  const [chatRes, embedRes] = await Promise.all([
-    fetch("https://openrouter.ai/api/v1/models?output_modalities=all", {
-      headers,
-    }).catch(() => null),
-    fetch("https://openrouter.ai/api/v1/embeddings/models", { headers }).catch(
-      () => null,
-    ),
-  ]);
+  let response: Response | null = null;
+  try {
+    response = await fetch(
+      "https://openrouter.ai/api/v1/models?output_modalities=all",
+      { headers },
+    );
+  } catch (e: unknown) {
+    logger.warn(
+      `[model-catalog] Failed to fetch OpenRouter models: ${e instanceof Error ? e.message : e}`,
+    );
+    return [];
+  }
 
   const models: CachedModel[] = [];
 
-  // Parse chat/text/image models
-  if (chatRes?.ok) {
+  if (response?.ok) {
     try {
-      const data = (await chatRes.json()) as { data?: ORModel[] };
+      const data = (await response.json()) as { data?: ORModel[] };
       for (const m of data.data ?? []) {
+        const inputs = (m.architecture?.input_modalities ?? []).map((value) =>
+          value.toLowerCase(),
+        );
         const outputs = (m.architecture?.output_modalities ?? []).map((value) =>
           value.toLowerCase(),
         );
         const modality = m.architecture?.modality?.toLowerCase() ?? "";
-        let category: ModelCategory = "chat";
-        if (outputs.includes("text") || modality.includes("text->text")) {
-          category = "chat";
-        } else if (outputs.includes("image")) category = "image";
-        else if (outputs.includes("audio")) category = "tts";
-        models.push({ id: m.id, name: m.name ?? m.id, category });
-      }
-    } catch {
-      /* parse error */
-    }
-  }
+        const isFree = isOpenRouterFreeModel(m);
+        const categories = new Set<ModelCategory>();
+        const hasTextOutput =
+          outputs.includes("text") || modality.includes("->text");
+        const hasImageInput =
+          inputs.includes("image") ||
+          modality.includes("image->") ||
+          modality.includes("+image");
 
-  // Parse embedding models
-  if (embedRes?.ok) {
-    try {
-      const data = (await embedRes.json()) as { data?: ORModel[] };
-      for (const m of data.data ?? []) {
-        models.push({ id: m.id, name: m.name ?? m.id, category: "embedding" });
+        if (outputs.includes("embeddings") || modality.includes("embedding")) {
+          categories.add("embedding");
+        }
+        if (hasImageInput && hasTextOutput) {
+          categories.add("vision");
+        }
+        if (outputs.includes("image") || modality.includes("->image")) {
+          categories.add("imageGeneration");
+        }
+        if (hasTextOutput && !outputs.includes("image")) {
+          categories.add(isFree ? "free" : "chat");
+        }
+        if (outputs.includes("audio")) {
+          categories.add("tts");
+        }
+        if (categories.size === 0) {
+          categories.add(classifyModel(m.id));
+        }
+
+        for (const category of categories) {
+          models.push({ id: m.id, name: m.name ?? m.id, category });
+        }
       }
-    } catch {
-      /* parse error */
+    } catch (e: unknown) {
+      logger.warn(
+        `[model-catalog] Failed to parse OpenRouter models: ${e instanceof Error ? e.message : e}`,
+      );
     }
   }
 
   const deduped = Array.from(
-    new Map(models.map((model) => [model.id, model])).values(),
+    new Map(
+      models.map((model) => [`${model.id}:${model.category}`, model]),
+    ).values(),
   );
   deduped.sort((a, b) => a.id.localeCompare(b.id));
   return deduped;
+}
+
+function isOpenRouterFreeModel(model: {
+  id: string;
+  name?: string;
+  pricing?: Record<string, string | number | null | undefined>;
+}): boolean {
+  if (model.id.toLowerCase().endsWith(":free")) return true;
+  if (model.name?.toLowerCase().includes("free")) return true;
+  const pricedFields = ["prompt", "completion", "request", "image"];
+  const values = pricedFields
+    .map((field) => model.pricing?.[field])
+    .filter((value) => value != null);
+  return (
+    values.length > 0 &&
+    values.every((value) => {
+      const numberValue =
+        typeof value === "number" ? value : Number.parseFloat(String(value));
+      return Number.isFinite(numberValue) && numberValue === 0;
+    })
+  );
 }
 
 /** Fetch Vercel AI Gateway models — no auth required, response has `type` field. */

--- a/packages/agent/src/api/plugin-routes.ts
+++ b/packages/agent/src/api/plugin-routes.ts
@@ -532,7 +532,9 @@ export async function handlePluginRoutes(
 
         const expectedCat = paramKeyToCategory(param.key);
         const filtered = providerModels.filter(
-          (m) => m.category === expectedCat,
+          (m) =>
+            m.category === expectedCat ||
+            (expectedCat === "chat" && m.category === "free"),
         );
 
         if (!plugin.configUiHints) plugin.configUiHints = {};
@@ -541,7 +543,10 @@ export async function handlePluginRoutes(
           type: "select",
           options: filtered.map((m) => ({
             value: m.id,
-            label: m.name !== m.id ? `${m.name} (${m.id})` : m.id,
+            label:
+              m.name !== m.id
+                ? `${m.name}${m.category === "free" ? " (free)" : ""} (${m.id})`
+                : `${m.id}${m.category === "free" ? " (free)" : ""}`,
           })),
         };
       }

--- a/packages/agent/src/auth/types.ts
+++ b/packages/agent/src/auth/types.ts
@@ -13,6 +13,7 @@ export type SubscriptionProvider = "anthropic-subscription" | "openai-codex";
 export type DirectAccountProvider =
   | "anthropic-api"
   | "openai-api"
+  | "openrouter-api"
   | "deepseek-api"
   | "zai-api"
   | "moonshot-api";
@@ -29,6 +30,7 @@ export const SUBSCRIPTION_PROVIDER_IDS = [
 export const DIRECT_ACCOUNT_PROVIDER_IDS = [
   "anthropic-api",
   "openai-api",
+  "openrouter-api",
   "deepseek-api",
   "zai-api",
   "moonshot-api",
@@ -59,6 +61,7 @@ export const DIRECT_ACCOUNT_PROVIDER_ENV: Record<
 > = {
   "anthropic-api": "ANTHROPIC_API_KEY",
   "openai-api": "OPENAI_API_KEY",
+  "openrouter-api": "OPENROUTER_API_KEY",
   "deepseek-api": "DEEPSEEK_API_KEY",
   "zai-api": "ZAI_API_KEY",
   "moonshot-api": "MOONSHOT_API_KEY",

--- a/packages/app-core/src/api/client-types-core.ts
+++ b/packages/app-core/src/api/client-types-core.ts
@@ -120,8 +120,11 @@ export type AgentAutomationMode = "connectors-only" | "full";
 
 export type ProviderModelCategory =
   | "chat"
+  | "free"
   | "embedding"
   | "image"
+  | "vision"
+  | "imageGeneration"
   | "tts"
   | "stt"
   | "other";

--- a/packages/app-core/src/api/credential-resolver.ts
+++ b/packages/app-core/src/api/credential-resolver.ts
@@ -199,6 +199,8 @@ const DIRECT_ACCOUNT_PROVIDER_BY_REQUEST: Readonly<
   "anthropic-api": "anthropic-api",
   openai: "openai-api",
   "openai-api": "openai-api",
+  openrouter: "openrouter-api",
+  "openrouter-api": "openrouter-api",
   deepseek: "deepseek-api",
   "deepseek-api": "deepseek-api",
   zai: "zai-api",

--- a/packages/app-core/src/components/accounts/AddAccountDialog.tsx
+++ b/packages/app-core/src/components/accounts/AddAccountDialog.tsx
@@ -99,6 +99,10 @@ function providerDisplayName(
       return t("accounts.provider.openaiApi", {
         defaultValue: "OpenAI API",
       });
+    case "openrouter-api":
+      return t("accounts.provider.openrouterApi", {
+        defaultValue: "OpenRouter API",
+      });
     case "deepseek-api":
       return t("accounts.provider.deepseekApi", {
         defaultValue: "DeepSeek API",

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -116,6 +116,7 @@ const DIRECT_PROVIDER_BY_BACKEND: Readonly<
 > = {
   anthropic: "anthropic-api",
   openai: "openai-api",
+  openrouter: "openrouter-api",
   deepseek: "deepseek-api",
   zai: "zai-api",
   moonshot: "moonshot-api",
@@ -124,6 +125,7 @@ const DIRECT_PROVIDER_BY_BACKEND: Readonly<
 const OPENAI_COMPAT_BASE_BY_DIRECT_PROVIDER: Readonly<
   Partial<Record<DirectAccountProvider, string>>
 > = {
+  "openrouter-api": "https://openrouter.ai/api/v1",
   "moonshot-api": "https://api.moonshot.ai/v1",
 };
 
@@ -455,6 +457,7 @@ function isPoolProviderId(value: string): value is PoolProviderId {
     value === "openai-codex" ||
     value === "anthropic-api" ||
     value === "openai-api" ||
+    value === "openrouter-api" ||
     value === "deepseek-api" ||
     value === "zai-api" ||
     value === "moonshot-api"

--- a/packages/app-core/src/services/local-inference/providers.ts
+++ b/packages/app-core/src/services/local-inference/providers.ts
@@ -31,6 +31,7 @@ export type ProviderId =
   | "openai-codex"
   | "anthropic"
   | "openai"
+  | "openrouter"
   | "deepseek"
   | "zai"
   | "moonshot"
@@ -269,6 +270,18 @@ const OPENAI_CODEX_PROVIDER: ProviderDefinition = {
   configureHref: "#ai-model",
 };
 
+const OPENROUTER_PROVIDER: ProviderDefinition = {
+  id: "openrouter",
+  label: "OpenRouter API",
+  kind: "cloud-api",
+  description: "OpenRouter models via API key or linked account pool.",
+  supportedSlots: ["TEXT_SMALL", "TEXT_LARGE", "OBJECT_SMALL", "OBJECT_LARGE"],
+  async getEnableState(): Promise<ProviderEnableState> {
+    return apiKeyOrLinkedAccountState("openrouter-api", ["OPENROUTER_API_KEY"]);
+  },
+  configureHref: "#ai-model",
+};
+
 const GOOGLE_PROVIDER: ProviderDefinition = {
   id: "google",
   label: "Google (Gemini)",
@@ -351,6 +364,7 @@ export const BUILT_IN_PROVIDERS: readonly ProviderDefinition[] = [
   ELIZACLOUD_PROVIDER,
   ANTHROPIC_PROVIDER,
   OPENAI_PROVIDER,
+  OPENROUTER_PROVIDER,
   DEEPSEEK_PROVIDER,
   ZAI_PROVIDER,
   MOONSHOT_PROVIDER,
@@ -360,7 +374,7 @@ export const BUILT_IN_PROVIDERS: readonly ProviderDefinition[] = [
 ];
 
 function apiKeyOrLinkedAccountState(
-  providerId: "deepseek-api" | "zai-api" | "moonshot-api",
+  providerId: "openrouter-api" | "deepseek-api" | "zai-api" | "moonshot-api",
   envKeys: readonly string[],
 ): ProviderEnableState {
   const hasEnv = envKeys.some((key) => process.env[key]?.trim());

--- a/packages/shared/src/contracts/onboarding.ts
+++ b/packages/shared/src/contracts/onboarding.ts
@@ -403,6 +403,7 @@ export const ONBOARDING_PROVIDER_CATALOG = [
 export const DIRECT_ACCOUNT_PROVIDER_BY_ONBOARDING_PROVIDER = {
   anthropic: "anthropic-api",
   openai: "openai-api",
+  openrouter: "openrouter-api",
   deepseek: "deepseek-api",
   zai: "zai-api",
   moonshot: "moonshot-api",

--- a/packages/shared/src/contracts/service-routing.ts
+++ b/packages/shared/src/contracts/service-routing.ts
@@ -37,6 +37,7 @@ export type LinkedAccountProviderId =
   | "openai-codex"
   | "anthropic-api"
   | "openai-api"
+  | "openrouter-api"
   | "deepseek-api"
   | "zai-api"
   | "moonshot-api";
@@ -387,6 +388,7 @@ export function isLinkedAccountProviderId(
     value === "openai-codex" ||
     value === "anthropic-api" ||
     value === "openai-api" ||
+    value === "openrouter-api" ||
     value === "deepseek-api" ||
     value === "zai-api" ||
     value === "moonshot-api"


### PR DESCRIPTION
## Summary
- Add OpenRouter as a first-class direct/linked provider across shared contracts, agent account APIs, credential resolution, app account pool, local inference providers, and settings account UI.
- Update OpenRouter catalog discovery to use `/api/v1/models?output_modalities=all` and bucket chat, free, embedding, vision, image generation, and TTS models from OpenRouter modality metadata.
- Surface free OpenRouter text models in plugin model selectors and label them clearly.

## Validation
- `bunx @biomejs/biome check packages/agent/src/api/accounts-routes.ts packages/agent/src/api/model-provider-helpers.test.ts packages/agent/src/api/model-provider-helpers.ts packages/agent/src/api/plugin-routes.ts packages/agent/src/auth/types.ts packages/app-core/src/api/client-types-core.ts packages/app-core/src/api/credential-resolver.ts packages/app-core/src/components/accounts/AddAccountDialog.tsx packages/app-core/src/services/account-pool.ts packages/app-core/src/services/local-inference/providers.ts packages/shared/src/contracts/onboarding.ts packages/shared/src/contracts/service-routing.ts`
- `bun run --cwd packages/agent test src/api/model-provider-helpers.test.ts`
- `git diff --check -- <touched files> && git diff --check --cached`

Typechecks were attempted and are blocked by the existing missing module resolution for `@elizaos/plugin-pdf` in `packages/agent/src/runtime/eliza.ts`:
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/app-core typecheck`

Unrelated pre-existing unstaged local edits were left out of this branch.
