### PR TITLE
fix(app-core): scope account pool lookups by provider

### DIFF
--- a/packages/agent/src/api/accounts-routes.test.ts
+++ b/packages/agent/src/api/accounts-routes.test.ts
@@ -1,0 +1,102 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LinkedAccountConfig } from "../contracts/service-routing";
+import {
+  _resetAccountsRoutesPoolCache,
+  type AccountsRouteContext,
+  handleAccountsRoutes,
+} from "./accounts-routes";
+
+const mockPool = vi.hoisted(() => ({
+  list: vi.fn(),
+  get: vi.fn(),
+  upsert: vi.fn(),
+  deleteMetadata: vi.fn(),
+  refreshUsage: vi.fn(),
+}));
+
+vi.mock("@elizaos/app-core/account-pool", () => ({
+  getDefaultAccountPool: () => mockPool,
+}));
+
+function account(
+  providerId: LinkedAccountConfig["providerId"],
+  overrides: Partial<LinkedAccountConfig> = {},
+): LinkedAccountConfig {
+  return {
+    id: "duplicate-id",
+    providerId,
+    label: `${providerId} account`,
+    source: "oauth",
+    enabled: true,
+    priority: 0,
+    createdAt: 1,
+    health: "ok",
+    ...overrides,
+  };
+}
+
+async function invoke(
+  method: string,
+  pathname: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; payload: unknown }> {
+  let status = 200;
+  let payload: unknown;
+  const ctx: AccountsRouteContext = {
+    req: { url: pathname } as IncomingMessage,
+    res: {} as ServerResponse,
+    method,
+    pathname,
+    state: { config: {} },
+    saveConfig: () => {},
+    readJsonBody: async () => body,
+    json: (_res, data, nextStatus = 200) => {
+      status = nextStatus;
+      payload = data;
+    },
+    error: (_res, message, nextStatus = 400) => {
+      status = nextStatus;
+      payload = { error: message };
+    },
+  };
+  await handleAccountsRoutes(ctx);
+  return { status, payload };
+}
+
+describe("handleAccountsRoutes provider-scoped account lookup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetAccountsRoutesPoolCache();
+  });
+
+  it("patches the account under the route provider when account ids collide", async () => {
+    const anthropic = account("anthropic-subscription", {
+      label: "Anthropic",
+    });
+    const codex = account("openai-codex", {
+      label: "Codex",
+    });
+    mockPool.get.mockImplementation(
+      (accountId: string, providerId?: LinkedAccountConfig["providerId"]) => {
+        if (accountId !== "duplicate-id") return null;
+        if (providerId === "openai-codex") return codex;
+        if (providerId === "anthropic-subscription") return anthropic;
+        return anthropic;
+      },
+    );
+
+    const result = await invoke(
+      "PATCH",
+      "/api/accounts/openai-codex/duplicate-id",
+      { enabled: false },
+    );
+
+    expect(result.status).toBe(200);
+    expect(mockPool.get).toHaveBeenCalledWith("duplicate-id", "openai-codex");
+    expect(mockPool.upsert).toHaveBeenCalledWith({
+      ...codex,
+      enabled: false,
+    });
+  });
+});

--- a/packages/agent/src/api/accounts-routes.ts
+++ b/packages/agent/src/api/accounts-routes.ts
@@ -72,13 +72,13 @@ import type { RouteRequestContext } from "./route-helpers.js";
 
 interface PoolFacade {
   list(providerId?: string): LinkedAccountConfig[];
-  get(accountId: string): LinkedAccountConfig | null;
+  get(accountId: string, providerId?: string): LinkedAccountConfig | null;
   upsert(account: LinkedAccountConfig): Promise<void>;
   deleteMetadata(providerId: string, accountId: string): Promise<void>;
   refreshUsage(
     accountId: string,
     accessToken: string,
-    opts?: { codexAccountId?: string },
+    opts?: { codexAccountId?: string; providerId?: string },
   ): Promise<void>;
 }
 
@@ -849,7 +849,7 @@ async function handlePatchAccount(
     return true;
   }
   const pool = await getPool();
