### PR TITLE
feat(LoginView): show actionable setup commands when remote password missing

### DIFF
--- a/packages/app-core/src/components/auth/LoginView.tsx
+++ b/packages/app-core/src/components/auth/LoginView.tsx
@@ -224,10 +224,38 @@ export function LoginView({ onLoginSuccess, loginFn, reason }: LoginViewProps) {
           {remotePasswordMissing ? (
             <div
               role="alert"
-              className="rounded-lg border border-border/60 bg-bg/50 px-4 py-3 text-sm leading-6 text-muted-foreground"
+              className="space-y-3 rounded-lg border border-border/60 bg-bg/50 px-4 py-3 text-sm leading-6 text-muted-foreground"
             >
-              Open Eliza on the host machine via localhost, then set a remote
-              password in Settings.
+              <p>
+                The remote agent has no owner password configured yet, so it
+                cannot accept logins from another machine. Set one on the host
+                first.
+              </p>
+              <div className="space-y-2">
+                <p className="text-xs uppercase tracking-wider text-muted-foreground/70">
+                  Two ways to fix it:
+                </p>
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground/80">
+                    From a browser on the host machine, open this URL then go
+                    to Settings → Security:
+                  </p>
+                  <code className="block break-all rounded bg-bg/70 px-2 py-1.5 font-mono text-[11px] text-foreground">
+                    http://localhost:31337/
+                  </code>
+                </div>
+                <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground/80">
+                    Or via SSH (replace YOURNAME and YOURPASS with your own):
+                  </p>
+                  <code className="block break-all rounded bg-bg/70 px-2 py-1.5 font-mono text-[11px] text-foreground">
+                    {`curl -X POST http://127.0.0.1:31337/api/auth/setup -H "Content-Type: application/json" -d '{"displayName":"YOURNAME","password":"YOURPASS"}'`}
+                  </code>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground/70">
+                Then return to this screen — it will refresh automatically.
+              </p>
             </div>
           ) : (
             <PasswordTab onLoginSuccess={onLoginSuccess} loginFn={loginFn} />


### PR DESCRIPTION
# Risks

Low. UI-only change to one component (`LoginView.tsx`). No state, API, or i18n keys touched. Behaviour for the `Sign in` (default) variant is unchanged.

# Background

## What does this PR do?

When `LoginView` renders with `reason="remote_password_not_configured"`, replaces the generic instruction with two copy-pasteable commands a user can actually run.

Before:

> Open Eliza on the host machine via localhost, then set a remote password in Settings.

This is unhelpful for VPS / headless / SSH-only operators — the host machine usually has no browser, and the message gives no command to copy.

After: same context line, plus two `<code>` blocks the user can paste:

1. From a browser running on the host: `open http://localhost:31337/ → Settings → Security`.
2. From SSH: a `curl` against `/api/auth/setup` with a placeholder for the password.

Plus a closing line ("Then return to this screen — it will refresh automatically.") to make the next-step obvious.

## What kind of change is this?

Improvement (UX). Non-breaking. The component contract (`onLoginSuccess`, `loginFn`, `reason`) is untouched.

## Why are we doing this?

Pairs cleanly with the bearer-only-paired startup fix in #7482 — once the coordinator advances to `LoginView` for a remote-no-password instance, the user actually needs guidance for what to do next, and "go to localhost" isn't useful when localhost is a VPS the user only reaches over SSH.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/app-core/src/components/auth/LoginView.tsx` — only the `remotePasswordMissing` branch of the render is changed. Read top-to-bottom: existing `<p>` tag becomes the same context line; two new `<div>`s wrap the command snippets in mono-font `<code>`; closing line added.

## Detailed testing steps

Verified visually on a Capacitor Android build:

1. Pair against a remote agent that has `passwordConfigured: false`.
2. With #7482 applied, the coordinator reaches `LoginView` showing the "Remote access blocked" variant.
3. Both code blocks render with mono font, are selectable, and break correctly on narrow phone widths (`break-all` class).

UI screenshots happy to add if helpful — change is small enough that I left them out.

## Screenshots
### Before
"Remote access blocked" → "Open Eliza on the host machine via localhost, then set a remote password in Settings." (one line)

### After
Same title, then:
- "The remote agent has no owner password configured yet, so it cannot accept logins from another machine. Set one on the host first."
- "Two ways to fix it:" + browser path + SSH curl path in `<code>` blocks
- "Then return to this screen — it will refresh automatically."

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the generic "Open Eliza on the host machine via localhost" message in `LoginView` with two concrete, copy-pasteable instructions — a browser URL and a `curl` command — when `reason="remote_password_not_configured"`. The change is UI-only and does not touch component props, state, API calls, or i18n.

- **Browser path**: renders `http://localhost:31337/` as a copyable `<code>` block with separate prose describing the Settings → Security navigation.
- **SSH/curl path**: renders the full `curl -X POST /api/auth/setup` command with `\"YOURNAME\"` and `\"YOURPASS\"` as obvious placeholders, addressing both issues raised in the previous review round.
- **Auto-refresh copy**: the closing line "it will refresh automatically" is technically backed by `useAuthStatus` polling, but the default interval is 5 minutes — worth validating against user expectations for the SSH flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one component, one render branch, no logic touched.

The change is entirely presentational: static copy and styling inside a single conditional block. No auth logic, API calls, or shared state are modified. The previous review concerns (macOS-specific `open` command, hardcoded `"owner"` display name) have both been addressed in this revision.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/auth/LoginView.tsx | Adds actionable browser-URL and curl setup commands to the `remote_password_not_configured` alert block; no logic, state, or API changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LoginView rendered] --> B{reason?}
    B -->|remote_password_not_configured| C[Remote Access Blocked UI]
    B -->|remote_auth_required / undefined| D[PasswordTab — Sign in form]
    C --> E[Context paragraph]
    E --> F[Two ways to fix it]
    F --> G[Browser path: http://localhost:31337/]
    F --> H[SSH curl path to /api/auth/setup]
    H --> I[YOURNAME + YOURPASS placeholders]
    C --> J[Auto-refresh footer note]
    J --> K[useAuthStatus polls every 5 min]
    K -->|password now configured| D
```

<sub>Reviews (2): Last reviewed commit: ["feat(LoginView): show actionable setup c..."](https://github.com/elizaos/eliza/commit/b14b9dca4ecca13e3deacc03907d0165f66de605) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330102)</sub>

<!-- /greptile_comment -->