### PR TITLE
fix(ci): retry bun install in docker smoke + cache install dir in cloud setup

### DIFF
--- a/cloud/.github/actions/setup-test-env/action.yml
+++ b/cloud/.github/actions/setup-test-env/action.yml
@@ -26,6 +26,14 @@ runs:
       with:
         bun-version: ${{ inputs.bun-version }}
 
+    - name: Cache Bun install
+      uses: actions/cache@v5
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('cloud/bun.lock') }}
+        restore-keys: |
+          bun-${{ runner.os }}-
+
     - name: Install dependencies
       shell: bash
       working-directory: cloud

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -208,7 +208,17 @@ trap cleanup EXIT
 log "Installing dependencies"
 node "$APP_CORE_SCRIPTS_DIR/init-submodules.mjs"
 ELIZA_SKIP_LOCAL_UPSTREAMS=1 ELIZA_SKIP_LOCAL_UPSTREAMS=1 node "$APP_CORE_SCRIPTS_DIR/disable-local-eliza-workspace.mjs"
-ELIZA_SKIP_LOCAL_UPSTREAMS=1 ELIZA_SKIP_LOCAL_UPSTREAMS=1 "$BUN_BIN" install --ignore-scripts --no-frozen-lockfile
+for attempt in 1 2 3; do
+  if ELIZA_SKIP_LOCAL_UPSTREAMS=1 "$BUN_BIN" install --ignore-scripts --no-frozen-lockfile; then
+    break
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    log "bun install failed after 3 attempts"
+    exit 1
+  fi
+  log "bun install attempt $attempt failed; retrying in 30s..."
+  sleep 30
+done
 # --ignore-scripts avoids running the full repo postinstall during the package
 # install, but build tools still need their platform binaries materialized.
 node node_modules/esbuild/install.js 2>/dev/null || true


### PR DESCRIPTION
## Summary

Two minimal mitigations for npm registry CDN 404 flakes that took down the Docker smoke job (40-min timeout box) and several cloud test runs over the past day. Real example: `@steerprotocol/sdk@3.0.9` returned 404 for ~1 hour even though the version was published and live — it's now back to HTTP 200 with no code change anywhere.

## Why two changes

The Docker smoke and the cloud test jobs are different code paths, both vulnerable to the same upstream flake:

1. **`packages/app-core/scripts/docker-ci-smoke.sh`** — `bun install` was a single bare invocation. A 404 inside a 40-min timeout box meant a single bad fetch nuked the entire job. Wrapped in a 3-try loop with 30s backoff. Lockfile errors still fail deterministically (same exit on every attempt); only registry-side flakes get the second chance.

2. **`cloud/.github/actions/setup-test-env/action.yml`** — added `actions/cache@v5` for `~/.bun/install/cache` keyed on `cloud/bun.lock`. On a cache hit, `bun install` reads tarballs from disk and is immune to upstream registry blips. The retry loop already in this composite (3×10s) stays as a fallback for cold-cache runs.

## Why not just retry everywhere

The cache fix is strictly better when it hits — no registry contact at all. The retry is the safety net for cold cache (first run on a new lockfile). Both keep their value because they cover different states.

## Test plan

- [ ] CI on this PR passes Docker CI Smoke first try (cache will be cold, will exercise the retry path naturally).
- [ ] Subsequent push to `develop` finds the cache populated → measure `bun install` wall-clock drops in the cloud test jobs.
- [ ] If npm registry 404s during a run, the retry log line `bun install attempt N failed; retrying in 30s...` shows in the smoke step output instead of a hard fail.

## Out of scope

- Switching to a pull-through proxy registry (Verdaccio etc.) — heavy, separate infra decision.
- Vendoring `@steerprotocol/sdk` — the package is transitive, not direct.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two targeted mitigations for npm registry CDN 404 flakes: a retry loop in the Docker smoke script and a Bun install cache in the cloud composite action. Both changes are minimal and low-risk.

- **`docker-ci-smoke.sh`**: Replaces the single bare `bun install` with a 3-attempt retry loop (30s backoff). The `if`-guarded invocation is safe under `set -Eeuo pipefail`, and the loop correctly avoids an unnecessary sleep after the final failed attempt before calling `exit 1`.
- **`action.yml`**: Inserts `actions/cache@v5` for `~/.bun/install/cache` before the install step, keyed on `hashFiles('cloud/bun.lock')`. The `hashFiles` path resolves correctly from `GITHUB_WORKSPACE` (the repo root), and the `restore-keys` fallback provides a partial-hit warm-start on lockfile changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are isolated CI infrastructure improvements with no impact on production code paths.

The retry loop in `docker-ci-smoke.sh` is correctly structured under `set -Eeuo pipefail`, sleeps only between attempts and not after the final failure, and exits with a clear error message. The `actions/cache@v5` step in `action.yml` is placed correctly before the install step, uses the right `hashFiles` path relative to `GITHUB_WORKSPACE`, and the partial restore-key is a safe fallback. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/docker-ci-smoke.sh | Wraps bare `bun install` in a 3-attempt retry loop with 30s backoff; logic is correct under `set -Eeuo pipefail` and avoids sleeping after the final failed attempt. |
| cloud/.github/actions/setup-test-env/action.yml | Adds `actions/cache@v5` for `~/.bun/install/cache` keyed on `cloud/bun.lock`; cache step is correctly placed before the install step and `hashFiles` path resolves from GITHUB_WORKSPACE root. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): retry bun install in docker smo..."](https://github.com/elizaos/eliza/commit/4848840bd8f186a44885e90f9691c92cef4f4e60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31055072)</sub>

<!-- /greptile_comment -->