### PR TITLE
fix(app-lifeops): expose ./platform and ./components/* via exports map

### DIFF
--- a/plugins/app-lifeops/package.json
+++ b/plugins/app-lifeops/package.json
@@ -30,9 +30,24 @@
       "default": "./dist/platform/index.js"
     },
     "./components/*": {
-      "types": "./src/components/*.ts",
+      "types": "./src/components/*.tsx",
       "import": "./dist/components/*.js",
       "default": "./dist/components/*.js"
+    },
+    "./components/*/*": {
+      "types": "./src/components/*/*.tsx",
+      "import": "./dist/components/*/*.js",
+      "default": "./dist/components/*/*.js"
+    },
+    "./components/*/*/*": {
+      "types": "./src/components/*/*/*.tsx",
+      "import": "./dist/components/*/*/*.js",
+      "default": "./dist/components/*/*/*.js"
+    },
+    "./components/*/*/*/*": {
+      "types": "./src/components/*/*/*/*.tsx",
+      "import": "./dist/components/*/*/*/*.js",
+      "default": "./dist/components/*/*/*/*.js"
     },
     "./inbox/types": {
       "types": "./src/inbox/types.ts",

--- a/plugins/app-lifeops/package.json
+++ b/plugins/app-lifeops/package.json
@@ -24,6 +24,16 @@
       "import": "./dist/client.js",
       "default": "./dist/client.js"
     },
+    "./platform": {
+      "types": "./src/platform/index.ts",
+      "import": "./dist/platform/index.js",
+      "default": "./dist/platform/index.js"
+    },
+    "./components/*": {
+      "types": "./src/components/*.ts",
+      "import": "./dist/components/*.js",
+      "default": "./dist/components/*.js"
+    },
     "./inbox/types": {
       "types": "./src/inbox/types.ts",
       "import": "./dist/inbox/types.js",


### PR DESCRIPTION
## Summary

The `@elizaos/app-lifeops` package ships `src/platform/` and `src/components/` directories with matching `dist/` output, but the `exports` map omits both subpaths. Any consumer that imports them — including the official entry point in `apps/app/src/main.tsx`, which does:

```ts
import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from
  "@elizaos/app-lifeops/platform";
import { LifeOpsActivitySignalsEffect } from
  "@elizaos/app-lifeops/components/LifeOpsActivitySignalsEffect";
```

— hits Vite/Node `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Changes

Add an explicit `./platform` export pointing at the existing `src/platform/index.ts` ↔ `dist/platform/index.js` pair, and a `./components/*` wildcard pattern matching the existing per-component layout. `types`/`import`/`default` are wired identically to neighbouring exports.

## Test plan

- [x] Repro: Vite dev server fails to resolve `@elizaos/app-lifeops/platform` from `apps/app/src/main.tsx`. After patch, resolve succeeds.
- [x] `@elizaos/app-lifeops/components/LifeOpsActivitySignalsEffect` resolves through the wildcard.
- [x] Existing exports unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `./platform` and `./components/*` (with wildcards up to four levels deep) to the `exports` map of `@elizaos/app-lifeops`, fixing `ERR_PACKAGE_PATH_NOT_EXPORTED` errors that blocked Vite and Node from resolving those subpaths.

- `./platform` is wired correctly to the existing `src/platform/index.ts` ↔ `dist/platform/index.js` pair.
- The four-tier `./components` wildcard ladder covers the majority of component files, but `src/components/chat/widgets/plugins/shared/use-lifeops-overview-data.ts` sits five levels deep and remains unreachable — a fifth wildcard entry (`./components/*/*/*/*/*`) is needed.
- `src/components/lifeops-labels.ts` is a plain `.ts` file; the `./components/*` pattern resolves `types` to `*.tsx`, so TypeScript cannot find its declarations and the import falls through to `any`.

<h3>Confidence Score: 3/5</h3>

Two component paths remain unresolvable after this patch: a depth-5 nested file is still unreachable at runtime, and a `.ts`-suffixed source file loses its TypeScript types through the wildcard.

The `./platform` export is correct and unambiguous. However, `src/components/chat/widgets/plugins/shared/use-lifeops-overview-data.ts` sits five segments below `components/` while the deepest wildcard only reaches four, leaving that import broken at runtime. Separately, `src/components/lifeops-labels.ts` has a plain `.ts` extension while every `./components/*` wildcard points `types` at `*.tsx`, so TypeScript silently loses type information for that module.

plugins/app-lifeops/package.json — the new wildcard export entries need a fifth-depth pattern and a `.ts` fallback for the `types` condition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/app-lifeops/package.json | Adds `./platform` and multi-depth `./components/*` wildcard exports; depth-5 nested file and a `.ts`-extension source file are not fully covered by the new patterns. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@elizaos/app-lifeops/platform"] --> B["dist/platform/index.js ✅"]
    C["@elizaos/app-lifeops/components/ComponentName"] --> D["./components/* → dist/components/*.js ✅"]
    E["@elizaos/app-lifeops/components/lifeops-labels"] --> F["types → src/components/lifeops-labels.tsx ❌ (file is .ts)"]
    G["@elizaos/app-lifeops/components/chat/widgets/plugins/Comp"] --> H["./components/*/*/*/* (depth 4) ✅"]
    I["@elizaos/app-lifeops/components/chat/widgets/plugins/shared/use-lifeops-overview-data"] --> J["No matching export (depth 5) ❌ ERR_PACKAGE_PATH_NOT_EXPORTED"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(app-lifeops): use .tsx for types map..."](https://github.com/elizaos/eliza/commit/cf399657e0836d5ce535debba41d2556ab881b8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31413841)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->