-  const existing = pool.get(accountId);
+  const existing = pool.get(accountId, providerId);
   if (!existing || existing.providerId !== providerId) {
     error(res, "Account not found", 404);
     return true;
@@ -917,7 +917,7 @@ async function handleTestAccount(
     return true;
   }
   const pool = await getPool();
-  const linked = pool.get(accountId);
+  const linked = pool.get(accountId, providerId);
   const codexAccountId =
     linked?.providerId === "openai-codex" ? linked.organizationId : undefined;
   const probe = direct
@@ -952,7 +952,7 @@ async function handleRefreshUsage(
     return true;
   }
   const pool = await getPool();
-  const linked = pool.get(accountId);
+  const linked = pool.get(accountId, providerId);
   if (!linked || linked.providerId !== providerId) {
     error(res, "Account not found", 404);
     return true;
@@ -991,11 +991,12 @@ async function handleRefreshUsage(
   // failure to the provider's usage endpoint, etc.).
   try {
     await pool.refreshUsage(accountId, accessToken, {
+      providerId,
       ...(linked.organizationId
         ? { codexAccountId: linked.organizationId }
         : {}),
     });
-    const refreshed = pool.get(accountId);
+    const refreshed = pool.get(accountId, providerId);
     if (refreshed) {
       json(res, { account: refreshed, source: "pool" });
       return true;

--- a/packages/app-core/src/services/account-pool.test.ts
+++ b/packages/app-core/src/services/account-pool.test.ts
@@ -1,0 +1,63 @@
+import type { LinkedAccountConfig } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { AccountPool } from "./account-pool";
+
+function account(
+  providerId: LinkedAccountConfig["providerId"],
+  overrides: Partial<LinkedAccountConfig> = {},
+): LinkedAccountConfig {
+  return {
+    id: "duplicate-id",
+    providerId,
+    label: `${providerId} account`,
+    source: "oauth",
+    enabled: true,
+    priority: 0,
+    createdAt: 1,
+    health: "ok",
+    ...overrides,
+  };
+}
+
+describe("AccountPool provider-scoped lookup", () => {
+  it("gets the account for the requested provider when ids collide", () => {
+    const anthropic = account("anthropic-subscription", {
+      label: "Anthropic",
+    });
+    const codex = account("openai-codex", {
+      label: "Codex",
+    });
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:duplicate-id": anthropic,
+        "openai-codex:duplicate-id": codex,
+      }),
+      writeAccount: async () => {},
+    });
+
+    expect(pool.get("duplicate-id", "openai-codex")).toBe(codex);
+    expect(pool.get("duplicate-id", "anthropic-subscription")).toBe(anthropic);
+  });
+
+  it("updates the provider-scoped account when marking health", async () => {
+    const writes: LinkedAccountConfig[] = [];
+    const anthropic = account("anthropic-subscription");
+    const codex = account("openai-codex");
+    const pool = new AccountPool({
+      readAccounts: () => ({
+        "anthropic-subscription:duplicate-id": anthropic,
+        "openai-codex:duplicate-id": codex,
+      }),
+      writeAccount: async (next) => {
+        writes.push(next);
+      },
+    });
+
+    await pool.markInvalid("duplicate-id", "bad token", "openai-codex");
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]?.providerId).toBe("openai-codex");
+    expect(writes[0]?.health).toBe("invalid");
+    expect(writes[0]?.healthDetail?.lastError).toBe("bad token");
+  });
+});

--- a/packages/app-core/src/services/account-pool.ts
+++ b/packages/app-core/src/services/account-pool.ts
@@ -242,8 +242,11 @@ export class AccountPool {
     return all.filter((a) => a.providerId === providerId);
   }
 
-  get(accountId: string): LinkedAccountConfig | null {
-    return findAccountById(this.deps.readAccounts(), accountId);
+  get(
+    accountId: string,
+    providerId?: PoolProviderId,
+  ): LinkedAccountConfig | null {
+    return findAccountById(this.deps.readAccounts(), accountId, providerId);
   }
 
   async upsert(account: LinkedAccountConfig): Promise<void> {
@@ -269,8 +272,13 @@ export class AccountPool {
       errorCode?: string;
       model?: string;
     },
+    providerId?: PoolProviderId,
   ): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      providerId,
+    );
     if (!account) return;
     recordUsageEntry(account.providerId, account.id, result);
     const next: LinkedAccountConfig = {
@@ -283,9 +291,17 @@ export class AccountPool {
   async refreshUsage(
     accountId: string,
     accessToken: string,
-    opts?: { codexAccountId?: string; fetch?: typeof fetch },
+    opts?: {
+      codexAccountId?: string;
+      fetch?: typeof fetch;
+      providerId?: PoolProviderId;
+    },
   ): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      opts?.providerId,
+    );
     if (!account) return;
 
     let usage: LinkedAccountUsage;
@@ -315,8 +331,13 @@ export class AccountPool {
     accountId: string,
     untilMs: number,
     detail?: string,
+    providerId?: PoolProviderId,
   ): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      providerId,
+    );
     if (!account) return;
     const healthDetail: LinkedAccountHealthDetail = {
       until:
@@ -333,8 +354,16 @@ export class AccountPool {
     });
   }
 
-  async markNeedsReauth(accountId: string, detail?: string): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+  async markNeedsReauth(
+    accountId: string,
+    detail?: string,
+    providerId?: PoolProviderId,
+  ): Promise<void> {
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      providerId,
+    );
     if (!account) return;
     await this.deps.writeAccount({
       ...account,
@@ -346,8 +375,16 @@ export class AccountPool {
     });
   }
 
-  async markInvalid(accountId: string, detail?: string): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+  async markInvalid(
+    accountId: string,
+    detail?: string,
+    providerId?: PoolProviderId,
+  ): Promise<void> {
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      providerId,
+    );
     if (!account) return;
     await this.deps.writeAccount({
       ...account,
@@ -359,8 +396,15 @@ export class AccountPool {
     });
   }
 
