### PR TITLE
fix(shared): use source imports for env utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,8 +285,6 @@ packages/shared/src/**/*.js.map
 packages/shared/src/**/*.d.ts
 packages/shared/src/**/*.d.ts.map
 !packages/shared/src/elizaos-core-roles.d.ts
-!packages/shared/src/env-utils.impl.js
-!packages/shared/src/env-utils.impl.d.ts
 apps/*/src/**/*.js
 apps/*/src/**/*.js.map
 apps/*/src/**/*.d.ts

--- a/packages/shared/src/contracts/onboarding.ts
+++ b/packages/shared/src/contracts/onboarding.ts
@@ -2,7 +2,7 @@
  * Shared onboarding contracts.
  */
 
-import { isTruthyEnvValue } from "../env-utils.impl.js";
+import { isTruthyEnvValue } from "../env-utils.ts";
 import type {
   DeploymentTargetConfig,
   LinkedAccountFlagsConfig,

--- a/packages/shared/src/env-utils.impl.ts
+++ b/packages/shared/src/env-utils.impl.ts
@@ -1,8 +1,0 @@
-const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "y", "on", "enabled"]);
-
-export function isTruthyEnvValue(value: string | undefined | null): boolean {
-  if (typeof value !== "string") return false;
-  const normalized = value.trim().toLowerCase();
-  if (!normalized) return false;
-  return TRUTHY_ENV_VALUES.has(normalized);
-}

--- a/packages/shared/src/env-utils.ts
+++ b/packages/shared/src/env-utils.ts
@@ -1,4 +1,11 @@
 /**
  * Shared environment variable utilities.
  */
-export { isTruthyEnvValue } from "./env-utils.impl.js";
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "y", "on", "enabled"]);
+
+export function isTruthyEnvValue(value: string | undefined | null): boolean {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  return TRUTHY_ENV_VALUES.has(normalized);
+}

--- a/packages/shared/src/runtime-env.ts
+++ b/packages/shared/src/runtime-env.ts
@@ -1,4 +1,4 @@
-import { isTruthyEnvValue } from "./env-utils.impl.js";
+import { isTruthyEnvValue } from "./env-utils.ts";
 
 const DEFAULT_API_BIND_HOST = "127.0.0.1";
 export const DEFAULT_SERVER_ONLY_PORT = 2138;

--- a/packages/shared/src/self-edit.ts
+++ b/packages/shared/src/self-edit.ts
@@ -23,7 +23,7 @@
  * @module self-edit
  */
 
-import { isTruthyEnvValue } from "./env-utils.impl.js";
+import { isTruthyEnvValue } from "./env-utils.ts";
 
 /**
  * Env var the operator sets to opt in to self-edit. Defaults off.

--- a/packages/shared/src/settings-debug.ts
+++ b/packages/shared/src/settings-debug.ts
@@ -3,7 +3,7 @@
  * Enable with ELIZA_SETTINGS_DEBUG=1 (and Vite: same env at build time, or VITE_ELIZA_SETTINGS_DEBUG=1).
  */
 
-import { isTruthyEnvValue } from "./env-utils.impl.js";
+import { isTruthyEnvValue } from "./env-utils.ts";
 
 /** Keys whose values are always redacted in debug dumps. */
 const SENSITIVE_KEY_RE =
@@ -47,6 +47,53 @@ function maskString(s: string): string {
   return `${t.slice(0, 4)}…${t.slice(-2)} (${t.length} chars)`;
 }
 
+function sanitizeDebugString(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return "";
+  if (trimmed.toUpperCase() === "[REDACTED]") return "[REDACTED]";
+  if (trimmed.length > 48 || /^(sk-|pk_|Bearer\s)/i.test(trimmed)) {
+    return maskString(trimmed);
+  }
+  if (trimmed.length > MAX_STRING) return `${trimmed.slice(0, MAX_STRING)}…`;
+  return trimmed;
+}
+
+function sanitizeDebugArray(
+  value: unknown[],
+  depth: number,
+  seen: WeakSet<object>,
+): unknown[] {
+  const out: unknown[] = [];
+  const cap = Math.min(value.length, MAX_ARRAY);
+  for (let i = 0; i < cap; i++) {
+    out.push(sanitizeForSettingsDebug(value[i], depth + 1, seen));
+  }
+  if (value.length > cap) {
+    out.push(`… +${value.length - cap} more`);
+  }
+  return out;
+}
+
+function sanitizeSensitiveDebugValue(value: unknown): unknown {
+  if (typeof value === "string" && value.trim()) return maskString(value);
+  if (value == null || value === "") return value;
+  return "[redacted]";
+}
+
+function sanitizeDebugObject(
+  value: Record<string, unknown>,
+  depth: number,
+  seen: WeakSet<object>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    out[key] = SENSITIVE_KEY_RE.test(key)
+      ? sanitizeSensitiveDebugValue(item)
+      : sanitizeForSettingsDebug(item, depth + 1, seen);
+  }
+  return out;
+}
+
 /**
  * Deep-clone-ish snapshot safe to log (secrets masked). Not for security boundaries — debug only.
  */
