### PR TITLE
fix(core): allow toon structured response format

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -165,10 +165,7 @@ import type {
 	StructuredOutputFailure,
 } from "./types/state";
 import type { ToolPolicyConfig, ToolProfileId } from "./types/tools";
-import {
-	parseJSONObjectFromText,
-	stringToUuid,
-} from "./utils";
+import { parseJSONObjectFromText, stringToUuid } from "./utils";
 import {
 	collectActionResultSizeWarnings,
 	getActionResultActionName,
@@ -270,7 +267,7 @@ const TEXT_GENERATION_MODEL_KEYS: readonly string[] = [
 	ModelType.TEXT_COMPLETION,
 ];
 
-type StructuredResponseFormat = "JSON";
+type StructuredResponseFormat = "JSON" | "TOON";
 
 type StructuredResponseCandidate = {
 	text: string;
@@ -3306,7 +3303,7 @@ export class AgentRuntime implements IAgentRuntime {
 										? result
 										: result === null
 											? null
-												: stringifyStructuredForPrompt({ result });
+											: stringifyStructuredForPrompt({ result });
 						actionResult = {
 							success: true,
 							data: {
@@ -3582,7 +3579,7 @@ export class AgentRuntime implements IAgentRuntime {
 				this.stateCache.set(`${message.id}_action_results`, {
 					values: { actionResults },
 					data: { actionResults, actionPlan },
-						text: stringifyStructuredForPrompt({ actionResults }),
+					text: stringifyStructuredForPrompt({ actionResults }),
 				});
 			}
 		}


### PR DESCRIPTION
## Summary
- Restore TOON as a structured response format candidate in the core runtime type
- Format the touched runtime file with Biome

## Why
The runtime still detects and branches on TOON structured responses for legacy callers, but the local type was narrowed to JSON only. That makes latest develop fail in source builds where the TOON branches are typechecked.

## Tests
- bun install --ignore-scripts --frozen-lockfile
- node node_modules/bun/install.js
- bun run generate:types
- bun run --cwd packages/core build:node
- bun run --cwd packages/core test src/__tests__/structured-parser.test.ts
- bunx @biomejs/biome check packages/core/src/runtime.ts
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores `"TOON"` to the `StructuredResponseFormat` union type in `packages/core/src/runtime.ts`, which was incorrectly narrowed to `"JSON"` only, causing TypeScript to flag existing `format === "TOON"` comparisons as unreachable-type errors during source builds. Three minor Biome-driven formatting fixes (import grouping and ternary indentation) are included alongside the type change.

- **Type fix**: `type StructuredResponseFormat = \"JSON\"` → `\"JSON\" | \"TOON\"` — unblocks `bun run --cwd packages/core build:node` and `generate:types` which typecheck the existing legacy TOON branches.
- **Formatting**: Three cosmetic indentation/import changes with no behavioural effect.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal type correction with no runtime behaviour change.

The only substantive change is widening a local private type from a single-member literal to a two-member union, restoring a value that was already used throughout the file. Runtime behaviour is unchanged: resolveDefaultOutputFormat still maps every string input to JSON at call time, and the format === TOON branch that now typechecks correctly was already present and already handled through the streaming extractor path. The three formatting edits are whitespace-only.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime.ts | Restores "TOON" to the StructuredResponseFormat union type so that existing `format === "TOON"` branches typecheck without error; also fixes three indentation/import formatting issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveDefaultOutputFormat] -->|input: 'toon'| B[returns 'JSON']
    A -->|input: 'json'| B
    A -->|other/undefined| B
    B --> C{format value}
    C -->|'JSON'| D[parseStructuredResponse\nlooks for JSON candidates]
    C -->|'TOON'\nlegacy path only| E[create streaming\nfield extractor\nformat === 'TOON' check]
    D --> F[extractStructuredResponseCandidates]
    F --> G[detectStructuredResponseFormats\nreturns 'JSON' only]
    F --> H[addCandidate with hints]
    G --> I[StructuredResponseCandidate\nformats: 'JSON' or empty]
    E --> J[ToonFieldStreamExtractor\nfor legacy streaming]
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): allow toon structured respons..."](https://github.com/elizaos/eliza/commit/5c3b3b7710f05c8398dbb38b42ffaa1f254b7dd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31123297)</sub>

<!-- /greptile_comment -->