### PR TITLE
fix(i18n): supply branding.appName as default translator var

### DIFF
--- a/packages/app-core/src/i18n/index.ts
+++ b/packages/app-core/src/i18n/index.ts
@@ -60,10 +60,18 @@ export function t(
   return interpolate(template, vars);
 }
 
-export function createTranslator(lang: UiLanguage | string | null | undefined) {
+export function createTranslator(
+  lang: UiLanguage | string | null | undefined,
+  defaultVars?: TranslationVars,
+) {
   const normalized = normalizeLanguage(lang);
-  return (key: string, vars?: TranslationVars): string =>
-    t(normalized, key, vars);
+  return (key: string, vars?: TranslationVars): string => {
+    const merged =
+      defaultVars && vars
+        ? { ...defaultVars, ...vars }
+        : (vars ?? defaultVars);
+    return t(normalized, key, merged);
+  };
 }
 
 export {

--- a/packages/app-core/src/state/AppContext.tsx
+++ b/packages/app-core/src/state/AppContext.tsx
@@ -170,7 +170,10 @@ export function AppProvider({
     console.warn("[eliza] Failed to sync language to server:", lang);
   }, []);
   return (
-    <TranslationProvider onLanguageSyncError={onLanguageSyncError}>
+    <TranslationProvider
+      onLanguageSyncError={onLanguageSyncError}
+      branding={brandingOverride}
+    >
       <AppProviderInner branding={brandingOverride}>
         {children}
       </AppProviderInner>

--- a/packages/app-core/src/state/TranslationContext.tsx
+++ b/packages/app-core/src/state/TranslationContext.tsx
@@ -16,6 +16,11 @@ import {
   useState,
 } from "react";
 import { client } from "../api";
+import {
+  appNameInterpolationVars,
+  type BrandingConfig,
+  DEFAULT_BRANDING,
+} from "../config/branding";
 import { createTranslator, normalizeLanguage, type UiLanguage } from "../i18n";
 import { loadUiLanguage, saveUiLanguage } from "./persistence";
 
@@ -38,10 +43,18 @@ const TranslationCtx = createContext<TranslationContextValue | null>(null);
 export function TranslationProvider({
   children,
   onLanguageSyncError,
+  branding,
 }: {
   children: ReactNode;
   /** Optional callback when the server config sync fails. */
   onLanguageSyncError?: (language: UiLanguage) => void;
+  /**
+   * Branding used to seed `{{appName}}` in translated strings. Threaded
+   * down explicitly because `TranslationProvider` wraps `AppProviderInner`,
+   * which is where `BrandingContext.Provider` lives — `useContext`
+   * here would always read the static default.
+   */
+  branding?: Partial<BrandingConfig>;
 }) {
   const [uiLanguage, setUiLanguageRaw] = useState<UiLanguage>(loadUiLanguage);
 
@@ -73,7 +86,15 @@ export function TranslationProvider({
     }
   }, [uiLanguage]);
 
-  const t = useMemo(() => createTranslator(uiLanguage), [uiLanguage]);
+  const mergedBranding = useMemo<BrandingConfig>(
+    () => ({ ...DEFAULT_BRANDING, ...branding }),
+    [branding],
+  );
+  const t = useMemo(
+    () =>
+      createTranslator(uiLanguage, appNameInterpolationVars(mergedBranding)),
+    [uiLanguage, mergedBranding],
+  );
 
   const value = useMemo<TranslationContextValue>(
     () => ({ t, uiLanguage, setUiLanguage }),


### PR DESCRIPTION
# Risks

Low. Purely additive change to the translator factory and provider. The interpolation path was already in use for explicit per-call vars; this PR seeds defaults from `BrandingContext`, which already wraps the entire app tree.

# Background

## What does this PR do?

Many translation strings include `{{appName}}` as a template variable, but most call sites use `t(key)` without a `vars` bag. The result is that the literal `{{appName}}` rendered into the UI in places like:

- `chat.inferenceCloudNotConnected` (cloud-not-connected alert tooltip)
- `conversations.scopeApp`
- `connectionlostoverlay.ConnectionLostBody`
- `header.MobileNavigationDescription`
- `onboarding.welcomeTitle`
- `onboarding.remoteTitle`
- `onboarding.remoteConnectedDesc`
- `onboarding.hostingQuestion`
- `musicplayersettings.Description`
- `browserworkspace.EmptyDescription`

— and the same set across every locale that ships with the codebase (en, zh-CN, ko, es, pt, vi, tl).

Since `branding.appName` is the canonical source for the product name everywhere else, this PR threads it into the translator as a default var so any `t(key)` call still substitutes correctly. Per-call `vars` still take precedence (e.g. an explicit `t("foo", { appName: "Custom" })` wins).

## What kind of change is this?

Bug fix.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Two small files:

- `packages/app-core/src/i18n/index.ts` — `createTranslator` gains an optional `defaultVars` parameter. When set, every produced translator merges defaults under per-call vars.
- `packages/app-core/src/state/TranslationContext.tsx` — provider now reads `branding.appName` from `BrandingContext` and passes it as the default. The `useMemo` dep array picks up `branding.appName` so a branding swap re-creates the translator.

## Detailed testing steps

Verified on a Capacitor Android build (DEFAULT_BRANDING.appName = "Eliza"):

1. Pair against a remote agent → reach `/chat`.
2. The cloud-not-connected alert tooltip now reads:
   > Eliza Cloud is enabled or your last reply used a cloud-hosted model, but **Eliza** is not connected. Sign in or add an API key under Settings → Cloud.
   — instead of `… but {{appName}} is not connected …`.
3. `document.body.innerText.includes('{{appName}}') === false` across every visible page.

Existing per-call vars are unaffected — covered by the existing `i18n` unit tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `{{appName}}` appearing as a literal string in translated UI copy by threading the `branding.appName` value into the translator as a default interpolation variable. The approach correctly solves the context-ordering problem — `TranslationProvider` wraps `AppProviderInner` (where `BrandingContext.Provider` lives), so `useContext` would always return the static default; instead, `branding` is now passed explicitly as a prop.

- **`i18n/index.ts`**: `createTranslator` gains an optional `defaultVars` parameter; per-call vars still shadow defaults, so existing call sites are unaffected.
- **`TranslationContext.tsx`**: `TranslationProvider` accepts an explicit `branding` prop, merges it with `DEFAULT_BRANDING`, and seeds the translator with `appNameInterpolationVars` (which handles trim + empty-string fallback).
- **`AppContext.tsx`**: `AppProvider` forwards its `brandingOverride` prop down to `TranslationProvider`, completing the data flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive and the explicit prop-threading correctly works around the context ordering constraint.

The translator change is backward-compatible (existing callers passing no `defaultVars` see identical behaviour). The branding prop is threaded explicitly rather than relying on context, which is the correct solution given that `TranslationProvider` is mounted above `BrandingContext.Provider`. The `appNameInterpolationVars` helper handles the empty-string / whitespace edge case. No data path, auth boundary, or persistence layer is touched.

No files require special attention — all three changes are small and self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/i18n/index.ts | Adds optional `defaultVars` parameter to `createTranslator`; per-call vars correctly shadow defaults via spread. Logic is clean and backward-compatible. |
| packages/app-core/src/state/TranslationContext.tsx | Accepts explicit `branding` prop (bypassing the unavailable BrandingContext), merges with DEFAULT_BRANDING, and seeds the translator with `appNameInterpolationVars`. One minor dep-array over-tracking noted (full object vs. scalar string). |
| packages/app-core/src/state/AppContext.tsx | Threads `brandingOverride` into `TranslationProvider` so the outer provider receives the same branding config that was previously inaccessible via context. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    AP["AppProvider\n(receives branding prop)"]
    TP["TranslationProvider\n(branding prop threaded in)"]
    API["AppProviderInner\n(BrandingContext.Provider lives here)"]
    MB["mergedBranding memo\n{ ...DEFAULT_BRANDING, ...branding }"]
    AV["appNameInterpolationVars(mergedBranding)\n→ { appName: string }"]
    CT["createTranslator(uiLanguage, defaultVars)"]
    TF["t(key, vars?) →\nmerge defaultVars + vars, interpolate"]

    AP -->|"branding={brandingOverride}"| TP
    AP --> API
    TP --> MB
    MB --> AV
    AV -->|"defaultVars"| CT
    CT --> TF
    TF -->|"{{appName}} replaced"| UI["Rendered UI strings"]
```

<sub>Reviews (3): Last reviewed commit: ["fix(i18n): supply branding.appName as de..."](https://github.com/elizaos/eliza/commit/1edb947b937d602b353e837baa8fbbb997b92931) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31330157)</sub>

<!-- /greptile_comment -->