### PR TITLE
feat(n8n): workflow execution visibility in Automations UI

### DIFF
--- a/packages/app-core/src/api/automations-compat-routes.ts
+++ b/packages/app-core/src/api/automations-compat-routes.ts
@@ -92,7 +92,8 @@ const BLOCKED_AUTOMATION_PROVIDER_NODES = new Set([
 ]);
 
 // 30s cache for last-execution data — avoids hammering n8n on every automations poll.
-const lastExecutionCache = new Map<string, { data: AutomationLastExecution; expiresAt: number }>();
+// null data = checked and found no executions yet (still cached to avoid re-polling).
+const lastExecutionCache = new Map<string, { data: AutomationLastExecution | null; expiresAt: number }>();
 const LAST_EXECUTION_TTL_MS = 30_000;
 
 interface StaticAutomationNodeSpec {
@@ -735,13 +736,19 @@ async function buildAutomationListResponse(
   // Fetch last execution for each live n8n workflow in parallel.
   // Promise.allSettled ensures one failure does not block the full list.
   if (!n8nOffline && workflowItemsById.size > 0) {
+    const now = Date.now();
+    for (const [k, v] of lastExecutionCache) {
+      if (v.expiresAt < now) lastExecutionCache.delete(k);
+    }
     const workflowIds = [...workflowItemsById.keys()];
     await Promise.allSettled(
       workflowIds.map(async (workflowId) => {
         const cached = lastExecutionCache.get(workflowId);
         if (cached && cached.expiresAt > Date.now()) {
-          const item = workflowItemsById.get(workflowId);
-          if (item) item.lastExecution = cached.data;
+          if (cached.data !== null) {
+            const item = workflowItemsById.get(workflowId);
+            if (item) item.lastExecution = cached.data;
+          }
           return;
         }
         const result = await invokeN8nCompatRoute<{ executions?: unknown[] }>(
@@ -753,8 +760,11 @@ async function buildAutomationListResponse(
         if (result.status !== 200 || !Array.isArray(result.payload?.executions)) {
           return;
         }
-        const raw = result.payload.executions[0] as Record<string, unknown> | undefined;
-        if (!raw) return;
+        if (result.payload.executions.length === 0) {
+          lastExecutionCache.set(workflowId, { data: null, expiresAt: Date.now() + LAST_EXECUTION_TTL_MS });
+          return;
+        }
+        const raw = result.payload.executions[0] as Record<string, unknown>;
         const exec = normalizeLastExecution(raw);
         if (!exec) return;
         lastExecutionCache.set(workflowId, { data: exec, expiresAt: Date.now() + LAST_EXECUTION_TTL_MS });
@@ -803,11 +813,14 @@ async function buildAutomationListResponse(
 function normalizeLastExecution(raw: Record<string, unknown>): AutomationLastExecution | null {
   const rawStatus = raw.status;
   if (typeof rawStatus !== "string") return null;
-  const status = (
-    ["success", "error", "running", "waiting"].includes(rawStatus)
-      ? rawStatus
-      : "unknown"
-  ) as AutomationLastExecution["status"];
+  const STATUS_MAP: Record<string, AutomationLastExecution["status"]> = {
+    success: "success",
+    error: "error",
+    crashed: "error",
+    running: "running",
+    waiting: "waiting",
+  };
+  const status = STATUS_MAP[rawStatus] ?? "unknown";
   const startedAt = typeof raw.startedAt === "string" ? raw.startedAt : null;
   if (!startedAt) return null;
   const stoppedAt = typeof raw.stoppedAt === "string" ? raw.stoppedAt : null;

--- a/packages/app-core/src/api/automations-compat-routes.ts
+++ b/packages/app-core/src/api/automations-compat-routes.ts
@@ -25,6 +25,7 @@ import { listAutomationNodeContributors } from "./automation-node-contributors";
 import type { N8nStatusResponse, N8nWorkflow } from "./client-types-chat";
 import type {
   AutomationItem,
+  AutomationLastExecution,
   AutomationNodeCatalogResponse,
   AutomationNodeDescriptor,
   AutomationRoomBinding,
@@ -89,6 +90,10 @@ const BLOCKED_AUTOMATION_PROVIDER_NODES = new Set([
   "recent-conversations",
   "relevant-conversations",
 ]);
+
+// 30s cache for last-execution data — avoids hammering n8n on every automations poll.
+const lastExecutionCache = new Map<string, { data: AutomationLastExecution; expiresAt: number }>();
+const LAST_EXECUTION_TTL_MS = 30_000;
 
 interface StaticAutomationNodeSpec {
   id: string;
@@ -727,6 +732,38 @@ async function buildAutomationListResponse(
     }
   }
 
+  // Fetch last execution for each live n8n workflow in parallel.
+  // Promise.allSettled ensures one failure does not block the full list.
+  if (!n8nOffline && workflowItemsById.size > 0) {
+    const workflowIds = [...workflowItemsById.keys()];
+    await Promise.allSettled(
+      workflowIds.map(async (workflowId) => {
+        const cached = lastExecutionCache.get(workflowId);
+        if (cached && cached.expiresAt > Date.now()) {
+          const item = workflowItemsById.get(workflowId);
+          if (item) item.lastExecution = cached.data;
+          return;
+        }
+        const result = await invokeN8nCompatRoute<{ executions?: unknown[] }>(
+          req,
+          res,
+          runtime,
+          `/api/n8n/workflows/${encodeURIComponent(workflowId)}/executions?limit=1`,
+        );
+        if (result.status !== 200 || !Array.isArray(result.payload?.executions)) {
+          return;
+        }
+        const raw = result.payload.executions[0] as Record<string, unknown> | undefined;
+        if (!raw) return;
+        const exec = normalizeLastExecution(raw);
+        if (!exec) return;
+        lastExecutionCache.set(workflowId, { data: exec, expiresAt: Date.now() + LAST_EXECUTION_TTL_MS });
+        const item = workflowItemsById.get(workflowId);
+        if (item) item.lastExecution = exec;
+      }),
+    );
+  }
+
   const coordinatorTriggerItems = triggerItems
     .filter((trigger) => trigger.kind !== "workflow")
     .map((trigger) =>
@@ -761,6 +798,26 @@ async function buildAutomationListResponse(
     n8nStatus,
     workflowFetchError,
   };
+}
+
+function normalizeLastExecution(raw: Record<string, unknown>): AutomationLastExecution | null {
+  const rawStatus = raw.status;
+  if (typeof rawStatus !== "string") return null;
+  const status = (
+    ["success", "error", "running", "waiting"].includes(rawStatus)
+      ? rawStatus
+      : "unknown"
+  ) as AutomationLastExecution["status"];
+  const startedAt = typeof raw.startedAt === "string" ? raw.startedAt : null;
+  if (!startedAt) return null;
+  const stoppedAt = typeof raw.stoppedAt === "string" ? raw.stoppedAt : null;
+  const errorMessage = (() => {
+    const data = raw.data as Record<string, unknown> | undefined;
+    const resultData = data?.resultData as Record<string, unknown> | undefined;
+    const error = resultData?.error as Record<string, unknown> | undefined;
+    return typeof error?.message === "string" ? error.message : undefined;
+  })();
+  return { status, startedAt, stoppedAt, ...(errorMessage ? { errorMessage } : {}) };
 }
 
 function normalizeCapabilityName(value: string): string {

--- a/packages/app-core/src/api/client-n8n.ts
+++ b/packages/app-core/src/api/client-n8n.ts
@@ -10,6 +10,7 @@ import { ElizaClient } from "./client-base";
 import type {
   N8nStatusResponse,
   N8nWorkflow,
+  N8nWorkflowExecution,
   N8nWorkflowGenerateRequest,
   N8nWorkflowGenerateResponse,
   N8nWorkflowResolveClarificationRequest,
@@ -40,6 +41,10 @@ declare module "./client-base" {
     deactivateN8nWorkflow(id: string): Promise<N8nWorkflow>;
     deleteN8nWorkflow(id: string): Promise<{ ok: boolean }>;
     startN8nSidecar(): Promise<{ ok: boolean }>;
+    getN8nWorkflowExecutions(
+      id: string,
+      limit?: number,
+    ): Promise<N8nWorkflowExecution[]>;
   }
 }
 
@@ -171,4 +176,15 @@ ElizaClient.prototype.startN8nSidecar = async function (
   return this.fetch<{ ok: boolean }>("/api/n8n/sidecar/start", {
     method: "POST",
   });
+};
+
+ElizaClient.prototype.getN8nWorkflowExecutions = async function (
+  this: ElizaClient,
+  id: string,
+  limit = 10,
+): Promise<N8nWorkflowExecution[]> {
+  const result = await this.fetch<{ executions?: N8nWorkflowExecution[] }>(
+    `/api/n8n/workflows/${encodeURIComponent(id)}/executions?limit=${limit}`,
+  );
+  return result.executions ?? [];
 };

--- a/packages/app-core/src/api/client-types-chat.ts
+++ b/packages/app-core/src/api/client-types-chat.ts
@@ -444,6 +444,21 @@ export interface N8nWorkflow {
   connections?: N8nConnectionMap;
 }
 
+export interface N8nWorkflowExecution {
+  id: string;
+  status: "success" | "error" | "running" | "waiting" | "canceled" | "crashed" | "new" | "unknown";
+  startedAt: string;
+  stoppedAt?: string | null;
+  mode?: string;
+  workflowId?: string;
+  data?: {
+    resultData?: {
+      error?: { message?: string };
+      lastNodeExecuted?: string;
+    };
+  };
+}
+
 /**
  * One missing credential entry on a workflow generate response. `authUrl` is
  * a `eliza://settings/connectors/<provider>` deep-link the UI may surface.

--- a/packages/app-core/src/api/client-types-config.ts
+++ b/packages/app-core/src/api/client-types-config.ts
@@ -538,6 +538,13 @@ export interface AutomationRoomBinding {
   terminalBridgeConversationId?: string;
 }
 
+export interface AutomationLastExecution {
+  status: 'success' | 'error' | 'running' | 'waiting' | 'unknown';
+  startedAt: string;
+  stoppedAt?: string | null;
+  errorMessage?: string;
+}
+
 export interface AutomationItem {
   id: string;
   type: AutomationType;
@@ -559,6 +566,7 @@ export interface AutomationItem {
   workflow?: import("./client-types-chat").N8nWorkflow;
   schedules: TriggerSummary[];
   room?: AutomationRoomBinding | null;
+  lastExecution?: AutomationLastExecution;
 }
 
 export interface AutomationSummary {

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -3957,6 +3957,7 @@ function WorkflowAutomationDetailPane({
       return undefined;
     }
     let cancelled = false;
+    setExecutions([]);
     setExecutionsLoading(true);
     void client
       .getN8nWorkflowExecutions(automation.workflowId, 10)

--- a/packages/app-core/src/components/pages/AutomationsView.tsx
+++ b/packages/app-core/src/components/pages/AutomationsView.tsx
@@ -73,6 +73,7 @@ import {
   type N8nClarificationTargetGroup,
   type N8nStatusResponse,
   type N8nWorkflow,
+  type N8nWorkflowExecution,
   type N8nWorkflowMissingCredential,
   type N8nWorkflowNeedsClarificationResponse,
   type N8nWorkflowWriteRequest,
@@ -3858,6 +3859,8 @@ function WorkflowAutomationDetailPane({
     null,
   );
   const [workflowPromptSaving, setWorkflowPromptSaving] = useState(false);
+  const [executions, setExecutions] = useState<N8nWorkflowExecution[]>([]);
+  const [executionsLoading, setExecutionsLoading] = useState(false);
   const workflowGenerating = useWorkflowGenerationState(automation.workflowId);
   const busy =
     workflowOpsBusy ||
@@ -3947,6 +3950,29 @@ function WorkflowAutomationDetailPane({
     automation.workflow,
     automation.workflowId,
   ]);
+
+  useEffect(() => {
+    if (!automation.workflowId || !automation.hasBackingWorkflow) {
+      setExecutions([]);
+      return undefined;
+    }
+    let cancelled = false;
+    setExecutionsLoading(true);
+    void client
+      .getN8nWorkflowExecutions(automation.workflowId, 10)
+      .then((data) => {
+        if (!cancelled) setExecutions(data);
+      })
+      .catch(() => {
+        if (!cancelled) setExecutions([]);
+      })
+      .finally(() => {
+        if (!cancelled) setExecutionsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [automation.hasBackingWorkflow, automation.workflowId]);
 
   return (
     <div className="space-y-4">
@@ -4114,6 +4140,59 @@ function WorkflowAutomationDetailPane({
         />
       </div>
 
+      {automation.hasBackingWorkflow && (
+        <DetailSection title="Recent runs">
+          {executionsLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Spinner className="h-4 w-4 text-muted" />
+            </div>
+          ) : executions.length === 0 ? (
+            <div className="px-3 py-3 text-xs text-muted">No executions yet.</div>
+          ) : (
+            <div className="divide-y divide-border/15">
+              {executions.slice(0, 10).map((exec) => {
+                const durationMs =
+                  exec.startedAt && exec.stoppedAt
+                    ? Date.parse(exec.stoppedAt) - Date.parse(exec.startedAt)
+                    : null;
+                const isErr = exec.status === "error" || exec.status === "crashed";
+                const errorMsg = exec.data?.resultData?.error?.message;
+                return (
+                  <div key={exec.id} className="flex flex-col gap-0.5 px-3 py-2">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${
+                          exec.status === "success"
+                            ? "bg-success"
+                            : isErr
+                              ? "bg-danger"
+                              : exec.status === "running"
+                                ? "bg-accent animate-pulse"
+                                : "bg-muted"
+                        }`}
+                      />
+                      <span className="text-xs text-txt">
+                        {formatDateTime(exec.startedAt, { locale: uiLanguage, fallback: "—" })}
+                      </span>
+                      {durationMs !== null && durationMs >= 0 && (
+                        <span className="ml-auto text-[10px] text-muted">
+                          {formatDurationMs(durationMs)}
+                        </span>
+                      )}
+                    </div>
+                    {isErr && errorMsg && (
+                      <div className="ml-3.5 truncate text-[10px] text-danger">
+                        {errorMsg}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </DetailSection>
+      )}
+
       {showWorkflowPromptBox && (
         <DetailSection title="Create workflow">
           <div className="p-3">
@@ -4275,7 +4354,11 @@ function AutomationSidebarItem({
 
   if (item.type === "n8n_workflow") {
     Icon = Workflow;
-    tone = item.isDraft ? "warning" : item.enabled ? "success" : "muted";
+    if (item.lastExecution?.status === "error") {
+      tone = "danger";
+    } else {
+      tone = item.isDraft ? "warning" : item.enabled ? "success" : "muted";
+    }
   } else if (item.type === "automation_draft") {
     Icon = FileText;
     tone = "warning";
@@ -4317,7 +4400,27 @@ function AutomationSidebarItem({
       <span className={`truncate text-xs-tight ${titleClass}`}>
         {getAutomationDisplayTitle(item)}
       </span>
-      <StatusDot tone={tone} className="ml-auto h-1.5 w-1.5 shrink-0" />
+      {item.type === "n8n_workflow" && item.lastExecution && (
+        <span
+          className={`ml-auto shrink-0 text-[10px] leading-none ${
+            item.lastExecution.status === "error"
+              ? "text-danger"
+              : item.lastExecution.status === "running"
+                ? "text-accent animate-pulse"
+                : "text-muted"
+          }`}
+        >
+          {item.lastExecution.status === "error"
+            ? "failed"
+            : item.lastExecution.status === "running"
+              ? "running"
+              : formatRelativePast(item.lastExecution.startedAt)}
+        </span>
+      )}
+      <StatusDot
+        tone={tone}
+        className={`${item.type === "n8n_workflow" && item.lastExecution ? "" : "ml-auto"} h-1.5 w-1.5 shrink-0`}
+      />
     </button>
   );
 }

--- a/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
+++ b/plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts
@@ -1038,7 +1038,127 @@ export async function handleN8nRoutes(ctx: N8nRouteContext): Promise<boolean> {
     }
   }
 
+  // --- Workflow executions --------------------------------------------------
+  const executionsMatch = parseWorkflowExecutionsPath(pathname);
+  if (executionsMatch && method === 'GET') {
+    const sidecar = await resolveSidecarForRequest(ctx, native);
+    return handleGetWorkflowExecutions(ctx, executionsMatch.id, sidecar, native);
+  }
+
   return false;
+}
+
+/**
+ * Parse `/api/n8n/workflows/{id}/executions` — returns id when matched.
+ */
+function parseWorkflowExecutionsPath(pathname: string): { id: string } | null {
+  const prefix = '/api/n8n/workflows/';
+  const suffix = '/executions';
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
+    return null;
+  }
+  const id = pathname.slice(prefix.length, pathname.length - suffix.length);
+  if (!id || id.includes('/')) {
+    return null;
+  }
+  return { id: decodeURIComponent(id) };
+}
+
+async function handleGetWorkflowExecutions(
+  ctx: N8nRouteContext,
+  id: string,
+  sidecar: N8nSidecar | null,
+  native: boolean
+): Promise<boolean> {
+  if (!id) {
+    sendJson(ctx, 400, { error: 'workflow id required' });
+    return true;
+  }
+
+  const rawLimit = new URL(`http://x${ctx.req.url ?? ''}`).searchParams.get('limit');
+  const limit = Math.min(Math.max(1, Number(rawLimit) || 10), 50);
+
+  // Executions live at /api/v1/executions?workflowId=... not under /workflows/
+  const resolved = resolveExecutionsProxyTarget(ctx, id, limit, sidecar, native);
+  if (!resolved.target) {
+    sendJson(ctx, 503, {
+      error: resolved.reason?.message ?? 'n8n not ready',
+      status: resolved.reason?.status ?? 'stopped',
+    });
+    return true;
+  }
+
+  const upstream = await fetchTargetAsJson(ctx, resolved.target, { method: 'GET' });
+  if (!upstream.ok) {
+    propagateError(ctx, upstream);
+    return true;
+  }
+
+  const body = upstream.body as { data?: unknown[] } | null;
+  sendJson(ctx, 200, { executions: Array.isArray(body?.data) ? body.data : [] });
+  return true;
+}
+
+function resolveExecutionsProxyTarget(
+  ctx: N8nRouteContext,
+  workflowId: string,
+  limit: number,
+  sidecar: N8nSidecar | null,
+  native: boolean
+): {
+  target: ProxyTarget | null;
+  reason?: { message: string; status: N8nSidecarStatus };
+} {
+  const { cloudConnected, localEnabled } = resolveN8nMode({
+    config: ctx.config,
+    runtime: ctx.runtime,
+    native,
+  });
+
+  const query = `?workflowId=${encodeURIComponent(workflowId)}&limit=${limit}`;
+
+  if (cloudConnected) {
+    const apiKey = ctx.config.cloud?.apiKey?.trim();
+    if (!apiKey) {
+      return { target: null, reason: { message: 'cloud api key missing', status: 'error' } };
+    }
+    const baseUrl = normalizeBaseUrl(ctx.config.cloud?.baseUrl);
+    const agentId = resolveAgentId(ctx);
+    return {
+      target: {
+        url: `${baseUrl}/api/v1/agents/${encodeURIComponent(agentId)}/n8n/executions${query}`,
+        headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' },
+      },
+    };
+  }
+
+  if (!localEnabled) {
+    return { target: null, reason: { message: 'n8n disabled', status: 'stopped' } };
+  }
+
+  const sidecarState = sidecar?.getState();
+  const status: N8nSidecarStatus = sidecarState?.status ?? 'stopped';
+  if (status !== 'ready') {
+    return { target: null, reason: { message: `n8n not ready (${status})`, status } };
+  }
+
+  const host = sidecarState?.host ?? ctx.config.n8n?.host ?? null;
+  if (!host) {
+    return { target: null, reason: { message: 'n8n host unknown', status: 'error' } };
+  }
+
+  const apiKey = sidecar?.getApiKey() ?? ctx.config.n8n?.apiKey ?? null;
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (apiKey) {
+    headers['X-N8N-API-KEY'] = apiKey;
+  }
+
+  return {
+    target: {
+      url: `${host.replace(/\/+$/, '')}/api/v1/executions${query}`,
+      headers,
+    },
+  };
 }
 
 async function handleStatus(


### PR DESCRIPTION
## Summary

- Adds `GET /api/n8n/workflows/:id/executions?limit=N` route to `plugin-n8n-workflow` — proxies to n8n's `/api/v1/executions` endpoint, supports both cloud gateway and local sidecar modes
- Adds `AutomationLastExecution` type and `lastExecution?` field on `AutomationItem` in client types
- `automations-compat-routes` populates `lastExecution` per n8n workflow in the list response (30s TTL cache, `Promise.allSettled` so one failed fetch doesn't block the rest)
- Adds `getN8nWorkflowExecutions()` to `ElizaClient`
- `AutomationsView` shows a status badge (success/error/running/waiting dot) on workflow list rows and a "Recent runs" panel in the detail pane with relative timestamps

## Files changed

- `plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts` — new executions route
- `packages/app-core/src/api/client-types-config.ts` — `AutomationLastExecution` type + `lastExecution` on `AutomationItem`
- `packages/app-core/src/api/client-types-chat.ts` — `N8nWorkflowExecution` type
- `packages/app-core/src/api/automations-compat-routes.ts` — `lastExecution` population with 30s cache
- `packages/app-core/src/api/client-n8n.ts` — `getN8nWorkflowExecutions()`
- `packages/app-core/src/components/pages/AutomationsView.tsx` — status badge + Recent runs panel

## Test plan

- [ ] `bun run dev` → open Automations → confirm status dot appears on workflow list rows
- [ ] Click a workflow → confirm "Recent runs" panel shows status + relative time
- [ ] With no executions yet: panel shows empty/waiting state, not an error
- [ ] Verify 30s cache: rapid reloads don't hammer n8n's executions endpoint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds workflow execution visibility to the Automations UI by introducing a new `GET /api/n8n/workflows/:id/executions` proxy route and wiring it through the client SDK, compat routes, and `AutomationsView` component.

- **Backend**: A new `handleGetWorkflowExecutions` handler in `plugin-n8n-workflow` proxies requests to n8n's `/api/v1/executions` for both cloud and local sidecar modes. The `automations-compat-routes` layer fetches last-execution data per workflow on list requests, caching results for 30 seconds (including `null` sentinels for zero-execution workflows) and pruning expired entries each poll.
- **Client types**: `N8nWorkflowExecution` and `AutomationLastExecution` types are added; the former carries the full execution shape for the detail panel, the latter carries the normalized sidebar badge shape.
- **UI**: `AutomationSidebarItem` shows a status text label (failed / running / relative timestamp) alongside the existing status dot, and `WorkflowAutomationDetailPane` gains a "Recent runs" section that fetches executions on mount with a cancellation guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three issues flagged in prior review threads are correctly resolved, and the new code follows established patterns throughout the codebase.

The cache eviction loop, the null sentinel for zero-execution workflows, and the setExecutions([]) stale-data fix are all present and correct. The route handler ordering is safe. The only remaining gap — not caching a sentinel when normalizeLastExecution fails on a non-empty result — affects only an edge case and degrades to extra API calls rather than incorrect data.

No files require special attention beyond the minor cache-miss edge case in automations-compat-routes.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/routes/n8n-routes.ts | Adds executions proxy route with correct routing order; limit clamped to 1–50; cloud and local modes both handled cleanly. |
| packages/app-core/src/api/automations-compat-routes.ts | 30-second TTL cache with sentinel-for-empty and eviction-on-poll correctly addresses all three issues from prior threads; minor gap remains when normalization fails on a non-empty result. |
| packages/app-core/src/components/pages/AutomationsView.tsx | Execution fetch uses a cancellation guard; stale-data-on-switch resolved by `setExecutions([])` at the top of the effect. |
| packages/app-core/src/api/client-n8n.ts | Adds `getN8nWorkflowExecutions` following existing SDK patterns. |
| packages/app-core/src/api/client-types-chat.ts | Adds `N8nWorkflowExecution` interface with comprehensive status union. |
| packages/app-core/src/api/client-types-config.ts | Adds `AutomationLastExecution` type; single-quote style inconsistent with rest of file. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as AutomationsView
    participant Compat as automations-compat-routes
    participant Cache as lastExecutionCache
    participant Route as plugin-n8n-workflow
    participant N8n as n8n API

    UI->>Compat: GET /api/automations
    Compat->>N8n: GET workflows list
    N8n-->>Compat: workflows[]

    loop Per workflow (Promise.allSettled)
        Compat->>Cache: get(workflowId)
        alt Cache hit
            Cache-->>Compat: data
            Compat->>Compat: attach lastExecution to item
        else Cache miss
            Compat->>Route: "invokeN8nCompatRoute /executions?limit=1"
            Route->>N8n: "GET /api/v1/executions?workflowId=x"
            N8n-->>Route: execution data
            Route-->>Compat: executions[]
            Compat->>Compat: normalizeLastExecution()
            Compat->>Cache: set with 30s TTL
            Compat->>Compat: attach lastExecution to item
        end
    end

    Compat-->>UI: automations[] with lastExecution
    UI->>UI: render sidebar badges
    UI->>Route: "GET /api/n8n/workflows/:id/executions?limit=10"
    Route->>N8n: "GET /api/v1/executions?workflowId=x&limit=10"
    N8n-->>Route: executions[]
    Route-->>UI: executions[]
    UI->>UI: render Recent runs panel
```

<sub>Reviews (3): Last reviewed commit: ["fix(automations): clear executions list ..."](https://github.com/elizaos/eliza/commit/cb43965d271e9cd07cfd2611bd2f08cc56d9ed22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31332159)</sub>

<!-- /greptile_comment -->