### PR TITLE
fix(startup): unstick coordinator when paired bearer needs password session

### DIFF
--- a/packages/app-core/src/state/startup-phase-poll.ts
+++ b/packages/app-core/src/state/startup-phase-poll.ts
@@ -197,6 +197,20 @@ export async function runPollingBackend(
         dispatch({ type: "BACKEND_AUTH_REQUIRED" });
         return;
       }
+      // Token holder, but the server still says auth is required (e.g. the
+      // remote owner password has not been set yet, so /api/auth/me will
+      // return 401 with reason="remote_password_not_configured"). Don't
+      // loop polling forever — advance the coordinator to "ready" so the
+      // top-level auth gate can render LoginView with an actionable
+      // "Remote access blocked" message. Without this, the phone is stuck
+      // on the splash because every onboarding/runtime endpoint returns 401.
+      if (auth.required && !auth.authenticated && client.hasToken()) {
+        deps.setAuthRequired(false);
+        deps.setOnboardingComplete(true);
+        deps.setOnboardingLoading(false);
+        dispatch({ type: "BACKEND_REACHED", onboardingComplete: true });
+        return;
+      }
       const onboardingStatusRes = await client.getOnboardingStatus();
       const { complete, cloudProvisioned } = onboardingStatusRes;
       if (cancelled.current) return;
@@ -319,8 +333,28 @@ export async function runPollingBackend(
         dispatch({ type: "BACKEND_AUTH_REQUIRED" });
         return;
       }
