### PR TITLE
fix(core): read primitive character env settings

### DIFF
--- a/packages/core/src/__tests__/runtime-settings.test.ts
+++ b/packages/core/src/__tests__/runtime-settings.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Character } from "../types";
+
+describe("AgentRuntime.getSetting", () => {
+	it("reads primitive character env values as runtime settings", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "env-settings-test",
+				env: {
+					FEATURE_FLAG: true,
+					TIMEOUT_MS: 5000,
+					vars: {
+						ROUTE_POLICY: '{"default":"guest"}',
+					},
+				},
+				settings: {
+					ROUTE_POLICY: '{"default":"owner"}',
+				},
+			} as Character,
+		});
+
+		expect(runtime.getSetting("FEATURE_FLAG")).toBe(true);
+		expect(runtime.getSetting("TIMEOUT_MS")).toBe(5000);
+		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"owner"}');
+	});
+
+	it("reads primitive values from character env vars", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "env-vars-settings-test",
+				env: {
+					vars: {
+						ROUTE_POLICY: '{"default":"guest"}',
+					},
+				},
+			} as Character,
+		});
+
+		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"guest"}');
+	});
+
+	it("falls back to env vars when direct env values are not primitive", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "env-vars-fallback-test",
+				env: {
+					ROUTE_POLICY: {
+						default: "owner",
+					},
+					vars: {
+						ROUTE_POLICY: '{"default":"guest"}',
+					},
+				},
+			} as Character,
+		});
+
+		expect(runtime.getSetting("ROUTE_POLICY")).toBe('{"default":"guest"}');
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -963,7 +963,9 @@ export class AgentRuntime implements IAgentRuntime {
 		return serviceType;
 	}
 
-	private nativeRuntimeFeatureSettingKey(feature: NativeRuntimeFeature): string {
+	private nativeRuntimeFeatureSettingKey(
+		feature: NativeRuntimeFeature,
+	): string {
 		return feature === "documents"
 			? "ENABLE_KNOWLEDGE"
 			: `ENABLE_${feature.toUpperCase()}`;
@@ -2173,6 +2175,42 @@ export class AgentRuntime implements IAgentRuntime {
 		}
 	}
 
+	private getCharacterEnvSetting(
+		key: string,
+	): string | boolean | number | undefined {
+		const env = (this.character as { env?: unknown }).env;
+		if (!env || typeof env !== "object" || Array.isArray(env)) {
+			return undefined;
+		}
+
+		const envRecord = env as Record<string, unknown>;
+		const vars =
+			envRecord.vars &&
+			typeof envRecord.vars === "object" &&
+			!Array.isArray(envRecord.vars)
+				? (envRecord.vars as Record<string, unknown>)
+				: undefined;
+
+		const directValue = envRecord[key];
+		if (
+			typeof directValue === "string" ||
+			typeof directValue === "boolean" ||
+			typeof directValue === "number"
+		) {
+			return directValue;
+		}
+
+		const varsValue = vars?.[key];
+		if (
+			typeof varsValue === "string" ||
+			typeof varsValue === "boolean" ||
+			typeof varsValue === "number"
+		) {
+			return varsValue;
+		}
+		return undefined;
+	}
+
 	getSetting(key: string): string | boolean | number | null {
 		const settings = this.character.settings;
 		const secrets = this.character.secrets;
@@ -2201,6 +2239,7 @@ export class AgentRuntime implements IAgentRuntime {
 			settings?.[key] ??
 			extraSettings?.[key] ??
 			nestedSecrets?.[key] ??
+			this.getCharacterEnvSetting(key) ??
 			this.settings[key];
 
 		// Handle each type appropriately


### PR DESCRIPTION
## Summary
- allow `AgentRuntime.getSetting()` to read primitive values from `character.env` and `character.env.vars`
- preserve existing precedence: secrets, settings, extra settings, and nested setting secrets still override character env values
- ignore object/array env values, and fall back from a non-primitive direct env value to a primitive `env.vars` value

## Review Follow-Up
- added a vars-only test so the `env.vars` branch is actually exercised
- fixed non-primitive direct env values blocking a valid primitive `env.vars[key]`

## Validation
- `git diff --check`
- `bunx biome check --write packages/core/src/runtime.ts packages/core/src/__tests__/runtime-settings.test.ts`
- `bun run --cwd packages/core test -- src/__tests__/runtime-settings.test.ts` (3 tests)
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`

Branch was checked against latest `origin/develop` before push: `1` ahead / `0` behind, with `origin/develop` an ancestor of `HEAD`.