### PR TITLE
fix(planner): preserve Anthropic cache_control on v5 planner/evaluator path

### DIFF
--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -289,9 +289,14 @@ function renderEvaluatorModelInput(params: {
 		template.split("context_object:")[0] ?? template
 	).trim();
 	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps);
+	// Mirrors planner-loop: the evaluator stage instructions are template-derived
+	// (`v5EvaluatorTemplate`) and structurally identical across calls. Marking
+	// the segment `stable: true` makes them cacheable on Anthropic's wire path
+	// (`buildSegmentedUserContent` stamps `cache_control` on stable parts) and
+	// lets `cachePrefixSegments` extend the cache-key prefix through them.
 	const promptSegments = normalizePromptSegments([
 		...renderedContext.promptSegments,
-		{ content: `evaluator_stage:\n${instructions}`, stable: false },
+		{ content: `evaluator_stage:\n${instructions}`, stable: true },
 	]);
 	// Use proper assistant/tool message pairs so the evaluator sees the same
 	// native tool-calling format as the planner. The trajectory JSON is NOT

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -357,9 +357,16 @@ function renderPlannerModelInput(params: {
 		template.split("context_object:")[0] ?? template
 	).trim();
 	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps);
+	// The planner stage instructions are template-derived (`v5PlannerTemplate`)
+	// and structurally identical across iterations and across user turns, so they
+	// belong in the cached prefix. Marking the segment `stable: true` lets
+	// `buildSegmentedUserContent` stamp `cache_control` on this block when the
+	// provider supports it (Anthropic), and lets `cachePrefixSegments` extend
+	// the cache-key prefix through these instructions when no unstable segments
+	// precede them.
 	const promptSegments = normalizePromptSegments([
 		...renderedContext.promptSegments,
-		{ content: `planner_stage:\n${instructions}`, stable: false },
+		{ content: `planner_stage:\n${instructions}`, stable: true },
 	]);
 	// Native tool-call messages: assistant (with toolCalls) + tool (result) per
 	// completed step. This grows append-only across planner iterations so the

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
@@ -249,7 +249,12 @@ describe("Anthropic native text plumbing", () => {
       promptSegments: [
         { content: "stable prefix", stable: true },
         { content: "dynamic context", stable: false },
-        { content: "planner_stage:\nDo X.", stable: false },
+        // The planner_stage instructions segment is `stable: true` in production
+        // (planner-loop.ts marks it so it enters the cached prefix). The test
+        // fixture must mirror that — otherwise this test would only verify the
+        // single "stable prefix" block carries cache_control, and a regression
+        // in the planner-loop stable flag would slip through silently.
+        { content: "planner_stage:\nDo X.", stable: true },
       ],
       tools,
       providerOptions: {
@@ -296,11 +301,17 @@ describe("Anthropic native text plumbing", () => {
     for (const part of cacheControlled) {
       expect((part.cache_control as Record<string, unknown>).type).toBe("ephemeral");
     }
-    // The stable runtime prefix must be one of the cached blocks.
+    // Both stable segments — the runtime prefix AND the planner_stage instructions —
+    // must be among the cached blocks. The planner-loop runtime marks both
+    // `stable: true`, and with only two stable segments the coalescing limit
+    // (≤4) does not strip either.
     const stableTextValues = cacheControlled.map((p) => p.text);
     expect(stableTextValues.some((t) => typeof t === "string" && t.includes("stable prefix"))).toBe(
       true
     );
+    expect(
+      stableTextValues.some((t) => typeof t === "string" && t.includes("planner_stage"))
+    ).toBe(true);
 
     // Tools must still reach the wire and trigger native tool-calling.
     expect(call.tools).toBe(tools);

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
@@ -306,6 +306,89 @@ describe("Anthropic native text plumbing", () => {
     expect(call.tools).toBe(tools);
   }, 60_000);
 
+  it("stamps cache_control on the evaluator path (handleResponseHandler) with messages and promptSegments", async () => {
+    // The evaluator (`runEvaluator`) calls `useModel` with the same
+    // messages + promptSegments shape as the planner — same builder
+    // (`buildStageChatMessages`) plus an `evaluator_stage` instructions segment
+    // that planner-loop / evaluator both now mark stable. The provider-side
+    // wire-path fix is in `generateTextWithModel`, which is shared by the
+    // planner (handleActionPlanner) and the evaluator (handleResponseHandler),
+    // so this test locks in that the evaluator entry point also benefits.
+    const generateText = vi.fn(async () => ({
+      text: '{"success":true,"decision":"FINISH","thought":"done"}',
+      finishReason: "stop",
+      usage: {
+        inputTokens: 50,
+        outputTokens: 8,
+        cacheReadInputTokens: 40,
+        cacheCreationInputTokens: 10,
+      },
+    }));
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText: vi.fn(),
+    }));
+    vi.doMock("../providers", () => ({
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelName }),
+    }));
+
+    const { handleResponseHandler } = await import("../models/text");
+    await handleResponseHandler(createRuntime(), {
+      prompt: "ignored when messages provided",
+      messages: [
+        { role: "system", content: "stable prefix\n\nevaluator_stage:\nGrade Y." },
+        { role: "user", content: "dynamic context" },
+        {
+          role: "assistant",
+          content: "thinking",
+          toolCalls: [{ id: "tc-1", type: "function", name: "READ", arguments: "{}" }],
+        },
+        { role: "tool", toolCallId: "tc-1", name: "READ", content: "ok" },
+      ],
+      promptSegments: [
+        { content: "stable prefix", stable: true },
+        { content: "dynamic context", stable: false },
+        { content: "evaluator_stage:\nGrade Y.", stable: true },
+      ],
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+    } as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const call = generateText.mock.calls[0][0] as {
+      system?: unknown;
+      messages: Array<{ role: string; content: unknown }>;
+    };
+
+    // Same invariants as the planner test: the system parameter is dropped
+    // (its content already lives inside the structured user content), and
+    // cache_control reaches the wire on stable parts.
+    expect(call.system).toBeUndefined();
+    const allTextParts: Array<Record<string, unknown>> = [];
+    for (const message of call.messages) {
+      if (Array.isArray(message.content)) {
+        for (const part of message.content as Array<Record<string, unknown>>) {
+          if (part.type === "text") allTextParts.push(part);
+        }
+      }
+    }
+    const cacheControlled = allTextParts.filter((part) => part.cache_control);
+    expect(cacheControlled.length).toBeGreaterThan(0);
+    expect(cacheControlled.length).toBeLessThanOrEqual(4);
+    const cachedTexts = cacheControlled.map((p) => p.text);
+    // Both the runtime stable prefix and the now-stable evaluator instructions
+    // are eligible for cache_control. Either (or both) should be marked,
+    // depending on coalescing — at minimum, one of them must be.
+    expect(
+      cachedTexts.some(
+        (t) =>
+          typeof t === "string" &&
+          (t.includes("stable prefix") || t.includes("evaluator_stage"))
+      )
+    ).toBe(true);
+  }, 60_000);
+
   it("coalesces cache_control to at most 4 breakpoints when many stable segments are provided", async () => {
     // Anthropic returns 400 if a request carries more than 4 cache_control
     // breakpoints. A realistic v5 planner call has 5-9 stable segments

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
@@ -198,4 +198,157 @@ describe("Anthropic native text plumbing", () => {
     expect((stableBlock.cache_control as Record<string, unknown>).type).toBe("ephemeral");
     expect((stableBlock.cache_control as Record<string, unknown>).ttl).toBe("1h");
   }, 60_000);
+
+  it("stamps cache_control on stable segments when messages and promptSegments are both provided (planner v5 path)", async () => {
+    // Regression for the v5 planner wire path.
+    //
+    // The planner-loop calls useModel with BOTH messages (system + user + assistant/tool
+    // trajectory) AND promptSegments (the same content as labeled stable/dynamic parts).
+    // Before this fix, the segmented userContent — which carries cache_control on stable
+    // parts — was built and then discarded because the messages branch sent wireMessages
+    // directly (plain string content, no breakpoints), and providerOptions.anthropic.
+    // cacheControl was explicitly stripped. Net effect: zero cache_control blocks on
+    // the wire for every planner / evaluator call.
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      toolCalls: [{ toolName: "READ", input: { path: "x" } }],
+      finishReason: "tool-calls",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 4,
+        cacheReadInputTokens: 80,
+        cacheCreationInputTokens: 20,
+      },
+    }));
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText: vi.fn(),
+    }));
+    vi.doMock("../providers", () => ({
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelName }),
+    }));
+
+    const { handleActionPlanner } = await import("../models/text");
+    const tools = { READ: { description: "Read a file", inputSchema: { type: "object" } } };
+    // Planner-shape inputs: messages built by buildStageChatMessages — leading system
+    // message holds the stable runtime prefix + planner_stage instructions; the user
+    // message holds the dynamic context; the trajectory follows as assistant/tool pairs.
+    // promptSegments is the same content split into stable / dynamic parts.
+    await handleActionPlanner(createRuntime(), {
+      prompt: "ignored when messages provided",
+      messages: [
+        { role: "system", content: "stable prefix\n\nplanner_stage:\nDo X." },
+        { role: "user", content: "dynamic context" },
+        {
+          role: "assistant",
+          content: "thinking",
+          toolCalls: [{ id: "tc-1", type: "function", name: "READ", arguments: "{}" }],
+        },
+        { role: "tool", toolCallId: "tc-1", name: "READ", content: "ok" },
+      ],
+      promptSegments: [
+        { content: "stable prefix", stable: true },
+        { content: "dynamic context", stable: false },
+        { content: "planner_stage:\nDo X.", stable: false },
+      ],
+      tools,
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+    } as never);
+
+    expect(generateText).toHaveBeenCalledTimes(1);
+    const call = generateText.mock.calls[0][0] as {
+      system?: unknown;
+      messages: Array<{ role: string; content: unknown }>;
+      providerOptions?: Record<string, unknown>;
+      tools?: unknown;
+    };
+
+    // The trajectory's assistant/tool pair must reach the wire untouched.
+    const assistantTurn = call.messages.find((m) => m.role === "assistant");
+    const toolTurn = call.messages.find((m) => m.role === "tool");
+    expect(assistantTurn).toBeDefined();
+    expect(toolTurn).toBeDefined();
+
+    // The combined planner prefix (stable runtime + instructions + dynamic context)
+    // must reach Anthropic with at least one cache_control breakpoint on a stable
+    // part. Before the fix this assertion fails because cache_control never makes
+    // it to the wire on the messages+promptSegments path.
+    const allTextParts: Array<Record<string, unknown>> = [];
+    for (const message of call.messages) {
+      if (Array.isArray(message.content)) {
+        for (const part of message.content as Array<Record<string, unknown>>) {
+          if (part.type === "text") allTextParts.push(part);
+        }
+      }
+    }
+    const cacheControlled = allTextParts.filter((part) => part.cache_control);
+    expect(cacheControlled.length).toBeGreaterThan(0);
+    expect(cacheControlled.length).toBeLessThanOrEqual(4); // Anthropic per-call limit
+    for (const part of cacheControlled) {
+      expect((part.cache_control as Record<string, unknown>).type).toBe("ephemeral");
+    }
+    // The stable runtime prefix must be one of the cached blocks.
+    const stableTextValues = cacheControlled.map((p) => p.text);
+    expect(stableTextValues.some((t) => typeof t === "string" && t.includes("stable prefix"))).toBe(
+      true,
+    );
+
+    // Tools must still reach the wire and trigger native tool-calling.
+    expect(call.tools).toBe(tools);
+  }, 60_000);
+
+  it("coalesces cache_control to at most 4 breakpoints when many stable segments are provided", async () => {
+    // Anthropic returns 400 if a request carries more than 4 cache_control
+    // breakpoints. A realistic v5 planner call has 5-9 stable segments
+    // (staticPrefix.systemPrompt, characterPrompt, staticProviders,
+    // messageHandlerThought, selectedContexts, contextDefinitions,
+    // contextProviders, planner_stage instructions, ...) so naive per-segment
+    // stamping would always trip the limit. We expect the LAST 4 stable
+    // segments to be marked, and everything else (stable or not) to ride along
+    // unmarked inside whichever cached prefix matches at request time.
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 1 },
+    }));
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText: vi.fn(),
+    }));
+    vi.doMock("../providers", () => ({
+      createAnthropicClientWithTopPSupport: () => (modelName: string) => ({ modelName }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(createRuntime(), {
+      prompt: "ignored",
+      promptSegments: [
+        { content: "stable A", stable: true },
+        { content: "stable B", stable: true },
+        { content: "stable C", stable: true },
+        { content: "dynamic 1", stable: false },
+        { content: "stable D", stable: true },
+        { content: "stable E", stable: true },
+        { content: "stable F", stable: true },
+        { content: "dynamic 2", stable: false },
+      ],
+      providerOptions: {
+        anthropic: { cacheControl: { type: "ephemeral" } },
+      },
+    } as never);
+
+    const call = generateText.mock.calls[0][0] as {
+      messages: Array<{ content: Array<Record<string, unknown>> }>;
+    };
+    const allParts = call.messages[0].content;
+    const marked = allParts.filter((p) => p.cache_control);
+    expect(marked.length).toBeLessThanOrEqual(4);
+    expect(marked.length).toBe(4);
+    // The marked parts must be the LAST four stable segments — that placement
+    // gives the longest matching cached prefix on subsequent calls.
+    const markedTexts = marked.map((p) => p.text);
+    expect(markedTexts).toEqual(["stable C", "stable D", "stable E", "stable F"]);
+  }, 60_000);
 });