-  async markHealthy(accountId: string): Promise<void> {
-    const account = findAccountById(this.deps.readAccounts(), accountId);
+  async markHealthy(
+    accountId: string,
+    providerId?: PoolProviderId,
+  ): Promise<void> {
+    const account = findAccountById(
+      this.deps.readAccounts(),
+      accountId,
+      providerId,
+    );
     if (!account) return;
     if (account.health === "ok") return;
     await this.deps.writeAccount({
@@ -399,7 +443,18 @@ function poolRecordKey(providerId: PoolProviderId, accountId: string): string {
 function findAccountById(
   all: Record<string, LinkedAccountConfig>,
   accountId: string,
+  providerId?: PoolProviderId,
 ): LinkedAccountConfig | null {
+  if (providerId) {
+    return (
+      all[poolRecordKey(providerId, accountId)] ??
+      Object.values(all).find(
+        (account) =>
+          account.id === accountId && account.providerId === providerId,
+      ) ??
+      null
+    );
+  }
   const direct = all[accountId];
   if (direct) return direct;
   return Object.values(all).find((account) => account.id === accountId) ?? null;
@@ -823,7 +878,11 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
       const token = await getAccountAccessToken(providerId, record.id);
       if (!token) {
         result.failed += 1;
-        await pool.markNeedsReauth(record.id, "No valid credential available");
+        await pool.markNeedsReauth(
+          record.id,
+          "No valid credential available",
+          providerId,
+        );
         continue;
       }
 
@@ -833,6 +892,7 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
 
       try {
         await pool.refreshUsage(record.id, token, {
+          providerId,
           ...(record.organizationId
             ? { codexAccountId: record.organizationId }
             : {}),
@@ -842,15 +902,16 @@ export async function sweepAccountPoolKeepAlive(): Promise<AccountPoolKeepAliveR
         result.failed += 1;
         const message = err instanceof Error ? err.message : String(err);
         if (/401|403|invalid|unauthor/i.test(message)) {
-          await pool.markNeedsReauth(record.id, message);
+          await pool.markNeedsReauth(record.id, message, providerId);
         } else if (/429|rate.?limit/i.test(message)) {
           await pool.markRateLimited(
             record.id,
             Date.now() + DEFAULT_RATE_LIMIT_BACKOFF_MS,
             message,
+            providerId,
           );
         } else {
-          await pool.markInvalid(record.id, message);
+          await pool.markInvalid(record.id, message, providerId);
         }
       }
     }
@@ -926,9 +987,15 @@ function installAnthropicShim(pool: AccountPool): void {
     },
     getAccessToken: (providerId, accountId) =>
       getAccountAccessToken(providerId, accountId),
-    markInvalid: (accountId, detail) => pool.markInvalid(accountId, detail),
+    markInvalid: (accountId, detail) =>
+      pool.markInvalid(accountId, detail, "anthropic-subscription"),
     markRateLimited: (accountId, untilMs, detail) =>
-      pool.markRateLimited(accountId, untilMs, detail),
+      pool.markRateLimited(
+        accountId,
+        untilMs,
+        detail,
+        "anthropic-subscription",
+      ),
   };
   (globalThis as Record<symbol, unknown>)[ANTHROPIC_POOL_SHIM_SYMBOL] = shim;
 }
@@ -951,13 +1018,18 @@ function installOrchestratorShim(pool: AccountPool): void {
       return { accessToken: token, accountId: account.id };
     },
     markRateLimited: (accountId, untilMs, detail) => {
-      void pool.markRateLimited(accountId, untilMs, detail);
+      void pool.markRateLimited(
+        accountId,
+        untilMs,
+        detail,
+        "anthropic-subscription",
+      );
     },
     markInvalid: (accountId, detail) => {
-      void pool.markInvalid(accountId, detail);
+      void pool.markInvalid(accountId, detail, "anthropic-subscription");
     },
     markNeedsReauth: (accountId, detail) => {
-      void pool.markNeedsReauth(accountId, detail);
+      void pool.markNeedsReauth(accountId, detail, "anthropic-subscription");
     },
   };
   (globalThis as Record<symbol, unknown>)[ORCHESTRATOR_POOL_SHIM_SYMBOL] = shim;


### PR DESCRIPTION
## Summary

Provider-scopes remaining account-pool lookups and route refresh paths so duplicate account ids across providers resolve to the intended provider account instead of whichever matching id is found first.

Adds collision coverage for AccountPool lookup/health mutation and the accounts PATCH route.

## Receipts

- `bun run --cwd packages/app-core test src/services/account-pool.test.ts`
- `bun run --cwd packages/agent test src/api/accounts-routes.test.ts`
- `bun x @biomejs/biome check packages/app-core/src/services/account-pool.ts packages/app-core/src/services/account-pool.test.ts packages/agent/src/api/accounts-routes.ts packages/agent/src/api/accounts-routes.test.ts`

## Notes

Draft for review. Scope intentionally avoids native-reasoning and unrelated account-pool refactors.