### PR TITLE
fix(agent-skills): read planned skill parameters

### DIFF
--- a/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts
@@ -11,6 +11,8 @@ vi.mock("@elizaos/core", () => {
 	};
 
 	return {
+		annotateActiveTrajectoryStep: vi.fn(),
+		getTrajectoryContext: vi.fn(() => undefined),
 		logger,
 	};
 });

--- a/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
@@ -1,0 +1,65 @@
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { useSkillAction } from "./use-skill";
+
+describe("useSkillAction", () => {
+	it("reads planned action arguments from handler parameters", async () => {
+		const skill = {
+			slug: "github",
+			name: "GitHub",
+			description: "GitHub workflow guidance",
+			version: "1.0.0",
+			content: "",
+			frontmatter: {},
+			path: "/skills/github",
+			scripts: [],
+			references: [],
+			assets: [],
+			loadedAt: 0,
+			source: "bundled",
+		};
+		const service = {
+			getLoadedSkill: vi.fn((slug: string) =>
+				slug === "github" ? skill : undefined,
+			),
+			getLoadedSkills: vi.fn(() => [skill]),
+			isSkillEnabled: vi.fn(() => true),
+			checkSkillEligibility: vi.fn(async () => ({
+				slug: "github",
+				eligible: true,
+				reasons: [],
+				checkedAt: 0,
+			})),
+			getSkillInstructions: vi.fn(() => ({
+				slug: "github",
+				body: "Use the repository host's API and local git state.",
+				estimatedTokens: 12,
+			})),
+		};
+		const runtime = {
+			getService: vi.fn((name: string) =>
+				name === "AGENT_SKILLS_SERVICE" ? service : undefined,
+			),
+		} as unknown as IAgentRuntime;
+		const callback = vi.fn();
+
+		const result = await useSkillAction.handler(
+			runtime,
+			{ content: { text: "use github skill" } } as Memory,
+			undefined,
+			{ parameters: { slug: "github", mode: "guidance" } },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.data).toMatchObject({
+			slug: "github",
+			mode: "guidance",
+		});
+		expect(callback).toHaveBeenCalledWith({
+			text: expect.stringContaining("Use the repository host's API"),
+			actions: ["USE_SKILL"],
+		});
+		expect(service.getLoadedSkill).toHaveBeenCalledWith("github");
+	});
+});

--- a/plugins/plugin-agent-skills/src/actions/use-skill.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.ts
@@ -196,7 +196,13 @@ export const useSkillAction: Action = {
 			return { success: false, error: new Error(errorText) };
 		}
 
-		const opts = (options ?? {}) as UseSkillOptions;
+		const rawOptions = (options ?? {}) as UseSkillOptions & {
+			parameters?: UseSkillOptions;
+		};
+		const opts =
+			rawOptions.parameters && typeof rawOptions.parameters === "object"
+				? rawOptions.parameters
+				: rawOptions;
 		const rawSlug = typeof opts.slug === "string" ? opts.slug.trim() : "";
 		if (!rawSlug) {
 			const errorText =


### PR DESCRIPTION
## Summary
- make `USE_SKILL` accept planned action arguments passed through `options.parameters`
- preserve the existing direct-options handler path for legacy/manual callers
- add a focused regression covering planner-style `{ parameters: { slug, mode } }` invocation

## Why
The planned action executor passes validated tool arguments under `options.parameters`. `USE_SKILL` only read direct `options.slug`, so planner-selected skill calls failed even when the planner supplied a valid slug.

## Validation
- `bunx biome check --write plugins/plugin-agent-skills/src/actions/use-skill.ts plugins/plugin-agent-skills/src/actions/use-skill.test.ts plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts`
- `bunx vitest run --config vitest.config.ts src/actions/use-skill.test.ts src/search-category.test.ts` from `plugins/plugin-agent-skills` passed `3/3`
- `bun run --cwd plugins/plugin-agent-skills typecheck`
- `bun run --cwd plugins/plugin-agent-skills build`
- `git diff --check`

Branch checked against latest `origin/develop` before push: `1` ahead / `0` behind, with `origin/develop` an ancestor of `HEAD`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `USE_SKILL` to read the `slug` and `mode` parameters from `options.parameters` when the planner executor passes validated tool arguments there, while preserving the existing direct-options path for legacy callers.

- **`use-skill.ts`**: Adds a shallow unwrap of `options.parameters` before resolving `slug`/`mode`; falls back to top-level `options` when `parameters` is absent, preserving backward compatibility.
- **`use-skill.test.ts`**: Introduces a focused regression test exercising the planner-style `{ parameters: { slug, mode } }` invocation from end to end.
- **`core-test-mock.ts`**: Adds `vi.fn()` stubs for `annotateActiveTrajectoryStep` and `getTrajectoryContext` so the new test can import the handler without errors.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a small, well-tested unwrap with a correct fallback for legacy callers.

The unwrap logic is minimal and the fallback preserves the legacy direct-options path. The one gap is that `typeof x === "object"` also matches arrays, so a badly-formed caller passing an array as `parameters` would silently fall into the slug-missing error rather than the legacy path — a narrow, non-production edge case but still worth tightening.

Only `use-skill.ts` around the `parameters` unwrap condition warrants a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-skills/src/actions/use-skill.ts | Adds `options.parameters` unwrapping so planner-dispatched calls reach the slug/mode resolution. The fix is minimal and the fallback to direct-options preserves legacy behavior. |
| plugins/plugin-agent-skills/src/actions/use-skill.test.ts | New regression test covering the planner-style `{ parameters: { slug, mode } }` invocation path; mocks are appropriately scoped and the guidance-mode path is fully exercised. |
| plugins/plugin-agent-skills/src/__tests__/core-test-mock.ts | Adds `vi.fn()` stubs for `annotateActiveTrajectoryStep` and `getTrajectoryContext` to satisfy imports used by the handler under test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Planner
    participant Handler as USE_SKILL handler
    participant Service as AgentSkillsService

    Planner->>Handler: "options = { parameters: { slug, mode } }"
    Note over Handler: rawOptions.parameters is object?
    Handler->>Handler: "opts = rawOptions.parameters"
    Handler->>Service: getLoadedSkill(opts.slug)
    Service-->>Handler: skill
    Handler->>Service: isSkillEnabled(skill.slug)
    Service-->>Handler: true
    Handler->>Service: checkSkillEligibility(skill)
    Service-->>Handler: "{ eligible: true }"
    alt "effectiveMode = guidance"
        Handler->>Service: getSkillInstructions(skill.slug)
        Service-->>Handler: instructions
        Handler-->>Planner: "{ success: true, data: { slug, mode: guidance } }"
    else "effectiveMode = script"
        Handler->>Service: getScriptPath / executeScript
        Handler-->>Planner: "{ success: true, data: { slug, mode: script } }"
    end

    Note over Handler: Legacy direct-options path
    Planner->>Handler: "options = { slug, mode }"
    Handler->>Handler: "opts = rawOptions (fallback)"
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent-skills): read planned skill pa..."](https://github.com/elizaos/eliza/commit/99f1aa1cd16b4dcb6a38276f6c543f48a4a74c7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31313472)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->