--- a/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
+++ b/plugins/plugin-anthropic/__tests__/native-plumbing.test.ts
@@ -265,6 +265,13 @@ describe("Anthropic native text plumbing", () => {
       tools?: unknown;
     };
 
+    // The runtime stable prefix + stage instructions live inside the structured
+    // user content (with cache_control on stable parts). Sending them ALSO via
+    // the system parameter would double the prompt cost on cache misses and
+    // contribute nothing on hits (the system parameter cannot carry
+    // cache_control). Assert the system parameter is dropped on this path.
+    expect(call.system).toBeUndefined();
+
     // The trajectory's assistant/tool pair must reach the wire untouched.
     const assistantTurn = call.messages.find((m) => m.role === "assistant");
     const toolTurn = call.messages.find((m) => m.role === "tool");
@@ -292,7 +299,7 @@ describe("Anthropic native text plumbing", () => {
     // The stable runtime prefix must be one of the cached blocks.
     const stableTextValues = cacheControlled.map((p) => p.text);
     expect(stableTextValues.some((t) => typeof t === "string" && t.includes("stable prefix"))).toBe(
-      true,
+      true
     );
 
     // Tools must still reach the wire and trigger native tool-calling.

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -529,17 +529,28 @@ async function generateTextWithModel(
           },
         ],
       };
-  // On the segmented + messages path, `buildPlannerWireMessages` injects the
-  // structured user content (which carries the runtime stable prefix with
-  // cache_control on stable parts) at the head of the wire. The same stable
-  // content already lives inside `systemPrompt` because
-  // `resolveEffectiveSystemPrompt` extracts it from `messages[0]` (which the
-  // planner built from those very segments). Sending it again as a flat
-  // `system: string` would (a) double the prompt cost on cache misses and (b)
-  // contribute nothing on cache hits since the system parameter cannot carry
-  // `cache_control` by itself. Drop it on this path — character / runtime
-  // identity is preserved inside the structured user content via
-  // `staticPrefix.systemPrompt` / `staticPrefix.characterPrompt` segments.
+  // PRECONDITION: when both `messages` and `promptSegments` are provided, the
+  // caller MUST construct `promptSegments` to fully cover the system content
+  // (character identity, static providers, stage instructions). The v5 planner
+  // (`planner-loop.ts`) and evaluator (`evaluator.ts`) — the only callers that
+  // pass both today — satisfy this: their `promptSegments` includes
+  // `staticPrefix.systemPrompt` / `staticPrefix.characterPrompt` rendered by
+  // `renderContextObject`, plus the appended planner_stage / evaluator_stage
+  // instructions segment. `buildPlannerWireMessages` injects that structured
+  // content (with cache_control on stable parts) at the head of the wire, so
+  // the system identity reaches the model via the user message.
+  //
+  // Given that precondition, sending `system: systemPrompt` ALSO would (a)
+  // double the prompt cost on cache misses and (b) contribute nothing on cache
+  // hits since the system parameter cannot carry `cache_control` by itself.
+  // We therefore drop it.
+  //
+  // CAUTION FOR FUTURE CALLERS: a caller that passes both `messages` and
+  // `promptSegments` but does NOT replicate the `system` content inside its
+  // segments would silently lose the system role here. If that use case
+  // appears, gate this drop on an explicit opt-in (e.g.
+  // `providerOptions.eliza.systemCoveredByPromptSegments === true`) rather
+  // than relying on the implicit segmented-prompt heuristic.
   const wireSystemPrompt =
     segmentedPrompt && paramsWithAttachments.messages ? undefined : systemPrompt;
   const generateParams: NativeTextParams = {

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -182,9 +182,7 @@ function buildSegmentedUserContent(
   const content: AnthropicUserContentPart[] = [];
   const segments = params.promptSegments ?? [];
   const breakpointIndices =
-    cacheControl !== undefined
-      ? selectCacheBreakpointIndices(segments)
-      : new Set<number>();
+    cacheControl !== undefined ? selectCacheBreakpointIndices(segments) : new Set<number>();
 
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i];
@@ -234,8 +232,7 @@ function buildPlannerWireMessages(
   wireMessages: ModelMessage[],
   userContent: UserContent | string
 ): ModelMessage[] {
-  const tail =
-    wireMessages[0]?.role === "user" ? wireMessages.slice(1) : wireMessages;
+  const tail = wireMessages[0]?.role === "user" ? wireMessages.slice(1) : wireMessages;
   return [{ role: "user", content: userContent }, ...tail];
 }
 
@@ -513,10 +510,7 @@ async function generateTextWithModel(
     ? wireMessages && wireMessages.length > 0
       ? segmentedPrompt
         ? {
-            messages: buildPlannerWireMessages(
-              wireMessages,
-              userContent ?? resolved.prompt
-            ),
+            messages: buildPlannerWireMessages(wireMessages, userContent ?? resolved.prompt),
           }
         : { messages: wireMessages }
       : {
@@ -535,10 +529,23 @@ async function generateTextWithModel(
           },
         ],
       };
+  // On the segmented + messages path, `buildPlannerWireMessages` injects the
+  // structured user content (which carries the runtime stable prefix with
+  // cache_control on stable parts) at the head of the wire. The same stable
+  // content already lives inside `systemPrompt` because
+  // `resolveEffectiveSystemPrompt` extracts it from `messages[0]` (which the
+  // planner built from those very segments). Sending it again as a flat
+  // `system: string` would (a) double the prompt cost on cache misses and (b)
+  // contribute nothing on cache hits since the system parameter cannot carry
+  // `cache_control` by itself. Drop it on this path — character / runtime
+  // identity is preserved inside the structured user content via
+  // `staticPrefix.systemPrompt` / `staticPrefix.characterPrompt` segments.
+  const wireSystemPrompt =
+    segmentedPrompt && paramsWithAttachments.messages ? undefined : systemPrompt;
   const generateParams: NativeTextParams = {
     model: anthropic(modelName),
     ...promptOrMessages,
-    system: systemPrompt,
+    system: wireSystemPrompt,
     temperature: resolved.temperature,
     stopSequences: resolved.stopSequences as string[],
     frequencyPenalty: resolved.frequencyPenalty,

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -157,18 +157,43 @@ function buildUserContent(params: GenerateTextParamsWithProviderOptions): UserCo
   return content;
 }
 
+// Anthropic accepts at most 4 `cache_control` breakpoints per request; sending
+// more returns a 400 from the API. The v5 planner / evaluator path can easily
+// exceed this once `staticPrefix`, the synthetic `selectedContexts` /
+// `contextDefinitions` blocks, optional `contextProviders`, and the now-stable
+// stage instructions are all present. Pick the LAST `MAX_CACHE_BREAKPOINTS`
+// stable segments — earlier stable segments still ride along inside any longer
+// matching prefix that a later breakpoint creates, so we lose granularity but
+// not coverage.
+const MAX_CACHE_BREAKPOINTS = 4;
+
+function selectCacheBreakpointIndices(segments: readonly { stable?: boolean }[]): Set<number> {
+  const stableIndices: number[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i]?.stable) stableIndices.push(i);
+  }
+  return new Set(stableIndices.slice(-MAX_CACHE_BREAKPOINTS));
+}
+
 function buildSegmentedUserContent(
   params: GenerateTextParamsWithProviderOptions,
   cacheControl?: AnthropicCacheControl
 ): UserContent {
   const content: AnthropicUserContentPart[] = [];
+  const segments = params.promptSegments ?? [];
+  const breakpointIndices =
+    cacheControl !== undefined
+      ? selectCacheBreakpointIndices(segments)
+      : new Set<number>();
 
-  for (const segment of params.promptSegments ?? []) {
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (!segment) continue;
     const textPart: AnthropicTextPart = {
       type: "text",
       text: segment.content,
     };
-    if (segment.stable && cacheControl) {
+    if (breakpointIndices.has(i) && cacheControl) {
       textPart.cache_control = {
         type: cacheControl.type,
         ...(cacheControl.ttl ? { ttl: cacheControl.ttl } : {}),
@@ -187,6 +212,31 @@ function buildSegmentedUserContent(
   }
 
   return content;
+}
+
+/**
+ * Build the wire `messages` array for the planner / evaluator path, where the
+ * runtime passes BOTH a `messages` array (system + user + assistant/tool
+ * trajectory, built by `buildStageChatMessages`) AND `promptSegments` (the same
+ * stable+dynamic content as labeled parts). The leading system message has
+ * already been peeled off by `dropDuplicateLeadingSystemMessage` and forwarded
+ * to the provider's separate `system` parameter; the leading user message that
+ * remains here was synthesized from dynamic context only and is fully covered
+ * by `promptSegments`, so we drop it to avoid duplicating tokens.
+ *
+ * The structured `userContent` (which carries `cache_control` on stable parts
+ * via `buildSegmentedUserContent`) is injected as the new leading user message,
+ * followed by the trajectory turns verbatim. Trajectory turns must NOT be
+ * rewritten — they are append-only across planner iterations and rewriting
+ * them would break the byte-stable prefix that prompt caching depends on.
+ */
+function buildPlannerWireMessages(
+  wireMessages: ModelMessage[],
+  userContent: UserContent | string
+): ModelMessage[] {
+  const tail =
+    wireMessages[0]?.role === "user" ? wireMessages.slice(1) : wireMessages;
+  return [{ role: "user", content: userContent }, ...tail];
 }
 
 function getRuntimeCacheControl(runtime: IAgentRuntime): AnthropicCacheControl {
@@ -446,9 +496,29 @@ async function generateTextWithModel(
     paramsWithAttachments.messages,
     systemPrompt
   );
+  // Planner / evaluator path: the runtime passes BOTH `messages` (built by
+  // `buildStageChatMessages` — leading system+user pair plus assistant/tool
+  // trajectory) AND `promptSegments` (the same stable+dynamic content as
+  // labeled parts). Without this branch, the segmented `userContent` (which
+  // carries cache_control on stable parts) was built and discarded because the
+  // messages branch sent `wireMessages` directly with flat string content; the
+  // global providerOptions.anthropic.cacheControl is also stripped a few lines
+  // above. Net result before this fix: zero cache_control blocks reached the
+  // wire on every planner / evaluator call, and Anthropic prompt caching was
+  // silently inert despite the v5 cache strategy being designed around it.
+  //
+  // See `buildPlannerWireMessages` for the per-message reshaping; covered by
+  // the "planner v5 path" test in `__tests__/native-plumbing.test.ts`.
   const promptOrMessages: NativePrompt = paramsWithAttachments.messages
     ? wireMessages && wireMessages.length > 0
-      ? { messages: wireMessages }
+      ? segmentedPrompt
+        ? {
+            messages: buildPlannerWireMessages(
+              wireMessages,
+              userContent ?? resolved.prompt
+            ),
+          }
+        : { messages: wireMessages }
       : {
           messages: [
             {


### PR DESCRIPTION
## Summary

Fixes the v5 planner/evaluator Anthropic prompt-cache path.

`planner-loop.ts` and `evaluator.ts` both call `useModel` with both `messages` AND `promptSegments`. Previously, `plugin-anthropic` built segmented structured content (with `cache_control` on stable parts) and then discarded it because the messages branch sent `wireMessages` directly with flat string content; the global `providerOptions.anthropic.cacheControl` was also explicitly stripped a few lines above. Net result: zero `cache_control` blocks reached the wire on every planner / evaluator call, and Anthropic prompt caching was silently inert despite the v5 cache strategy being designed around stable / dynamic segment tagging.

This PR:

- **`plugin-anthropic/models/text.ts`** — when both `messages` and `promptSegments` are provided, the structured `userContent` (with `cache_control` on stable parts) replaces the leading user message produced by `buildStageChatMessages`. Trajectory turns (assistant/tool pairs) are preserved verbatim to keep the prefix byte-stable across iterations.
- **`plugin-anthropic/models/text.ts`** — drops the separate `system` parameter on this structured path. Its content (extracted from `messages[0]` by `resolveEffectiveSystemPrompt`) duplicates the runtime stable prefix already inside the structured user content via `staticPrefix.systemPrompt` / `staticPrefix.characterPrompt` segments rendered by `renderContextObject`. Sending it twice doubled token cost on cache miss and contributed nothing on cache hit (the `system` parameter cannot carry `cache_control` on its own).
- **`plugin-anthropic/models/text.ts`** — coalesces `cache_control` to the LAST 4 stable segments. Anthropic returns 400 above 4 breakpoints, and a realistic v5 call now has 5–9 stable segments. Earlier stable segments still ride along inside whichever longer matching cached prefix a later breakpoint creates.
- **`packages/core/src/runtime/planner-loop.ts`** and **`packages/core/src/runtime/evaluator.ts`** — mark the appended `planner_stage` and `evaluator_stage` instructions segments `stable: true`. They are template-derived (`v5PlannerTemplate` / `v5EvaluatorTemplate`) and structurally identical across iterations and across user turns, so they belong in the cached prefix.

The provider-side wire-path fix is in `generateTextWithModel`, which is shared by `handleActionPlanner` and `handleResponseHandler` — so both the planner entry (`runPlannerLoop`) and the evaluator entry (`runEvaluator`) benefit.

## Test plan

- [x] `plugin-anthropic` regression: planner v5 path with `messages` + `promptSegments` + `tools` — asserts `cache_control` reaches `generateText.mock.calls[0][0]` and is bounded by Anthropic's 4-block limit
- [x] `plugin-anthropic` regression: evaluator path (`handleResponseHandler`) with the same shape — locks in that the evaluator entry point also receives `cache_control` on stable segments and has `system` dropped on the structured path
- [x] `plugin-anthropic` regression: `call.system` is `undefined` on the structured planner/evaluator path
- [x] `plugin-anthropic` regression: 6 stable segments → exactly 4 `cache_control` markers, on the LAST 4 segments
- [x] All existing `plugin-anthropic` tests still pass (**8/8**)
- [x] `plugin-openai` (**13/13**) and `plugin-openrouter` (**5/5**) suites pass — confirms the core stable-flag change does not affect non-Anthropic providers (their caching uses server-side `promptCacheKey` via `providerOptions`, untouched here)
- [x] `bunx turbo run lint --filter=@elizaos/core --filter=@elizaos/plugin-anthropic` clean on touched files
- [x] `@elizaos/plugin-anthropic` typecheck passes

## Reviewer note

The key thing to review is the serialization boundary in `plugin-anthropic/models/text.ts`: `cache_control` metadata should be present on the actual final message content passed to `generateText`, not only on intermediate prompt segments. The new tests assert against `generateText.mock.calls[0][0]` so the regression is anchored at the wire layer.

The `system`-drop change is deliberately scoped to the `segmentedPrompt && messages` branch in `plugin-anthropic` only. The non-segmented messages path (`{ messages: wireMessages }`) is unchanged — the existing "passes system separately and strips the duplicate leading system message" test still passes. Other providers are untouched.

## Notes

`@elizaos/core` typecheck reports 11 unresolved sibling-plugin imports (`@elizaos/skills`, `@elizaos/plugin-local-embedding`, `@elizaos/plugin-discord`, `@elizaos/plugin-telegram`, and one generated codegen file). The exact same 11-error set is observed on `develop` at the same commit — `diff` of the captured error sets is empty. Pre-existing, unrelated to touched files; likely workspace/build-order related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent bug in the v5 planner/evaluator Anthropic prompt-caching path: when both `messages` and `promptSegments` were provided, the provider was constructing structured `userContent` with `cache_control` breakpoints and then discarding it, sending flat string content instead. The result was that zero `cache_control` blocks ever reached the wire despite the caching infrastructure being in place.

- **`plugin-anthropic/models/text.ts`**: adds `buildPlannerWireMessages` (replaces the leading wire user message with the structured, `cache_control`-annotated content), drops the redundant `system` parameter on this path, and adds `selectCacheBreakpointIndices` to coalesce breakpoints to the last 4 stable segments (Anthropic's per-request cap).
- **`evaluator.ts` / `planner-loop.ts`**: marks the `evaluator_stage` / `planner_stage` instructions segments `stable: true`, since they are template-derived constants that belong in the cached prefix.
- **`native-plumbing.test.ts`**: adds three targeted regression tests locking in that `cache_control` reaches the `generateText` wire call and is bounded by the 4-block limit.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is scoped to the Anthropic planner/evaluator wire path and does not affect other providers or the non-segmented messages flow.

The fix correctly threads cache_control-bearing structured content through the planner/evaluator code path that previously discarded it. The two new helper functions (selectCacheBreakpointIndices, buildPlannerWireMessages) are simple and have deterministic behavior. The system-drop is gated on the exact condition where it is safe (segmentedPrompt && messages), is clearly documented with a precondition comment and a future-caller warning, and is covered by explicit test assertions on call.system === undefined. Regression tests are anchored at the generateText wire call, not at an internal intermediate step, making them robust. Non-Anthropic providers and the non-segmented messages path are untouched.

No files require special attention. The most complex change is in plugins/plugin-anthropic/models/text.ts and is well-covered by the new tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-anthropic/models/text.ts | Core fix: adds buildPlannerWireMessages to inject cache_control-bearing structured content into wire messages, coalesces breakpoints to ≤4 via selectCacheBreakpointIndices, and drops the system parameter (which cannot carry cache_control) when the structured planner path is active. Logic is correct and well-commented. |
| plugins/plugin-anthropic/__tests__/native-plumbing.test.ts | Adds three regression tests anchored at the generateText wire call: planner v5 path (messages + promptSegments), evaluator path, and 6-stable-segment coalescing to exactly 4 breakpoints. Planner test correctly uses stable: true for the stage segment, matching the production change. |
| packages/core/src/runtime/evaluator.ts | Changes evaluator_stage instructions segment from stable: false to stable: true; appropriate since the segment content is derived from a static template constant across all calls. |
| packages/core/src/runtime/planner-loop.ts | Changes planner_stage instructions segment from stable: false to stable: true; same rationale as evaluator.ts — v5PlannerTemplate is structurally invariant across planner iterations. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateTextWithModel()"] --> B{messages provided?}
    B -->|No| C["buildSegmentedUserContent()\nor resolved.prompt"]
    B -->|Yes| D{wireMessages.length > 0?}
    D -->|No| E["messages: [{role: user, content: userContent}]"]
    D -->|Yes| F{segmentedPrompt?}
    F -->|No - old path| G["messages: wireMessages\n(flat string, no cache_control)"]
    F -->|Yes - NEW planner/evaluator path| H["buildPlannerWireMessages(wireMessages, userContent)"]
    H --> I["Drop leading user message\nInject structured userContent\nwith cache_control breakpoints\nPreserve trajectory tail verbatim"]
    I --> N["generateText() call\nsystem: undefined\nmessages: user+cache_control, trajectory..."]
    G --> O["generateText() call\nsystem: systemPrompt\nmessages: wireMessages"]
    C --> P["generateText() call\nsystem: systemPrompt\nmessages: [{role: user, userContent}]"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-anthropic): address Greptile ..."](https://github.com/elizaos/eliza/commit/4d5c4553fa3b1f25b0313a6e4dec26b377680231) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31268421)</sub>

<!-- /greptile_comment -->