### PR TITLE
feat(cloud): agent-router daemon — replaces /opt/milady-cloud/agent-lookup.cjs

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -13,7 +13,9 @@ on:
     paths:
       - '.github/workflows/deploy-eliza-provisioning-worker.yml'
       - 'cloud/packages/scripts/daemons/provisioning-worker.ts'
+      - 'cloud/packages/scripts/daemons/agent-router.ts'
       - 'cloud/packages/scripts/eliza-provisioning-worker.service'
+      - 'cloud/packages/scripts/eliza-agent-router.service'
       - 'cloud/packages/lib/services/provisioning-jobs.ts'
       - 'cloud/packages/lib/services/docker-sandbox-provider.ts'
       - 'cloud/packages/lib/services/eliza-sandbox.ts'
@@ -118,15 +120,19 @@ jobs:
             done
             cd /opt/eliza
 
-            # Install/refresh the systemd unit.
+            # Install/refresh both systemd units (provisioning worker + agent router).
             sudo install -m 0644 \
               cloud/packages/scripts/eliza-provisioning-worker.service \
               "/etc/systemd/system/$SYSTEMD_UNIT"
+            sudo install -m 0644 \
+              cloud/packages/scripts/eliza-agent-router.service \
+              /etc/systemd/system/eliza-agent-router.service
             sudo systemctl daemon-reload
-            sudo systemctl enable "$SYSTEMD_UNIT"
+            sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service
 
             sudo systemctl restart "$SYSTEMD_UNIT"
-            echo "=== Restart issued; waiting for first poll cycle ==="
+            sudo systemctl restart eliza-agent-router.service
+            echo "=== Restart issued for both daemons ==="
 
       - name: Health check
         if: steps.deploy_config.outputs.configured == 'true'
@@ -161,7 +167,20 @@ jobs:
                 NOW_SEC=$(awk '{print int($1)}' /proc/uptime)
                 AGE=$(( NOW_SEC - UPTIME_SEC ))
                 if [ "$AGE" -ge "$STABLE_THRESHOLD_SEC" ]; then
-                  echo "Worker active and stable for ${AGE}s (>= ${STABLE_THRESHOLD_SEC}s threshold) on attempt $attempt."
+                  if ! sudo systemctl is-active --quiet eliza-agent-router.service; then
+                    echo "::error::eliza-agent-router.service is not active."
+                    sudo systemctl status eliza-agent-router.service --no-pager || true
+                    sudo journalctl -u eliza-agent-router.service -n 50 --no-pager || true
+                    exit 1
+                  fi
+                  ROUTER_PORT=$(systemctl show eliza-agent-router.service --property=Environment --value | tr ' ' '\n' | awk -F= '$1=="AGENT_ROUTER_PORT" {print $2}')
+                  : "${ROUTER_PORT:=3458}"
+                  if ! curl -sf -m 3 "http://127.0.0.1:${ROUTER_PORT}/healthz" >/dev/null 2>&1; then
+                    echo "::error::eliza-agent-router /healthz did not respond on port ${ROUTER_PORT}."
+                    sudo journalctl -u eliza-agent-router.service -n 50 --no-pager || true
+                    exit 1
+                  fi
+                  echo "Both daemons active and stable (worker ${AGE}s, router /healthz OK) on attempt $attempt."
                   exit 0
                 fi
                 echo "Health check attempt $attempt/18: active but only ${AGE}s old, waiting for stability..."

