### PR TITLE
fix(core): parse inline planner action params

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { parseActionParams } from "../actions";
 import type { ActionResult, IAgentRuntime } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
+	extractPlannerActionNames,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
@@ -19,6 +21,45 @@ const logger = {
 };
 
 describe("live routing regressions", () => {
+	it("extracts inline params from planner action strings", () => {
+		const shellPlan: Record<string, unknown> = {
+			actions: 'SHELL_COMMAND <params>{"command":"df -h"}</params>',
+			params: {},
+		};
+		expect(extractPlannerActionNames(shellPlan)).toEqual(["SHELL_COMMAND"]);
+		expect(parseActionParams(shellPlan.params).get("SHELL_COMMAND")).toEqual({
+			command: "df -h",
+		});
+
+		const appPlan: Record<string, unknown> = {
+			actions:
+				'APP {"mode":"create","app":"normie-slider","intent":"build, verify, and report"}',
+			params: {},
+		};
+		expect(extractPlannerActionNames(appPlan)).toEqual(["APP"]);
+		expect(parseActionParams(appPlan.params).get("APP")).toEqual({
+			mode: "create",
+			app: "normie-slider",
+			intent: "build, verify, and report",
+		});
+	});
+
+	it("does not treat params tags inside inline JSON strings as XML wrappers", () => {
+		const plan: Record<string, unknown> = {
+			actions:
+				'APP {"note":"literal <params, marker","intent":"build, verify"}, SHELL_COMMAND <params>{"command":"df -h"}</params>',
+			params: {},
+		};
+
+		expect(extractPlannerActionNames(plan)).toEqual(["APP", "SHELL_COMMAND"]);
+		const params = parseActionParams(plan.params);
+		expect(params.get("APP")).toEqual({
+			note: "literal <params, marker",
+			intent: "build, verify",
+		});
+		expect(params.get("SHELL_COMMAND")).toEqual({ command: "df -h" });
+	});
+
 	it("collapses duplicate visible REPLY planner actions", () => {
 		expect(
 			stripReplyWhenActionOwnsTurn(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -258,6 +258,14 @@ function splitPlannerActionList(actionsText: string): string[] {
 	for (let index = 0; index < actionsText.length; index += 1) {
 		if (!inJsonString && lower.startsWith("<params", index)) {
 			inParams = true;
+			// Advance through the rest of the opening tag, including any
+			// attributes (e.g. `<params type="json">`), so the loop's char
+			// handling doesn't iterate the tag's interior. Mirrors the
+			// closing-tag branch's full-length advance.
+			const close = actionsText.indexOf(">", index);
+			if (close >= 0) {
+				index = close;
+			}
 			continue;
 		}
 		if (!inJsonString && lower.startsWith("</params>", index)) {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -246,14 +246,109 @@ function attachInlinePlannerActionParams(
 	parsedPlanner.params = nextParams;
 }
 
+function splitPlannerActionList(actionsText: string): string[] {
+	const parts: string[] = [];
+	let start = 0;
+	let inParams = false;
+	let inJsonString = false;
+	let jsonEscape = false;
+	let jsonDepth = 0;
+	const lower = actionsText.toLowerCase();
+
+	for (let index = 0; index < actionsText.length; index += 1) {
+		if (!inJsonString && lower.startsWith("<params", index)) {
+			inParams = true;
+			continue;
+		}
+		if (!inJsonString && lower.startsWith("</params>", index)) {
+			inParams = false;
+			index += "</params>".length - 1;
+			continue;
+		}
+
+		const char = actionsText[index];
+		if (!inParams) {
+			if (inJsonString) {
+				if (jsonEscape) {
+					jsonEscape = false;
+				} else if (char === "\\") {
+					jsonEscape = true;
+				} else if (char === '"') {
+					inJsonString = false;
+				}
+			} else if (jsonDepth > 0 && char === '"') {
+				inJsonString = true;
+			} else if (char === "{") {
+				jsonDepth += 1;
+			} else if (char === "}" && jsonDepth > 0) {
+				jsonDepth -= 1;
+			}
+		}
+
+		if (char === "," && !inParams && jsonDepth === 0 && !inJsonString) {
+			parts.push(actionsText.slice(start, index));
+			start = index + 1;
+		}
+	}
+
+	parts.push(actionsText.slice(start));
+	return parts;
+}
+
+function parseInlinePlannerParams(
+	value: string,
+): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(value);
+		return isRecord(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+function extractInlinePlannerActionParams(value: string): {
+	name: string;
+	params?: Record<string, unknown>;
+} {
+	const inlineJsonMatch = value.match(
+		/^\s*([A-Z][A-Z0-9_:-]*)\s+(\{[\s\S]*\})\s*$/i,
+	);
+	if (inlineJsonMatch) {
+		const params = parseInlinePlannerParams(inlineJsonMatch[2]);
+		if (params) {
+			return {
+				name: unwrapPlannerIdentifier(inlineJsonMatch[1]),
+				params,
+			};
+		}
+	}
+
+	const inlineParamsMatch = value.match(
+		/^([\s\S]*?)\s*<params\b[^>]*>([\s\S]*?)<\/params>\s*$/i,
+	);
+	if (inlineParamsMatch) {
+		return {
+			name: unwrapPlannerIdentifier(inlineParamsMatch[1]),
+			params: parseInlinePlannerParams(inlineParamsMatch[2]) ?? undefined,
+		};
+	}
+
+	return { name: unwrapPlannerIdentifier(value) };
+}
+
 export function extractPlannerActionNames(
 	parsedPlanner: Record<string, unknown>,
 ): string[] {
 	return (() => {
 		if (typeof parsedPlanner.actions === "string") {
-			return parsedPlanner.actions
-				.split(",")
-				.map((action) => unwrapPlannerIdentifier(String(action)))
+			return splitPlannerActionList(parsedPlanner.actions)
+				.map((action) => {
+					const { name, params } = extractInlinePlannerActionParams(
+						String(action),
+					);
+					attachInlinePlannerActionParams(parsedPlanner, name, params);
+					return name;
+				})
 				.filter((action) => action.length > 0);
 		}
 		if (Array.isArray(parsedPlanner.actions)) {
@@ -268,7 +363,11 @@ export function extractPlannerActionNames(
 						);
 						return actionName;
 					}
-					return unwrapPlannerIdentifier(String(action));
+					const { name, params } = extractInlinePlannerActionParams(
+						String(action),
+					);
+					attachInlinePlannerActionParams(parsedPlanner, name, params);
+					return name;
 				})
 				.filter((action) => action.length > 0);
 		}


### PR DESCRIPTION
## Summary
- parse inline planner action parameters from string action lists, including JSON payloads and `<params>{...}</params>` wrappers
- split comma-separated planner actions without breaking commas inside inline JSON params or params wrappers
- keep extracted params in the existing planner params map so downstream action execution can reuse the normal action-param path
- address review feedback by ignoring `<params` markers that appear inside JSON string values

## Validation
- `git diff --check`
- `bunx biome check --write packages/core/src/services/message.ts packages/core/src/__tests__/message-routing-live-regression.test.ts`
- `bun run --cwd packages/core test -- src/__tests__/message-routing-live-regression.test.ts`
- `bun run --cwd packages/core build:node`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the naive `.split(",")` planner-action splitting with a character-level parser (`splitPlannerActionList`) that is aware of JSON object depth, JSON string escaping, and `<params>...</params>` XML wrapper tags, then extracts and stores inline params into `parsedPlanner.params` so downstream action execution can reuse them normally.

- **`splitPlannerActionList`** tracks `jsonDepth`, `inJsonString`, `jsonEscape`, and `inParams` to split on commas only at the top level, correctly handling payloads like `APP {"intent":"build, verify"}` and `SHELL_COMMAND <params>{"command":"df -h"}</params>` in a single string.
- **`extractInlinePlannerActionParams`** tries an inline-JSON regex first, then a `<params>` tag regex, and falls back to a plain identifier; the extracted params are merged into `parsedPlanner.params` keyed by the uppercased action name (a deliberate side effect on `extractPlannerActionNames`).
- Two new regression tests cover both inline-JSON and `<params>`-tag formats, including the guard against literal `<params` text appearing inside a JSON string value.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new parser handles all documented input formats correctly and the added tests pin the fixed behaviour.

The character-level splitting logic correctly threads the inJsonString guard through both the <params opening-tag detection and the comma-split check. The one asymmetry — </params> detection while inside params content is not JSON-string-aware — requires a JSON value that literally embeds the closing tag text, which is not a realistic planner output. All other paths degrade gracefully for malformed input.

packages/core/src/services/message.ts — the </params> closing-tag branch (line 271) could be hardened against JSON string values that contain the literal text </params>.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Adds splitPlannerActionList, parseInlinePlannerParams, and extractInlinePlannerActionParams helpers; updates extractPlannerActionNames to parse inline JSON and <params>...</params> action payloads. Core logic is sound for expected inputs; one subtle asymmetry exists where </params> inside a JSON string value within a <params> block is not protected by the inJsonString guard. |
| packages/core/src/__tests__/message-routing-live-regression.test.ts | Adds two regression tests covering inline JSON params extraction and <params>-tag wrapper parsing, including the case where a literal <params string appears inside a JSON value. Tests are well-scoped and validate both action-name extraction and the mutated params map. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["extractPlannerActionNames(parsedPlanner)"] --> B{actions type?}
    B -- string --> C["splitPlannerActionList(actionsText)"]
    B -- array --> G{element type?}
    B -- other --> Z["return []"]

    C --> D["Character-by-character scan\n(tracks: inParams, inJsonString,\njsonDepth, jsonEscape)"]
    D --> E["Split on commas only when:\n!inParams && jsonDepth==0 && !inJsonString"]
    E --> F["string[] of raw action tokens"]

    F --> MAP1["extractInlinePlannerActionParams(token)"]
    MAP1 --> R1{regex: ACTION JSON?}
    R1 -- match --> R2["parseInlinePlannerParams"]
    R1 -- no match --> R3{regex: ACTION params tag?}
    R3 -- match --> R4["parseInlinePlannerParams inner"]
    R3 -- no match --> R5["unwrapPlannerIdentifier"]

    R2 --> ATTACH["attachInlinePlannerActionParams\nmutates parsedPlanner.params"]
    R4 --> ATTACH
    R5 --> ATTACH
    G -- Record --> H["getPlannerActionObjectName + attach"]
    G -- string --> MAP1
    ATTACH --> OUT["return name"]
```

<sub>Reviews (3): Last reviewed commit: ["fix(core): symmetric tag consumption in ..."](https://github.com/elizaos/eliza/commit/6b3d563c643b78148213d4b6f6dfb6e591b7ed87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31090098)</sub>

<!-- /greptile_comment -->