### PR TITLE
feat(cloud): protect canonical (non-autoscaled) docker nodes from health-check flapping

### DIFF
--- a/cloud/packages/lib/services/docker-node-manager.ts
+++ b/cloud/packages/lib/services/docker-node-manager.ts
@@ -50,6 +50,25 @@ export interface NodeSelectionOptions {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether a node was provisioned by the autoscaler (Hetzner Cloud) and is
+ * therefore safe to mark offline on health-check failure. Canonical cores
+ * (manually-provisioned, no `provider` metadata, or any non-autoscaled
+ * provider) are protected — they remain healthy in DB even if a transient
+ * ssh probe fails, because flapping them removes real production capacity.
+ *
+ * Operators always have `enabled=false` to disable a node explicitly.
+ */
+function isAutoscaledNode(node: DockerNode): boolean {
+  const meta = node.metadata as Record<string, unknown> | null | undefined;
+  if (!meta || typeof meta !== "object") return false;
+  return meta.provider === "hetzner-cloud" && meta.autoscaled === true;
+}
+
+// ---------------------------------------------------------------------------
 // DockerNodeManager
 // ---------------------------------------------------------------------------
 
@@ -181,6 +200,20 @@ export class DockerNodeManager {
       `[docker-node-manager] Health check failed for ${node.node_id} after ${MAX_RETRIES} attempts: ${lastError}`,
     );
     const status: DockerNodeStatus = lastError.includes("empty ID") ? "degraded" : "offline";
+
+    // Canonical (operator-managed) nodes are never marked offline from
+    // health-check failures. The autoscaler-provisioned hetzner-cloud nodes
+    // are ephemeral and OK to flap; manually-provisioned cores host long-lived
+    // production sandboxes, where a transient ssh hiccup should not pull the
+    // node out of rotation. Operators retain explicit `enabled=false` to
+    // disable nodes; status flapping is reserved for autoscaler-managed nodes.
+    if (status === "offline" && !isAutoscaledNode(node)) {
+      logger.warn(
+        `[docker-node-manager] Suppressed offline status for canonical node ${node.node_id} (${node.hostname}); leaving prior status intact. Set enabled=false to remove from rotation.`,
+      );
+      return status;
+    }
+
     await dockerNodesRepository.updateStatus(node.node_id, status);
     return status;
   }