+      if (
+        (ae?.status === 401 || ae?.status === 429) &&
+        client.hasToken() &&
+        latestAuth.authenticated
+      ) {
+        // Bearer-only token (paired but no password session). /api/auth/status
+        // returned authenticated:true but a downstream endpoint
+        // (onboarding-status, etc.) still 401s, or the server's auth rate
+        // limiter starts returning 429 ("Too many authentication attempts")
+        // because every poll re-checks bearer-vs-session. /api/auth/me responds
+        // with reason="remote_auth_required" in this state. Don't loop forever
+        // — advance to ready so the top-level auth gate can render LoginView
+        // with an actionable "Sign in" / "Remote access blocked" prompt.
+        deps.setAuthRequired(false);
+        deps.setOnboardingComplete(true);
+        deps.setOnboardingLoading(false);
+        dispatch({ type: "BACKEND_REACHED", onboardingComplete: true });
+        return;
+      }
       if (ae?.status === 401 && client.hasToken()) {
-        // Transient 401: retry; pairing is gated by /api/auth/status.
+        // 401-with-token but auth/status hasn't confirmed we're authenticated
+        // yet — port race / pre-bearer endpoint window. Fall through to retry.
       }
       if (ae?.status === 404) {
         deps.setStartupError(describeBackendFailure(err, false));

--- a/packages/app-core/src/state/startup-phase-runtime.test.ts
+++ b/packages/app-core/src/state/startup-phase-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runStartingRuntime } from "./startup-phase-runtime";
 
 const clientMock = vi.hoisted(() => ({
@@ -11,7 +11,25 @@ vi.mock("../api", () => ({
   client: clientMock,
 }));
 
+function createDeps() {
+  return {
+    setAgentStatus: vi.fn(),
+    setConnected: vi.fn(),
+    setStartupError: vi.fn(),
+    setOnboardingLoading: vi.fn(),
+    setAuthRequired: vi.fn(),
+    setPairingEnabled: vi.fn(),
+    setPairingExpiresAt: vi.fn(),
+    setPendingRestart: vi.fn(),
+    setPendingRestartReasons: vi.fn(),
+  };
+}
+
 describe("runStartingRuntime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("routes tokenless 401s to pairing instead of retrying until timeout", async () => {
     clientMock.getStatus.mockRejectedValue({ status: 401 });
     clientMock.getAuthStatus.mockResolvedValue({
@@ -22,17 +40,7 @@ describe("runStartingRuntime", () => {
     clientMock.hasToken.mockReturnValue(false);
 
     const dispatch = vi.fn();
-    const deps = {
-      setAgentStatus: vi.fn(),
-      setConnected: vi.fn(),
-      setStartupError: vi.fn(),
-      setOnboardingLoading: vi.fn(),
-      setAuthRequired: vi.fn(),
-      setPairingEnabled: vi.fn(),
-      setPairingExpiresAt: vi.fn(),
-      setPendingRestart: vi.fn(),
-      setPendingRestartReasons: vi.fn(),
-    };
+    const deps = createDeps();
 
     await runStartingRuntime(
       deps,
@@ -48,6 +56,62 @@ describe("runStartingRuntime", () => {
     expect(deps.setPairingExpiresAt).toHaveBeenCalledWith(1234);
     expect(deps.setOnboardingLoading).toHaveBeenCalledWith(false);
     expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_AUTH_REQUIRED" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
+  it("advances paired bearer sessions to the auth gate after endpoint 401s", async () => {
+    clientMock.getStatus.mockRejectedValue({ status: 401 });
+    clientMock.getAuthStatus.mockResolvedValue({
+      required: false,
+      authenticated: true,
+      pairingEnabled: true,
+      expiresAt: 1234,
+    });
+    clientMock.hasToken.mockReturnValue(true);
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(deps.setOnboardingLoading).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+
+  it("advances remote password setup blockers without accepting every required auth status", async () => {
+    clientMock.getStatus.mockRejectedValue({ status: 401 });
+    clientMock.getAuthStatus.mockResolvedValue({
+      required: true,
+      authenticated: false,
+      loginRequired: true,
+      passwordConfigured: false,
+      pairingEnabled: true,
+      expiresAt: 1234,
+    });
+    clientMock.hasToken.mockReturnValue(true);
+
+    const dispatch = vi.fn();
+    const deps = createDeps();
+
+    await runStartingRuntime(
+      deps,
+      dispatch,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(deps.setOnboardingLoading).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
     expect(deps.setStartupError).not.toHaveBeenCalled();
   });
 });

--- a/packages/app-core/src/state/startup-phase-runtime.ts
+++ b/packages/app-core/src/state/startup-phase-runtime.ts
@@ -164,10 +164,30 @@ export async function runStartingRuntime(
         dispatch({ type: "BACKEND_AUTH_REQUIRED" });
         return;
       }
-      if (ae?.status === 401 && client.hasToken()) {
-        // Transient 401 (port race / pre-bearer endpoint): retry without
-        // wiping the token. /api/auth/status in startup-phase-poll is the
-        // canonical pairing gate.
+      if ((ae?.status === 401 || ae?.status === 429) && client.hasToken()) {
+        // 401/429 with a token. Two flavors to distinguish:
+        //   1. Genuine port race / pre-bearer endpoint window — /api/auth/status
+        //      itself isn't reachable yet. Keep retrying.
+        //   2. Bearer-only token (paired but no password session). Server says
+        //      /api/auth/status is fine (authenticated:true) but app endpoints
+        //      like /api/agent/status still 401, or 429 from the auth rate
+        //      limiter on those endpoints. /api/auth/me returns
+        //      reason="remote_auth_required". Advance to ready so the auth gate
+        //      can render LoginView. Hydrating tolerates 401s.
+        try {
+          const auth = await client.getAuthStatus();
+          const remotePasswordMissing =
+            auth.required &&
+            auth.loginRequired &&
+            auth.passwordConfigured === false;
+          if (auth.authenticated || remotePasswordMissing) {
+            deps.setOnboardingLoading(false);
+            dispatch({ type: "AGENT_RUNNING" });
+            return;
+          }
+        } catch {
+          // /api/auth/status itself unreachable — keep retrying.
+        }
       }
       lastErr = err;
       deps.setConnected(false);


### PR DESCRIPTION
## Summary
- unstick remote paired startup when a bearer token is recognized by `/api/auth/status` but app/runtime endpoints still return 401 or auth-rate-limited 429
- advance the startup coordinator to the auth gate so `LoginView` can render the password/session step instead of looping forever on the splash screen
- keep tokenless 401s on the existing pairing path

## Follow-up
- tightened the runtime-phase guard after review so it no longer treats every `auth.required` response as sufficient evidence to advance
- runtime now advances only when `/api/auth/status` reports the bearer as authenticated, or when the server specifically reports the remote-password-missing setup blocker
- added focused tests for tokenless pairing, paired bearer sessions, and remote password setup blockers

## Validation
- `bunx biome check --write packages/app-core/src/state/startup-phase-runtime.ts packages/app-core/src/state/startup-phase-runtime.test.ts`
- `git diff --check`
- `bun run --cwd packages/app-core test -- src/state/startup-phase-runtime.test.ts` (3/3, isolated PR worktree using temporary ignored dependency/generated links)

## Notes
- This is scoped to startup coordinator catch paths. It does not change auth token validation, session creation, or API route behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes an indefinite startup hang affecting remote-paired bearer clients where `/api/auth/status` reports the bearer as valid but downstream app endpoints (e.g. `/api/onboarding/status`, `/api/agent/status`) respond with 401 or 429 — a state the previous retry loops never recognised as terminal.

- **`startup-phase-poll.ts`**: Adds two exit branches. A pre-onboarding-fetch branch advances the coordinator when `auth.required && !auth.authenticated && hasToken()`, covering the \"password not yet configured\" remote case. An outer-catch branch handles 401/429 when `latestAuth.authenticated` is true, covering the bearer-only-paired case where the rate limiter eventually starts responding 429.
- **`startup-phase-runtime.ts`**: Adds a fresh `getAuthStatus()` call inside the existing 401/429-with-token catch path; advances via `AGENT_RUNNING` when the bearer is fully authenticated or when the remote password is explicitly unconfigured (`passwordConfigured === false`).
- **`startup-phase-runtime.test.ts`**: Introduces `createDeps()` helper and `beforeEach` cleanup to prevent mock bleed-through; adds two new test cases covering both new runtime branches.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two new branches each guard a narrow condition and return early; all previously-reachable paths to BACKEND_REACHED and AGENT_RUNNING are unchanged.

Both new catch branches are gated on precise conjunctions (token present + specific HTTP status + prior auth-status confirmation), so neither can fire during normal non-paired startup. The latestAuth initialisation in poll.ts means the outer-catch branch is safely inert until getAuthStatus() has succeeded at least once. New tests cover both added branches.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/state/startup-phase-poll.ts | Two new early-exit branches correctly break the infinite retry loop for bearer-only-paired sessions; latestAuth initialisation ensures the outer-catch branch is safely inert before the first successful getAuthStatus() call. |
| packages/app-core/src/state/startup-phase-runtime.ts | New 401/429 catch path makes a fresh getAuthStatus() call to distinguish port-race retries from bearer-only-paired advances; inner catch silently swallows unreachable-status errors to preserve the retry loop, which is intentional. |
| packages/app-core/src/state/startup-phase-runtime.test.ts | createDeps() factory and beforeEach clearAllMocks() eliminate mock-bleed risk; two new tests exercise both authenticated and remotePasswordMissing branches of the new runtime catch path. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(startup): unstick coordinator when p..."](https://github.com/elizaos/eliza/commit/ae0346e5f783afaadc42d8474d9f3bea3237bc60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330050)</sub>

<!-- /greptile_comment -->