### PR TITLE
fix(plugin-n8n-workflow): import register-routes side effect from index.ts

### DIFF
--- a/plugins/plugin-n8n-workflow/src/index.ts
+++ b/plugins/plugin-n8n-workflow/src/index.ts
@@ -8,6 +8,11 @@ import {
   pendingDraftProvider,
 } from './providers/index';
 import { n8nRoutes } from './routes/index';
+// Side-effect: register the rawPath route plugin (`@elizaos/plugin-n8n-workflow:routes`)
+// with the app-route-plugin-registry so the runtime mounts /api/n8n/* on the
+// host HTTP server. Without this import the registry call in register-routes.ts
+// never fires and every /api/n8n/* request returns 404.
+import './register-routes';
 
 /**
  * n8n Workflow Plugin for ElizaOS


### PR DESCRIPTION
## Summary

`@elizaos/plugin-n8n-workflow` ships its HTTP routes (`/api/n8n/*`) through a side-effect file that no one imports, so the routes are never mounted and every `/api/n8n/*` request returns 404 — including `/api/n8n/workflows/generate`, which the Automations UI hits when a user clicks **Describe your workflow**.

## Root cause

The plugin is split across three files:

| File | Exports | Role |
|---|---|---|
| `src/index.ts` | `n8nWorkflowPlugin` | services / actions / providers / runtime routes |
| `src/plugin-routes.ts` | `n8nWorkflowRoutePlugin` | `rawPath` `/api/n8n/*` HTTP route plugin |
| `src/register-routes.ts` | side effect | calls `registerAppRoutePluginLoader('@elizaos/plugin-n8n-workflow:routes', ...)` |

The runtime mounts `/api/n8n/*` by enumerating loaders that have been added via `registerAppRoutePluginLoader` (see `packages/app-core/src/runtime/eliza.ts` → `getAppRoutePluginLoaders`). `register-routes.ts` is the only thing that registers the n8n loader.

But nothing in the runtime imports `@elizaos/plugin-n8n-workflow/register-routes`. The other app-route plugins (`app-polymarket`, `app-hyperliquid`, etc.) sidestep this because they're declared in the app registry at `packages/app-core/src/registry/entries/apps/`, which makes the runtime call their loader specifier directly. The n8n plugin is **not** registry-backed; it relies on the side-effect import — which means the side-effect file must actually be loaded.

## Fix

Add `import './register-routes'` at the top of `src/index.ts` so the side effect fires whenever the plugin is loaded.

## Verification

Before:
```
GET  /api/n8n/status              → 404
GET  /api/n8n/workflows           → 404
POST /api/n8n/workflows/generate  → 404
```

After (`bun run dev`):
```
[eliza] Registered app route plugin: @elizaos/plugin-n8n-workflow:routes (9 routes)
GET  /api/n8n/status              → 200
GET  /api/n8n/workflows           → 200
POST /api/n8n/workflows/generate  → 400  (validation; was 404)
```

Confirmed by clicking **Describe your workflow** in the Automations UI: the request now reaches the route handler instead of falling through to the catch-all 404.

## Test plan

- [x] Boot dev server, observe registration log
- [x] Hit `/api/n8n/status`, `/workflows`, `/workflows/generate` directly
- [x] Click Automations UI 'Describe your workflow' button — POST lands at handler
- [x] No-op for callers that already imported `./register-routes` separately

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes missing HTTP route registration for the n8n workflow plugin by adding a single side-effect import (`import './register-routes'`) to `src/index.ts`. Without it, `registerAppRoutePluginLoader` was never called for `@elizaos/plugin-n8n-workflow:routes`, so every `/api/n8n/*` request fell through to a 404.

- **Root cause fixed**: `register-routes.ts` existed but was never executed because nothing imported it; the plugin is not registry-backed like the other app-route plugins, so its loader had to be self-registered.
- **Safe duplicate handling**: The underlying registry uses a `Map.set` keyed by loader ID, so if any caller already imports `./register-routes` separately the entry is simply overwritten with an identical value — no double-mount risk.
- **Scope**: One line added in one file, with a thorough explanatory comment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line import that wires up an already-written side-effect file, and the underlying registry handles re-registration gracefully.

The fix is minimal, well-understood, and has no edge cases: adding the side-effect import to `index.ts` is the correct way to ensure `registerAppRoutePluginLoader` is called when the plugin loads. The registry uses `Map.set` so any accidental double-import is harmless. No logic is changed, no new code is introduced, and the PR description includes manual end-to-end verification.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/index.ts | Adds `import './register-routes'` so the app-route-plugin-registry side effect fires whenever the plugin is loaded, fixing 404s on all `/api/n8n/*` routes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runtime
    participant index.ts
    participant register-routes.ts
    participant Registry as app-route-plugin-registry
    participant plugin-routes.ts

    Runtime->>index.ts: "import @elizaos/plugin-n8n-workflow"
    index.ts->>register-routes.ts: import (side effect)
    register-routes.ts->>Registry: registerAppRoutePluginLoader(...)
    Registry-->>register-routes.ts: stored in Map

    Note over Runtime,Registry: Later — route mounting phase
    Runtime->>Registry: listAppRoutePluginLoaders()
    Registry-->>Runtime: [...entries] including n8n entry
    Runtime->>plugin-routes.ts: loader()
    plugin-routes.ts-->>Runtime: n8nWorkflowRoutePlugin (9 routes)
    Runtime->>Runtime: "mount /api/n8n/* routes"
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-n8n-workflow): import registe..."](https://github.com/elizaos/eliza/commit/1da04493d963e6d50fa58ce308a9dbbd58e15146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31419508)</sub>

<!-- /greptile_comment -->