### PR TITLE
fix(chat): keep message-action rail inside bubble on narrow viewports

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -504,9 +504,15 @@ export const ChatMessage = memo(function ChatMessage({
             <div
               className={cn(
                 "absolute top-0 flex items-center gap-1 transition-opacity duration-200",
+                // Below the `sm` breakpoint (narrow phones) anchor the
+                // action rail to the bubble's top-right corner so it can
+                // never overflow the viewport. From `sm` up the rail
+                // floats outside the bubble (left of right-aligned user
+                // bubbles, right of left-aligned bot bubbles) where there
+                // is enough horizontal room.
                 isRightAligned
-                  ? "left-0 -translate-x-full"
-                  : "right-0 translate-x-full",
+                  ? "right-1 sm:right-auto sm:left-0 sm:-translate-x-full"
+                  : "right-1 sm:right-0 sm:translate-x-full",
                 actionsVisible
                   ? "opacity-100"
                   : "pointer-events-none opacity-0",


### PR DESCRIPTION
# Risks

Low. Two-line change to one Tailwind class string in `packages/ui/src/components/composites/chat/chat-message.tsx`. From the `sm` breakpoint up (640px+), classes resolve to the existing desktop behaviour. Below `sm`, position changes to anchor inside the bubble's top-right corner.

# Background

## What does this PR do?

The message-action rail (Copy / Play / Edit / Delete) was absolutely positioned **outside** the bubble using `translate-x-full`:

- Right-aligned user bubble → rail floats to the LEFT of the bubble (`left-0 -translate-x-full`).
- Left-aligned bot bubble → rail floats to the RIGHT of the bubble (`right-0 translate-x-full`).

On narrow phone viewports (Capacitor Android build, e.g. Solana Seeker) bot-side bubbles extend close to the right viewport edge. The rail then projects past the screen — the Copy / Play buttons render off-screen and aren't tappable.

Below the `sm` breakpoint we now anchor the rail at `right-1` (inside the bubble's top-right corner), so it stays inside the viewport on both sides. From `sm` up the existing outside-the-bubble desktop layout is preserved verbatim.

## What kind of change is this?

Bug fix.

## Why?

Reproduced on a Capacitor Android build paired against a remote agent. After the safe-area inset PR (#7496) the bubble area now respects the system bars, but the action rail was still escaping the right edge — most consistently on bot replies. The mobile-first anchor pattern (rail inside the bubble corner) is the standard for native chat clients (Telegram, Discord, iMessage) and is what users expect on small viewports.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/composites/chat/chat-message.tsx` — only the action-rail wrapper's className changes:

```diff
-isRightAligned
-  ? "left-0 -translate-x-full"
-  : "right-0 translate-x-full"
+isRightAligned
+  ? "right-1 sm:right-auto sm:left-0 sm:-translate-x-full"
+  : "right-1 sm:right-0 sm:translate-x-full"
```

Comment block above documents the intent.

## Detailed testing steps

Verified on a Solana Seeker (Android 16, Capacitor 8.3.1) Capacitor build:

1. Send a long-ish bot reply that fills most of the bubble width.
2. Hover/long-press to surface the action rail.
3. Before: rail clipped beyond the viewport's right edge — Copy / Play unreachable.
4. After: rail anchors inside the bubble's top-right corner, fully visible.

Desktop / web rendering at `sm` and above is unchanged — same `translate-x-full` outside-the-bubble layout.

## Screenshots

### Before
Bot bubble's action rail extending past the right viewport edge; Copy / Play icons clipped.

### After
Rail anchored inside the bubble's top-right corner, all four icons fully visible.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a mobile viewport overflow bug where the message action rail (Copy / Play / Edit / Delete) escaped the right edge of the screen on narrow phones, making buttons unreachable. The fix uses Tailwind responsive prefixes to anchor the rail inside the bubble's top-right corner below the `sm` breakpoint while preserving the existing outside-bubble desktop layout at `sm` and above.

- On mobile (below 640 px) the rail is now `right-1 top-0` relative to the `ChatBubble` wrapper for both user and bot messages, keeping all buttons within the viewport.
- On desktop (`sm`+) the behaviour is unchanged: right-aligned user bubbles float the rail to the left (`left-0 -translate-x-full`) and bot bubbles float it to the right (`right-0 translate-x-full`).

<h3>Confidence Score: 5/5</h3>

A two-line Tailwind class change scoped to one component with no logic alterations; desktop rendering is unchanged and the mobile fix directly addresses a reproduced overflow bug.

The change is minimal and purely presentational — no logic, state, or data flow is touched. The responsive class sequence is CSS-correct: sm:right-auto properly clears the mobile right-1 before sm:left-0 takes over on the right-aligned branch. The ChatBubble wrapper already carries relative so absolute positioning resolves against it as expected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/composites/chat/chat-message.tsx | Action-rail wrapper className updated with responsive Tailwind classes to anchor the rail inside the bubble on narrow viewports and preserve the existing outside-bubble layout at sm breakpoint and above. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Viewport width] -->|below sm / 640px| B[Mobile layout]
    A -->|sm and above| C[Desktop layout]

    B --> D["Rail anchored inside bubble\nright-1 top-0\n(both user & bot)"]

    C --> E{isRightAligned?}
    E -->|user bubble| F["Rail floats LEFT of bubble\nleft-0 -translate-x-full"]
    E -->|bot bubble| G["Rail floats RIGHT of bubble\nright-0 translate-x-full"]

    D --> H[All buttons visible within viewport]
    F --> I[Rail outside bubble, room on left]
    G --> J[Rail outside bubble, room on right]
```

<sub>Reviews (1): Last reviewed commit: ["fix(chat): keep message-action rail insi..."](https://github.com/elizaos/eliza/commit/69800f78a9a51252e4bf7a1de52ee3938252e359) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31421511)</sub>

<!-- /greptile_comment -->