--- a/cloud/packages/scripts/daemons/agent-router.ts
+++ b/cloud/packages/scripts/daemons/agent-router.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Agent Router daemon.
+ *
+ * Replaces /opt/milady-cloud/agent-lookup.cjs which queried the legacy
+ * `milady_sandboxes` table. This daemon queries `agent_sandboxes` and
+ * returns the same response shape so nginx Lua (`agent-router.lua`) keeps
+ * working without changes.
+ *
+ * Usage:
+ *   npx tsx packages/scripts/daemons/agent-router.ts
+ *
+ * Environment:
+ *   AGENT_ROUTER_PORT  default 3458 — picked to avoid conflict with the
+ *                      legacy agent-lookup.cjs on 3456 during transition.
+ *   DATABASE_URL       Postgres connection (loaded from .env.local).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Logger = typeof import("../../lib/utils/logger").logger;
+type Repo = typeof import("../../db/repositories/agent-sandboxes").agentSandboxesRepository;
+
+interface RouterDeps {
+  logger: Logger;
+  agentSandboxesRepository: Repo;
+}
+
+export interface AgentRouterConfig {
+  port: number;
+  bindHost: string;
+}
+
+const DEFAULT_PORT = 3458;
+const DEFAULT_BIND_HOST = "127.0.0.1";
+
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx);
+    let value = trimmed.slice(eqIdx + 1);
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function loadLocalEnv(): void {
+  const scriptPath = fileURLToPath(import.meta.url);
+  const projectRoot = path.resolve(path.dirname(scriptPath), "../../..");
+  loadEnvFile(path.join(projectRoot, ".env.local"));
+  loadEnvFile(path.join(projectRoot, ".env"));
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function readRouterConfig(env: NodeJS.ProcessEnv = process.env): AgentRouterConfig {
+  return {
+    port: parsePositiveInt(env.AGENT_ROUTER_PORT, DEFAULT_PORT),
+    bindHost: env.AGENT_ROUTER_BIND_HOST?.trim() || DEFAULT_BIND_HOST,
+  };
+}
+
+let depsPromise: Promise<RouterDeps> | null = null;
+
+async function loadDeps(): Promise<RouterDeps> {
+  if (!depsPromise) {
+    depsPromise = Promise.all([
+      import("../../db/repositories/agent-sandboxes"),
+      import("../../lib/utils/logger"),
+    ]).then(([repoModule, loggerModule]) => ({
+      agentSandboxesRepository: repoModule.agentSandboxesRepository,
+      logger: loggerModule.logger,
+    }));
+  }
+  return depsPromise;
+}
+
+interface RoutingResponse {
+  headscaleIp: string;
+  bridgePort: number;
+  webUiPort: number;
+  target: string;
+}
+
+/**
+ * Resolve routing info for a given agent id.
+ * Exported so unit tests can call it without spinning up an HTTP server.
+ */
+export async function resolveAgentRouting(agentId: string): Promise<RoutingResponse | null> {
+  const { agentSandboxesRepository } = await loadDeps();
+  const sandbox = await agentSandboxesRepository.findById(agentId);
+  if (!sandbox || sandbox.status !== "running") return null;
+  if (!sandbox.bridge_url || !sandbox.web_ui_port) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(sandbox.bridge_url);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname;
+  const bridgePort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
+  const webUiPort = sandbox.web_ui_port;
+
+  return {
+    headscaleIp: host,
+    bridgePort,
+    webUiPort,
+    target: `${host}:${webUiPort}`,
+  };
+}
+
+const AGENT_ID_RE = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+
+async function handleRequest(url: URL): Promise<Response> {
+  if (url.pathname === "/healthz") {
+    return Response.json({ ok: true }, { status: 200 });
+  }
+  const match = url.pathname.match(/^\/agents\/([^/]+)\/(headscale-ip|routing)$/);
+  if (!match) {
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+  const agentId = match[1] ?? "";
+  if (!AGENT_ID_RE.test(agentId)) {
+    return Response.json({ error: "invalid agent id" }, { status: 400 });
+  }
+  const routing = await resolveAgentRouting(agentId);
+  if (!routing) {
+    return Response.json({ error: "agent not found or not running" }, { status: 404 });
+  }
+  return Response.json(routing, { status: 200 });
+}
+
+let server: import("node:http").Server | null = null;
+let shuttingDown = false;
+
+async function main(): Promise<void> {
+  loadLocalEnv();
+  const config = readRouterConfig();
+  const { logger } = await loadDeps();
+
+  const { createServer } = await import("node:http");
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host || "localhost"}`);
+    handleRequest(url)
+      .then((response) => {
+        res.statusCode = response.status;
+        response.headers.forEach((v, k) => res.setHeader(k, v));
+        return response.text();
+      })
+      .then((body) => {
+        res.end(body);
+      })
+      .catch((err) => {
+        logger.error("[agent-router] handler error", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.setHeader("content-type", "application/json");
+        }
+        res.end(JSON.stringify({ error: "internal error" }));
+      });
+  });
+
+  server.listen(config.port, config.bindHost, () => {
+    logger.info("[agent-router] starting", {
+      port: config.port,
+      bindHost: config.bindHost,
+    });
+  });
+
+  server.on("error", (err) => {
+    logger.error("[agent-router] server error", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    process.exitCode = 1;
+  });
+}
+
+function shutdown(signal: NodeJS.Signals): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  if (!server) {
+    process.exit(0);
+  }
+  server.close((err) => {
+    if (err) {
+      void loadDeps().then(({ logger }) => {
+        logger.error("[agent-router] close error", {
+          signal,
+          error: err.message,
+        });
+      });
+      process.exitCode = 1;
+    }
+    process.exit(process.exitCode ?? 0);
+  });
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+process.on("unhandledRejection", (reason) => {
+  void loadDeps().then(({ logger }) => {
+    logger.error("[agent-router] unhandled rejection", {
+      error: reason instanceof Error ? reason.message : String(reason),
+    });
+  });
+});
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    process.stderr.write(
+      `[agent-router] fatal: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/cloud/packages/scripts/daemons/agent-router.ts
+++ b/cloud/packages/scripts/daemons/agent-router.ts
@@ -2,23 +2,21 @@
 /**
  * Agent Router daemon.
  *
- * Replaces /opt/milady-cloud/agent-lookup.cjs which queried the legacy
- * `milady_sandboxes` table. This daemon queries `agent_sandboxes` and
- * returns the same response shape so nginx Lua (`agent-router.lua`) keeps
- * working without changes.
+ * Resolves agent id → headscale IP / bridge port / web UI port for the nginx
+ * Lua subdomain router.
  *
  * Usage:
  *   npx tsx packages/scripts/daemons/agent-router.ts
  *
  * Environment:
- *   AGENT_ROUTER_PORT  default 3458 — picked to avoid conflict with the
- *                      legacy agent-lookup.cjs on 3456 during transition.
- *   DATABASE_URL       Postgres connection (loaded from .env.local).
+ *   AGENT_ROUTER_PORT       default 3458
+ *   AGENT_ROUTER_BIND_HOST  default 127.0.0.1
+ *   DATABASE_URL            Postgres connection (loaded from .env.local).
  */
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadLocalEnv } from "./shared/load-env";
 
 type Logger = typeof import("../../lib/utils/logger").logger;
 type Repo = typeof import("../../db/repositories/agent-sandboxes").agentSandboxesRepository;
@@ -28,42 +26,13 @@ interface RouterDeps {
   agentSandboxesRepository: Repo;
 }
 
-export interface AgentRouterConfig {
+interface AgentRouterConfig {
   port: number;
   bindHost: string;
 }
 
 const DEFAULT_PORT = 3458;
 const DEFAULT_BIND_HOST = "127.0.0.1";
-
-function loadEnvFile(filePath: string): void {
-  if (!fs.existsSync(filePath)) return;
-  const content = fs.readFileSync(filePath, "utf-8");
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eqIdx = trimmed.indexOf("=");
-    if (eqIdx < 0) continue;
-    const key = trimmed.slice(0, eqIdx);
-    let value = trimmed.slice(eqIdx + 1);
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    if (!(key in process.env)) {
-      process.env[key] = value;
-    }
-  }
-}
-
-function loadLocalEnv(): void {
-  const scriptPath = fileURLToPath(import.meta.url);
-  const projectRoot = path.resolve(path.dirname(scriptPath), "../../..");
-  loadEnvFile(path.join(projectRoot, ".env.local"));
-  loadEnvFile(path.join(projectRoot, ".env"));
-}
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -100,10 +69,6 @@ interface RoutingResponse {
   target: string;
 }
 
-/**
- * Resolve routing info for a given agent id.
- * Exported so unit tests can call it without spinning up an HTTP server.
- */
 export async function resolveAgentRouting(agentId: string): Promise<RoutingResponse | null> {
   const { agentSandboxesRepository } = await loadDeps();
   const sandbox = await agentSandboxesRepository.findById(agentId);
@@ -117,8 +82,9 @@ export async function resolveAgentRouting(agentId: string): Promise<RoutingRespo
     return null;
   }
 
+  if (!parsed.port) return null;
   const host = parsed.hostname;
-  const bridgePort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
+  const bridgePort = Number.parseInt(parsed.port, 10);
   const webUiPort = sandbox.web_ui_port;
 
   return {
@@ -135,11 +101,13 @@ async function handleRequest(url: URL): Promise<Response> {
   if (url.pathname === "/healthz") {
     return Response.json({ ok: true }, { status: 200 });
   }
+  // /headscale-ip is the path nginx Lua already calls; /routing is the alias
+  // for new callers.
   const match = url.pathname.match(/^\/agents\/([^/]+)\/(headscale-ip|routing)$/);
   if (!match) {
     return Response.json({ error: "not found" }, { status: 404 });
   }
-  const agentId = match[1] ?? "";
+  const agentId = match[1];
   if (!AGENT_ID_RE.test(agentId)) {
     return Response.json({ error: "invalid agent id" }, { status: 400 });
   }
@@ -154,7 +122,7 @@ let server: import("node:http").Server | null = null;
 let shuttingDown = false;
 
 async function main(): Promise<void> {
-  loadLocalEnv();
+  loadLocalEnv(import.meta.url);
   const config = readRouterConfig();
   const { logger } = await loadDeps();
 
@@ -229,8 +197,7 @@ process.on("unhandledRejection", (reason) => {
 });
 
 function isMainModule(): boolean {
-  const entry = process.argv[1];
-  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+  return path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 }
 
 if (isMainModule()) {

--- a/cloud/packages/scripts/daemons/provisioning-worker.ts
+++ b/cloud/packages/scripts/daemons/provisioning-worker.ts
@@ -12,10 +12,10 @@
  *   npx tsx packages/scripts/daemons/provisioning-worker.ts --once
  */
 
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HeartbeatResult, ProcessingResult } from "../../lib/services/provisioning-jobs";
+import { loadLocalEnv } from "./shared/load-env";
 
 type WorkerLogger = typeof import("../../lib/utils/logger").logger;
 type WorkerService = typeof import("../../lib/services/provisioning-jobs").provisioningJobService;
@@ -33,38 +33,6 @@ export interface ProvisioningWorkerConfig {
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_BATCH_SIZE = 3;
-
-function loadEnvFile(filePath: string): void {
-  if (!fs.existsSync(filePath)) return;
-
-  const content = fs.readFileSync(filePath, "utf-8");
-  for (const line of content.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-
-    const eqIdx = trimmed.indexOf("=");
-    if (eqIdx < 0) continue;
-
-    const key = trimmed.slice(0, eqIdx);
-    let value = trimmed.slice(eqIdx + 1);
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    if (!(key in process.env)) {
-      process.env[key] = value;
-    }
-  }
-}
-
-function loadLocalEnv(): void {
-  const scriptPath = fileURLToPath(import.meta.url);
-  const projectRoot = path.resolve(path.dirname(scriptPath), "../../..");
-  loadEnvFile(path.join(projectRoot, ".env.local"));
-  loadEnvFile(path.join(projectRoot, ".env"));
-}
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -158,7 +126,7 @@ async function pollCycle(logger: WorkerLogger, config: ProvisioningWorkerConfig)
 }
 
 async function main(): Promise<void> {
-  loadLocalEnv();
+  loadLocalEnv(import.meta.url);
 
   const config = readWorkerConfig();
   const { logger } = await loadDeps();

--- a/cloud/packages/scripts/daemons/shared/load-env.ts
+++ b/cloud/packages/scripts/daemons/shared/load-env.ts
@@ -1,0 +1,37 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function loadEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf-8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx);
+    let value = trimmed.slice(eqIdx + 1);
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+/**
+ * Load .env.local then .env from the cloud package root, without overwriting
+ * already-set process.env entries. `daemonUrl` should be `import.meta.url` of
+ * the calling daemon at packages/scripts/daemons/<name>.ts.
+ */
+export function loadLocalEnv(daemonUrl: string): void {
+  const scriptPath = fileURLToPath(daemonUrl);
+  const projectRoot = path.resolve(path.dirname(scriptPath), "../../..");
+  loadEnvFile(path.join(projectRoot, ".env.local"));
+  loadEnvFile(path.join(projectRoot, ".env"));
+}

--- a/cloud/packages/scripts/eliza-agent-router.service
+++ b/cloud/packages/scripts/eliza-agent-router.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=Eliza Agent Router (subdomain routing lookup for cloud agents)
+Documentation=https://github.com/elizaOS/eliza
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/opt/eliza/cloud
+EnvironmentFile=/opt/eliza/cloud/.env.local
+ExecStart=/usr/bin/npx tsx packages/scripts/daemons/agent-router.ts
+
+Restart=always
+RestartSec=5
+
+MemoryMax=256M
+MemoryHigh=192M
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=eliza-agent-router
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+PrivateTmp=true
+ReadWritePaths=/opt/eliza
+ReadOnlyPaths=/home/deploy/.ssh
+
+TimeoutStopSec=10
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target

--- a/cloud/packages/tests/unit/agent-router.test.ts
+++ b/cloud/packages/tests/unit/agent-router.test.ts
@@ -80,6 +80,40 @@ describe("resolveAgentRouting", () => {
       target: "195.201.57.227:23790",
     });
   });
+
+  test("returns null when bridge_url has no explicit port", async () => {
+    // Sandboxes always store bridge_url with an explicit port. A portless URL
+    // is treated as malformed rather than silently defaulting to 80.
+    state.rows.set("66666666-6666-6666-6666-666666666666", {
+      id: "66666666-6666-6666-6666-666666666666",
+      status: "running",
+      bridge_url: "http://1.2.3.4",
+      web_ui_port: 21000,
+    });
+    expect(await resolveAgentRouting("66666666-6666-6666-6666-666666666666")).toBeNull();
+  });
+
+  test("returns null when status is the empty string", async () => {
+    state.rows.set("77777777-7777-7777-7777-777777777777", {
+      id: "77777777-7777-7777-7777-777777777777",
+      status: "",
+      bridge_url: "http://1.2.3.4:19000",
+      web_ui_port: 21000,
+    });
+    expect(await resolveAgentRouting("77777777-7777-7777-7777-777777777777")).toBeNull();
+  });
+
+  test("returns null when web_ui_port is 0 (falsy)", async () => {
+    // web_ui_port === 0 is rejected by the daemon's `!sandbox.web_ui_port`
+    // check. Documenting this so a future switch to `== null` is intentional.
+    state.rows.set("88888888-8888-8888-8888-888888888888", {
+      id: "88888888-8888-8888-8888-888888888888",
+      status: "running",
+      bridge_url: "http://1.2.3.4:19000",
+      web_ui_port: 0,
+    });
+    expect(await resolveAgentRouting("88888888-8888-8888-8888-888888888888")).toBeNull();
+  });
 });
 
 describe("readRouterConfig", () => {
@@ -111,6 +145,46 @@ describe("readRouterConfig", () => {
     ).toEqual({
       port: 3458,
       bindHost: "127.0.0.1",
+    });
+  });
+
+  test("falls back to default port when AGENT_ROUTER_PORT is zero or negative", () => {
+    expect(readRouterConfig({ AGENT_ROUTER_PORT: "0" } as NodeJS.ProcessEnv)).toEqual({
+      port: 3458,
+      bindHost: "127.0.0.1",
+    });
+    expect(readRouterConfig({ AGENT_ROUTER_PORT: "-1" } as NodeJS.ProcessEnv)).toEqual({
+      port: 3458,
+      bindHost: "127.0.0.1",
+    });
+  });
+
+  test("uses custom port with default bind host when only port is set", () => {
+    expect(readRouterConfig({ AGENT_ROUTER_PORT: "4567" } as NodeJS.ProcessEnv)).toEqual({
+      port: 4567,
+      bindHost: "127.0.0.1",
+    });
+  });
+
+  test("uses custom bind host with default port when only host is set", () => {
+    expect(
+      readRouterConfig({
+        AGENT_ROUTER_BIND_HOST: "0.0.0.0",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      port: 3458,
+      bindHost: "0.0.0.0",
+    });
+  });
+
+  test("trims whitespace from AGENT_ROUTER_BIND_HOST", () => {
+    expect(
+      readRouterConfig({
+        AGENT_ROUTER_BIND_HOST: "  10.0.0.1  ",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      port: 3458,
+      bindHost: "10.0.0.1",
     });
   });
 });

--- a/cloud/packages/tests/unit/agent-router.test.ts
+++ b/cloud/packages/tests/unit/agent-router.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface SandboxRow {
+  id: string;
+  status: string;
+  bridge_url: string | null;
+  web_ui_port: number | null;
+}
+
+const state: { rows: Map<string, SandboxRow> } = { rows: new Map() };
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    findById: async (id: string): Promise<SandboxRow | undefined> => state.rows.get(id),
+  },
+}));
+
+const { resolveAgentRouting, readRouterConfig } = await import(
+  "../../scripts/daemons/agent-router"
+);
+
+describe("resolveAgentRouting", () => {
+  beforeEach(() => {
+    state.rows.clear();
+  });
+
+  test("returns null when sandbox is missing", async () => {
+    expect(await resolveAgentRouting("00000000-0000-0000-0000-000000000000")).toBeNull();
+  });
+
+  test("returns null when sandbox status is not running", async () => {
+    state.rows.set("11111111-1111-1111-1111-111111111111", {
+      id: "11111111-1111-1111-1111-111111111111",
+      status: "pending",
+      bridge_url: "http://1.2.3.4:19000",
+      web_ui_port: 21000,
+    });
+    expect(await resolveAgentRouting("11111111-1111-1111-1111-111111111111")).toBeNull();
+  });
+
+  test("returns null when bridge_url or web_ui_port is missing", async () => {
+    state.rows.set("22222222-2222-2222-2222-222222222222", {
+      id: "22222222-2222-2222-2222-222222222222",
+      status: "running",
+      bridge_url: null,
+      web_ui_port: 21000,
+    });
+    state.rows.set("33333333-3333-3333-3333-333333333333", {
+      id: "33333333-3333-3333-3333-333333333333",
+      status: "running",
+      bridge_url: "http://1.2.3.4:19000",
+      web_ui_port: null,
+    });
+
+    expect(await resolveAgentRouting("22222222-2222-2222-2222-222222222222")).toBeNull();
+    expect(await resolveAgentRouting("33333333-3333-3333-3333-333333333333")).toBeNull();
+  });
+
+  test("returns null when bridge_url is not a valid URL", async () => {
+    state.rows.set("44444444-4444-4444-4444-444444444444", {
+      id: "44444444-4444-4444-4444-444444444444",
+      status: "running",
+      bridge_url: "not a url",
+      web_ui_port: 21000,
+    });
+    expect(await resolveAgentRouting("44444444-4444-4444-4444-444444444444")).toBeNull();
+  });
+
+  test("returns the routing payload for a healthy sandbox", async () => {
+    state.rows.set("55555555-5555-5555-5555-555555555555", {
+      id: "55555555-5555-5555-5555-555555555555",
+      status: "running",
+      bridge_url: "http://195.201.57.227:19610",
+      web_ui_port: 23790,
+    });
+    expect(await resolveAgentRouting("55555555-5555-5555-5555-555555555555")).toEqual({
+      headscaleIp: "195.201.57.227",
+      bridgePort: 19610,
+      webUiPort: 23790,
+      target: "195.201.57.227:23790",
+    });
+  });
+});
+
+describe("readRouterConfig", () => {
+  test("uses defaults when env is empty", () => {
+    expect(readRouterConfig({} as NodeJS.ProcessEnv)).toEqual({
+      port: 3458,
+      bindHost: "127.0.0.1",
+    });
+  });
+
+  test("reads AGENT_ROUTER_PORT and AGENT_ROUTER_BIND_HOST from env", () => {
+    expect(
+      readRouterConfig({
+        AGENT_ROUTER_PORT: "4567",
+        AGENT_ROUTER_BIND_HOST: "0.0.0.0",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      port: 4567,
+      bindHost: "0.0.0.0",
+    });
+  });
+
+  test("falls back to defaults on invalid values", () => {
+    expect(
+      readRouterConfig({
+        AGENT_ROUTER_PORT: "not-a-number",
+        AGENT_ROUTER_BIND_HOST: "   ",
+      } as NodeJS.ProcessEnv),
+    ).toEqual({
+      port: 3458,
+      bindHost: "127.0.0.1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small Node HTTP server that nginx (Lua agent-router on the control plane) can query to resolve a sandbox's `host:port` from the new `agent_sandboxes` table. The legacy `/opt/milady-cloud/agent-lookup.cjs` queried `milady_sandboxes`; this daemon queries the new table and returns the **same response shape** so nginx Lua keeps working without changes.

## What lands

- `cloud/packages/scripts/daemons/agent-router.ts` — Node http server, default port `3458` (avoids conflict with legacy `agent-lookup.cjs` on `3456` during transition). Routes:
  - `GET /agents/:id/routing` → resolve from `agent_sandboxes`
  - `GET /agents/:id/headscale-ip` → alias for the legacy nginx subrequest path
  - `GET /healthz` → for systemd / deploy probe
- `cloud/packages/scripts/eliza-agent-router.service` — systemd unit, same hardening pattern as the provisioning worker (deploy user, ProtectSystem=strict + PrivateTmp).
- `.github/workflows/deploy-eliza-provisioning-worker.yml` — extends the existing deploy flow to install + restart the new unit, plus a `/healthz` probe in the post-deploy health check.
- `cloud/packages/tests/unit/agent-router.test.ts` — 8 tests, sociable, covers not-found / bad-status / bad-bridge_url / happy-path + config parse.

## Why this PR (not just patching agent-lookup.cjs)

Team intent: retire `/opt/milady-cloud` entirely, keep all provisioning + routing code in `elizaos/eliza`. Patching the legacy script would prolong its life. This daemon ships the replacement upfront so the cutover step is "stop the legacy unit, point nginx at the new port" instead of a code migration.

## Test plan

- [ ] CI green (lint, typecheck, unit tests)
- [ ] Once merged, auto-deploy lands the daemon on the Hetzner control plane (port 3458)
- [ ] Manual probe: `curl http://127.0.0.1:3458/healthz` → `{"ok":true}`
- [ ] Manual probe: `curl http://127.0.0.1:3458/agents/<running-agent-id>/routing` → `{headscaleIp, bridgePort, webUiPort, target}`
- [ ] Operator (shadow) updates nginx Lua to try `:3458` first, fallback to legacy `:3456`

## Out of scope (follow-up PRs)

- Wiring `POST /api/v1/steward/tenants` into wallet-signup so new orgs get a Steward tenant created on first login (currently manual).
- `bootstrap-static-core.sh` for the 6 dedicated cores (network create, deploy authorized_keys).
- nginx Lua reorder + retiring of `/opt/milady-cloud/*` services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `agent-router.ts`, a small Node HTTP daemon that replaces the legacy `/opt/milady-cloud/agent-lookup.cjs` by querying the new `agent_sandboxes` table and returning the same response shape nginx Lua expects. It also extracts the shared env-file loader into `shared/load-env.ts`, adds a matching systemd unit with the same hardening pattern as the provisioning worker, and extends the deploy workflow to install, enable, and health-check the new service.

- **`agent-router.ts`**: Exposes `/agents/:id/routing`, `/agents/:id/headscale-ip`, and `/healthz`; correctly guards against invalid agent IDs, non-running sandboxes, bad bridge URLs, and port-less URLs (returns `null` rather than defaulting to port 80).
- **`shared/load-env.ts`**: Simple extraction of the existing env-file loader; used by both daemons via `loadLocalEnv(import.meta.url)`.
- **Deploy workflow**: Extended to install both systemd units, restart them, and verify the router's `/healthz` responds on the configured port before marking the deployment healthy.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of two pre-existing open issues flagged in earlier review threads: the server-error handler sets process.exitCode but does not call process.exit(), and the depsPromise rejection is permanently cached.

The routing logic and URL parsing are solid, and the deploy workflow health check is well-constructed. The two issues noted in prior threads (server error not exiting, permanent rejection cache) remain unresolved in this revision. The shutdown log-swallowing issue found in this review is a minor logging gap in an error path that does not affect correctness.

cloud/packages/scripts/daemons/agent-router.ts — specifically the server error handler (line 160) and the depsPromise caching (line 50), both from prior review threads.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/scripts/daemons/agent-router.ts | New Node HTTP daemon that resolves agent sandbox routing info from `agent_sandboxes`; core routing logic is correct and well-guarded, but there are open concerns around the server-error exit flow and the shutdown close-error log path. |
| cloud/packages/scripts/daemons/shared/load-env.ts | Extraction of the env-file loader from provisioning-worker into a shared module; logic is unchanged, correctly guards against overwriting existing process.env entries. |
| cloud/packages/scripts/eliza-agent-router.service | Systemd unit with solid hardening (ProtectSystem=strict, PrivateTmp, NoNewPrivileges); mirrors the provisioning-worker pattern. Missing trailing newline (noted in existing thread). |
| .github/workflows/deploy-eliza-provisioning-worker.yml | Deploy workflow extended to install/enable/restart the agent-router unit and probe `/healthz` before declaring the deploy healthy; health-check fallback port logic is correct. |
| cloud/packages/scripts/daemons/provisioning-worker.ts | Minor refactor: inline `loadLocalEnv` replaced with the new shared `loadLocalEnv(import.meta.url)` call; no behavioural change. |
| cloud/packages/tests/unit/agent-router.test.ts | 8 sociable unit tests covering the main routing logic paths including the explicit null-return for port-less bridge URLs; good coverage of config parsing edge cases. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant nginx as nginx Lua
    participant router as agent-router :3458
    participant db as Postgres (agent_sandboxes)
    participant sandbox as Agent Sandbox

    nginx->>router: GET /agents/:id/headscale-ip (or /routing)
    router->>router: validate UUID format
    router->>db: agentSandboxesRepository.findById(id)
    db-->>router: "{ status, bridge_url, web_ui_port }"
    alt "status == running && bridge_url has explicit port"
        router-->>nginx: "200 { headscaleIp, bridgePort, webUiPort, target }"
        nginx->>sandbox: proxy to target
    else not found / not running / bad URL
        router-->>nginx: "404 { error }"
    end

    Note over router: GET /healthz → 200 { ok: true } (no DB call)
```

<sub>Reviews (2): Last reviewed commit: ["clean(agent-router): extract shared load..."](https://github.com/elizaos/eliza/commit/16d52ea7f1cd0526929815a291d3aa82224d206b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31401757)</sub>

<!-- /greptile_comment -->