### PR TITLE
fix(plugins): normalize entry paths to forward-slashes for fast-glob on Windows

### DIFF
--- a/plugins/tsup.plugin-packages.shared.ts
+++ b/plugins/tsup.plugin-packages.shared.ts
@@ -36,7 +36,7 @@ function collectSrcEntries(srcRoot: string): string[] {
         ) {
           continue;
         }
-        out.push(path.relative(resolvePackageRoot(), full));
+        out.push(path.relative(resolvePackageRoot(), full).split(path.sep).join("/"));
       }
     }
   };


### PR DESCRIPTION
## Summary

The shared tsup config emits entry paths via `path.relative()`, which on Windows produces backslash-separated paths like `src\index.ts`. tsup forwards entries to esbuild's fast-glob, which interprets backslashes as glob escape characters — so on Windows the entry list matches no files and every plugin/app-* package fails to build with errors like:

```
Cannot find src\client.ts,src\index.ts,src\plugin.ts,...
```

Normalize each entry to forward slashes via `.split(path.sep).join("/")` before pushing it to the entry list. POSIX paths are unchanged; Windows paths now match the file system.

## Reproduction

Clean checkout on Windows, then `bun install`. The postinstall task graph (turbo `build`) hits this on the first plugin or app-* package that has TSX entries (`app-vincent`, `app-companion`, etc.).

## Test plan

- [x] Repro: confirmed `Cannot find src\X` errors disappear after the patch on Windows.
- [x] No-op on POSIX: `path.sep === "/"` so the `.split(path.sep).join("/")` call is identity.
- [ ] Reviewer: spot-check one plugin's build on Linux to confirm no regression.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Windows-only build failure in the shared tsup config for plugins and app packages. When `path.relative()` produces backslash-separated paths on Windows, fast-glob interprets them as escape characters and fails to match any files, causing every plugin/app build to fail with "Cannot find" errors.

- Adds `.split(path.sep).join(\"/\")` to normalize backslash paths to forward slashes before they are passed to the entry list; the operation is a no-op on POSIX since `path.sep === \"/\"`.
- The fix is minimal (one line changed) and correctly targets the only call site where `path.relative()` feeds into the tsup/esbuild entry array.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line, platform-conditional no-op on Linux/macOS and directly fixes a broken build on Windows.

The fix is narrow and correct: it replaces the only call site where path.relative() output flows into tsup's entry array, and .split(path.sep).join('/') is an identity function on POSIX. No other logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/tsup.plugin-packages.shared.ts | Single-line fix normalizes path separators to forward slashes in collectSrcEntries; no logic changes elsewhere in the file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(plugins): normalize entry paths to f..."](https://github.com/elizaos/eliza/commit/e348eca9022121598451169b6d0c201acb5119cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31413777)</sub>

<!-- /greptile_comment -->