### PR TITLE
fix(schemas): exclude buf module cache (v3/) from buf source scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -249,6 +249,10 @@ packages/python/elizaos/types/generated/
 packages/rust/src/types/generated/
 packages/rust/.cargo-tools/
 
+# buf module cache (populated by `buf build` / `buf mod update`,
+# excluded from the buf source scan via packages/schemas/buf.yaml).
+packages/schemas/v3/
+
 # i18n keyword codegen (regenerated from keywords/*.keywords.json)
 packages/shared/src/i18n/generated/
 packages/core/src/i18n/generated/

--- a/packages/schemas/buf.yaml
+++ b/packages/schemas/buf.yaml
@@ -5,6 +5,7 @@ modules:
     name: buf.build/elizaos/eliza
     excludes:
       - node_modules
+      - v3
 lint:
   use:
     - STANDARD


### PR DESCRIPTION
## Summary

When buf populates its local module cache under `packages/schemas/v3/` (`modules/`, `plugins/`, etc.), buf re-scans that cache as part of the source module because `buf.yaml` only excludes `node_modules`. The cached `google/api/*.proto` files then collide with the same files imported via the `deps: googleapis` declaration, producing duplicate-field-number errors during `buf generate`:

```
google/api/client.proto:78:25:field number `1049` used more than once
google/api/client.proto:100:25:field number `1050` used more than once
google/api/resource.proto:30:53:field number `1055` used more than once
google/api/resource.proto:36:64:field number `1053` used more than once
```

The `v3/` directory is buf's internal cache and never source — exclude it from the module scan so cached `google/api` protos can't shadow the ones resolved through `deps`.

## Test plan

- [x] Repro: with `v3/` populated locally, `bun run build` (which runs `buf generate`) fails with the duplicate-field-number errors above. After the patch, the build succeeds.
- [x] No regression when `v3/` is absent (default fresh checkout): `buf` finds no source files at `v3/` and the exclude is a no-op.

The cache appears in checkouts where buf has been invoked locally; CI may not see it because of cache layout differences. Worth landing defensively.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a build-time collision in `packages/schemas` where buf's local module cache (`v3/`) was being treated as proto source, causing duplicate field-number errors when `google/api/*.proto` files in the cache shadowed the same files pulled in via the `deps: googleapis` declaration.

- **`packages/schemas/buf.yaml`**: Adds `v3` to the module `excludes` list so buf does not scan the BSR cache directory as source, eliminating the duplicate-field-number errors during `buf generate`.
- **`.gitignore`**: Adds `packages/schemas/v3/` to the root ignore list with a descriptive comment, preventing the populated cache from being accidentally committed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are purely additive and defensive, with no risk of breaking existing builds.

The fix is minimal and targeted: one line added to `buf.yaml` excludes, one line added to `.gitignore`. The exclude is a no-op on fresh checkouts where `v3/` doesn't exist, and on checkouts where it does exist it removes the source of the duplicate-field collision. There are no logic changes, no API surface changes, and no risk of regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/schemas/buf.yaml | Adds `v3` to the buf module excludes list, preventing the local BSR cache from being scanned as proto source and causing duplicate-field-number collisions with googleapis deps. |
| .gitignore | Adds `packages/schemas/v3/` to the root `.gitignore` with a descriptive comment, preventing the buf module cache from being accidentally staged and committed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buf generate] --> B{Scan module path '.'
in packages/schemas/}
    B --> C[excludes: node_modules]
    B --> D[excludes: v3 NEW]
    B --> E[Proto source files
e.g. *.proto]
    C --> F[Skipped]
    D --> G[Skipped buf BSR cache]
    E --> H[Resolve deps:
buf.build/googleapis/googleapis]
    H --> I[Merged proto graph]
    I --> J[buf generate succeeds]
```

<sub>Reviews (2): Last reviewed commit: ["chore(gitignore): exclude packages/schem..."](https://github.com/elizaos/eliza/commit/ec174cb4d0bc22814cf859a30ced06561f8bda87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31413819)</sub>

<!-- /greptile_comment -->