### PR TITLE
fix(plugin-elizacloud): inject params.schema into prompt for OBJECT_SMALL/LARGE

### DIFF
--- a/plugins/plugin-elizacloud/models/object.ts
+++ b/plugins/plugin-elizacloud/models/object.ts
@@ -131,14 +131,32 @@ async function generateObjectByModelType(
     content: [{ type: "input_text", text: params.prompt }],
   });
 
+  // Enforce JSON output at the API layer. Without this, the model can return
+  // prose ("I'll help you...") or markdown-fenced JSON, both of which choke
+  // the JSON.parse below.
+  //
+  // When the caller passes a `schema`, inject it into the prompt so the
+  // model receives the exact shape it must produce. The previous
+  // `json_object`-only mode silently dropped `params.schema`, so callers that
+  // asked for `{ keywords: [...] }` would get back `keywords: [...]` (no
+  // braces) or a free-form prose answer that fails downstream `JSON.parse`.
+  // Schema-in-prompt works across the whole cloud provider matrix (OpenAI,
+  // Anthropic, etc.) where the Responses API `json_schema` format is not
+  // uniformly supported.
+  if (params.schema) {
+    const lastUserMsg = input[input.length - 1];
+    if (lastUserMsg && lastUserMsg.role === "user") {
+      const schemaDirective = `\n\nReturn ONLY a valid JSON value (no prose, no markdown fences) that matches this JSON Schema exactly:\n${JSON.stringify(params.schema)}`;
+      lastUserMsg.content = lastUserMsg.content.map((part) => ({
+        ...part,
+        text: part.text + schemaDirective,
+      }));
+    }
+  }
   const requestBody: Record<string, unknown> = {
     model: modelName,
     input,
     max_output_tokens: params.maxTokens ?? 8192,
-    // Enforce JSON output at the API layer. Without this, the model
-    // can ignore the caller's `schema` parameter and return prose
-    // ("I'll help you...") or markdown-fenced JSON, both of which
-    // choke the JSON.parse below.
     text: { format: { type: "json_object" } },
   };
   if (!reasoning && typeof params.temperature === "number") {

--- a/plugins/plugin-elizacloud/models/object.ts
+++ b/plugins/plugin-elizacloud/models/object.ts
@@ -147,10 +147,17 @@ async function generateObjectByModelType(
     const lastUserMsg = input[input.length - 1];
     if (lastUserMsg && lastUserMsg.role === "user") {
       const schemaDirective = `\n\nReturn ONLY a valid JSON value (no prose, no markdown fences) that matches this JSON Schema exactly:\n${JSON.stringify(params.schema)}`;
-      lastUserMsg.content = lastUserMsg.content.map((part) => ({
-        ...part,
-        text: part.text + schemaDirective,
-      }));
+      const firstTextIdx = lastUserMsg.content.findIndex(
+        (p) => p.type === "input_text"
+      );
+      if (firstTextIdx !== -1) {
+        const part = lastUserMsg.content[firstTextIdx];
+        lastUserMsg.content = [
+          ...lastUserMsg.content.slice(0, firstTextIdx),
+          { ...part, text: part.text + schemaDirective },
+          ...lastUserMsg.content.slice(firstTextIdx + 1),
+        ];
+      }
     }
   }
   const requestBody: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

The Responses API call for `OBJECT_SMALL` / `OBJECT_LARGE` silently drops the caller's `schema` parameter. Without the schema, the model only sees the `json_object` format directive and emits free-form output that either wraps the requested shape in prose ("What you want is...") or omits the surrounding object braces (`keywords: [...]`) — both of which fail the downstream `JSON.parse` with:

```
Keyword extraction failed: JSON Parse error: Unexpected identifier "keywords"
Keyword extraction failed: JSON Parse error: Unexpected identifier "What"
```

Symptom in production: `POST /api/n8n/workflows/generate` returns a 500 with that error every time, blocking workflow generation through Eliza Cloud entirely.

## Why not Responses API `json_schema` format?

The OpenAI Responses API supports `text.format = { type: "json_schema", schema: ... }` for strict-schema enforcement. Tried that first — it gets silently ignored or rejected when the cloud gateway routes to a non-OpenAI backend (Anthropic, in particular, has no equivalent concept). Coupling `json_schema` with `json_object` doesn't help: the `json_schema` block is parsed by the gateway and either passed through (OpenAI path) or stripped (Anthropic path), and the model behavior diverges across providers.

## Fix

Inject the schema into the user message as an explicit directive before sending to the Responses API:

```
{user prompt}

Return ONLY a valid JSON value (no prose, no markdown fences) that matches this JSON Schema exactly:
{...JSON.stringify(schema)}
```

Schema-in-prompt works across the whole cloud provider matrix. Combined with the existing `text.format = json_object` guarantee, this gives reliable structured output regardless of which backend the cloud routes to.

## Verification

End-to-end via the n8n workflow generator:

```bash
curl -X POST .../api/n8n/workflows/generate   -d '{"prompt":"Send a Slack message to #general saying hello"}'
```

Before: `{"error":"Keyword extraction failed: JSON Parse error: Unexpected identifier \"keywords\""}`

After: a real n8n workflow draft with Slack node, clarification asking for the channel ID, full graph + connections — the keyword extractor's Cloud call returns parseable JSON matching the schema.

## Test plan

- [x] `runtime.useModel(ModelType.OBJECT_SMALL, { prompt, schema })` produces JSON matching schema (verified via n8n keyword extraction)
- [x] `runtime.useModel(ModelType.OBJECT_SMALL, { prompt })` (no schema) unchanged — falls through to bare `json_object` directive
- [x] No client-visible behavior change for callers that already wrap their prompt with schema text manually — the directive is just appended

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production bug in `plugin-elizacloud` where `OBJECT_SMALL`/`OBJECT_LARGE` model calls silently discarded the caller's `schema` parameter when invoking the Responses API, causing `JSON.parse` failures on workflow generation endpoints.

- **Schema injection**: When `params.schema` is present, the fix appends a structured JSON Schema directive to the first `input_text` content part of the last user message before the API call, giving the model the exact shape it must produce.
- **Cross-provider approach**: Inlining the schema in the prompt (instead of using the Responses API `json_schema` format) ensures consistent behavior across OpenAI and Anthropic-routed cloud backends, which handles the schema directive differently.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the change is narrowly scoped to injecting an optional schema directive into the prompt and does not alter any existing code paths for callers that omit the schema.

The fix correctly mutates the input array in place before the API call, targets only the first input_text content part, and is fully guarded by if (params.schema) so callers without a schema are unaffected. The JSONSchema type is a plain serializable data object, so JSON.stringify is safe. No control flow, error handling, or API contract is changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-elizacloud/models/object.ts | Adds targeted schema injection into the prompt when params.schema is provided; correctly targets the first input_text content part and mutates the input array in place before the API call. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant generateObjectByModelType
    participant CloudAPI as Eliza Cloud Responses API
    participant JSONParser

    Caller->>generateObjectByModelType: "useModel(OBJECT_SMALL, { prompt, schema })"
    generateObjectByModelType->>generateObjectByModelType: Build input array (system + user messages)
    alt params.schema present
        generateObjectByModelType->>generateObjectByModelType: Find first input_text part in last user message
        generateObjectByModelType->>generateObjectByModelType: Append schema directive to part.text
    end
    generateObjectByModelType->>CloudAPI: "POST /responses { input, text.format: json_object }"
    CloudAPI-->>generateObjectByModelType: Raw response text
    generateObjectByModelType->>JSONParser: extractFirstBalancedJsonValue(text)
    JSONParser-->>generateObjectByModelType: Isolated JSON value
    generateObjectByModelType->>JSONParser: JSON.parse(jsonText)
    alt parse succeeds
        JSONParser-->>generateObjectByModelType: "Record<string, JsonValue>"
    else parse fails
        generateObjectByModelType->>generateObjectByModelType: jsonRepair fallback
    end
    generateObjectByModelType-->>Caller: Structured object
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-elizacloud): target text part..."](https://github.com/elizaos/eliza/commit/2f33f4661c1f02edcfa5aa0561a82fb2f6063255) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31421444)</sub>

<!-- /greptile_comment -->