### PR TITLE
fix(shell): collapse empty mobile header row on non-chat tabs

### DIFF
--- a/packages/app-core/src/components/shell/Header.tsx
+++ b/packages/app-core/src/components/shell/Header.tsx
@@ -626,7 +626,14 @@ export function Header({
           <div
             className={
               isMobileViewport
-                ? "grid min-h-[2.75rem] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-2"
+                ? `grid ${
+                    mobileLeft ||
+                    breadcrumbNode ||
+                    chatInferenceNotice ||
+                    pageRightExtras
+                      ? "min-h-[2.75rem]"
+                      : "min-h-0"
+                  } grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-2`
                 : "grid min-h-[2.375rem] grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 px-3"
             }
             data-window-titlebar-padding={
@@ -654,7 +661,7 @@ export function Header({
                   className={
                     breadcrumbNode || chatInferenceNotice
                       ? "flex h-[2.375rem] min-w-0 items-center justify-center gap-2"
-                      : "pointer-events-none h-[2.375rem] min-w-0"
+                      : "pointer-events-none min-w-0"
                   }
                   data-testid={
                     showMacDesktopTitleBar


### PR DESCRIPTION
# Risks

Low. Conditional Tailwind classes on two grid wrappers in `packages/app-core/src/components/shell/Header.tsx`. Tabs that populate any of the three mobile slots (chat shell, character detail, etc.) keep the existing 44px row verbatim. Only tabs with all three slots empty get the collapse, and those previously rendered as a 44px black gap with no content.

# Background

## What does this PR do?

The mobile-viewport variant of the global Header always rendered a 44px row, even when none of the three column slots had content:

- `mobileLeft` (passed in by the chat shell, etc.)
- middle column = `breadcrumbNode || chatInferenceNotice` (computed)
- `pageRightExtras` (passed in by the chat shell, etc.)

Tabs that don't opt into any header chrome (Browser workspace, Wallet, Apps detail, Phone, Automations, etc.) ended up with an empty 44px sticky bar between the system status bar and their own page chrome — visible as a black gap above the page's first button row on the Browser tab and similar.

When all three slots are empty, drop the grid's `min-h-[2.75rem]` to `min-h-0` and let the centre column collapse to its natural height (no fixed `h-[2.375rem]`). The row then takes ~1px (the existing border-bottom) instead of 44px.

## What kind of change is this?

Bug fix.

## Why?

Reproduced visually on a Capacitor Android Solana Seeker build. Browser tab + several settings sub-pages had a noticeable empty bar between the system status bar and their content.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/components/shell/Header.tsx` — only the className expressions on the existing grid wrapper and the inner centre-column div change. No prop/contract changes, no behaviour changes for tabs that populate any slot.

```diff
-isMobileViewport
-  ? "grid min-h-[2.75rem] grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-2"
+isMobileViewport
+  ? `grid ${
+      mobileLeft ||
+      breadcrumbNode ||
+      chatInferenceNotice ||
+      pageRightExtras
+        ? "min-h-[2.75rem]"
+        : "min-h-0"
+    } grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-2`
```

```diff
-: "pointer-events-none h-[2.375rem] min-w-0"
+: "pointer-events-none min-w-0"
```

## Detailed testing steps

Verified on a Solana Seeker (Android 16, Capacitor 8.3.1):

1. Pair the app with a remote agent and reach `/chat`.
2. Tap the Chat tab → header retains its 44px row with hamburger / alert / show-tasks (`mobileLeft` + `chatInferenceNotice` + `pageRightExtras`).
3. Tap Browser, Wallet, Apps, Phone, Automations → header collapses to its border-bottom (1px). Page chrome (e.g. browser-workspace mobile pane switcher, URL row) sits directly under the system status bar.
4. PairingView (no-pair state) also benefits: previously had the same dead bar; now content starts right below the system status bar.

## Screenshots

### Before
~44px black bar between the system status bar and the page's first content row on Browser / Wallet / Phone / etc.

### After
Status bar sits directly above the page chrome; only a 1px border separates them where the empty header used to be.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visible 44 px empty bar on mobile (Capacitor) viewports for tabs that provide no header content by making the mobile grid wrapper's minimum height conditional on whether any of its three slots (`mobileLeft`, `breadcrumbNode` / `chatInferenceNotice`, `pageRightExtras`) are populated.

- The outer grid wrapper switches between `min-h-[2.75rem]` (any slot filled) and `min-h-0` (all slots empty) on mobile, collapsing the dead row to the existing `border-bottom` (~1 px).
- The redundant `h-[2.375rem]` is removed from the empty-centre-column class; on mobile the row height is already driven by the grid container or the non-empty left/right columns, and on desktop the container's own `min-h-[2.375rem]` is unaffected by this change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to two className expressions in the mobile branch and has no effect on desktop or any tab that populates a header slot.

Both min-h-[2.75rem] and min-h-0 are static string literals in a ternary, so Tailwind's JIT scanner picks them up without a safelist entry. The truthiness check mirrors the same guard already used for the centre-column class and for aria-hidden, so the logic is consistent with the existing pattern. Removing h-[2.375rem] from the empty-centre-column case is safe: on desktop the container's own min-h-[2.375rem] is unchanged, and on mobile the row height is driven by the left/right column content whenever any slot is filled. No prop contracts, no type changes, no behaviour change for populated tabs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/components/shell/Header.tsx | Adds conditional min-h-0 / min-h-[2.75rem] on the mobile grid wrapper and removes the redundant h-[2.375rem] from the empty centre-column class; collapses the 44 px mobile header row to ~1 px when all three content slots are empty. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Header renders] --> B{isMobileViewport?}
    B -- No --> C["Desktop layout — min-h fixed always"]
    B -- Yes --> D{"Any of mobileLeft, breadcrumbNode,\nchatInferenceNotice, pageRightExtras?"}
    D -- Yes --> E["min-h-2.75rem — 44px row with header chrome"]
    D -- No --> F["min-h-0 — row collapses to border-bottom only"]
    E --> G{"breadcrumbNode OR chatInferenceNotice?"}
    F --> H["Centre col: no explicit height, collapses with grid"]
    G -- Yes --> I["Centre col: flex h-2.375rem with content"]
    G -- No --> J["Centre col: pointer-events-none, no explicit height"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(shell): collapse empty mobile header..."](https://github.com/elizaos/eliza/commit/52ab686a59f093baa3da4a0bb242daa6367804eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31423092)</sub>

<!-- /greptile_comment -->