### PR TITLE
fix(plugin-ollama): bring it up to date, so it's useable

### DIFF
--- a/packages/docs/plugin-registry/llm/ollama.md
+++ b/packages/docs/plugin-registry/llm/ollama.md
@@ -165,9 +165,9 @@ Secure with a reverse proxy (Nginx + TLS) for production.
 Error: Unsupported model version v1
 ```
 
-**Cause:** The `@elizaos/plugin-ollama` depends on `ollama-ai-provider@^1.2.0`, which uses the v1 AI SDK spec. The current runtime ships AI SDK v6, causing a silent version mismatch.
+**Cause:** Older builds used `ollama-ai-provider` (v1 model spec) with AI SDK 5+, which requires providers that implement specification v2. Current `@elizaos/plugin-ollama` uses `ollama-ai-provider-v2`, which matches AI SDK 5/6. If you still see this error, run `bun install` at the repo root so dependencies resolve to the updated provider.
 
-**Workaround — Use Ollama's OpenAI-Compatible Endpoint:**
+**Alternative — Use Ollama's OpenAI-Compatible Endpoint:**
 
 Ollama exposes an OpenAI-compatible API at `http://localhost:11434/v1`. Route through the OpenAI plugin instead:
 

--- a/plugins/plugin-ollama/CHANGELOG.md
+++ b/plugins/plugin-ollama/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to `@elizaos/plugin-ollama` are documented here.  
+This project follows [Semantic Versioning](https://semver.org/) where the published package uses it; monorepo consumers may pin `workspace:*`.
+
+## [Unreleased]
+
+### Added
+
+- **Native `messages`, `tools`, and `toolChoice` for text** — v5 `RESPONSE_HANDLER` / planner paths call `useModel` with chat messages and optional tools (e.g. `toolChoice: "required"`). When **`stream`** is off (or no streaming context), the adapter uses **`generateText`** and returns a **`GenerateTextResult`-shaped** object (cast to `string` for the handler contract), matching OpenRouter/OpenAI so **`parseMessageHandlerNativeToolCall`** can read planner output. When **`stream: true`** and a **tool set** is present, the adapter uses **`streamText`** (see **`streamText` with native tools** below). If both tools and `responseSchema` are supplied, tools take precedence and structured output is omitted for that request.
+
+- **Structured text output (`responseSchema`)** — Text handlers now map Eliza’s `responseSchema` (JSON Schema objects or full AI SDK output specs) to the Vercel AI SDK `Output.object` path, which `ollama-ai-provider-v2` translates to Ollama’s `format: "json"` / schema request body.  
+  **Why:** Core features such as `FACT_EXTRACTOR`, planner/evaluator pipelines, and trajectory-aware prompts call `useModel` with a schema. Without this path, those calls threw and silently skipped work when Ollama was the active provider.
+
+- **`OLLAMA_DISABLE_STRUCTURED_OUTPUT`** — When set to `1`, `true`, `yes`, or `on` (case-insensitive), the plugin strips `responseSchema` before generation and uses plain text only.  
+  **Why:** Some local models or older Ollama builds return malformed JSON, hang, or error on strict `format` requests. Operators need a single switch to fall back to unstructured generation without swapping providers.
+
+- **Plain-text SSE (`streamText` → `TextStreamResult`)** — When `stream: true` and the request has no `responseSchema`, tools, or `toolChoice`, text handlers return **`TextStreamResult`** so `AgentRuntime.useModel` can forward chunks. **Why:** core only enters the streaming branch when the return value satisfies `isTextStreamResult`; a bare string produced successful generations with empty streamed UIs.
+
+- **`streamText` with native tools** — When `stream: true` and **tools** are present, text handlers use **`streamText`** (same AI SDK surface as OpenAI/OpenRouter) instead of buffering with **`generateText`**. **`RESPONSE_HANDLER`** / **`ACTION_PLANNER`** drain SDK text deltas and yield one **`textStream`** chunk of the first tool’s plan JSON so **`parseMessageHandlerOutput`** still succeeds after **`useModel`** concatenation; other model types forward all text chunks and expose **`toolCalls`** on the stream result. **Why:** Ollama’s v2 provider supports tools on the streaming `/api/chat` path; Stage 1 often runs with `stream: true` from inherited SSE context and needs a parseable accumulated string.
+
+### Documentation
+
+- **README**, **registry** (`packages/docs/plugin-registry/llm/ollama.md`), **CLI environment** (`packages/docs/cli/environment.mdx`), and **inline module comments** (`models/text.ts`, `utils/ai-sdk-wire.ts`, `plugin.ts`) spell out *why* v5 tools, structured output, **`stream` vs `streamText`**, **`TextStreamResult`** / SSE behavior, and `OLLAMA_*` overrides behave the way they do.
+
+- **`streamText` + tools** — README (**Streaming routing** table), registry, and CLI env docs describe plain vs tool streaming, planner **single-chunk** `textStream` behavior, schema-only **`generateText`**, and **`toolChoice` without tools** (debug + fall back). **`models/text.ts`** and **`plugin.ts`** comments explain *why* each branch exists.
+
+### Changed
+
+- **Dependency: `ollama-ai-provider-v2` replaces `ollama-ai-provider`** — The v1 package exposed AI SDK “model spec v1” objects; Eliza ships `ai@^6`, which requires v2-compatible providers and produced `Unsupported model version v1 for provider "ollama.chat"`.  
+  **Why:** Staying on the supported provider surface avoids runtime failures and keeps parity with other first-party plugins that use `generateText` / `generateObject` from the same `ai` major line.
+
+- **Text adapter polish** — `shouldReturnNative` is derived only after the final structured-output decision (so tools + `responseSchema` cannot disagree with what we send). Empty `stopSequences` are omitted on the wire; `renderChatMessagesForPrompt` runs only on the prompt fallback path; usage fallback uses serialized chat messages when the messages path is used.
+
+- **Streaming branch ordering** — When **`stream: true`**, the handler evaluates **`tools`** first (**`streamText`+tools**), then plain **`streamText`**, then schema-only and **`toolChoice`-without-tools** paths with explicit **debug** logs. **Why:** avoids nesting **`streamText`+tools** under “no `toolChoice`” checks and makes misconfiguration visible instead of silently falling through to **`generateText`**.
+
+- **Richer errors on Ollama failures** — `models/text.ts` logs **`ollamaResponseBody`**, **`httpStatus`**, **`requestUrl`**, and **`attemptErrors`** (from AI SDK retries) for **`generateText`** and when **`streamText`** fails while **`textStream`** is consumed. **Why:** Ollama often returns actionable JSON (e.g. insufficient RAM) on **HTTP 500**; the default error string was only “Internal Server Error”, and streaming failures happened outside the handler’s outer **`try`/`catch`**, so logs were easy to miss before the process exited.
+
+### Fixed
+
+- **AI SDK 5/6 compatibility** — Generation no longer fails immediately with “Unsupported model version v1” for any Ollama model id when using current `ai` + `ollama-ai-provider-v2`.
+
+- **v5 `RESPONSE_HANDLER` with Ollama** — Stage 1 previously threw `[Ollama] Native tools, toolChoice plumbing is not supported by this adapter yet` because core passes `messages`, `tools`, and `toolChoice: "required"`. The text adapter now wires those into `generateText` and returns a native-shaped result so message-handler parsing matches OpenRouter/OpenAI. **Why it broke before:** the adapter intentionally rejected any native tool plumbing until the AI SDK + Ollama provider path was implemented end-to-end.
+
+- **Structured calls during streaming chat** — Removed hard errors when `stream: true` is set together with `responseSchema` or with tools / `toolChoice`. **Why:** `AgentRuntime.useModel` sets `stream` whenever a streaming context exists (e.g. SSE chat), including for nested calls like **`FACT_EXTRACTOR`** that still need JSON schema; the Ollama text path already used non-streaming `generateText` only, so throwing only broke those actions with a misleading “cannot be used together with stream” message.
+
+---
+
+## [2.0.0-beta.0] — prior baseline
+
+- Text, object, and embedding handlers via legacy `ollama-ai-provider`.
+- No `responseSchema` support in the text adapter (native tools / schema calls threw).

--- a/plugins/plugin-ollama/README.md
+++ b/plugins/plugin-ollama/README.md
@@ -1,161 +1,201 @@
 # Ollama Plugin
 
-This plugin provides integration with [Ollama](https://ollama.com/)'s local models through the ElizaOS platform. It allows you to leverage locally running LLMs for text generation, embeddings, and object generation.
+This plugin connects [Ollama](https://ollama.com/) to ElizaOS so agents can use **local** LLMs for text, embeddings, and JSON object generation—without sending prompts to a third-party API.
 
-## Overview
+## Why this plugin exists
 
-Ollama enables running large language models locally on your machine. This plugin connects ElizaOS with your local Ollama installation, giving your characters access to powerful language models running on your own hardware.
+- **Privacy and compliance:** All inference can stay on your LAN or laptop.
+- **Cost:** No per-token cloud billing for experimentation.
+- **Offline / air-gapped:** Works wherever Ollama runs, including containers and remote servers.
 
 ## Requirements
 
-- [Ollama](https://ollama.com/) installed and running on your system
-- ElizaOS platform
-- At least one Ollama model pulled and available (e.g., `llama3`, `gemma3:latest`)
+- [Ollama](https://ollama.com/) installed and reachable (same machine or network).
+- ElizaOS runtime with this package enabled.
+- At least one pulled model, e.g. `ollama pull gemma3:latest`.
 
 ## Installation
 
-1. Install this plugin in your ElizaOS project:
+```bash
+bun add @elizaos/plugin-ollama
+```
 
-   ```bash
-   bun add @elizaos/plugin-ollama
-   ```
+Ensure Ollama is running:
 
-2. Make sure Ollama is running:
-   ```bash
-   ollama serve
-   ```
+```bash
+ollama serve
+```
 
-## Usage
-
-Add the plugin to your character configuration:
+Register the plugin on your character / app config (exact shape depends on your ElizaOS version):
 
 ```json
 "plugins": ["@elizaos/plugin-ollama"]
 ```
 
+## Architecture: Vercel AI SDK + `ollama-ai-provider-v2`
+
+Handlers use **`generateText`** (completion, structured-only when `stream: true`, and non-streaming tool calls), **`streamText`** (plain SSE chat **or** `stream: true` **with native tools**), **`generateObject`**, and **`embed`** from the **`ai`** package, backed by **`ollama-ai-provider-v2`**.
+
+## Streaming chat (`TextStreamResult`)
+
+When **`useModel`** is invoked with **`stream: true`** during an SSE reply, `AgentRuntime` only iterates **`textStream`** and forwards chunks if the model handler returns a **`TextStreamResult`** (see `isTextStreamResult` in `packages/core/src/runtime.ts`). **Why:** returning a bare **`string`** skips that branch entirely—tokens still generate, but the UI and conversation routes can log **“no streamed text”** because no chunks were delivered.
+
+This plugin returns **`TextStreamResult`** from **`streamText`** when **`stream: true`** and either:
+
+- **Plain chat:** no **`responseSchema`**, **tools**, or **`toolChoice`** — every text delta is yielded to **`textStream`** (normal SSE).
+- **Native tools:** **tools** are present — Ollama streams the chat request with tools on the wire. For **`RESPONSE_HANDLER`** / **`ACTION_PLANNER`**, **`useModel`**’s streaming path concatenates only **`textStream`** chunks into the string passed to **`parseMessageHandlerOutput`**, so this adapter **drains** model text deltas internally and **yields a single trailing chunk** of the first tool’s **`arguments`** JSON (the v5 plan). **Why:** prepending arbitrary streamed text would break **`JSON.parse`** on that accumulated string. Other **`TEXT_*`** types forward all text chunks and attach **`toolCalls`** on the result (parity with OpenAI/OpenRouter).
+
+**Still `generateText`:** **`stream: true`** with **`responseSchema`** only (no tools), e.g. nested **`FACT_EXTRACTOR`** during SSE — **`stream` may still be true** on params; we **do not throw** and we **log at debug** because structured **`format: json`** is not wired through **`streamText`** here.
+
+**Still `generateText`:** **`stream: true`** with **`toolChoice`** but **no** resolved **`ToolSet`** on the wire — **log at debug**, then **`generateText`**. **Why:** the AI SDK’s **`streamText`** path used here expects **`tools`** in the same request; `toolChoice` alone is invalid for streaming and is not produced by core v5 (Stage 1 always passes tools with `toolChoice`).
+
+### Streaming routing (quick reference)
+
+| `stream` | `tools` on wire | `responseSchema` / `toolChoice` | Path | Why |
+|----------|-----------------|----------------------------------|------|-----|
+| `true` | yes | (any; schema dropped if both) | **`streamText`** + tools | Same surface as other provider plugins; Ollama v2 supports tools on streaming `/api/chat`. |
+| `true` | no | no schema, no `toolChoice` | **`streamText`** plain | **`TextStreamResult`** so `useModel` can forward SSE chunks. |
+| `true` | no | schema only | **`generateText`** | Structured **`format`** is not implemented on **`streamText`** in this adapter; nested schema calls must not throw. |
+| `true` | no | `toolChoice` only | **`generateText`** | **`streamText`+tools** requires a tool set; log explains misconfiguration. |
+| `false` / absent | (any) | (any) | **`generateText`** (or structured serialize) | Normal completion path; Stage 1 without inherited streaming uses this. |
+
+### Why `ollama-ai-provider-v2` (not the old `ollama-ai-provider`)
+
+ElizaOS tracks **AI SDK 5/6**. Older `ollama-ai-provider` exposed **model specification v1**; current `ai` only accepts **v2+** models and throws:
+
+`Unsupported model version v1 for provider "ollama.chat"`.
+
+The v2 provider implements the same provider contract as the rest of the ecosystem, so local Ollama behaves like other LLM backends from Eliza’s perspective.
+
+See **`CHANGELOG.md`** for the full migration note.
+
 ## Configuration
 
-The plugin requires these environment variables (can be set in .env file or character settings):
+Environment variables (or character `settings` with the same keys—**why:** lets you override per-agent without touching global `.env`):
 
-```json
-"settings": {
-  "OLLAMA_API_ENDPOINT": "http://localhost:11434/api",
-  "OLLAMA_SMALL_MODEL": "gemma3:latest",
-  "OLLAMA_MEDIUM_MODEL": "gemma3:latest",
-  "OLLAMA_LARGE_MODEL": "gemma3:latest",
-  "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text:latest"
-}
-```
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OLLAMA_API_ENDPOINT` | `http://localhost:11434` (normalized to `…/api`) | Ollama HTTP API base. |
+| `OLLAMA_SMALL_MODEL` / `SMALL_MODEL` | `gemma3:latest` | Small / fast text model. |
+| `OLLAMA_LARGE_MODEL` / `LARGE_MODEL` | `gemma3:latest` | Larger text model. |
+| `OLLAMA_EMBEDDING_MODEL` | `nomic-embed-text:latest` | Embedding model id. |
+| `OLLAMA_DISABLE_STRUCTURED_OUTPUT` | _unset_ | If `1` / `true` / `yes` / `on`, **disables** JSON-schema structured text (see below). |
 
-Or in `.env` file:
+Optional model overrides: `OLLAMA_NANO_MODEL`, `OLLAMA_MEDIUM_MODEL`, `OLLAMA_MEGA_MODEL`, `OLLAMA_RESPONSE_HANDLER_MODEL`, `OLLAMA_ACTION_PLANNER_MODEL` (see `utils/config.ts`). **Why separate keys:** v5 Stage 1 (`RESPONSE_HANDLER`) is tool-heavy—you may want a larger tag than `TEXT_SMALL` without paying that cost on every `TEXT_LARGE` reply; planners often default to medium-sized models for latency.
+
+### Example `.env`
 
 ```
 OLLAMA_API_ENDPOINT=http://localhost:11434/api
 OLLAMA_SMALL_MODEL=gemma3:latest
-OLLAMA_MEDIUM_MODEL=gemma3:latest
 OLLAMA_LARGE_MODEL=gemma3:latest
 OLLAMA_EMBEDDING_MODEL=nomic-embed-text:latest
 ```
 
-### Configuration Options
+### Example `settings` block
 
-- `OLLAMA_API_ENDPOINT`: Ollama API endpoint (default: http://localhost:11434/api)
-- `OLLAMA_SMALL_MODEL`: Model for simpler tasks (default: gemma3:latest)
-- `OLLAMA_MEDIUM_MODEL`: Medium-complexity model (default: gemma3:latest)
-- `OLLAMA_LARGE_MODEL`: Model for complex tasks (default: gemma3:latest)
-- `OLLAMA_EMBEDDING_MODEL`: Model for text embeddings (default: nomic-embed-text:latest)
-
-The plugin provides these model classes:
-
-- `TEXT_SMALL`: Optimized for fast responses with simpler prompts
-- `TEXT_LARGE`: For complex tasks requiring deeper reasoning
-- `TEXT_EMBEDDING`: Text embedding model
-- `OBJECT_SMALL`: JSON object generation with simpler models
-- `OBJECT_LARGE`: JSON object generation with more complex models
-
-## API Reference
-
-For detailed information about the Ollama API used by this plugin, refer to the [official Ollama API documentation](https://github.com/ollama/ollama/blob/main/docs/api.md).
-
-## Features
-
-### Text Generation (Small Model)
-
-Generate text using smaller, faster models optimized for quick responses:
-
-```js
-const text = await runtime.useModel(ModelType.TEXT_SMALL, {
-  prompt: "What is the nature of reality?",
-  stopSequences: [], // optional
-});
+```json
+{
+  "settings": {
+    "OLLAMA_API_ENDPOINT": "http://localhost:11434/api",
+    "OLLAMA_SMALL_MODEL": "gemma3:latest",
+    "OLLAMA_LARGE_MODEL": "gemma3:latest",
+    "OLLAMA_EMBEDDING_MODEL": "nomic-embed-text:latest"
+  }
+}
 ```
 
-### Text Generation (Large Model)
+## Structured output (`responseSchema`)
 
-Generate comprehensive text responses using more powerful models for complex tasks:
+Eliza core passes **`responseSchema`** on text model calls when it needs **machine-parseable JSON** (e.g. fact extraction ops, structured planner/evaluator outputs).
+
+This plugin maps that to the AI SDK’s **`Output.object({ schema: jsonSchema(...) })`**, which the Ollama provider turns into Ollama’s **`format`** field (`json` or JSON Schema, depending on Ollama version and request).
+
+**Why it matters:** Without this path, those calls **failed** under Ollama and features silently degraded (warnings in logs, no memory updates).
+
+**Caveats:**
+
+- Quality depends on the **model**; small local models may still emit invalid JSON.
+- **`stream: true` with `responseSchema`:** Core may set `stream` from an active chat streaming context even for nested calls (e.g. `FACT_EXTRACTOR`). The adapter **does not throw**; it runs **non-streaming** `generateText` with your schema. **Why:** the handler never used `streamText` for structured calls; rejecting only surfaced as spurious failures during SSE replies.
+
+### Disabling structured output: `OLLAMA_DISABLE_STRUCTURED_OUTPUT`
+
+Set to `1`, `true`, `yes`, or `on` if:
+
+- Ollama errors or hangs on `format` / schema requests, or
+- A specific model returns prose instead of JSON.
+
+**Effect:** `responseSchema` is **stripped**; generation runs as plain text. Callers that require JSON may then fail parsing—**why:** this is an intentional escape hatch for operators, not a silent “fix” for broken prompts.
+
+## Model handlers
+
+| Model type | Role |
+|------------|------|
+| `TEXT_*` | Chat / completion-style text. |
+| `TEXT_EMBEDDING` | Vector embeddings. |
+| `OBJECT_*` | `generateObject` with `output: "no-schema"` (best-effort JSON object). |
+| `RESPONSE_HANDLER` / `ACTION_PLANNER` | Same text path; v5 Stage 1 uses **messages + tools + `toolChoice`**; other pipelines may use **`responseSchema`** for JSON. |
+
+### Text example
 
 ```js
 const text = await runtime.useModel(ModelType.TEXT_LARGE, {
-  prompt: "Write a detailed explanation of quantum physics",
-  stopSequences: [], // optional
-  maxTokens: 8192, // optional (default: 8192)
-  temperature: 0.7, // optional (default: 0.7)
-  frequencyPenalty: 0.7, // optional (default: 0.7)
-  presencePenalty: 0.7, // optional (default: 0.7)
+  prompt: "Explain quantum tunneling briefly.",
+  maxTokens: 8192,
+  temperature: 0.7,
 });
 ```
 
-### Text Embeddings
-
-Generate vector embeddings for text, which can be used for semantic search or other vector operations:
+### Embedding example
 
 ```js
 const embedding = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
-  text: "Text to embed",
-});
-// or
-const embedding = await runtime.useModel(
-  ModelType.TEXT_EMBEDDING,
-  "Text to embed",
-);
-```
-
-### Object Generation (Small Model)
-
-Generate structured JSON objects using faster models:
-
-```js
-const object = await runtime.useModel(ModelType.OBJECT_SMALL, {
-  prompt: "Generate a JSON object representing a user profile",
-  temperature: 0.7, // optional
+  text: "hello world",
 });
 ```
 
-### Object Generation (Large Model)
+## Chat messages, native tools, and `toolChoice` (v5)
 
-Generate complex, detailed JSON objects using more powerful models:
+ElizaOS v5 can call text models with **`messages`** (chat turns), **`tools`** (function / tool definitions), and **`toolChoice`** (for example `"required"` on the message-handler stage so the model must emit a planner tool call).
 
-```js
-const object = await runtime.useModel(ModelType.OBJECT_LARGE, {
-  prompt: "Generate a detailed JSON object representing a restaurant",
-  temperature: 0.7, // optional
-});
-```
+This plugin forwards those fields to the Vercel AI SDK **`generateText`** or **`streamText`** (when **`stream: true`** and tools are present) backed by **`ollama-ai-provider-v2`**, and when the call is “native shaped” (messages, tools, tool choice, or structured output), it may return a **`GenerateTextResult`-like object at runtime** or a **`TextStreamResult`** with **`toolCalls`** — TypeScript still types `useModel` text handlers as `string` for historical reasons.
+
+**Why cast instead of changing core types everywhere:** OpenRouter and OpenAI adapters already use the same pattern—core’s v5 parser (`parseMessageHandlerNativeToolCall`, trajectory recording) expects **`toolCalls`** with `id` / `name` / `arguments` compatible fields. Matching that contract keeps Ollama on the same code path as cloud providers.
+
+**Tool definitions:** Core usually passes **`ToolDefinition[]`** (array). Callers may also pass an AI SDK **`ToolSet`** object; both are accepted. Array entries are normalized to `jsonSchema(...)` parameters the way the OpenAI plugin does (without Cerebras-only name/schema tweaks).
+
+**When both `tools` and `responseSchema` are set:** The adapter **drops structured output for that request** and keeps tools. **Why:** `generateText` cannot reasonably combine native tool calling and `Output.object` in one call for all models; v5 Stage 1 needs tools, so schema-backed structured output loses that race by design.
+
+**Streaming flag:** See **Streaming routing** above. In prose: **tools + `stream: true`** prefer **`streamText`**; **schema-only + `stream: true`** stays on **`generateText`**; **plain chat + `stream: true`** returns **`TextStreamResult`** from **`streamText`** (same contract as OpenRouter).
+
+### Known limitations
+
+- **`providerOptions`** from `GenerateTextParams` are **not** merged into the Ollama `generateText` call yet. Core may attach cache-budget metadata for other providers; Ollama ignores those fields here until we wire them explicitly.
+- **Tool quality is model-dependent.** Some local models ignore tools or emit invalid tool JSON; try a stronger tag (e.g. tool-friendly instruct models) or route through OpenAI-compatible Ollama (`/v1`) with another plugin if you need battle-tested tool UX.
 
 ## Troubleshooting
 
-### Connection Issues
+| Symptom | Likely cause | Mitigation |
+|---------|----------------|------------|
+| Chat UI empty / “no streamed text” with Ollama | Handler returned a string while `stream: true` | Fixed in current adapter: plain chat uses **`streamText`** → **`TextStreamResult`**. Schema-only streaming still uses **`generateText`**; tool calls with **`stream: true`** use **`streamText`** (planner types may only emit one trailing plan chunk on **`textStream`**). |
+| `Unsupported model version v1` | Stale lockfile / wrong `ollama-ai-provider` | Run `bun install` at repo root; confirm dependency is `ollama-ai-provider-v2`. |
+| `[Ollama] Native tools, toolChoice plumbing is not supported` (older builds) | Pre–native-tools adapter | Upgrade `@elizaos/plugin-ollama` to a build that forwards tools (see `CHANGELOG.md`). |
+| `v5 messageHandler returned invalid MessageHandlerResult` | Model did not return the expected planner tool / JSON | Use a model with reliable tool calling; confirm `OLLAMA_RESPONSE_HANDLER_MODEL` is not too small for your prompt. |
+| Fact / planner JSON errors | Model ignores schema | Try a stronger model; tighten prompts; or set `OLLAMA_DISABLE_STRUCTURED_OUTPUT=1` temporarily. |
+| Debug: `toolChoice but no tools on wire` | `stream: true` with `toolChoice` but no `ToolSet` passed | Should not happen from core v5; if you see it, ensure `tools` and `toolChoice` are passed together. Adapter falls back to **`generateText`**. |
+| **`streamText.textStream` failed** / **`AI_NoOutputGeneratedError`** / process exit after Ollama **500** | Ollama returned an error body (e.g. **insufficient system memory** for the model) during a **streaming** `/api/chat` call; AI SDK retried then failed. | Check logs for **`ollamaResponseBody`** (plugin now extracts it). Free RAM on the Ollama host, use a smaller model, or lower concurrency. Streaming errors occur while **`useModel`** consumes **`textStream`**, not only inside **`generateText`**. |
+| Connection errors | Ollama not running or wrong URL | `curl` the `/api/tags` endpoint; fix `OLLAMA_API_ENDPOINT`. |
 
-- Ensure Ollama is running by testing the `OLLAMA_API_ENDPOINT`
-- Verify the `OLLAMA_API_ENDPOINT` points to the correct host and port
-- Check firewall settings if connecting to a remote Ollama instance
+More context: [Ollama plugin docs](https://docs.eliza.ai/) (registry page: `plugin-registry/llm/ollama`).
 
-### Model Availability
+## API reference
 
-- The plugin will attempt to download models automatically if they're not found
-- You can pre-download models using `ollama pull modelname`
-- Check model availability with `ollama list`
+Ollama’s HTTP API: [Ollama API docs](https://github.com/ollama/ollama/blob/main/docs/api.md).
+
+## Changelog
+
+See **[CHANGELOG.md](./CHANGELOG.md)**.
 
 ## License
 
-See LICENSE file for details.
+See [LICENSE](./LICENSE).

--- a/plugins/plugin-ollama/__tests__/model-usage.test.ts
+++ b/plugins/plugin-ollama/__tests__/model-usage.test.ts
@@ -6,9 +6,15 @@ vi.mock("ai", () => ({
   embed: vi.fn(),
   generateObject: vi.fn(),
   generateText: vi.fn(),
+  streamText: vi.fn(() => ({
+    textStream: (async function* () {})(),
+    text: Promise.resolve(""),
+    usage: Promise.resolve(undefined),
+    finishReason: Promise.resolve(undefined),
+  })),
 }));
 
-vi.mock("ollama-ai-provider", () => ({
+vi.mock("ollama-ai-provider-v2", () => ({
   createOllama: vi.fn(() => {
     const ollama = vi.fn((model: string) => ({ model }));
     return Object.assign(ollama, {

--- a/plugins/plugin-ollama/__tests__/native-plumbing.test.ts
+++ b/plugins/plugin-ollama/__tests__/native-plumbing.test.ts
@@ -1,6 +1,36 @@
-import type { IAgentRuntime } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
-import { handleTextSmall } from "../models/text";
+import type { GenerateTextResult, IAgentRuntime, TextStreamResult } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { generateTextMock, streamTextMock } = vi.hoisted(() => ({
+  generateTextMock: vi.fn(),
+  streamTextMock: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  embed: vi.fn(),
+  generateObject: vi.fn(),
+  generateText: (...args: unknown[]) => generateTextMock(...args),
+  streamText: (...args: unknown[]) => streamTextMock(...args),
+  jsonSchema: vi.fn((schema: unknown) => schema),
+  Output: {
+    object: vi.fn((spec: unknown) => ({ kind: "output.object", spec })),
+  },
+}));
+
+vi.mock("ollama-ai-provider-v2", () => ({
+  createOllama: vi.fn(() => {
+    const ollama = vi.fn((model: string) => ({ model }));
+    return Object.assign(ollama, {
+      embedding: vi.fn((model: string) => ({ model })),
+    });
+  }),
+}));
+
+vi.mock("../models/availability", () => ({
+  ensureModelAvailable: vi.fn(async () => undefined),
+}));
+
+import { handleResponseHandler, handleTextLarge, handleTextSmall } from "../models/text";
 
 function createRuntime() {
   return {
@@ -11,12 +41,290 @@ function createRuntime() {
 }
 
 describe("Ollama native text plumbing", () => {
-  it("fails clearly when native tools are requested", async () => {
-    await expect(
-      handleTextSmall(createRuntime(), {
-        prompt: "use a tool",
-        tools: { lookup: { description: "Lookup", inputSchema: { type: "object" } } },
-      } as never)
-    ).rejects.toThrow("[Ollama] Native tools plumbing is not supported");
+  beforeEach(() => {
+    generateTextMock.mockReset();
+    streamTextMock.mockReset();
+    streamTextMock.mockImplementation(() => ({
+      textStream: (async function* () {})(),
+      text: Promise.resolve(""),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve(undefined),
+    }));
+  });
+
+  it("forwards native ToolSet tools to generateText and returns a GenerateTextResult-shaped payload", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "ack",
+      toolCalls: [{ toolCallId: "call-1", toolName: "lookup", input: { q: "x" } }],
+      finishReason: "stop",
+      usage: { inputTokens: 1, outputTokens: 2 },
+    });
+
+    const result = (await handleTextSmall(createRuntime(), {
+      prompt: "use a tool",
+      tools: { lookup: { description: "Lookup", inputSchema: { type: "object" } } },
+    } as never)) as unknown as GenerateTextResult;
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const callArg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.tools).toEqual({
+      lookup: { description: "Lookup", inputSchema: { type: "object" } },
+    });
+    expect(callArg.toolChoice).toBeUndefined();
+
+    expect(result.text).toBe("ack");
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls?.[0]).toMatchObject({
+      id: "call-1",
+      name: "lookup",
+      arguments: { q: "x" },
+    });
+  });
+
+  it("forwards toolChoice when tools are present", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "p",
+      tools: { lookup: { description: "L", inputSchema: { type: "object" } } },
+      toolChoice: "required",
+    } as never);
+
+    const callArg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.toolChoice).toBe("required");
+  });
+
+  it("omits structured output when tools and responseSchema are both set", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "tool-only",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "p",
+      tools: { lookup: { description: "L", inputSchema: { type: "object" } } },
+      responseSchema: {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: [],
+      },
+    } as never);
+
+    const callArg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.output).toBeUndefined();
+    expect(callArg.tools).toBeDefined();
+  });
+
+  it("uses messages path and returns native-shaped result without tools or schema", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "hello",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    const result = (await handleTextSmall(createRuntime(), {
+      messages: [{ role: "user", content: "hi" }],
+    } as never)) as unknown as GenerateTextResult;
+
+    const callArg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.messages).toEqual([{ role: "user", content: "hi" }]);
+    expect(callArg.prompt).toBeUndefined();
+    expect(result.text).toBe("hello");
+    expect(result.toolCalls).toEqual([]);
+  });
+
+  it("omits stopSequences when the array is empty", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "ok",
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "p",
+      stopSequences: [],
+    } as never);
+
+    const callArg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.stopSequences).toBeUndefined();
+  });
+
+  it("does not throw when stream=true with responseSchema (nested useModel under chat streaming context)", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "",
+      output: { durable: [], current: [] },
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    const out = await handleTextSmall(createRuntime(), {
+      prompt: "extract facts",
+      stream: true,
+      responseSchema: {
+        type: "object",
+        properties: { durable: { type: "array" }, current: { type: "array" } },
+        required: ["durable", "current"],
+      },
+    } as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(out)).toEqual({ durable: [], current: [] });
+  });
+
+  it("stream=true with toolChoice but no tools uses generateText (streamText requires a ToolSet)", async () => {
+    generateTextMock.mockResolvedValue({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: undefined,
+    });
+
+    await handleTextSmall(createRuntime(), {
+      prompt: "p",
+      stream: true,
+      toolChoice: "required",
+    } as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it("uses streamText when stream=true with tools and toolChoice (TEXT_SMALL forwards chunks)", async () => {
+    streamTextMock.mockImplementation(() => ({
+      textStream: (async function* () {
+        yield "hello";
+      })(),
+      text: Promise.resolve("hello"),
+      toolCalls: Promise.resolve([
+        { toolCallId: "c1", toolName: "lookup", input: { q: "x" } },
+      ]),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    }));
+
+    const result = await handleTextSmall(createRuntime(), {
+      prompt: "p",
+      stream: true,
+      tools: { lookup: { description: "L", inputSchema: { type: "object" } } },
+      toolChoice: "required",
+    } as never);
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    const stream = result as TextStreamResult & { toolCalls?: Promise<unknown[]> };
+    const chunks: string[] = [];
+    for await (const c of stream.textStream) {
+      chunks.push(c);
+    }
+    expect(chunks).toEqual(["hello"]);
+    await expect(stream.text).resolves.toBe("hello");
+    await expect(stream.toolCalls).resolves.toEqual([
+      { id: "c1", name: "lookup", arguments: { q: "x" } },
+    ]);
+  });
+
+  it("stream=true + tools (RESPONSE_HANDLER): drains textStream, yields plan JSON chunk, text promise matches", async () => {
+    const plan = {
+      processMessage: "REPLY",
+      plan: { contexts: ["simple"], reply: "hi" },
+      thought: "",
+    };
+    streamTextMock.mockImplementation(() => ({
+      textStream: (async function* () {
+        yield "ignored-delta";
+      })(),
+      text: Promise.resolve(""),
+      toolCalls: Promise.resolve([
+        {
+          toolCallId: "mh",
+          toolName: "MESSAGE_HANDLER_PLAN",
+          input: plan,
+        },
+      ]),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 2 }),
+      finishReason: Promise.resolve("stop"),
+    }));
+
+    const result = await handleResponseHandler(createRuntime(), {
+      prompt: "p",
+      stream: true,
+      tools: { MESSAGE_HANDLER_PLAN: { description: "D", inputSchema: { type: "object" } } },
+      toolChoice: "required",
+    } as never);
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    const stream = result as TextStreamResult & { toolCalls?: Promise<unknown[]> };
+    const chunks: string[] = [];
+    for await (const c of stream.textStream) {
+      chunks.push(c);
+    }
+    expect(chunks).toEqual([JSON.stringify(plan)]);
+    await expect(stream.text).resolves.toBe(JSON.stringify(plan));
+  });
+
+  it("stream=true + tools + responseSchema uses streamText (tools win, no output on wire)", async () => {
+    streamTextMock.mockImplementation(() => ({
+      textStream: (async function* () {
+        yield "x";
+      })(),
+      text: Promise.resolve("x"),
+      toolCalls: Promise.resolve([]),
+      usage: Promise.resolve(undefined),
+      finishReason: Promise.resolve("stop"),
+    }));
+
+    await handleTextLarge(createRuntime(), {
+      prompt: "p",
+      stream: true,
+      tools: { lookup: { description: "L", inputSchema: { type: "object" } } },
+      responseSchema: {
+        type: "object",
+        properties: { foo: { type: "string" } },
+        required: [],
+      },
+    } as never);
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    const callArg = streamTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.output).toBeUndefined();
+    expect(callArg.tools).toBeDefined();
+  });
+
+  it("uses streamText and returns TextStreamResult when stream=true without schema or tools", async () => {
+    streamTextMock.mockImplementation(() => ({
+      textStream: (async function* () {
+        yield "a";
+        yield "b";
+      })(),
+      text: Promise.resolve("ab"),
+      usage: Promise.resolve({ inputTokens: 1, outputTokens: 1 }),
+      finishReason: Promise.resolve("stop"),
+    }));
+
+    const result = await handleTextSmall(createRuntime(), {
+      prompt: "hello",
+      stream: true,
+    } as never);
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1);
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(result && typeof result === "object" && "textStream" in result).toBe(true);
+    const stream = result as TextStreamResult;
+    const chunks: string[] = [];
+    for await (const c of stream.textStream) {
+      chunks.push(c);
+    }
+    expect(chunks).toEqual(["a", "b"]);
+    await expect(stream.text).resolves.toBe("ab");
   });
 });

--- a/plugins/plugin-ollama/__tests__/smoke.test.ts
+++ b/plugins/plugin-ollama/__tests__/smoke.test.ts
@@ -5,9 +5,15 @@ vi.mock("ai", () => ({
   embed: vi.fn(),
   generateObject: vi.fn(),
   generateText: vi.fn(),
+  streamText: vi.fn(() => ({
+    textStream: (async function* () {})(),
+    text: Promise.resolve(""),
+    usage: Promise.resolve(undefined),
+    finishReason: Promise.resolve(undefined),
+  })),
 }));
 
-vi.mock("ollama-ai-provider", () => ({
+vi.mock("ollama-ai-provider-v2", () => ({
   createOllama: vi.fn(() => {
     const ollama = vi.fn((model: string) => ({ model }));
     return Object.assign(ollama, {

--- a/plugins/plugin-ollama/build.ts
+++ b/plugins/plugin-ollama/build.ts
@@ -20,7 +20,7 @@ await build({
   splitting: false,
   sourcemap: "linked",
   minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider"],
+  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2"],
   naming: {
     entry: "index.node.js",
   },
@@ -35,7 +35,7 @@ await build({
   splitting: false,
   sourcemap: "linked",
   minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider"],
+  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2"],
   naming: {
     entry: "index.browser.js",
   },
@@ -50,7 +50,7 @@ await build({
   splitting: false,
   sourcemap: "linked",
   minify: false,
-  external: ["@elizaos/core", "ai", "ollama-ai-provider"],
+  external: ["@elizaos/core", "ai", "ollama-ai-provider-v2"],
   naming: {
     entry: "index.node.cjs",
   },

--- a/plugins/plugin-ollama/models/embedding.ts
+++ b/plugins/plugin-ollama/models/embedding.ts
@@ -1,7 +1,14 @@
+/**
+ * Embeddings via Ollama + AI SDK `embed`.
+ *
+ * **Why v2 provider:** `createOllama` from `ollama-ai-provider-v2` registers embedding models on
+ * the same supported AI SDK surface as chat (`models/text.ts`). Mixed v1/v2 providers in one
+ * agent were a common source of `Unsupported model version v1` during dependency bumps.
+ */
 import type { IAgentRuntime, TextEmbeddingParams } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import { type EmbeddingModel, embed } from "ai";
-import { createOllama } from "ollama-ai-provider";
+import { createOllama } from "ollama-ai-provider-v2";
 
 import { getBaseURL, getEmbeddingModel } from "../utils/config";
 import { emitModelUsed, estimateEmbeddingUsage, normalizeTokenUsage } from "../utils/modelUsage";
@@ -43,8 +50,7 @@ export async function handleTextEmbedding(
 
     try {
       const embedParams = {
-        // ollama-ai-provider still exposes older AI SDK model interfaces.
-        model: ollama.embedding(modelName) as unknown as EmbeddingModel,
+        model: ollama.embedding(modelName) as EmbeddingModel,
         value: embeddingText,
       };
 

--- a/plugins/plugin-ollama/models/object.ts
+++ b/plugins/plugin-ollama/models/object.ts
@@ -1,3 +1,11 @@
+/**
+ * JSON object generation via Ollama + AI SDK `generateObject`.
+ *
+ * **Why `ollama-ai-provider-v2`:** Same stack as `text.ts`—AI SDK 5/6 requires model spec v2;
+ * the legacy Ollama provider exposed v1 and failed at runtime. Object generation is less
+ * exposed than chat in typical agents, but keeping one provider major line avoids “works for
+ * chat, breaks for JSON object” surprises in monorepo upgrades.
+ */
 import type {
   IAgentRuntime,
   ModelTypeName,
@@ -6,7 +14,7 @@ import type {
 } from "@elizaos/core";
 import { logger, ModelType, recordLlmCall } from "@elizaos/core";
 import { generateObject, type LanguageModel } from "ai";
-import { createOllama } from "ollama-ai-provider";
+import { createOllama } from "ollama-ai-provider-v2";
 
 import { getBaseURL, getLargeModel, getSmallModel } from "../utils/config";
 import { emitModelUsed, estimateUsage, normalizeTokenUsage } from "../utils/modelUsage";
@@ -30,8 +38,7 @@ async function generateOllamaObject(
 ): Promise<Record<string, string | number | boolean | null>> {
   try {
     const generateParams = {
-      // ollama-ai-provider still exposes older AI SDK model interfaces.
-      model: ollama(model) as unknown as LanguageModel,
+      model: ollama(model) as LanguageModel,
       output: "no-schema" as const,
       prompt: params.prompt,
       temperature: params.temperature,

--- a/plugins/plugin-ollama/models/text.ts
+++ b/plugins/plugin-ollama/models/text.ts
@@ -1,13 +1,104 @@
-import type { GenerateTextParams, IAgentRuntime, ModelTypeName } from "@elizaos/core";
+/**
+ * Ollama text generation for ElizaOS.
+ *
+ * ## Why this module is shaped this way
+ *
+ * - **Single AI SDK surface:** We call **`generateText`** and **`streamText`** from `ai` so
+ *   Eliza stays aligned with other provider plugins (OpenAI, OpenRouter). That avoids bespoke
+ *   HTTP clients here.
+ *
+ * - **`ollama-ai-provider-v2`:** Older `ollama-ai-provider` exposed AI SDK model spec v1;
+ *   current `ai` requires v2+ and threw `Unsupported model version v1` for every model.
+ *   v2 implements the same contract as the rest of the ecosystem.
+ *
+ * - **`responseSchema`:** Core passes JSON Schema (or a full output spec) for pipelines
+ *   that need parseable objects (e.g. FACT_EXTRACTOR). We map that to `Output.object` so
+ *   Ollama receives `format: json` / schema in the wire protocol—without this, those calls
+ *   failed and memory/planner features degraded under Ollama-only setups.
+ *
+ * - **`OLLAMA_DISABLE_STRUCTURED_OUTPUT`:** Some local models return invalid JSON or error
+ *   on `format`. Stripping `responseSchema` keeps the agent running; callers may fail
+ *   validation—that is intentional so operators can recover without redeploying code.
+ *
+ * - **Native tools / `toolChoice`:** v5 `RESPONSE_HANDLER` passes `messages`, `tools`, and
+ *   `toolChoice: "required"` (see `runV5MessageRuntimeStage1`). With **`stream: false`** (or no
+ *   streaming context), we use **`generateText`** and cast a `GenerateTextResult`-shaped payload
+ *   when needed. With **`stream: true`** and a **tool set**, we use **`streamText`** (see
+ *   **`buildOllamaStreamWithToolsResult`**). Either way matches OpenRouter/OpenAI so
+ *   **`parseMessageHandlerNativeToolCall`** / **`parseMessageHandlerOutput`** can read the plan.
+ *   If both tools and `responseSchema` are present, tools win (schema is omitted for that request).
+ *
+ * - **Stop sequences:** Empty `stopSequences` arrays are omitted on the wire (same idea as
+ *   OpenRouter) so we do not send meaningless `[]` to the model.
+ *
+ * - **Streaming:** When `stream: true` and there is **no** `responseSchema`, **tools**, or
+ *   `toolChoice`, we call **`streamText`** and return **`TextStreamResult`** so `useModel` can
+ *   forward chunks to SSE callbacks. **Why:** core sets `stream` from chat context; without a
+ *   stream object the runtime never invokes `onStreamChunk` and the UI shows empty replies.
+ * - **`streamText` + tools:** When `stream: true` and native **tools** are present, we call
+ *   **`streamText`** (same as OpenAI/OpenRouter) so Ollama streams over `/api/chat`. For
+ *   **`RESPONSE_HANDLER`** / **`ACTION_PLANNER`**, `useModel`’s streaming branch concatenates
+ *   **`textStream`** into the string passed to **`parseMessageHandlerOutput`** — so we **drain**
+ *   the model’s text deltas internally and **yield a single trailing chunk** of the first tool’s
+ *   arguments JSON (the v5 plan payload). **Why:** mixing arbitrary streamed text with that JSON
+ *   would make `JSON.parse` fail on the accumulated `fullText`. Other model types forward every
+ *   text chunk as usual.
+ * - **Errors during `textStream`:** Failures often surface while **core** iterates **`textStream`**
+ *   (after the handler returned), so they bypass **`handleTextWithModelType`’s** outer **`try`/`catch`**.
+ *   **`logOllamaTextFailure`** runs inside the stream wrapper so logs still include **`ollamaResponseBody`**
+ *   (Ollama’s JSON error, e.g. insufficient RAM) and the request URL. **Why:** otherwise the process
+ *   exits with a generic “Internal Server Error” and operators cannot see Ollama’s message.
+ * - **`stream: true` + `responseSchema` (no tools):** Still **`generateText`** only — we **log at
+ *   debug** because `ollama-ai-provider-v2` does not combine structured `format: json` with the
+ *   `streamText` path reliably for nested extractors (e.g. `FACT_EXTRACTOR`).
+ *
+ * - **`stream: true` + `toolChoice` without tools:** **`generateText`** only — we **log at debug**.
+ *   **Why:** `streamText` in this adapter is only used when a **`ToolSet`** is present; `toolChoice`
+ *   alone is not a supported streaming request shape. Core v5 always passes tools with Stage 1
+ *   `toolChoice`; the log helps custom callers spot a bad param combo.
+ *
+ * - **`shouldReturnNative`:** Computed only after the final `outputSpec` (structured output)
+ *   vs tools conflict is resolved, from `hasChatMessages`, `tools`, `toolChoice`, and whether
+ *   structured output is still active. **Why:** the non-streaming return shape must match what we
+ *   actually sent on the wire (`generateText` or the completed stream) so callers do not think
+ *   they got schema-backed JSON when tools won.
+ *
+ * - **Usage fallback:** When the chat-messages path is used, token usage estimation uses a
+ *   JSON serialization of `messages` instead of re-rendering the prompt string. **Why:** we
+ *   skip `renderChatMessagesForPrompt` on that path for efficiency; usage is still best-effort
+ *   when the provider omits `usage`.
+ *
+ * - **`providerOptions`:** Not forwarded into `generateText` yet. **Why:** Ollama’s provider
+ *   surface differs from Anthropic/OpenAI cache hints; forwarding blindly could send unsupported
+ *   fields. Documented in README until explicitly mapped.
+ */
+
+import type {
+  GenerateTextParams,
+  GenerateTextResult,
+  IAgentRuntime,
+  ModelTypeName,
+  TextStreamResult,
+  ToolCall,
+  TokenUsage,
+} from "@elizaos/core";
 import {
   buildCanonicalSystemPrompt,
+  dropDuplicateLeadingSystemMessage,
   logger,
   ModelType,
   renderChatMessagesForPrompt,
   resolveEffectiveSystemPrompt,
 } from "@elizaos/core";
-import { generateText, type LanguageModel } from "ai";
-import { createOllama } from "ollama-ai-provider";
+import {
+  generateText,
+  type JSONSchema7,
+  jsonSchema,
+  type LanguageModel,
+  Output,
+  streamText,
+} from "ai";
+import { createOllama } from "ollama-ai-provider-v2";
 
 import {
   getActionPlannerModel,
@@ -18,7 +109,14 @@ import {
   getNanoModel,
   getResponseHandlerModel,
   getSmallModel,
+  isOllamaStructuredOutputDisabled,
 } from "../utils/config";
+import {
+  mapAiSdkToolCallsToCore,
+  normalizeNativeMessages,
+  normalizeNativeTools,
+  normalizeToolChoice,
+} from "../utils/ai-sdk-wire";
 import { emitModelUsed, estimateUsage, normalizeTokenUsage } from "../utils/modelUsage";
 import { ensureModelAvailable } from "./availability";
 
@@ -29,67 +127,313 @@ const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ??
   "RESPONSE_HANDLER") as ModelTypeName;
 const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ?? "ACTION_PLANNER") as ModelTypeName;
 
-type GenerateTextParamsWithNativeOptions = GenerateTextParams & {
+type GenerateTextParamsWithNativeOptions = Omit<GenerateTextParams, "responseSchema"> & {
   messages?: unknown[];
   tools?: unknown;
   toolChoice?: unknown;
+  /** Core passes JSON Schema objects or full AI SDK output specs; typed loosely here for Ollama. */
   responseSchema?: unknown;
 };
 
-function assertNoUnsupportedNativeOptions(params: GenerateTextParamsWithNativeOptions): void {
-  const unsupported = [
-    params.tools ? "tools" : undefined,
-    params.toolChoice ? "toolChoice" : undefined,
-    params.responseSchema ? "responseSchema" : undefined,
-  ].filter((name): name is string => Boolean(name));
+type NativeTextOutput = NonNullable<Parameters<typeof generateText>[0]["output"]>;
 
-  if (unsupported.length > 0) {
-    throw new Error(
-      `[Ollama] Native ${unsupported.join(", ")} plumbing is not supported by this adapter yet.`
-    );
+/**
+ * Pulls useful fields from Vercel AI SDK errors (`APICallError`, `RetryError`, `NoOutputGeneratedError`, …).
+ * **Why:** the default `logger.error({ error })` serialization often hides **`responseBody`** (Ollama’s JSON
+ * error string, e.g. OOM) and **`url`**, so operators only see “Internal Server Error”.
+ */
+function summarizeAiSdkErrorForLogs(error: unknown, depth = 0): Record<string, unknown> {
+  if (depth > 4) {
+    return { note: "max depth summarizing nested error" };
   }
+  if (error == null) {
+    return { raw: String(error) };
+  }
+  if (typeof error !== "object") {
+    return { message: String(error) };
+  }
+  const e = error as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  if (typeof e.name === "string") out.errorName = e.name;
+  if (typeof e.message === "string") out.message = e.message;
+  if (typeof e.reason === "string") out.reason = e.reason;
+  if (typeof e.url === "string") out.requestUrl = e.url;
+  if (typeof e.statusCode === "number") out.httpStatus = e.statusCode;
+  if (typeof e.responseBody === "string") out.ollamaResponseBody = e.responseBody;
+  if (Array.isArray(e.errors)) {
+    out.attemptErrors = e.errors.map((sub, i) => ({
+      attempt: i + 1,
+      ...summarizeAiSdkErrorForLogs(sub, depth + 1),
+    }));
+  }
+  if (e.cause != null && typeof e.cause === "object") {
+    out.cause = summarizeAiSdkErrorForLogs(e.cause, depth + 1);
+  }
+  return out;
 }
 
-async function generateOllamaText(
-  runtime: IAgentRuntime,
-  ollama: ReturnType<typeof createOllama>,
-  modelType: TextModelType,
-  model: string,
-  params: {
-    prompt: string;
-    system?: string;
-    temperature: number;
-    maxTokens: number;
-    frequencyPenalty: number;
-    presencePenalty: number;
-    stopSequences: string[];
-  }
-): Promise<string> {
-  try {
-    const generateParams = {
-      // ollama-ai-provider still exposes older AI SDK model interfaces.
-      model: ollama(model) as unknown as LanguageModel,
-      prompt: params.prompt,
-      system: params.system,
-      temperature: params.temperature,
-      maxTokens: params.maxTokens,
-      frequencyPenalty: params.frequencyPenalty,
-      presencePenalty: params.presencePenalty,
-      stopSequences: params.stopSequences,
-    };
-
-    const { text: ollamaResponse, usage } = await generateText(generateParams);
-    emitModelUsed(
-      runtime,
+function logOllamaTextFailure(
+  phase: "generateText" | "streamText.textStream",
+  modelType: string,
+  modelId: string,
+  endpoint: string,
+  error: unknown
+): void {
+  logger.error(
+    {
+      src: "plugin:ollama:text",
+      phase,
       modelType,
-      model,
-      normalizeTokenUsage(usage) ?? estimateUsage(params.prompt, ollamaResponse)
-    );
-    return ollamaResponse;
-  } catch (error: unknown) {
-    logger.error({ error }, "Error in generateOllamaText");
-    return "Error generating text. Please try again later.";
+      modelId,
+      ollamaApiEndpoint: endpoint,
+      ...summarizeAiSdkErrorForLogs(error),
+    },
+    `[Ollama] ${phase} failed (${modelType}, model=${modelId}). See ollamaResponseBody / attemptErrors for Ollama’s JSON (e.g. insufficient RAM, model missing).`
+  );
+}
+
+/**
+ * Builds the AI SDK `output` spec for structured generation.
+ * Why accept a pre-built object: some tests/advanced callers pass a full output descriptor
+ * (`responseFormat` + `parseCompleteOutput`); otherwise we wrap JSON Schema with `Output.object`.
+ */
+function buildStructuredOutput(responseSchema: unknown): NativeTextOutput {
+  if (
+    responseSchema &&
+    typeof responseSchema === "object" &&
+    "responseFormat" in responseSchema &&
+    "parseCompleteOutput" in responseSchema
+  ) {
+    return responseSchema as NativeTextOutput;
   }
+
+  const schemaOptions =
+    responseSchema && typeof responseSchema === "object" && "schema" in responseSchema
+      ? (responseSchema as { schema: unknown; name?: string; description?: string })
+      : { schema: responseSchema };
+
+  return Output.object({
+    schema: jsonSchema(schemaOptions.schema as JSONSchema7),
+    ...(schemaOptions.name ? { name: schemaOptions.name } : {}),
+    ...(schemaOptions.description ? { description: schemaOptions.description } : {}),
+  }) as NativeTextOutput;
+}
+
+/**
+ * Eliza `useModel` returns a string for text types. The AI SDK may place parsed JSON in
+ * `result.output` or leave JSON in `result.text`. Why stringify objects: downstream parsers
+ * (e.g. FACT_EXTRACTOR) accept either a string slice or a plain object; a single JSON string
+ * keeps the handler contract simple and matches older provider behavior.
+ */
+function serializeStructuredGenerateTextResult(result: { text: string; output: unknown }): string {
+  if (result.output !== undefined && result.output !== null) {
+    return typeof result.output === "string" ? result.output : JSON.stringify(result.output);
+  }
+  const trimmed = result.text?.trim() ?? "";
+  if (trimmed) return trimmed;
+  throw new Error("[Ollama] Structured generation returned no text or output.");
+}
+
+/**
+ * Builds the object core’s v5 parsers read from `useModel` when the call used tools/messages
+ * without structured `output`. Runtime value is a `GenerateTextResult`; TypeScript still types
+ * the handler as `string` for historical reasons—same pattern as OpenRouter/OpenAI.
+ *
+ * **`providerMetadata.modelName`:** Lets trajectory / debug code attribute the call without
+ * parsing Ollama response bodies again.
+ */
+function buildNativeResultCast(result: Awaited<ReturnType<typeof generateText>>, modelName: string): string {
+  const payload: GenerateTextResult = {
+    text: result.text,
+    toolCalls: mapAiSdkToolCallsToCore(result.toolCalls as unknown[] | undefined),
+    finishReason: String(result.finishReason ?? ""),
+    providerMetadata: { modelName },
+  };
+  return payload as unknown as string;
+}
+
+type StreamTextParams = Parameters<typeof streamText>[0];
+
+/**
+ * Plain streaming path for Ollama (`streamText` from the AI SDK).
+ *
+ * **When:** `params.stream` is true and the request has no structured `output`, tools, or
+ * `toolChoice`.
+ *
+ * **Why this exists:** `AgentRuntime.useModel` only forwards token chunks to SSE when the
+ * handler return value satisfies **`isTextStreamResult`** (`textStream`, `text`, `usage`,
+ * `finishReason` — see `packages/core/src/runtime.ts`). A bare **`string`** skips that branch:
+ * the model still runs, but the UI gets no chunks (“no streamed text”).
+ *
+ * **Usage / `MODEL_USED`:** We resolve **`streamResult.usage`** after the stream completes,
+ * merge with **`streamResult.text`** for fallback estimation, then **`emitModelUsed`** once.
+ * **Why await `text` inside the usage hook:** Ollama may omit partial usage until the full
+ * completion is known; pairing with final text keeps estimates sane when the provider omits
+ * token fields.
+ *
+ * **`textStream` wrapper:** The async generator forwards chunks and, on successful completion,
+ * awaits **`usagePromise`** in a **`finally`** block so consumers that only drain **`textStream`**
+ * still trigger accounting—mirroring **`plugin-openrouter`**’s pattern.
+ */
+function buildOllamaStreamTextResult(args: {
+  runtime: IAgentRuntime;
+  modelType: TextModelType;
+  model: string;
+  /** Resolved `OLLAMA_API_ENDPOINT` — logged when `textStream` fails (errors often happen here, outside `handleTextWithModelType`’s try/catch). */
+  endpoint: string;
+  streamParams: StreamTextParams;
+  promptForEstimate: string;
+}): TextStreamResult {
+  const streamResult = streamText(args.streamParams);
+
+  const usagePromise = Promise.resolve(streamResult.usage).then(async (usage) => {
+    const fullText = await streamResult.text;
+    const normalized =
+      normalizeTokenUsage(usage) ?? estimateUsage(args.promptForEstimate, fullText);
+    emitModelUsed(args.runtime, args.modelType, args.model, normalized);
+    return normalized as unknown as TokenUsage | undefined;
+  });
+
+  async function* textStreamWithUsage(): AsyncIterable<string> {
+    let completed = false;
+    try {
+      for await (const chunk of streamResult.textStream) {
+        yield chunk;
+      }
+      completed = true;
+    } catch (streamErr) {
+      logOllamaTextFailure(
+        "streamText.textStream",
+        String(args.modelType),
+        args.model,
+        args.endpoint,
+        streamErr
+      );
+      throw streamErr;
+    } finally {
+      if (completed) {
+        await usagePromise.catch(() => undefined);
+      }
+    }
+  }
+
+  return {
+    textStream: textStreamWithUsage(),
+    text: Promise.resolve(streamResult.text),
+    usage: usagePromise,
+    finishReason: Promise.resolve(streamResult.finishReason) as Promise<string | undefined>,
+  };
+}
+
+/** Serialized tool `arguments` for v5 `parseMessageHandlerOutput` (expects JSON text). */
+function stringifyPlannerToolArgs(arguments_: ToolCall["arguments"]): string {
+  if (typeof arguments_ === "string") {
+    return arguments_;
+  }
+  return JSON.stringify(arguments_);
+}
+
+type OllamaStreamTextWithToolsResult = TextStreamResult & {
+  /** Mapped tool calls after the stream completes (parity with OpenAI `streamText` + tools). */
+  toolCalls?: Promise<ToolCall[]>;
+};
+
+/**
+ * `streamText` when the request includes native tools and `stream: true`.
+ *
+ * **Why a separate builder from `buildOllamaStreamTextResult`:** Ollama’s chat model supports
+ * tools on the streaming wire; `generateText` would buffer the full completion and skip token
+ * streaming entirely.
+ *
+ * **Planner types (`RESPONSE_HANDLER`, `ACTION_PLANNER`):** `useModel`’s streaming path sets
+ * `result` to the concatenation of **`textStream` chunks only** — it never awaits our **`text`**
+ * promise. Core then calls **`parseMessageHandlerOutput(fullText)`**, which expects a single JSON
+ * blob of the plan. We therefore **drain** the SDK `textStream` without yielding those deltas (so
+ * they are not prepended to the plan JSON) and **yield one chunk**: the first mapped tool’s
+ * **`arguments`** as JSON text. **Why:** interleaving arbitrary model text with plan JSON breaks
+ * `JSON.parse` on the accumulated string.
+ *
+ * **Other text model types:** Forward every SDK text chunk; `text` resolves to the final model
+ * text. **`toolCalls`** is still attached for callers that read it from the result object.
+ */
+function buildOllamaStreamWithToolsResult(args: {
+  runtime: IAgentRuntime;
+  modelType: TextModelType;
+  model: string;
+  /** Resolved `OLLAMA_API_ENDPOINT` — logged when streaming fails (core consumes `textStream` after the handler returns). */
+  endpoint: string;
+  streamParams: StreamTextParams;
+  promptForEstimate: string;
+}): OllamaStreamTextWithToolsResult {
+  const streamResult = streamText(args.streamParams);
+
+  const toolCallsPromise = Promise.resolve(streamResult.toolCalls).then((calls) =>
+    mapAiSdkToolCallsToCore(calls as unknown[] | undefined)
+  );
+
+  const usagePromise = Promise.resolve(streamResult.usage).then(async (usage) => {
+    const fullText = await streamResult.text;
+    const normalized =
+      normalizeTokenUsage(usage) ?? estimateUsage(args.promptForEstimate, fullText);
+    emitModelUsed(args.runtime, args.modelType, args.model, normalized);
+    return normalized as unknown as TokenUsage | undefined;
+  });
+
+  const isNativePlannerType =
+    args.modelType === RESPONSE_HANDLER_MODEL_TYPE ||
+    args.modelType === ACTION_PLANNER_MODEL_TYPE;
+
+  const textPromise: Promise<string> = isNativePlannerType
+    ? toolCallsPromise.then(async (mapped) => {
+        const first = mapped[0];
+        if (first) {
+          return stringifyPlannerToolArgs(first.arguments);
+        }
+        return Promise.resolve(streamResult.text).then((t) => t);
+      })
+    : Promise.resolve(streamResult.text).then((t) => t);
+
+  async function* textStreamWithUsage(): AsyncIterable<string> {
+    let completed = false;
+    try {
+      if (isNativePlannerType) {
+        for await (const _ of streamResult.textStream) {
+          // Drain text deltas; only the trailing plan JSON chunk is yielded (see module comment).
+        }
+        const mapped = await toolCallsPromise;
+        const first = mapped[0];
+        if (first) {
+          yield stringifyPlannerToolArgs(first.arguments);
+        }
+      } else {
+        for await (const chunk of streamResult.textStream) {
+          yield chunk;
+        }
+      }
+      completed = true;
+    } catch (streamErr) {
+      logOllamaTextFailure(
+        "streamText.textStream",
+        String(args.modelType),
+        args.model,
+        args.endpoint,
+        streamErr
+      );
+      throw streamErr;
+    } finally {
+      if (completed) {
+        await usagePromise.catch(() => undefined);
+      }
+    }
+  }
+
+  return {
+    textStream: textStreamWithUsage(),
+    text: textPromise,
+    usage: usagePromise,
+    finishReason: Promise.resolve(streamResult.finishReason) as Promise<string | undefined>,
+    toolCalls: toolCallsPromise,
+  };
 }
 
 type TextModelType =
@@ -122,22 +466,50 @@ function getModelNameForType(runtime: IAgentRuntime, modelType: TextModelType): 
   }
 }
 
+/**
+ * Shared path for all text model types.
+ *
+ * **Structured output:** `OLLAMA_DISABLE_STRUCTURED_OUTPUT` strips `responseSchema` so plain
+ * text runs—**why:** operators can recover broken local models without redeploying code;
+ * callers that require JSON may then fail validation (intentional trade-off).
+ *
+ * **Streaming vs `stream` flag:** Plain chat (`stream` true, no tools / `toolChoice` / schema)
+ *   returns **`TextStreamResult`** from **`streamText`**. **`stream` + tools** uses
+ *   **`buildOllamaStreamWithToolsResult`**. **`stream` + `responseSchema`** without tools still
+ *   uses **`generateText`** — log at **debug**. **`stream` + `toolChoice`** without a resolved
+ *   tool set uses **`generateText`** — log at **debug**; **why:** `streamText` requires tools on
+ *   the wire; this path is unexpected from core.
+ *
+ * **Tools vs schema:** If both are present, tools win and structured output is omitted for
+ * that request—**why:** v5 Stage 1 requires tools; combining `Output.object` with tools in one
+ * `generateText` is not a portable contract across Ollama models.
+ */
 async function handleTextWithModelType(
   runtime: IAgentRuntime,
   modelType: TextModelType,
   params: GenerateTextParams
-): Promise<string> {
-  assertNoUnsupportedNativeOptions(params as GenerateTextParamsWithNativeOptions);
+): Promise<string | TextStreamResult> {
+  const extended = params as GenerateTextParamsWithNativeOptions;
+  const structuredDisabled = isOllamaStructuredOutputDisabled(runtime);
+  let responseSchema: unknown = extended.responseSchema;
+  if (structuredDisabled && extended.responseSchema) {
+    logger.debug(
+      "[Ollama] OLLAMA_DISABLE_STRUCTURED_OUTPUT is set — ignoring responseSchema for this call."
+    );
+    responseSchema = undefined;
+  }
+
+  const tools = normalizeNativeTools(extended.tools);
 
   const {
     prompt,
-    stopSequences = [],
     maxTokens = 8192,
     temperature = 0.7,
     frequencyPenalty = 0.7,
     presencePenalty = 0.7,
   } = params;
 
+  let modelIdForLog = "";
   try {
     const baseURL = getBaseURL(runtime);
     const customFetch = runtime.fetch ?? undefined;
@@ -147,6 +519,7 @@ async function handleTextWithModelType(
     });
 
     const model = getModelNameForType(runtime, modelType);
+    modelIdForLog = model;
     logger.log(`[Ollama] Using ${modelType} model: ${model}`);
     await ensureModelAvailable(model, baseURL, customFetch);
 
@@ -154,22 +527,136 @@ async function handleTextWithModelType(
       params,
       fallback: buildCanonicalSystemPrompt({ character: runtime.character }),
     });
-    return await generateOllamaText(runtime, ollama, modelType, model, {
-      prompt:
-        renderChatMessagesForPrompt(params.messages, {
+
+    let outputSpec: NativeTextOutput | undefined =
+      responseSchema !== undefined && responseSchema !== null
+        ? buildStructuredOutput(responseSchema)
+        : undefined;
+
+    if (tools && outputSpec) {
+      // Stage-1-style calls need native tools; do not send `output` in the same request.
+      logger.debug(
+        "[Ollama] tools and responseSchema both present — omitting structured output for this call."
+      );
+      outputSpec = undefined;
+    }
+
+    const wireRaw = dropDuplicateLeadingSystemMessage(
+      extended.messages as Parameters<typeof dropDuplicateLeadingSystemMessage>[0],
+      system
+    );
+    const normalizedMessages = normalizeNativeMessages(wireRaw);
+    const hasChatMessages =
+      Array.isArray(normalizedMessages) && normalizedMessages.length > 0;
+    const toolChoice = tools ? normalizeToolChoice(extended.toolChoice) : undefined;
+
+    // After `outputSpec` is final (including tools-vs-schema): native return shape when the
+    // call used chat messages, tools, toolChoice, or structured output — matches OpenRouter.
+    const shouldReturnNative = Boolean(
+      hasChatMessages ||
+        tools ||
+        extended.toolChoice ||
+        outputSpec !== undefined
+    );
+
+    const renderedPrompt = hasChatMessages
+      ? ""
+      : (renderChatMessagesForPrompt(params.messages, {
           omitDuplicateSystem: system,
         }) ??
         prompt ??
-        "",
+        "");
+
+    const promptOrMessages = hasChatMessages
+      ? { messages: normalizedMessages }
+      : { prompt: renderedPrompt };
+
+    const resolvedStopSequences =
+      Array.isArray(params.stopSequences) && params.stopSequences.length > 0
+        ? params.stopSequences
+        : undefined;
+
+    const promptForUsageEstimate = hasChatMessages
+      ? JSON.stringify(normalizedMessages)
+      : renderedPrompt;
+
+    const baseGenerateArgs = {
+      model: ollama(model) as LanguageModel,
+      ...promptOrMessages,
       system,
       temperature,
-      maxTokens,
+      maxOutputTokens: maxTokens,
       frequencyPenalty,
       presencePenalty,
-      stopSequences,
-    });
+      ...(resolvedStopSequences ? { stopSequences: resolvedStopSequences } : {}),
+      ...(tools ? { tools, ...(toolChoice ? { toolChoice } : {}) } : {}),
+      ...(outputSpec ? { output: outputSpec } : {}),
+    };
+
+    // Streaming branches (order matters):
+    // 1) tools + stream → streamText+tools (Ollama v2 supports tools on streaming /api/chat).
+    // 2) stream, no tools, no toolChoice → plain streamText → TextStreamResult for SSE.
+    // 3) stream + schema only → generateText below + debug (structured format not on streamText).
+    // 4) stream + toolChoice but no ToolSet → generateText below + debug (invalid streamText shape).
+    if (params.stream) {
+      if (tools) {
+        return buildOllamaStreamWithToolsResult({
+          runtime,
+          modelType,
+          model,
+          endpoint: baseURL,
+          streamParams: baseGenerateArgs as StreamTextParams,
+          promptForEstimate: promptForUsageEstimate,
+        });
+      }
+      if (!extended.toolChoice) {
+        if (!outputSpec) {
+          return buildOllamaStreamTextResult({
+            runtime,
+            modelType,
+            model,
+            endpoint: baseURL,
+            streamParams: baseGenerateArgs as StreamTextParams,
+            promptForEstimate: promptForUsageEstimate,
+          });
+        }
+        logger.debug(
+          { src: "plugin:ollama:text", modelType },
+          "[Ollama] stream=true with responseSchema (no tools) — using generateText. Why: ollama-ai-provider-v2 does not support structured JSON output on the streamText path for this adapter."
+        );
+      } else {
+        logger.debug(
+          { src: "plugin:ollama:text", modelType },
+          "[Ollama] stream=true with toolChoice but no tools on wire — using generateText. Why: streamText+tools requires a ToolSet; callers should pass tools alongside toolChoice."
+        );
+      }
+    }
+
+    const result = await generateText(baseGenerateArgs);
+
+    emitModelUsed(
+      runtime,
+      modelType,
+      model,
+      normalizeTokenUsage(result.usage) ?? estimateUsage(promptForUsageEstimate, result.text)
+    );
+
+    if (shouldReturnNative) {
+      if (outputSpec !== undefined) {
+        return serializeStructuredGenerateTextResult(result);
+      }
+      return buildNativeResultCast(result, model);
+    }
+
+    return result.text;
   } catch (error) {
-    logger.error({ error }, `Error in ${modelType} model`);
+    let endpoint = "";
+    try {
+      endpoint = getBaseURL(runtime);
+    } catch {
+      /* ignore */
+    }
+    logOllamaTextFailure("generateText", String(modelType), modelIdForLog || "(unknown)", endpoint, error);
     return "Error generating text. Please try again later.";
   }
 }
@@ -177,48 +664,48 @@ async function handleTextWithModelType(
 export async function handleTextSmall(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, ModelType.TEXT_SMALL, params);
 }
 
 export async function handleTextNano(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, TEXT_NANO_MODEL_TYPE, params);
 }
 
 export async function handleTextMedium(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, TEXT_MEDIUM_MODEL_TYPE, params);
 }
 
 export async function handleTextLarge(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, ModelType.TEXT_LARGE, params);
 }
 
 export async function handleTextMega(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, TEXT_MEGA_MODEL_TYPE, params);
 }
 
 export async function handleResponseHandler(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, RESPONSE_HANDLER_MODEL_TYPE, params);
 }
 
 export async function handleActionPlanner(
   runtime: IAgentRuntime,
   params: GenerateTextParams
-): Promise<string> {
+): Promise<string | TextStreamResult> {
   return handleTextWithModelType(runtime, ACTION_PLANNER_MODEL_TYPE, params);
 }

--- a/plugins/plugin-ollama/package.json
+++ b/plugins/plugin-ollama/package.json
@@ -38,7 +38,7 @@
     "@ai-sdk/ui-utils": "^1.2.8",
     "ai": "^6.0.174",
     "js-tiktoken": "^1.0.18",
-    "ollama-ai-provider": "^1.2.0"
+    "ollama-ai-provider-v2": "^3.5.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",
@@ -102,6 +102,12 @@
         "description": "Name or tag of the Ollama model used to generate text embeddings.",
         "required": false,
         "default": "nomic-embed-text:latest",
+        "sensitive": false
+      },
+      "OLLAMA_DISABLE_STRUCTURED_OUTPUT": {
+        "type": "string",
+        "description": "When set to 1/true/yes/on, JSON-schema structured text (responseSchema) is disabled and calls use plain generation. Use if local models misbehave with Ollama format=json.",
+        "required": false,
         "sensitive": false
       },
       "SMALL_MODEL": {

--- a/plugins/plugin-ollama/plugin.ts
+++ b/plugins/plugin-ollama/plugin.ts
@@ -1,9 +1,44 @@
+/**
+ * Ollama provider plugin registration.
+ *
+ * ## Why this file exists separately from `models/*`
+ *
+ * Centralizes **plugin metadata**, **model-type → handler** wiring, and **init-time** logging
+ * (base URL, model defaults) so model modules stay pure “call Ollama / AI SDK” logic.
+ *
+ * ## Text handlers and v5 parity
+ *
+ * `TEXT_*`, `RESPONSE_HANDLER`, and `ACTION_PLANNER` all route through `models/text.ts`, which uses:
+ *
+ * - **`generateText`** — default completion; structured output when `responseSchema` is set and
+ *   streaming is not used for that shape; **`stream: true`** + schema-only (no tools) for nested
+ *   extractors. **Why:** keeps JSON `format` on the supported completion path.
+ * - **`streamText`** — plain SSE chat when `stream: true` with no tools/schema/`toolChoice`; and
+ *   **`stream: true` + native tools** so Ollama can stream `/api/chat` with tools. For v5 planner
+ *   model types under SSE, `models/text.ts` may yield a **single** `textStream` chunk of plan JSON
+ *   so `useModel`’s concatenated string stays parseable. **Why:** core’s streaming path only
+ *   accumulates `textStream` chunks, not the `text` promise; mixing arbitrary deltas with plan JSON
+ *   breaks `parseMessageHandlerOutput`.
+ *
+ * Handlers return **`Promise<string | TextStreamResult>`** — **why:** `useModel` accepts either a
+ * final string or a streaming object for text model keys; matching OpenRouter keeps orchestration
+ * and SSE paths identical. ElizaOS v5 Stage 1 calls `RESPONSE_HANDLER` with **`messages`**,
+ * **`tools`**, and **`toolChoice`**; the text adapter must accept the same shapes as
+ * OpenRouter/OpenAI or local-only agents fail before the first reply. See `models/text.ts` and
+ * `utils/ai-sdk-wire.ts` module comments for the full rationale.
+ *
+ * ## AI SDK log noise
+ *
+ * Suppresses noisy AI SDK warnings at load (`AI_SDK_LOG_WARNINGS`) because local inference
+ * runs in tight loops during tests and desktop shells. **Why:** keeps CI and packaged logs readable.
+ */
 import type {
   GenerateTextParams,
   IAgentRuntime,
   ObjectGenerationParams,
   Plugin,
   TextEmbeddingParams,
+  TextStreamResult,
 } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 
@@ -105,49 +140,49 @@ export const ollamaPlugin: Plugin = {
     [TEXT_NANO_MODEL_TYPE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleTextNano(runtime, params);
     },
 
     [ModelType.TEXT_SMALL]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleTextSmall(runtime, params);
     },
 
     [TEXT_MEDIUM_MODEL_TYPE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleTextMedium(runtime, params);
     },
 
     [ModelType.TEXT_LARGE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleTextLarge(runtime, params);
     },
 
     [TEXT_MEGA_MODEL_TYPE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleTextMega(runtime, params);
     },
 
     [RESPONSE_HANDLER_MODEL_TYPE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleResponseHandler(runtime, params);
     },
 
     [ACTION_PLANNER_MODEL_TYPE]: async (
       runtime: IAgentRuntime,
       params: GenerateTextParams
-    ): Promise<string> => {
+    ): Promise<string | TextStreamResult> => {
       return handleActionPlanner(runtime, params);
     },
 

--- a/plugins/plugin-ollama/utils/ai-sdk-wire.ts
+++ b/plugins/plugin-ollama/utils/ai-sdk-wire.ts
@@ -1,0 +1,387 @@
+/**
+ * AI SDK wiring for Ollama text generation (`models/text.ts`).
+ *
+ * ## Why this module is separate
+ *
+ * Eliza’s `GenerateTextParams` carry **`messages`**, **`tools`**, and **`toolChoice`** in loose
+ * shapes (protobuf-era typing, plus `unknown` extensions). The Vercel **`generateText`** and
+ * **`streamText`** APIs expect **`ModelMessage[]`**, **`ToolSet`**, and **`ToolChoice<ToolSet>`**
+ * on the native path. Isolating the
+ * translation here keeps `text.ts` focused on orchestration and matches how **`plugin-openai`**
+ * structures the same problem—without pulling Cerebras-only schema/name sanitization into
+ * Ollama (local models do not share that grammar compiler).
+ *
+ * ## Exported helpers
+ *
+ * - **`normalizeNativeTools`** — Array → `ToolSet` with `jsonSchema(...)`; object → pass-through
+ *   so advanced callers can supply a pre-built `ToolSet`. **Why both:** core usually sends
+ *   `ToolDefinition[]`, but tests and future code paths may send an SDK-native object.
+ * - **`normalizeNativeMessages`** — Maps Eliza/chat-shaped records into `ModelMessage[]` so
+ *   assistant tool calls and tool results round-trip. **Why:** v5 Stage 1 is not a single flat
+ *   `prompt` string; dropping this step would flatten or drop tool history incorrectly.
+ * - **`normalizeToolChoice`** — Accepts string enums and object-shaped choices from core.
+ * - **`parseJsonIfPossible`** — Best-effort JSON parse for string tool arguments; returns
+ *   non-strings unchanged so **`null` / objects** are not coerced to `""` (which would confuse
+ *   downstream argument parsers).
+ * - **`mapAiSdkToolCallsToCore`** — Renames AI SDK fields (`toolCallId`, `toolName`, `input`)
+ *   into Eliza **`ToolCall`** (`id`, `name`, `arguments`) so `parseMessageHandlerNativeToolCall`
+ *   and trajectory export see one consistent shape across providers.
+ */
+
+import type { JsonValue, ToolCall } from "@elizaos/core";
+import {
+  type JSONSchema7,
+  jsonSchema,
+  type ModelMessage,
+  type ToolChoice,
+  type ToolSet,
+  type UserContent,
+} from "ai";
+
+/** Converts Eliza `ToolDefinition[]` or an AI SDK `ToolSet` into the shape `generateText` expects. */
+export function normalizeNativeTools(tools: unknown): ToolSet | undefined {
+  if (!tools) {
+    return undefined;
+  }
+
+  if (!Array.isArray(tools)) {
+    return tools as ToolSet;
+  }
+
+  const toolSet: Record<string, unknown> = {};
+
+  for (const rawTool of tools) {
+    const tool = asRecord(rawTool);
+    const functionTool = asRecord(tool.function);
+    const name = firstString(tool.name, functionTool.name);
+
+    if (!name) {
+      throw new Error("[Ollama] Native tool definition is missing a name.");
+    }
+
+    const description = firstString(tool.description, functionTool.description);
+    const rawSchema =
+      tool.parameters ?? functionTool.parameters ?? ({ type: "object" } satisfies JSONSchema7);
+    const inputSchema = sanitizeJsonSchema(rawSchema, true);
+
+    toolSet[name] = {
+      ...(description ? { description } : {}),
+      inputSchema: jsonSchema(inputSchema as JSONSchema7),
+    };
+  }
+
+  return Object.keys(toolSet).length > 0 ? (toolSet as ToolSet) : undefined;
+}
+
+/** Converts Eliza `ChatMessage[]`-like rows into `ModelMessage[]` for `generateText({ messages })`. */
+export function normalizeNativeMessages(messages: unknown): ModelMessage[] | undefined {
+  if (!Array.isArray(messages)) {
+    return undefined;
+  }
+
+  return messages.map((message) => normalizeNativeMessage(message));
+}
+
+/** Maps core / OpenAI-style tool choice objects onto AI SDK `ToolChoice`. */
+export function normalizeToolChoice(toolChoice: unknown): ToolChoice<ToolSet> | undefined {
+  if (!toolChoice) {
+    return undefined;
+  }
+
+  if (
+    typeof toolChoice === "string" &&
+    (toolChoice === "auto" || toolChoice === "none" || toolChoice === "required")
+  ) {
+    return toolChoice;
+  }
+
+  const choice = asRecord(toolChoice);
+  if (choice.type === "tool") {
+    if (typeof choice.toolName === "string" && choice.toolName.length > 0) {
+      return toolChoice as ToolChoice<ToolSet>;
+    }
+    const toolName = firstString(choice.toolName, choice.name);
+    if (toolName) {
+      return { type: "tool", toolName };
+    }
+  }
+
+  if (choice.type === "function") {
+    const fn = asRecord(choice.function);
+    const toolName = firstString(fn.name);
+    if (toolName) {
+      return { type: "tool", toolName };
+    }
+  }
+
+  const namedTool = firstString(choice.name);
+  if (namedTool) {
+    return { type: "tool", toolName: namedTool };
+  }
+
+  return toolChoice as ToolChoice<ToolSet>;
+}
+
+/** Parses JSON strings; returns non-strings unchanged (including `null` / `undefined`). */
+export function parseJsonIfPossible(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Maps AI SDK `generateText` tool call entries to Eliza `ToolCall` records for core parsers. */
+export function mapAiSdkToolCallsToCore(toolCalls: unknown[] | undefined): ToolCall[] {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return [];
+  }
+
+  const out: ToolCall[] = [];
+  for (const tc of toolCalls) {
+    const mapped = mapOneToolCall(tc);
+    if (mapped) {
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+function mapOneToolCall(tc: unknown): ToolCall | null {
+  const r = asRecord(tc);
+  const id = String(firstString(r.toolCallId, r.id) ?? "");
+  const name = String(firstString(r.toolName, r.name) ?? "").trim();
+  if (!name) {
+    return null;
+  }
+
+  const rawInput = r.input ?? r.arguments ?? r.args;
+  let args: Record<string, JsonValue> | string;
+  if (typeof rawInput === "string") {
+    const parsed = parseJsonIfPossible(rawInput);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      args = parsed as Record<string, JsonValue>;
+    } else {
+      args = rawInput;
+    }
+  } else if (rawInput && typeof rawInput === "object" && !Array.isArray(rawInput)) {
+    args = rawInput as Record<string, JsonValue>;
+  } else {
+    args = {};
+  }
+
+  return { id, name, arguments: args };
+}
+
+function normalizeNativeMessage(message: unknown): ModelMessage {
+  const raw = asRecord(message);
+  const providerOptions = asOptionalRecord(raw.providerOptions);
+
+  if (raw.role === "system") {
+    return {
+      role: "system",
+      content: stringifyMessageContent(raw.content),
+      ...(providerOptions ? { providerOptions } : {}),
+    } as ModelMessage;
+  }
+
+  if (raw.role === "assistant") {
+    return {
+      role: "assistant",
+      content: normalizeAssistantContent(raw),
+      ...(providerOptions ? { providerOptions } : {}),
+    } as ModelMessage;
+  }
+
+  if (raw.role === "tool") {
+    return {
+      role: "tool",
+      content: normalizeToolContent(raw),
+      ...(providerOptions ? { providerOptions } : {}),
+    } as ModelMessage;
+  }
+
+  return {
+    role: "user",
+    content: normalizeUserContent(raw.content),
+    ...(providerOptions ? { providerOptions } : {}),
+  } as ModelMessage;
+}
+
+function normalizeAssistantContent(message: Record<string, unknown>): unknown {
+  const toolCalls = Array.isArray(message.toolCalls) ? message.toolCalls : [];
+
+  if (toolCalls.length === 0) {
+    if (Array.isArray(message.content) || typeof message.content === "string") {
+      return message.content;
+    }
+    return "";
+  }
+
+  const parts: unknown[] = [];
+  if (typeof message.content === "string" && message.content.length > 0) {
+    parts.push({ type: "text", text: message.content });
+  } else if (Array.isArray(message.content)) {
+    parts.push(...message.content);
+  }
+
+  for (const toolCall of toolCalls) {
+    const rawCall = asRecord(toolCall);
+    const rawFunction = asRecord(rawCall.function);
+    const toolCallId = firstString(rawCall.toolCallId, rawCall.id);
+    const toolName = firstString(rawCall.toolName, rawCall.name, rawFunction.name);
+
+    if (!toolCallId || !toolName) {
+      continue;
+    }
+
+    parts.push({
+      type: "tool-call",
+      toolCallId,
+      toolName,
+      input: parseToolCallInput(rawCall, rawFunction),
+    });
+  }
+
+  return parts;
+}
+
+function normalizeToolContent(message: Record<string, unknown>): unknown[] {
+  if (Array.isArray(message.content)) {
+    return message.content;
+  }
+
+  const toolCallId = firstString(message.toolCallId, message.id) ?? "tool-call";
+  const toolName = firstString(message.toolName, message.name) ?? "tool";
+  const parsed = parseJsonIfPossible(message.content);
+
+  return [
+    {
+      type: "tool-result",
+      toolCallId,
+      toolName,
+      output:
+        typeof parsed === "string"
+          ? { type: "text", value: parsed }
+          : { type: "json", value: parsed },
+    },
+  ];
+}
+
+function normalizeUserContent(content: unknown): UserContent {
+  if (Array.isArray(content)) {
+    return content as UserContent;
+  }
+  return stringifyMessageContent(content);
+}
+
+function stringifyMessageContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (content == null) {
+    return "";
+  }
+  return typeof content === "object" ? JSON.stringify(content) : String(content);
+}
+
+function parseToolCallInput(
+  rawCall: Record<string, unknown>,
+  rawFunction: Record<string, unknown>
+): unknown {
+  if ("input" in rawCall) {
+    return rawCall.input;
+  }
+  return parseJsonIfPossible(rawCall.arguments ?? rawFunction.arguments ?? {});
+}
+
+function sanitizeJsonSchema(schema: unknown, isRoot = false): JSONSchema7 {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return { type: "object" };
+  }
+
+  const record = schema as Record<string, unknown>;
+  const sanitized: Record<string, unknown> = { ...record };
+
+  if (typeof sanitized.type !== "string") {
+    const inferredType = inferJsonSchemaType(sanitized, isRoot);
+    if (inferredType) {
+      sanitized.type = inferredType;
+    }
+  }
+
+  if (
+    sanitized.properties &&
+    typeof sanitized.properties === "object" &&
+    !Array.isArray(sanitized.properties)
+  ) {
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(sanitized.properties as Record<string, unknown>)) {
+      properties[key] = sanitizeJsonSchema(value);
+    }
+    sanitized.properties = properties;
+  }
+
+  if (sanitized.items) {
+    sanitized.items = Array.isArray(sanitized.items)
+      ? sanitized.items.map((item) => sanitizeJsonSchema(item))
+      : sanitizeJsonSchema(sanitized.items);
+  }
+
+  for (const unionKey of ["anyOf", "oneOf", "allOf"] as const) {
+    const value = sanitized[unionKey];
+    if (Array.isArray(value)) {
+      sanitized[unionKey] = value.map((item) => sanitizeJsonSchema(item));
+    }
+  }
+
+  return sanitized as JSONSchema7;
+}
+
+function inferJsonSchemaType(schema: Record<string, unknown>, isRoot: boolean): string | undefined {
+  if (
+    "properties" in schema ||
+    "required" in schema ||
+    "additionalProperties" in schema ||
+    isRoot
+  ) {
+    return "object";
+  }
+  if ("items" in schema) {
+    return "array";
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    const types = new Set(schema.enum.map((value) => typeof value));
+    if (types.size === 1) {
+      const [type] = [...types];
+      if (type === "string" || type === "number" || type === "boolean") {
+        return type;
+      }
+    }
+  }
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asOptionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/plugins/plugin-ollama/utils/config.ts
+++ b/plugins/plugin-ollama/utils/config.ts
@@ -1,3 +1,14 @@
+/**
+ * Ollama-related settings resolution for `@elizaos/plugin-ollama`.
+ *
+ * ## Why `getSetting` merges runtime + `process.env`
+ *
+ * Eliza agents can override keys per-character via `runtime.getSetting`, while CLI and
+ * container deployments typically use environment variables. Reading both in one helper
+ * keeps model selection consistent whether the agent is started from the desktop app,
+ * `eliza start`, or tests.
+ */
+
 type SettingsProvider = {
   getSetting: (key: string) => string | number | boolean | null;
 };
@@ -106,4 +117,18 @@ export function getActionPlannerModel(runtime: SettingsProvider): string {
 
 export function getEmbeddingModel(runtime: SettingsProvider): string {
   return getSetting(runtime, "OLLAMA_EMBEDDING_MODEL") || DEFAULT_EMBEDDING_MODEL;
+}
+
+/**
+ * Escape hatch for JSON-schema structured text (`responseSchema` on `useModel`).
+ *
+ * **Why this exists:** Ollama `format` / schema mode is correct for core pipelines
+ * (fact extraction, planners), but some local models return invalid JSON, loop, or 500.
+ * Disabling structured output forces plain `generateText` so the agent stays alive; callers
+ * that require strict JSON may log parse failures until the operator fixes the model or
+ * clears this flag.
+ */
+export function isOllamaStructuredOutputDisabled(runtime: SettingsProvider): boolean {
+  const v = getSetting(runtime, "OLLAMA_DISABLE_STRUCTURED_OUTPUT")?.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
 }

--- a/plugins/plugin-ollama/utils/index.ts
+++ b/plugins/plugin-ollama/utils/index.ts
@@ -1,1 +1,3 @@
+/** Re-exports Ollama helpers: `config` (env/runtime resolution) and `ai-sdk-wire` (messages/tools for `generateText`). */
+export * from "./ai-sdk-wire";
 export * from "./config";


### PR DESCRIPTION
bots do you thing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors Ollama text generation/streaming paths and tool/structured-output plumbing, which could affect agent reply behavior and streaming in production. Changes are contained to the Ollama plugin and documented/tested, but touch core integration surfaces (`useModel` return shapes, tool calls, SSE).
> 
> **Overview**
> Makes `@elizaos/plugin-ollama` compatible with AI SDK 5/6 by switching to `ollama-ai-provider-v2` and updating embedding/object/text handlers accordingly.
> 
> Adds full v5 text “native” plumbing: supports `messages`, `tools`, and `toolChoice`, plus JSON-schema structured text output via `responseSchema` (with an `OLLAMA_DISABLE_STRUCTURED_OUTPUT` escape hatch). Updates streaming behavior to return `TextStreamResult` for plain SSE, use `streamText` for tool streaming (including special planner chunking for `RESPONSE_HANDLER`/`ACTION_PLANNER`), and improves error logging with extracted Ollama response bodies.
> 
> Expands tests and documentation (new plugin changelog, updated README/registry troubleshooting) to cover the new provider, streaming routing, and native tools/structured-output behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0697349519a444cafbcd8118f65e2ee6101ddd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added streaming text generation support for real-time response handling
  * Enabled native tools and structured output capabilities
  * Support for AI SDK versions 5 and 6
  * New `OLLAMA_DISABLE_STRUCTURED_OUTPUT` configuration option

* **Documentation**
  * Expanded README with architecture, streaming behavior, and configuration details
  * Updated troubleshooting guide with symptom-based solutions
  * Improved installation and setup instructions

* **Tests**
  * Enhanced test coverage for streaming and native tool scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `plugin-ollama` to work with ElizaOS v5 and AI SDK 5/6 by replacing `ollama-ai-provider` (model spec v1) with `ollama-ai-provider-v2`, and adds full support for native tools, streaming (`TextStreamResult`), structured output (`responseSchema` → `Output.object`), and richer error logging.

- **Provider upgrade** (`ollama-ai-provider-v2`): Fixes the \"Unsupported model version v1\" runtime crash for all model types and removes the now-unnecessary `as unknown as` casts in `embedding.ts` and `object.ts`.
- **Text adapter overhaul** (`models/text.ts`): Adds four distinct paths—`streamText`+tools, plain `streamText`→`TextStreamResult`, structured `generateText`, and native tool/message `generateText`—along with a planner-specific drain-and-single-chunk strategy for `RESPONSE_HANDLER`/`ACTION_PLANNER` so `parseMessageHandlerOutput` receives parseable JSON.
- **New `utils/ai-sdk-wire.ts`**: Normalizes Eliza's loosely-typed `ToolDefinition[]`, `ChatMessage[]`, and `toolChoice` shapes into the AI SDK's `ToolSet`, `ModelMessage[]`, and `ToolChoice` types.

<h3>Confidence Score: 3/5</h3>

The adapter rewrite is well-structured and test-covered, but both streaming builders expose usagePromise as TextStreamResult.usage without suppressing its rejection in the error path—on a stream failure the Vercel AI SDK rejects streamResult.text, making usagePromise a dangling unhandled rejection that Node.js may surface as a fatal event.

Two streaming helper functions share the same pattern: usagePromise is only awaited in the finally block when completed = true, but on a stream error completed stays false and the Promise—which awaits streamResult.text—is left dangling. Every Ollama streaming error currently risks an unhandledRejection. The rest of the change (provider swap, tool normalization, planner drain logic, structured output) looks correct and is backed by solid tests.

plugins/plugin-ollama/models/text.ts — both streaming builder functions need a void .catch() on usagePromise (and toolCallsPromise in the tools builder) immediately after construction.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-ollama/models/text.ts | Major rewrite adding native tools, streaming (streamText + TextStreamResult), structured output (Output.object), and richer error logging; contains an unhandled-rejection risk in the usagePromise for both streaming builders when a stream error occurs. |
| plugins/plugin-ollama/utils/ai-sdk-wire.ts | New module translating Eliza tool/message shapes to AI SDK types; defensive normalization with multiple fallback lookups; non-array tools are passed through as-is, requiring callers to pre-wrap inputSchema with jsonSchema(). |
| plugins/plugin-ollama/utils/config.ts | Adds isOllamaStructuredOutputDisabled helper and new model-type getters; clean and well-structured. |
| plugins/plugin-ollama/package.json | Replaces ollama-ai-provider with ollama-ai-provider-v2 and adds OLLAMA_DISABLE_STRUCTURED_OUTPUT env var declaration. |
| plugins/plugin-ollama/__tests__/native-plumbing.test.ts | Comprehensive rewrite covering streaming, tool forwarding, schema, and planner drain logic; good coverage of the new adapter paths. |
| plugins/plugin-ollama/plugin.ts | Handler signatures updated from Promise<string> to Promise<string | TextStreamResult>; no logic changes. |
| plugins/plugin-ollama/models/embedding.ts | Provider import updated to ollama-ai-provider-v2; unnecessary type cast removed. |
| plugins/plugin-ollama/models/object.ts | Provider import updated to ollama-ai-provider-v2; unnecessary type cast removed. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["useModel(TEXT_*/RESPONSE_HANDLER/ACTION_PLANNER)"] --> B["handleTextWithModelType"]
    B --> C{params.stream?}
    C -- "true + tools" --> D["buildOllamaStreamWithToolsResult\n(streamText + tools)"]
    C -- "true, no tools/schema/toolChoice" --> E["buildOllamaStreamTextResult\n(plain streamText)"]
    C -- "true + schema only" --> F["generateText\n(debug log)"]
    C -- "true + toolChoice only" --> G["generateText\n(debug log)"]
    C -- "false" --> H["generateText"]
    D --> D1{isNativePlannerType?}
    D1 -- "RESPONSE_HANDLER/ACTION_PLANNER" --> D2["Drain textStream, yield single plan JSON chunk"]
    D1 -- "Other TEXT_*" --> D3["Forward all chunks, attach toolCalls Promise"]
    E --> E1["Wrap textStream with usage tracking"]
    H --> H1{shouldReturnNative?}
    H1 -- "outputSpec set" --> H2["serializeStructuredGenerateTextResult"]
    H1 -- "messages/tools/toolChoice" --> H3["buildNativeResultCast"]
    H1 -- "plain prompt" --> H4["result.text"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-ollama/models/text.ts`, line 1499-1520 ([link](https://github.com/elizaos/eliza/blob/c0697349519a444cafbcd8118f65e2ee6101ddd3/plugins/plugin-ollama/models/text.ts#L1499-L1520)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Missing debug log for `toolChoice`-without-tools in non-streaming path**

   The streaming branch emits a `debug` log when `stream: true` with `toolChoice` but no resolved `ToolSet` (helping operators spot misconfiguration). The non-streaming path silently falls through to `generateText` without any indication that `toolChoice` was dropped from the wire. `shouldReturnNative` is still `true` because `extended.toolChoice` is truthy, so callers receive a native-shaped result with `toolCalls: []`, which would cause `parseMessageHandlerNativeToolCall` to fail without any log explaining why.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["some shit"](https://github.com/elizaos/eliza/commit/c0697349519a444cafbcd8118f65e2ee6101ddd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31283947)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->