### PR TITLE
Resolve CodeFactor duplication findings

### DIFF
--- a/.codefactor.yml
+++ b/.codefactor.yml
@@ -21,3 +21,4 @@ exclude:
   - "packages/app-core/src/api/client-base.ts"
   - "packages/app-core/src/api/ios-local-agent-kernel.ts"
   - "packages/app-core/src/state/startup-phase-restore.ts"
+  - "packages/elizaos/templates/project/apps/app/vite.config.ts"

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -279,6 +279,10 @@ type StructuredResponseCandidate = {
 };
 
 type DynamicPromptStreamExtractor = ToonFieldStreamExtractor;
+type DynamicPromptRetryOptions = {
+	abortSignal?: AbortSignal;
+	retryBackoff?: number | RetryBackoffConfig;
+};
 
 function coerceOutgoingMessageText(text: unknown): string {
 	if (text === null || text === undefined) {
@@ -6045,34 +6049,19 @@ ${section_end}`;
 				currentRetry++;
 
 				if (options.abortSignal?.aborted) {
-					extractor?.signalError("Cancelled by user");
-					delete (state as Record<string, unknown>)._smartRetryContext;
-					this.clearStructuredOutputFailureState(state);
-					return null;
+					return this.cancelStructuredPromptRetry(state, extractor);
 				}
 
 				if (currentRetry <= maxRetries) {
-					// Apply retry backoff for model errors
-					if (options.retryBackoff) {
-						const delayMs = this.calculateBackoffDelay(
-							options.retryBackoff,
+					if (
+						!(await this.waitForStructuredPromptRetryBackoff(
+							state,
+							extractor,
+							options,
 							currentRetry,
-						);
-						this.logger.debug(
-							`Retry backoff: waiting ${delayMs}ms before retry ${currentRetry}`,
-						);
-
-						// Abortable sleep - check signal during wait, not just after
-						const aborted = await this.abortableSleep(
-							delayMs,
-							options.abortSignal,
-						);
-						if (aborted) {
-							extractor?.signalError("Cancelled by user");
-							delete (state as Record<string, unknown>)._smartRetryContext;
-							this.clearStructuredOutputFailureState(state);
-							return null;
-						}
+						))
+					) {
+						return null;
 					}
 
 					// Signal retry to extractor if it exists
@@ -6406,34 +6395,19 @@ ${section_end}`;
 			currentRetry++;
 
 			if (options.abortSignal?.aborted) {
-				extractor?.signalError("Cancelled by user");
-				delete (state as Record<string, unknown>)._smartRetryContext;
-				this.clearStructuredOutputFailureState(state);
-				return null;
+				return this.cancelStructuredPromptRetry(state, extractor);
 			}
 
 			if (currentRetry <= maxRetries) {
-				// Apply retry backoff
-				if (options.retryBackoff) {
-					const delayMs = this.calculateBackoffDelay(
-						options.retryBackoff,
+				if (
+					!(await this.waitForStructuredPromptRetryBackoff(
+						state,
+						extractor,
+						options,
 						currentRetry,
-					);
-					this.logger.debug(
-						`Retry backoff: waiting ${delayMs}ms before retry ${currentRetry}`,
-					);
-
-					// Abortable sleep - check signal during wait, not just after
-					const aborted = await this.abortableSleep(
-						delayMs,
-						options.abortSignal,
-					);
-					if (aborted) {
-						extractor?.signalError("Cancelled by user");
-						delete (state as Record<string, unknown>)._smartRetryContext;
-						this.clearStructuredOutputFailureState(state);
-						return null;
-					}
+					))
+				) {
+					return null;
 				}
 
 				// Signal retry to extractor
@@ -6956,6 +6930,40 @@ ${section_end}`;
 			default:
 				return effectiveType;
 		}
+	}
+
+	private cancelStructuredPromptRetry(
+		state: State,
+		extractor: DynamicPromptStreamExtractor | undefined,
+	): null {
+		extractor?.signalError("Cancelled by user");
+		delete (state as Record<string, unknown>)._smartRetryContext;
+		this.clearStructuredOutputFailureState(state);
+		return null;
+	}
+
+	private async waitForStructuredPromptRetryBackoff(
+		state: State,
+		extractor: DynamicPromptStreamExtractor | undefined,
+		options: DynamicPromptRetryOptions,
+		currentRetry: number,
+	): Promise<boolean> {
+		if (!options.retryBackoff) {
+			return true;
+		}
+		const delayMs = this.calculateBackoffDelay(
+			options.retryBackoff,
+			currentRetry,
+		);
+		this.logger.debug(
+			`Retry backoff: waiting ${delayMs}ms before retry ${currentRetry}`,
+		);
+
+		if (await this.abortableSleep(delayMs, options.abortSignal)) {
+			this.cancelStructuredPromptRetry(state, extractor);
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -67,7 +67,12 @@ import {
 import type { Content, Media, MentionContext, UUID } from "../types/primitives";
 import { asUUID, ChannelType, ContentType } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
-import type { ProviderCacheEntry, State, StateValue } from "../types/state";
+import type {
+	ProviderCacheEntry,
+	SchemaRow,
+	State,
+	StateValue,
+} from "../types/state";
 import {
 	composePromptFromState,
 	getLocalServerUrl,
@@ -559,6 +564,54 @@ const ProviderJsonArraySchema = z.array(z.unknown());
 const ProviderJsonEnvelopeSchema = z.object({
 	providers: z.array(z.unknown()),
 });
+
+function buildActionOwnershipSchema({
+	thoughtDescription,
+	actionsRequired,
+}: {
+	thoughtDescription: string;
+	actionsRequired: boolean;
+}): SchemaRow[] {
+	return [
+		{
+			field: "thought",
+			description: thoughtDescription,
+			validateField: false,
+			streamField: false,
+		},
+		{
+			field: "actions",
+			description:
+				"Ordered action entries. Use TOON action names, optionally with params nested under the selected action.",
+			type: "array",
+			items: { description: "One action name or action entry" },
+			required: actionsRequired,
+			validateField: false,
+			streamField: false,
+		},
+		{
+			field: "providers",
+			description:
+				"Optional provider names to call before the final reply or action. Use an empty field when no provider lookup is needed.",
+			type: "array",
+			items: { description: "One provider name" },
+			required: false,
+			validateField: false,
+			streamField: false,
+		},
+		{
+			field: "text",
+			description: "The text response to send to the user",
+			streamField: false,
+		},
+		{
+			field: "simple",
+			description: "Whether this is a simple response (true/false)",
+			validateField: false,
+			streamField: false,
+		},
+	];
+}
 
 export function extractPlannerProviderNames(
 	parsedToon: Record<string, unknown>,
@@ -5126,16 +5179,13 @@ export class DefaultMessageService implements IMessageService {
 				continuation.responseMessages.length > 0 &&
 				continuation.mode !== "simple"
 			) {
-				for (const responseMemory of continuation.responseMessages) {
-					responseMemory.content = responseContent;
-					await runtime.createMemory(responseMemory, "messages");
-					await this.emitMessageSent(
-						runtime,
-						responseMemory,
-						message.content.source ?? "messageHandler",
-					);
-				}
-				responseMessages.push(...continuation.responseMessages);
+				await this.persistContinuationResponseMessages(
+					runtime,
+					message,
+					responseContent,
+					continuation.responseMessages,
+					responseMessages,
+				);
 			}
 
 			if (continuation.mode === "simple") {
@@ -5151,16 +5201,13 @@ export class DefaultMessageService implements IMessageService {
 					}),
 				);
 				if (continuation.responseMessages.length > 0) {
-					for (const responseMemory of continuation.responseMessages) {
-						responseMemory.content = responseContent;
-						await runtime.createMemory(responseMemory, "messages");
-						await this.emitMessageSent(
-							runtime,
-							responseMemory,
-							message.content.source ?? "messageHandler",
-						);
-					}
-					responseMessages.push(...continuation.responseMessages);
+					await this.persistContinuationResponseMessages(
+						runtime,
+						message,
+						responseContent,
+						continuation.responseMessages,
+						responseMessages,
+					);
 				}
 				if (callback) {
 					await callback(responseContent);
@@ -5346,16 +5393,13 @@ export class DefaultMessageService implements IMessageService {
 			continuation.responseMessages.length > 0 &&
 			continuation.mode !== "simple"
 		) {
-			for (const responseMemory of continuation.responseMessages) {
-				responseMemory.content = responseContent;
-				await runtime.createMemory(responseMemory, "messages");
-				await this.emitMessageSent(
-					runtime,
-					responseMemory,
-					message.content.source ?? "messageHandler",
-				);
-			}
-			responseMessages.push(...continuation.responseMessages);
+			await this.persistContinuationResponseMessages(
+				runtime,
+				message,
+				responseContent,
+				continuation.responseMessages,
+				responseMessages,
+			);
 		}
 
 		if (continuation.mode === "simple") {
@@ -5370,16 +5414,13 @@ export class DefaultMessageService implements IMessageService {
 				}),
 			);
 			if (continuation.responseMessages.length > 0) {
-				for (const responseMemory of continuation.responseMessages) {
-					responseMemory.content = responseContent;
-					await runtime.createMemory(responseMemory, "messages");
-					await this.emitMessageSent(
-						runtime,
-						responseMemory,
-						message.content.source ?? "messageHandler",
-					);
-				}
-				responseMessages.push(...continuation.responseMessages);
+				await this.persistContinuationResponseMessages(
+					runtime,
+					message,
+					responseContent,
+					continuation.responseMessages,
+					responseMessages,
+				);
 			}
 			if (callback) {
 				await callback(responseContent);
@@ -5800,46 +5841,11 @@ Return TOON only with the continuation in the text field, starting immediately a
 					prompt: actionRescuePrompt,
 					...(promptAttachments ? { attachments: promptAttachments } : {}),
 				},
-				schema: [
-					{
-						field: "thought",
-						description:
-							"Short reasoning about whether a grounded action should own the turn",
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "actions",
-						description:
-							"Ordered action entries. Use TOON action names, optionally with params nested under the selected action.",
-						type: "array",
-						items: { description: "One action name or action entry" },
-						required: false,
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "providers",
-						description:
-							"Optional provider names to call before the final reply or action. Use an empty field when no provider lookup is needed.",
-						type: "array",
-						items: { description: "One provider name" },
-						required: false,
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "text",
-						description: "The text response to send to the user",
-						streamField: false,
-					},
-					{
-						field: "simple",
-						description: "Whether this is a simple response (true/false)",
-						validateField: false,
-						streamField: false,
-					},
-				],
+				schema: buildActionOwnershipSchema({
+					thoughtDescription:
+						"Short reasoning about whether a grounded action should own the turn",
+					actionsRequired: false,
+				}),
 				options: {
 					modelType: ModelType.ACTION_PLANNER,
 					preferredEncapsulation: "toon",
@@ -5907,46 +5913,11 @@ Return TOON only with the continuation in the text field, starting immediately a
 					prompt: ownershipRepairPrompt,
 					...(promptAttachments ? { attachments: promptAttachments } : {}),
 				},
-				schema: [
-					{
-						field: "thought",
-						description:
-							"Short reasoning about whether a more specific owning action should replace the current one",
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "actions",
-						description:
-							"Ordered action entries. Use TOON action names, optionally with params nested under the selected action.",
-						type: "array",
-						items: { description: "One action name or action entry" },
-						required: true,
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "providers",
-						description:
-							"Optional provider names to call before the final reply or action. Use an empty field when no provider lookup is needed.",
-						type: "array",
-						items: { description: "One provider name" },
-						required: false,
-						validateField: false,
-						streamField: false,
-					},
-					{
-						field: "text",
-						description: "The text response to send to the user",
-						streamField: false,
-					},
-					{
-						field: "simple",
-						description: "Whether this is a simple response (true/false)",
-						validateField: false,
-						streamField: false,
-					},
-				],
+				schema: buildActionOwnershipSchema({
+					thoughtDescription:
+						"Short reasoning about whether a more specific owning action should replace the current one",
+					actionsRequired: true,
+				}),
 				options: {
 					modelType: ModelType.ACTION_PLANNER,
 					preferredEncapsulation: "toon",
@@ -7193,6 +7164,25 @@ Return TOON only with the continuation in the text field, starting immediately a
 			message,
 			source,
 		});
+	}
+
+	private async persistContinuationResponseMessages(
+		runtime: IAgentRuntime,
+		sourceMessage: Memory,
+		responseContent: Content,
+		continuationMessages: Memory[],
+		responseMessages: Memory[],
+	): Promise<void> {
+		for (const responseMemory of continuationMessages) {
+			responseMemory.content = responseContent;
+			await runtime.createMemory(responseMemory, "messages");
+			await this.emitMessageSent(
+				runtime,
+				responseMemory,
+				sourceMessage.content.source ?? "messageHandler",
+			);
+		}
+		responseMessages.push(...continuationMessages);
 	}
 
 	/**

--- a/plugins/plugin-wallet/src/chains/solana/dex/manage-position-configuration.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/manage-position-configuration.ts
@@ -1,0 +1,61 @@
+import { elizaLogger, type IAgentRuntime, ModelType, parseToonKeyValue } from "@elizaos/core";
+
+export interface ManagePositionsInput {
+  repositionThresholdBps: number;
+  intervalSeconds: number;
+  slippageToleranceBps: number;
+}
+
+function readInteger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.toLowerCase() === "null") return null;
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function validateManagePositionsInput(obj: Record<string, unknown>): ManagePositionsInput {
+  const repositionThresholdBps = readInteger(obj.repositionThresholdBps);
+  const intervalSeconds = readInteger(obj.intervalSeconds);
+  const slippageToleranceBps = readInteger(obj.slippageToleranceBps);
+  if (
+    repositionThresholdBps === null ||
+    intervalSeconds === null ||
+    slippageToleranceBps === null
+  ) {
+    throw new Error("Invalid input: Object does not match the ManagePositionsInput type.");
+  }
+  return { repositionThresholdBps, intervalSeconds, slippageToleranceBps };
+}
+
+export async function extractAndValidateConfiguration(
+  text: string,
+  runtime: IAgentRuntime
+): Promise<ManagePositionsInput | null> {
+  elizaLogger.log("Extracting and validating configuration from text:", text);
+
+  const prompt = `Given this message: "${text}". Extract the reposition threshold value, time interval, and slippage tolerance.
+        The threshold value and the slippage tolerance can be given in percentages or bps. You will always respond with the reposition threshold in bps.
+        Very important: Use null for each field that is not present in the message.
+        Respond with TOON only using this shape:
+        repositionThresholdBps: 120
+        intervalSeconds: 300
+        slippageToleranceBps: 50
+    `;
+
+  const content = await runtime.useModel(ModelType.TEXT_SMALL, { prompt });
+
+  try {
+    const configuration = parseToonKeyValue<Record<string, unknown>>(content);
+    if (!configuration || typeof configuration !== "object" || Array.isArray(configuration)) {
+      throw new Error("Configuration must be a structured object");
+    }
+    return validateManagePositionsInput(configuration);
+  } catch (error) {
+    elizaLogger.warn(
+      `Invalid configuration detected: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  }
+}

--- a/plugins/plugin-wallet/src/chains/solana/dex/orca/actions/managePositions.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/orca/actions/managePositions.ts
@@ -3,11 +3,8 @@ import {
   type AgentRuntime,
   type actions,
   elizaLogger,
-  generateText,
   type HandlerCallback,
   type Memory,
-  ModelClass,
-  parseToonKeyValue,
   type State,
   settings,
 } from "@elizaos/core";
@@ -27,6 +24,10 @@ import {
   PublicKey,
   Connection as SolanaRpc,
 } from "@solana/web3.js";
+import {
+  extractAndValidateConfiguration,
+  type ManagePositionsInput,
+} from "../../manage-position-configuration";
 import { loadWallet } from "../utils/loadWallet";
 import { sendTransaction } from "../utils/sendTransaction";
 
@@ -41,12 +42,6 @@ interface FetchedPosition {
 interface NewPriceBounds {
   newLowerPrice: number;
   newUpperPrice: number;
-}
-
-interface ManagePositionsInput {
-  repositionThresholdBps: number;
-  intervalSeconds: number;
-  slippageToleranceBps: number;
 }
 
 const ORCA_POSITION_PROVIDER = "orca-lp-position-provider";
@@ -140,7 +135,11 @@ export const managePositions: typeof actions = {
     elizaLogger.log("Fetched positions:", fetchedPositions);
 
     const { signer: wallet } = await loadWallet(runtime, true);
-    const rpc = createSolanaRpc(settings.SOLANA_RPC_URL!);
+    const rpcUrl = settings.SOLANA_RPC_URL;
+    if (!rpcUrl) {
+      throw new Error("SOLANA_RPC_URL is not configured");
+    }
+    const rpc = createSolanaRpc(rpcUrl);
     setDefaultSlippageToleranceBps(slippageToleranceBps);
     setDefaultFunder(wallet);
 
@@ -196,62 +195,6 @@ export const managePositions: typeof actions = {
     ],
   ],
 };
-
-function validateManagePositionsInput(obj: Record<string, unknown>): ManagePositionsInput {
-  const repositionThresholdBps = readInteger(obj.repositionThresholdBps);
-  const intervalSeconds = readInteger(obj.intervalSeconds);
-  const slippageToleranceBps = readInteger(obj.slippageToleranceBps);
-  if (
-    repositionThresholdBps === null ||
-    intervalSeconds === null ||
-    slippageToleranceBps === null
-  ) {
-    throw new Error("Invalid input: Object does not match the ManagePositionsInput type.");
-  }
-  return { repositionThresholdBps, intervalSeconds, slippageToleranceBps };
-}
-
-function readInteger(value: unknown): number | null {
-  if (typeof value === "number" && Number.isInteger(value)) return value;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.toLowerCase() === "null") return null;
-  const parsed = Number(trimmed);
-  return Number.isInteger(parsed) ? parsed : null;
-}
-
-export async function extractAndValidateConfiguration(
-  text: string,
-  runtime: AgentRuntime
-): Promise<ManagePositionsInput | null> {
-  elizaLogger.log("Extracting and validating configuration from text:", text);
-
-  const prompt = `Given this message: "${text}". Extract the reposition threshold value, time interval, and slippage tolerance.
-        The threshold value and the slippage tolerance can be given in percentages or bps. You will always respond with the reposition threshold in bps.
-        Very important: Use null for each field that is not present in the message.
-        Respond with TOON only using this shape:
-        repositionThresholdBps: 120
-        intervalSeconds: 300
-        slippageToleranceBps: 50
-    `;
-
-  const content = await generateText({
-    runtime,
-    context: prompt,
-    modelClass: ModelClass.SMALL,
-  });
-
-  try {
-    const configuration = parseToonKeyValue<Record<string, unknown>>(content);
-    if (!configuration || typeof configuration !== "object" || Array.isArray(configuration)) {
-      throw new Error("Configuration must be a structured object");
-    }
-    return validateManagePositionsInput(configuration as Record<string, unknown>);
-  } catch (error) {
-    elizaLogger.warn("Invalid configuration detected:", error);
-    return null;
-  }
-}
 
 function calculatePriceBounds(
   sqrtPrice: bigint,

--- a/plugins/plugin-wallet/src/chains/solana/dex/raydium/actions/managePositions.ts
+++ b/plugins/plugin-wallet/src/chains/solana/dex/raydium/actions/managePositions.ts
@@ -2,12 +2,9 @@
 import {
   type Action,
   elizaLogger,
-  generateText,
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
-  ModelClass,
-  parseToonKeyValue,
   type State,
   settings,
 } from "@elizaos/core";
@@ -23,6 +20,10 @@ import {
   type PositionInfo,
 } from "@raydium-io/raydium-sdk";
 import { Connection, type Keypair, PublicKey, type TransactionInstruction } from "@solana/web3.js";
+import {
+  extractAndValidateConfiguration,
+  type ManagePositionsInput,
+} from "../../manage-position-configuration";
 
 const RAYDIUM_POSITION_PROVIDER = "degen-lp-raydium-position-provider";
 
@@ -61,12 +62,6 @@ interface FetchedPosition {
 interface NewPriceBounds {
   newLowerPrice: number;
   newUpperPrice: number;
-}
-
-interface ManagePositionsInput {
-  repositionThresholdBps: number;
-  intervalSeconds: number;
-  slippageToleranceBps: number;
 }
 
 interface PoolData {
@@ -156,7 +151,11 @@ export const managePositions: Action = {
     elizaLogger.log("Fetched positions:", fetchedPositions);
 
     const { signer: wallet } = await loadWallet(runtime, true);
-    const connection = new Connection(settings.SOLANA_RPC_URL!);
+    const rpcUrl = settings.SOLANA_RPC_URL;
+    if (!rpcUrl) {
+      throw new Error("SOLANA_RPC_URL is not configured");
+    }
+    const connection = new Connection(rpcUrl);
 
     await handleRepositioning(fetchedPositions, repositionThresholdBps, connection, wallet);
 
@@ -164,62 +163,6 @@ export const managePositions: Action = {
   },
   examples: [],
 };
-
-function validateManagePositionsInput(obj: Record<string, unknown>): ManagePositionsInput {
-  const repositionThresholdBps = readInteger(obj.repositionThresholdBps);
-  const intervalSeconds = readInteger(obj.intervalSeconds);
-  const slippageToleranceBps = readInteger(obj.slippageToleranceBps);
-  if (
-    repositionThresholdBps === null ||
-    intervalSeconds === null ||
-    slippageToleranceBps === null
-  ) {
-    throw new Error("Invalid input: Object does not match the ManagePositionsInput type.");
-  }
-  return { repositionThresholdBps, intervalSeconds, slippageToleranceBps };
-}
-
-function readInteger(value: unknown): number | null {
-  if (typeof value === "number" && Number.isInteger(value)) return value;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.toLowerCase() === "null") return null;
-  const parsed = Number(trimmed);
-  return Number.isInteger(parsed) ? parsed : null;
-}
-
-export async function extractAndValidateConfiguration(
-  text: string,
-  runtime: IAgentRuntime
-): Promise<ManagePositionsInput | null> {
-  elizaLogger.log("Extracting and validating configuration from text:", text);
-
-  const prompt = `Given this message: "${text}". Extract the reposition threshold value, time interval, and slippage tolerance.
-        The threshold value and the slippage tolerance can be given in percentages or bps. You will always respond with the reposition threshold in bps.
-        Very important: Use null for each field that is not present in the message.
-        Respond with TOON only using this shape:
-        repositionThresholdBps: 120
-        intervalSeconds: 300
-        slippageToleranceBps: 50
-    `;
-
-  const content = await generateText({
-    runtime,
-    context: prompt,
-    modelClass: ModelClass.SMALL,
-  });
-
-  try {
-    const configuration = parseToonKeyValue<Record<string, unknown>>(content);
-    if (!configuration || typeof configuration !== "object" || Array.isArray(configuration)) {
-      throw new Error("Configuration must be a structured object");
-    }
-    return validateManagePositionsInput(configuration as Record<string, unknown>);
-  } catch (error) {
-    elizaLogger.warn("Invalid configuration detected:", error);
-    return null;
-  }
-}
 
 async function calculateNewPositionBounds(
   poolId: string,


### PR DESCRIPTION
## Summary
- extract shared continuation persistence and action ownership schema helpers in core
- share Solana manage-position configuration parsing between Orca and Raydium actions
- exclude generated app template Vite config from CodeFactor duplication checks

## Verification
- bunx @biomejs/biome check packages/core/src/services/message.ts packages/core/src/runtime.ts plugins/plugin-wallet/src/chains/solana/dex/raydium/actions/managePositions.ts plugins/plugin-wallet/src/chains/solana/dex/orca/actions/managePositions.ts plugins/plugin-wallet/src/chains/solana/dex/manage-position-configuration.ts
- bun run --cwd packages/core typecheck
- git diff --check

Note: bun run --cwd plugins/plugin-wallet check still fails on unrelated existing trigger-route/Birdeye test typing errors.