### PR TITLE
fix(orchestrator): harden codex exec sessions

### DIFF
--- a/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
+++ b/plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs
@@ -8,8 +8,53 @@ const CODEX_APPROVAL_FLAGS = {
   permissive: ["-s", "workspace-write"],
   autonomous: ["--yolo"],
 };
+const CODEX_WEB_SEARCH_BY_PRESET = {
+  readonly: false,
+  standard: true,
+  permissive: true,
+  autonomous: true,
+};
+const CODEX_SANDBOX_MODES = new Set([
+  "read-only",
+  "workspace-write",
+  "danger-full-access",
+]);
 
 const CODEX_TASK_AGENT_REASONING_EFFORT = "xhigh";
+
+function settingIsOff(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return /^(?:off|false|0|none|disabled)$/i.test(value.trim());
+}
+
+function resolveCodexApprovalFlags(approvalPreset) {
+  const sandboxMode =
+    typeof process.env.CODEX_EXEC_SANDBOX_MODE === "string"
+      ? process.env.CODEX_EXEC_SANDBOX_MODE.trim().toLowerCase()
+      : "";
+
+  if (sandboxMode) {
+    if (settingIsOff(sandboxMode)) {
+      return ["--dangerously-bypass-approvals-and-sandbox"];
+    }
+
+    if (CODEX_SANDBOX_MODES.has(sandboxMode)) {
+      return ["-s", sandboxMode];
+    }
+
+    return ["-s", "read-only"];
+  }
+
+  if (settingIsOff(process.env.CODING_AGENT_SANDBOX)) {
+    return ["--dangerously-bypass-approvals-and-sandbox"];
+  }
+
+  return (
+    CODEX_APPROVAL_FLAGS[approvalPreset] ?? CODEX_APPROVAL_FLAGS.autonomous
+  );
+}
 
 function patchCodexAdapter(adapter) {
   if (!adapter || adapter.adapterType !== "codex") {
@@ -36,6 +81,10 @@ function patchCodexAdapter(adapter) {
     args.push(
       "-c",
       `model_reasoning_effort=${CODEX_TASK_AGENT_REASONING_EFFORT}`,
+      "-c",
+      `tools.web_search=${
+        CODEX_WEB_SEARCH_BY_PRESET[approvalPreset] === false ? "false" : "true"
+      }`,
     );
 
     const model =
@@ -46,10 +95,7 @@ function patchCodexAdapter(adapter) {
       args.push("--model", model);
     }
 
-    args.push(
-      ...(CODEX_APPROVAL_FLAGS[approvalPreset] ??
-        CODEX_APPROVAL_FLAGS.autonomous),
-    );
+    args.push(...resolveCodexApprovalFlags(approvalPreset));
 
     if (config.workdir) {
       args.push("-C", config.workdir);

--- a/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { splitAgentSpecsParam } from "../actions/coding-task-handlers.js";
+import { pushDefaultRules } from "../services/pty-auto-response.js";
 import { shouldSuppressCodexExecPtyManagerEvent } from "../services/pty-service.js";
 import {
   type SessionIOContext,
@@ -90,6 +91,8 @@ describe("Codex exec adapter", () => {
       "--ephemeral",
       "-c",
       "model_reasoning_effort=xhigh",
+      "-c",
+      "tools.web_search=true",
       "--model",
       "gpt-codex-test",
       "--yolo",
@@ -102,6 +105,216 @@ describe("Codex exec adapter", () => {
       "/tmp/codex-last-message.txt",
       "build the app",
     ]);
+  });
+
+  it("can disable Codex CLI sandboxing for externally sandboxed deployments", () => {
+    const previousSandboxMode = process.env.CODEX_EXEC_SANDBOX_MODE;
+    const previousCodingSandbox = process.env.CODING_AGENT_SANDBOX;
+    process.env.CODEX_EXEC_SANDBOX_MODE = "off";
+    delete process.env.CODING_AGENT_SANDBOX;
+
+    try {
+      const adapters = require("../../scripts/codex-exec-adapters.cjs") as {
+        createAllAdapters(): Array<{
+          adapterType: string;
+          getArgs(config: {
+            workdir?: string;
+            env?: Record<string, string>;
+            adapterConfig?: Record<string, unknown>;
+          }): string[];
+        }>;
+      };
+      const codex = adapters
+        .createAllAdapters()
+        .find((adapter) => adapter.adapterType === "codex");
+
+      const args = codex?.getArgs({
+        workdir: "/tmp/workdir",
+        env: { OPENAI_MODEL: "gpt-codex-test" },
+        adapterConfig: {
+          initialPrompt: "inspect status",
+          approvalPreset: "readonly",
+        },
+      });
+
+      expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(args).not.toContain("read-only");
+    } finally {
+      if (previousSandboxMode === undefined) {
+        delete process.env.CODEX_EXEC_SANDBOX_MODE;
+      } else {
+        process.env.CODEX_EXEC_SANDBOX_MODE = previousSandboxMode;
+      }
+      if (previousCodingSandbox === undefined) {
+        delete process.env.CODING_AGENT_SANDBOX;
+      } else {
+        process.env.CODING_AGENT_SANDBOX = previousCodingSandbox;
+      }
+    }
+  });
+
+  it("lets explicit Codex sandbox mode take precedence over legacy sandbox disable", () => {
+    const previousSandboxMode = process.env.CODEX_EXEC_SANDBOX_MODE;
+    const previousCodingSandbox = process.env.CODING_AGENT_SANDBOX;
+    process.env.CODEX_EXEC_SANDBOX_MODE = "read-only";
+    process.env.CODING_AGENT_SANDBOX = "off";
+
+    try {
+      const adapters = require("../../scripts/codex-exec-adapters.cjs") as {
+        createAllAdapters(): Array<{
+          adapterType: string;
+          getArgs(config: {
+            workdir?: string;
+            env?: Record<string, string>;
+            adapterConfig?: Record<string, unknown>;
+          }): string[];
+        }>;
+      };
+      const codex = adapters
+        .createAllAdapters()
+        .find((adapter) => adapter.adapterType === "codex");
+
+      const args = codex?.getArgs({
+        adapterConfig: {
+          initialPrompt: "inspect status",
+          approvalPreset: "autonomous",
+        },
+      });
+
+      expect(args).toContain("read-only");
+      expect(args).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+    } finally {
+      if (previousSandboxMode === undefined) {
+        delete process.env.CODEX_EXEC_SANDBOX_MODE;
+      } else {
+        process.env.CODEX_EXEC_SANDBOX_MODE = previousSandboxMode;
+      }
+      if (previousCodingSandbox === undefined) {
+        delete process.env.CODING_AGENT_SANDBOX;
+      } else {
+        process.env.CODING_AGENT_SANDBOX = previousCodingSandbox;
+      }
+    }
+  });
+
+  it("uses shared off-value parsing for explicit Codex sandbox disable", () => {
+    const previousSandboxMode = process.env.CODEX_EXEC_SANDBOX_MODE;
+    const previousCodingSandbox = process.env.CODING_AGENT_SANDBOX;
+    process.env.CODEX_EXEC_SANDBOX_MODE = "false";
+    delete process.env.CODING_AGENT_SANDBOX;
+
+    try {
+      const adapters = require("../../scripts/codex-exec-adapters.cjs") as {
+        createAllAdapters(): Array<{
+          adapterType: string;
+          getArgs(config: {
+            workdir?: string;
+            env?: Record<string, string>;
+            adapterConfig?: Record<string, unknown>;
+          }): string[];
+        }>;
+      };
+      const codex = adapters
+        .createAllAdapters()
+        .find((adapter) => adapter.adapterType === "codex");
+
+      const args = codex?.getArgs({
+        adapterConfig: {
+          initialPrompt: "inspect status",
+          approvalPreset: "readonly",
+        },
+      });
+
+      expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(args).not.toContain("read-only");
+    } finally {
+      if (previousSandboxMode === undefined) {
+        delete process.env.CODEX_EXEC_SANDBOX_MODE;
+      } else {
+        process.env.CODEX_EXEC_SANDBOX_MODE = previousSandboxMode;
+      }
+      if (previousCodingSandbox === undefined) {
+        delete process.env.CODING_AGENT_SANDBOX;
+      } else {
+        process.env.CODING_AGENT_SANDBOX = previousCodingSandbox;
+      }
+    }
+  });
+
+  it("fails closed when explicit Codex sandbox mode is not recognized", () => {
+    const previousSandboxMode = process.env.CODEX_EXEC_SANDBOX_MODE;
+    const previousCodingSandbox = process.env.CODING_AGENT_SANDBOX;
+    process.env.CODEX_EXEC_SANDBOX_MODE = "readonly";
+    process.env.CODING_AGENT_SANDBOX = "off";
+
+    try {
+      const adapters = require("../../scripts/codex-exec-adapters.cjs") as {
+        createAllAdapters(): Array<{
+          adapterType: string;
+          getArgs(config: {
+            workdir?: string;
+            env?: Record<string, string>;
+            adapterConfig?: Record<string, unknown>;
+          }): string[];
+        }>;
+      };
+      const codex = adapters
+        .createAllAdapters()
+        .find((adapter) => adapter.adapterType === "codex");
+
+      const args = codex?.getArgs({
+        adapterConfig: {
+          initialPrompt: "inspect status",
+          approvalPreset: "autonomous",
+        },
+      });
+
+      expect(args).toContain("-s");
+      expect(args).toContain("read-only");
+      expect(args).not.toContain("--yolo");
+      expect(args).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+    } finally {
+      if (previousSandboxMode === undefined) {
+        delete process.env.CODEX_EXEC_SANDBOX_MODE;
+      } else {
+        process.env.CODEX_EXEC_SANDBOX_MODE = previousSandboxMode;
+      }
+      if (previousCodingSandbox === undefined) {
+        delete process.env.CODING_AGENT_SANDBOX;
+      } else {
+        process.env.CODING_AGENT_SANDBOX = previousCodingSandbox;
+      }
+    }
+  });
+});
+
+describe("pushDefaultRules", () => {
+  it("lets non-interactive Codex sessions accept routine organization selection prompts", async () => {
+    const rules: Array<{ pattern: RegExp; keys?: string[]; type: string }> = [];
+
+    await pushDefaultRules(
+      {
+        manager: {
+          addAutoResponseRule: async (_sessionId: string, rule: never) => {
+            rules.push(rule);
+          },
+        },
+        usingBunWorker: true,
+        runtime: {},
+        log: () => undefined,
+      } as never,
+      "session-1",
+      "codex",
+    );
+
+    const rule = rules.find((candidate) =>
+      candidate.pattern.test("Organization selection"),
+    );
+
+    expect(rule).toMatchObject({
+      type: "config",
+      keys: ["enter"],
+    });
   });
 });
 

--- a/plugins/plugin-agent-orchestrator/src/services/pty-auto-response.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-auto-response.ts
@@ -26,6 +26,8 @@ const CODEX_KEEP_CURRENT_MODEL_NEVER_PROMPT_RE =
   /keep\s+current\s+model\s*\(never\s+show\s+again\)|hide\s+future\s+rate\s+limit\s+reminders\s+about\s+switching\s+models/i;
 const CODEX_KEEP_CURRENT_MODEL_PROMPT_RE =
   /^(?![\s\S]*(?:never\s+show\s+again|hide\s+future\s+rate\s+limit\s+reminders))(?=[\s\S]*\bkeep\s+current\s+model\b)(?=[\s\S]*(?:efficient\s+model|less\s+capable|faster|rate\s+limit|switching\s+models))/i;
+const CODEX_DEFAULT_ACCOUNT_SELECTION_PROMPT_RE =
+  /(?:organization|account|team)\s+selection|select\s+(?:an?\s+)?(?:organization|account|team)\b/i;
 
 /**
  * Push session-specific auto-response rules that depend on runtime config.
@@ -74,6 +76,16 @@ export async function pushDefaultRules(
       keys: ["1", "enter"],
       description:
         "Retry Codex workspace trust approval with option 1 ('Yes, continue') until the prompt clears",
+      safe: true,
+    });
+    rules.push({
+      pattern: CODEX_DEFAULT_ACCOUNT_SELECTION_PROMPT_RE,
+      type: "config",
+      response: "",
+      responseType: "keys" as const,
+      keys: ["enter"],
+      description:
+        "Accept Codex's default organization/account selection for non-interactive subscription sessions",
       safe: true,
     });
   }


### PR DESCRIPTION
## Summary
- run Codex task agents through non-interactive `codex exec` with deterministic exec flags
- configure Codex CLI web search by approval preset: readonly sessions stay offline, other presets can use web search
- make sandbox resolution explicit and fail-closed:
  - `CODEX_EXEC_SANDBOX_MODE` takes precedence over legacy `CODING_AGENT_SANDBOX`
  - shared off-value parsing supports `off`, `false`, `0`, `none`, and `disabled`
  - unrecognized explicit sandbox values fall back to `read-only` instead of preset defaults or legacy bypass
- let non-interactive Codex sessions accept routine organization/account/team selection prompts with Enter

## Review Follow-Up
- addressed Greptile's sandbox-precedence/off-value comments
- added a fail-closed guard for invalid explicit `CODEX_EXEC_SANDBOX_MODE` values such as `readonly`

## Validation
- `git diff --check`
- `bunx biome check --write plugins/plugin-agent-orchestrator/scripts/codex-exec-adapters.cjs plugins/plugin-agent-orchestrator/src/__tests__/pty-auto-response.test.ts`
- `bun run --cwd plugins/plugin-agent-orchestrator test -- src/__tests__/pty-auto-response.test.ts` (12 tests)
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck`
- `bun run --cwd plugins/plugin-agent-orchestrator build`

Branch was checked against latest `origin/develop` before push: `1` ahead / `0` behind, with `origin/develop` an ancestor of `HEAD`.