### PR TITLE
fix(plugin-pdf): use tsc.exe instead of tsc.cmd on Windows

### DIFF
--- a/plugins/plugin-pdf/build.ts
+++ b/plugins/plugin-pdf/build.ts
@@ -58,7 +58,7 @@ async function build(): Promise<void> {
     rootDir,
     "node_modules",
     ".bin",
-    process.platform === "win32" ? "tsc.cmd" : "tsc"
+    process.platform === "win32" ? "tsc.exe" : "tsc"
   );
 
   await $`${tscPath} --project tsconfig.build.json`;


### PR DESCRIPTION
## Summary

Bun creates `.exe` shims for binary dependencies on Windows, not `.cmd` shims. The DTS step in `build.ts` hard-codes `tsc.cmd` in the Windows branch, which fails with:

```
bun: command not found: ...\node_modules\.bin\tsc.cmd
```

Switch to `tsc.exe` so the DTS step finds the bun-managed TypeScript binary. Linux/macOS branch is unchanged.

## Reproduction

Clean Windows checkout, run `bun install` (which triggers `turbo build` → `@elizaos/plugin-pdf:build`).

## Test plan

- [x] Repro: `bun run build` now completes through the DTS step on Windows.
- [x] No-op on POSIX: the `win32` branch is unaffected on Linux/macOS.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a Windows-only build failure in `plugin-pdf` where Bun's `.exe` shim for `tsc` was being looked up as `.cmd`, causing the DTS generation step to fail. The one-line change in `build.ts` corrects the extension; the POSIX path is untouched.

- `plugins/plugin-pdf/build.ts`: changes `tsc.cmd` → `tsc.exe` in the `win32` branch of the tsc binary path construction.
- `plugins/plugin-ollama/build.ts` contains the identical `tsc.cmd` pattern and would fail on Windows under Bun for the same reason — that file was not updated in this PR.

<h3>Confidence Score: 4/5</h3>

The plugin-pdf fix is correct and safe to merge, but the identical broken pattern remains in plugin-ollama and will cause the same Windows build failure there.

The change in plugin-pdf is exactly right — Bun creates `.exe` shims on Windows, not `.cmd` shims, and the one-line fix resolves the reported failure. However, plugins/plugin-ollama/build.ts has the identical tsc.cmd reference on line 66 that this PR leaves untouched, meaning Windows users building plugin-ollama will hit the same error. The fix is incomplete across the repo.

plugins/plugin-ollama/build.ts — contains the same tsc.cmd pattern and needs the matching fix.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-pdf/build.ts | Correctly changes the Windows tsc binary extension from `.cmd` to `.exe` to match how Bun creates shims on Windows; POSIX path is untouched. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-ollama/build.ts`, line 62-67 ([link](https://github.com/elizaos/eliza/blob/87d07c6c3e7b8ae99e9588fd21ceba9a4c4f304e/plugins/plugin-ollama/build.ts#L62-L67)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Same `tsc.cmd` bug in plugin-ollama**

   `plugins/plugin-ollama/build.ts` has the identical Windows path issue — it still uses `tsc.cmd` on line 66. On a Bun-managed Windows install the DTS step here would fail with the same `bun: command not found: ...tsc.cmd` error that this PR fixes in `plugin-pdf`. The fix should be applied here too.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-pdf): use tsc.exe instead of ..."](https://github.com/elizaos/eliza/commit/87d07c6c3e7b8ae99e9588fd21ceba9a4c4f304e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31413793)</sub>

<!-- /greptile_comment -->