@@ -58,14 +105,7 @@ export function sanitizeForSettingsDebug(
   if (depth > MAX_DEPTH) return "[max-depth]";
   if (value === null || value === undefined) return value;
   if (typeof value === "boolean" || typeof value === "number") return value;
-  if (typeof value === "string") {
-    const t = value.trim();
-    if (t.length === 0) return "";
-    if (t.toUpperCase() === "[REDACTED]") return "[REDACTED]";
-    if (t.length > 48 || /^(sk-|pk_|Bearer\s)/i.test(t)) return maskString(t);
-    if (t.length > MAX_STRING) return `${t.slice(0, MAX_STRING)}…`;
-    return t;
-  }
+  if (typeof value === "string") return sanitizeDebugString(value);
   if (typeof value === "bigint") return String(value);
   if (typeof value === "function") return `[fn ${value.name || "anonymous"}]`;
   if (typeof value !== "object") return String(value);
@@ -74,32 +114,10 @@ export function sanitizeForSettingsDebug(
   seen.add(value as object);
 
   if (Array.isArray(value)) {
-    const out: unknown[] = [];
-    const cap = Math.min(value.length, MAX_ARRAY);
-    for (let i = 0; i < cap; i++) {
-      out.push(sanitizeForSettingsDebug(value[i], depth + 1, seen));
-    }
-    if (value.length > cap) {
-      out.push(`… +${value.length - cap} more`);
-    }
-    return out;
+    return sanitizeDebugArray(value, depth, seen);
   }
 
-  const o = value as Record<string, unknown>;
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(o)) {
-    if (SENSITIVE_KEY_RE.test(k)) {
-      out[k] =
-        typeof v === "string" && v.trim()
-          ? maskString(v)
-          : v == null || v === ""
-            ? v
-            : "[redacted]";
-    } else {
-      out[k] = sanitizeForSettingsDebug(v, depth + 1, seen);
-    }
-  }
-  return out;
+  return sanitizeDebugObject(value as Record<string, unknown>, depth, seen);
 }
 
 /** Compact cloud slice for logs (no raw secrets). */


### PR DESCRIPTION
## Summary
- remove the duplicate `env-utils.impl.ts` compatibility shim by moving `isTruthyEnvValue` into `env-utils.ts`
- update shared source imports to use the public `env-utils.ts` source module directly
- remove stale `.gitignore` exceptions for generated `env-utils.impl` artifacts
- split `sanitizeForSettingsDebug()` into focused string, array, sensitive-value, and object sanitizers to reduce method complexity in the touched settings-debug module without changing behavior

## Review Follow-Up
- addressed the orphaned `.gitignore` exceptions and duplicate-purpose shim called out in review
- reduced the CodeFactor complexity warning in `settings-debug.ts` with responsibility-separated helpers rather than preserving one large sanitizer body

## Validation
- `git diff --check`
- `bunx biome check --write packages/shared/src/env-utils.ts packages/shared/src/runtime-env.ts packages/shared/src/settings-debug.ts packages/shared/src/self-edit.ts packages/shared/src/contracts/onboarding.ts`
- `bun run --cwd packages/shared typecheck`
- `bun run --cwd packages/shared build`

Branch was checked against latest `origin/develop` before push: `1` ahead / `0` behind, with `origin/develop` an ancestor of `HEAD`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates the `env-utils.impl.ts` compatibility shim by inlining `isTruthyEnvValue` directly into `env-utils.ts` and updating all internal consumers to import from the source file. Behavior is unchanged — the implementation is byte-for-byte identical to what the shim contained.

- **Shim removal**: `env-utils.impl.ts` is deleted; its `isTruthyEnvValue` implementation is copied verbatim into `env-utils.ts`, and four import sites (`runtime-env.ts`, `self-edit.ts`, `settings-debug.ts`, `onboarding.ts`) are updated to point at the new location.
- **`settings-debug.ts` refactor**: The monolithic `sanitizeForSettingsDebug` function is split into four private helpers (`sanitizeDebugString`, `sanitizeDebugArray`, `sanitizeSensitiveDebugValue`, `sanitizeDebugObject`); all extracted logic is semantically equivalent to the original.
- **`.gitignore` cleanup**: Two stale negation entries for the now-deleted `env-utils.impl.js` and `env-utils.impl.d.ts` artifacts are removed, along with a missing trailing newline.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure consolidation of a re-export shim, with no logic changes anywhere in the diff.

All changed files either update a single import path or extract already-correct inline logic into private helpers. The isTruthyEnvValue implementation in env-utils.ts is character-for-character identical to the deleted shim, and the settings-debug.ts refactor produces the same output for every input class.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/shared/src/env-utils.ts | Inlines isTruthyEnvValue implementation from the deleted shim; logic is byte-for-byte identical to env-utils.impl.ts |
| packages/shared/src/env-utils.impl.ts | Deleted shim file; its implementation is now directly in env-utils.ts with no behavioral change |
| packages/shared/src/settings-debug.ts | Import updated to env-utils.ts; large inline sanitizeForSettingsDebug logic extracted into four private helper functions with identical behavior |
| packages/shared/src/runtime-env.ts | Single-line import path update from env-utils.impl.js to env-utils.ts; no logic changes |
| packages/shared/src/contracts/onboarding.ts | Import updated from ../env-utils.impl.js to ../env-utils.ts; no other changes |
| .gitignore | Removes two dead negation exceptions for the now-deleted env-utils.impl artifacts; adds trailing newline |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(shared): use source imports for env ..."](https://github.com/elizaos/eliza/commit/5ccd04d2940692313847e9048fc38f5417d27cf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31281650)</sub>

<!-- /greptile_comment -->