@@ -221,12 +254,20 @@ export class DockerNodeManager {
       return false;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      await dockerNodesRepository.updateStatus(node.node_id, "offline").catch((updateError) => {
-        logger.warn("[docker-node-manager] Failed to mark node offline", {
-          nodeId: node.node_id,
-          error: updateError instanceof Error ? updateError.message : String(updateError),
+      // See healthCheckNode for rationale: canonical nodes are never marked
+      // offline from a transient ssh failure during scheduling.
+      if (isAutoscaledNode(node)) {
+        await dockerNodesRepository.updateStatus(node.node_id, "offline").catch((updateError) => {
+          logger.warn("[docker-node-manager] Failed to mark node offline", {
+            nodeId: node.node_id,
+            error: updateError instanceof Error ? updateError.message : String(updateError),
+          });
         });
-      });
+      } else {
+        logger.warn(
+          `[docker-node-manager] Suppressed offline mark for canonical node ${node.node_id} (${node.hostname}): ${message}`,
+        );
+      }
       logger.warn(`[docker-node-manager] Node ${node.node_id} is not reachable: ${message}`);
       return false;
     }

--- a/cloud/packages/tests/unit/docker-node-manager.test.ts
+++ b/cloud/packages/tests/unit/docker-node-manager.test.ts
@@ -41,9 +41,15 @@ describe("DockerNodeManager", () => {
     mock.restore();
   });
 
-  test("skips stale healthy nodes that fail the live SSH/Docker probe", async () => {
+  test("skips stale healthy autoscaled nodes that fail the live SSH/Docker probe and marks them offline", async () => {
     const nodes = [
-      makeNode({ node_id: "stale", capacity: 10 }),
+      makeNode({
+        node_id: "stale",
+        capacity: 10,
+        // Autoscaled (Hetzner Cloud) nodes flap to offline on ssh probe
+        // failure so the autoscaler can drain + reprovision them.
+        metadata: { provider: "hetzner-cloud", autoscaled: true },
+      }),
       makeNode({ node_id: "ready", capacity: 4 }),
     ];
     const statusUpdates: Array<{ nodeId: string; status: DockerNodeStatus }> = [];
@@ -86,6 +92,60 @@ describe("DockerNodeManager", () => {
       { nodeId: "stale", status: "offline" },
       { nodeId: "ready", status: "healthy" },
     ]);
+  });
+
+  test("does NOT mark canonical (non-autoscaled) nodes offline when ssh probe fails", async () => {
+    // Canonical nodes (operator-provisioned, no `metadata.autoscaled === true`)
+    // are protected from health-check flapping. Their status is left intact in
+    // the DB; operators retain explicit `enabled=false` to remove them from
+    // rotation. Rationale: these nodes host long-lived production sandboxes
+    // and a transient ssh hiccup should not pull them out of the pool.
+    const nodes = [
+      makeNode({ node_id: "stale-canonical", capacity: 100, metadata: {} }),
+      makeNode({ node_id: "ready", capacity: 4 }),
+    ];
+    const statusUpdates: Array<{ nodeId: string; status: DockerNodeStatus }> = [];
+
+    mock.module("@/db/repositories/docker-nodes", () => ({
+      dockerNodesRepository: {
+        findEnabled: async () => nodes,
+        updateStatus: async (nodeId: string, status: DockerNodeStatus) => {
+          statusUpdates.push({ nodeId, status });
+          const node = nodes.find((candidate) => candidate.node_id === nodeId);
+          if (node) node.status = status;
+        },
+      },
+    }));
+    mock.module("@/lib/services/docker-node-workloads", () => ({
+      countAllocatedWorkloadsOnNode: async () => 0,
+      countRetainedWorkloadsOnNode: async () => 0,
+    }));
+    mock.module("@/lib/services/docker-ssh", () => ({
+      DockerSSHClient: {
+        getClient: (hostname: string) => ({
+          connect: async () => {
+            if (hostname.startsWith("stale-canonical.")) {
+              throw new Error("All configured authentication methods failed");
+            }
+          },
+          exec: async () => "docker-id",
+        }),
+      },
+    }));
+    mock.module("@/lib/utils/logger", () => ({
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    }));
+
+    const { DockerNodeManager } = await importManager();
+    const selected = await DockerNodeManager.getInstance().getAvailableNode();
+
+    // Selection still falls through to the healthy `ready` node (canonical
+    // node failed ensureNodeReady's probe so it was skipped for THIS pick).
+    expect(selected?.node_id).toBe("ready");
+    // Critical: NO `offline` status write for the canonical node.
+    expect(statusUpdates).toEqual([{ nodeId: "ready", status: "healthy" }]);
+    // The canonical node's in-memory status is unchanged (still healthy).
+    expect(nodes.find((n) => n.node_id === "stale-canonical")?.status).toBe("healthy");
   });
 
   test("probes unknown nodes so newly bootstrapped capacity can become available", async () => {


### PR DESCRIPTION
## Summary

Adds an `isAutoscaledNode()` helper and protects manually-provisioned ("canonical") docker nodes from being flapped to `status='offline'` by `docker-node-manager`'s health-check loops.

Autoscaler-provisioned hetzner-cloud nodes still flap normally so the autoscaler can drain and reprovision them. Canonical cores stay at their last-known status until an operator explicitly disables them via `enabled=false`.

## Why

Operators on milady's production cloud observed all 6 manually-provisioned cores (`milady-core-1` through `milady-core-6`, capacity 100 each) being marked `status='offline'` every ~5 minutes by the cf-worker's periodic health check, despite all 6 being reachable via ssh and running healthy production containers.

Root cause: a transient ssh probe failure (any of: key path mismatch in worker env, ssh user mismatch, host fingerprint drift, brief network blip) writes `status='offline'` for the affected node. `findLeastLoaded` then excludes it from selection. New sandboxes overflow onto autoscaler-provisioned hetzner-cloud nodes, which have far smaller capacity (8 each) and are billed per-instance.

Net effect: cheaper, larger canonical cores sit idle while the autoscaler creates expensive fresh hcloud VMs to absorb load that the cores were already provisioned to handle.

## Behavior change

| Node type | Health-check failure | Status write |
|---|---|---|
| Autoscaler-provisioned (`metadata.provider='hetzner-cloud'`, `metadata.autoscaled=true`) | unchanged: marked `offline` so autoscaler can drain | yes |
| Canonical (anything else, including no metadata) | new: status left intact, error logged | no |

Selection logic in `findLeastLoaded` is unchanged. A canonical node that fails `ensureNodeReady`'s probe in a given scheduling pass is still skipped from THAT pass; the next pass re-probes. Status writes are reserved for autoscaler-managed nodes only.

This restores the intended placement order: canonical cores take prominence in `findLeastLoaded` (capacity 100/node, allocated_count grows slowly); autoscaler nodes absorb overflow only when cores fill up.

## Operator escape hatch

Operators retain explicit control: set `enabled=false` on a canonical node to remove it from rotation. The health-check no longer fights operator intent.

## Tests

- Renamed `skips stale healthy nodes that fail the live SSH/Docker probe` → `skips stale healthy autoscaled nodes that fail the live SSH/Docker probe and marks them offline` and added `metadata: { provider: 'hetzner-cloud', autoscaled: true }` to the stale node so the assertion remains accurate (autoscaled nodes still get the offline write).
- Added `does NOT mark canonical (non-autoscaled) nodes offline when ssh probe fails` — asserts `statusUpdates` contains only the healthy node's update and that the canonical node's in-memory `status` is unchanged.

```
$ bun test packages/tests/unit/docker-node-manager.test.ts
4 pass
0 fail
10 expect() calls
Ran 4 tests across 1 file. [100ms]
```

Biome clean on both touched files.

## Out of scope

This PR doesn't fix the underlying transient ssh failures (likely a worker-side ssh-config issue). Surfacing those errors as `logger.error` and pinpointing the actual root cause is a follow-up — but until that's fixed, this stops the operationally-painful symptom of healthy cores being yanked out of rotation.

---

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR protects manually-provisioned ("canonical") Docker nodes from having their status flapped to `"offline"` by transient SSH probe failures in the health-check and scheduling loops, while leaving autoscaler-provisioned Hetzner Cloud nodes free to flap so the autoscaler can drain and reprovision them.

- Adds `isAutoscaledNode(node)` (checks `metadata.provider === "hetzner-cloud" && metadata.autoscaled === true`) and gates the `updateStatus(..., "offline")` call in both `healthCheckNode` and `ensureNodeReady` behind it.
- Updates the existing autoscaled-flap test and adds a new test confirming no `"offline"` DB write occurs for canonical nodes when the SSH probe throws.

<h3>Confidence Score: 3/5</h3>

The scheduling-path guard in `ensureNodeReady` works correctly, but `healthCheckNode` returns `"offline"` to `healthCheckAll` callers even when the DB write is suppressed, so consumers of that Map still see canonical nodes as down.

The scheduling-path guard in `ensureNodeReady` is correct and the new test validates it well. The gap is in `healthCheckNode`: the early return hands `"offline"` back to `healthCheckAll`'s result Map even though no DB write occurred, so any consumer of that Map still observes the canonical node as down — potentially reintroducing the capacity-starvation issue on the periodic health-check cycle.

cloud/packages/lib/services/docker-node-manager.ts — specifically the early-return value in `healthCheckNode` and the unguarded `"degraded"` write path in `ensureNodeReady`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/docker-node-manager.ts | Adds `isAutoscaledNode` helper and guards both `healthCheckNode` and `ensureNodeReady` from writing `"offline"` to canonical nodes — but `healthCheckNode` still returns the computed `"offline"` value to callers (including `healthCheckAll`) even when the DB write is suppressed, and the `"degraded"` path in `ensureNodeReady` is not guarded. |
| cloud/packages/tests/unit/docker-node-manager.test.ts | Adds two targeted tests covering autoscaled vs canonical node behaviour in the `ensureNodeReady` (scheduling) path; the `healthCheckNode` / `healthCheckAll` path is not covered by a new test. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CW as CF Worker (health-check loop)
    participant DNM as DockerNodeManager
    participant SSH as DockerSSHClient
    participant DB as dockerNodesRepository

    Note over CW,DB: healthCheckAll path (periodic)
    CW->>DNM: healthCheckAll()
    DNM->>DNM: healthCheckNode(canonicalNode)
    loop "MAX_RETRIES = 3"
        DNM->>SSH: connect() + exec(docker info)
        SSH-->>DNM: throws (transient SSH failure)
    end
    Note over DNM: status = offline, isAutoscaledNode false, suppress DB write
    DNM-->>CW: returns offline (DB still healthy)

    DNM->>DNM: healthCheckNode(autoscaledNode)
    loop "MAX_RETRIES = 3"
        DNM->>SSH: connect() + exec(docker info)
        SSH-->>DNM: throws
    end
    DNM->>DB: updateStatus(autoscaledNode, offline)
    DNM-->>CW: returns offline

    Note over CW,DB: getAvailableNode path (scheduling)
    CW->>DNM: getAvailableNode()
    DNM->>DB: findEnabled()
    DB-->>DNM: canonicalNode healthy, autoscaledNode offline
    DNM->>DNM: ensureNodeReady(canonicalNode)
    DNM->>SSH: connect()
    SSH-->>DNM: throws (transient SSH)
    Note over DNM: isAutoscaledNode false, no DB write, skip node
    DNM->>DNM: ensureNodeReady(nextCandidate)
    DNM->>SSH: connect() + exec(docker info)
    SSH-->>DNM: "docker-id|x86_64"
    DNM->>DB: updateStatus(nextCandidate, healthy)
    DNM-->>CW: returns nextCandidate
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/packages/lib/services/docker-node-manager.ts`, line 251-254 ([link](https://github.com/elizaos/eliza/blob/bb4465df04d47b14a3458a34131bbf18d536d4f0/cloud/packages/lib/services/docker-node-manager.ts#L251-L254)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`ensureNodeReady` still writes `"degraded"` for canonical nodes without going through the autoscaler guard**

   Inside the `try` block, when SSH succeeds but Docker returns an empty ID, `updateStatus(node.node_id, "degraded")` is called unconditionally — before the `catch` that now has the `isAutoscaledNode` check. A canonical node whose SSH is reachable but whose `docker info` probe returns empty will still get its DB status written to `"degraded"`. Whether this is intentional should be clarified in a comment; if the intent is that canonical nodes' status is never written by the health-check machinery, the guard should also be applied to the empty-ID branch.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(cloud): protect canonical (non-auto..."](https://github.com/elizaos/eliza/commit/bb4465df04d47b14a3458a34131bbf18d536d4f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31305355)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->