### PR TITLE
fix(n8n-workflow): tolerate name-keyed and unresolvable clarification paramPaths

### DIFF
--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
@@ -153,4 +153,17 @@ describe("applyResolutions", () => {
       expect(result.error).toContain("must be a string");
     }
   });
+
+  test("structurally invalid paramPath fails the batch (does not silently fall through to userNotes)", () => {
+    const draft: Record<string, unknown> = { nodes: [] };
+    const result = applyResolutions(draft, [
+      { paramPath: 'nodes["Unclosed', value: "X" },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("structurally invalid");
+      expect(result.paramPath).toBe('nodes["Unclosed');
+    }
+    expect((draft as any)._meta).toBeUndefined();
+  });
 });

--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect } from "bun:test";
+import {
+  setByDotPath,
+  applyResolutions,
+} from "../../src/lib/n8n-clarification";
+
+describe("setByDotPath", () => {
+  test("writes through a numeric array index (existing behavior)", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { name: "A", parameters: {} },
+        { name: "B", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, "nodes[1].parameters.channelId", "C-123");
+    expect((obj.nodes as any)[1].parameters.channelId).toBe("C-123");
+    expect((obj.nodes as any)[0].parameters).toEqual({});
+  });
+
+  test("resolves a string array segment by entry .name (n8n nodes)", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { name: "Webhook", parameters: { path: "/in" } },
+        { name: "Post to Slack", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, 'nodes["Post to Slack"].parameters.channelId', "C-42");
+    expect((obj.nodes as any)[1].parameters.channelId).toBe("C-42");
+    // Other nodes untouched
+    expect((obj.nodes as any)[0].parameters.path).toBe("/in");
+  });
+
+  test("resolves a string array segment by entry .id when name does not match", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { id: "uuid-slack", name: "Post to Slack", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, 'nodes["uuid-slack"].parameters.channelId', "C-99");
+    expect((obj.nodes as any)[0].parameters.channelId).toBe("C-99");
+  });
+
+  test("throws when string segment matches no element by name or id", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [{ name: "Webhook", parameters: {} }],
+    };
+    expect(() =>
+      setByDotPath(obj, 'nodes["Placeholder Notification"].parameters.x', "y"),
+    ).toThrow(/did not match any element by name\/id/);
+  });
+
+  test("dot identifiers still work end-to-end", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: 1 } } };
+    setByDotPath(obj, "a.b.c", 42);
+    expect((obj.a as any).b.c).toBe(42);
+  });
+});
+
+describe("applyResolutions", () => {
+  test("applies a name-keyed paramPath to the matching node", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [
+        { name: "Hourly Trigger", parameters: { rule: "everyHour" } },
+        { name: "Notify", parameters: {} },
+      ],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Notify"].parameters.channelId',
+        value: "discord-channel-1",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft.nodes as any)[1].parameters.channelId).toBe(
+      "discord-channel-1",
+    );
+  });
+
+  test("falls back to userNotes when paramPath references a non-existent node", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "Hourly Trigger", parameters: {} }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Placeholder Notification"].parameters',
+        value: "discord",
+      },
+    ]);
+    // Resolution doesn't fail the batch — the user's answer is preserved.
+    expect(result.ok).toBe(true);
+    const meta = (draft as any)._meta;
+    expect(meta).toBeDefined();
+    expect(meta.userNotes).toEqual(["discord"]);
+    // Workflow nodes untouched.
+    expect((draft.nodes as any).length).toBe(1);
+    expect((draft.nodes as any)[0].name).toBe("Hourly Trigger");
+  });
+
+  test("falls back to userNotes when paramPath descends into a non-object", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "X", parameters: "this is a string not an object" }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["X"].parameters.channelId',
+        value: "C-1",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft as any)._meta.userNotes).toEqual(["C-1"]);
+  });
+
+  test("empty paramPath stores answer as userNote (existing behavior)", () => {
+    const draft: Record<string, unknown> = { nodes: [], connections: {} };
+    const result = applyResolutions(draft, [
+      { paramPath: "", value: "use email" },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft as any)._meta.userNotes).toEqual(["use email"]);
+  });
+
+  test("multiple resolutions can mix successful path writes and userNote fallbacks", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "Real Node", parameters: {} }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Real Node"].parameters.target',
+        value: "ok",
+      },
+      {
+        paramPath: 'nodes["Imaginary Node"].parameters.target',
+        value: "fallback",
+      },
+      { paramPath: "", value: "free-form note" },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft.nodes as any)[0].parameters.target).toBe("ok");
+    expect((draft as any)._meta.userNotes).toEqual([
+      "fallback",
+      "free-form note",
+    ]);
+  });
+
+  test("non-string value still rejects the batch (validation, not path failure)", () => {
+    const draft: Record<string, unknown> = { nodes: [] };
+    const result = applyResolutions(draft, [
+      // @ts-expect-error — testing runtime guard
+      { paramPath: "x", value: 42 },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+});

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -285,18 +285,33 @@ export function applyResolutions(
       appendUserNote(draft, r.value);
       continue;
     }
+    // Surface structural parse errors (unterminated bracket, empty
+     // identifier, etc.) up to the caller as a 400 — these signal a
+     // malformed LLM emission and cannot be silently recovered into
+     // userNotes without losing the failure mode in the metrics pipeline.
+    try {
+      parseParamPath(r.paramPath);
+    } catch (err) {
+      return {
+        ok: false,
+        error: `paramPath is structurally invalid: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        paramPath: r.paramPath,
+      };
+    }
     try {
       setByDotPath(draft, r.paramPath, r.value);
     } catch (err) {
-      // The LLM occasionally emits a paramPath that references a node it
-      // didn't actually create (e.g. "Placeholder Notification") or points
-      // at a parent scope rather than a leaf field. Failing the whole
-      // resolution batch with a 400 is a dead-end — the user has no way to
-      // recover without re-prompting from scratch. Instead, log a warn and
-      // record the answer as a free-form note so the next regeneration
-      // round can use it. The clarification still gets pruned by
-      // `pruneResolvedClarifications` because we keep the original
-      // paramPath in the resolutions list.
+      // Lookup-time failure: the path parsed cleanly but didn't resolve
+      // against the current draft (e.g. references a node the LLM didn't
+      // actually create, or points at a parent scope rather than a leaf
+      // field). Failing the whole resolution batch with a 400 is a
+      // dead-end — the user has no way to recover without re-prompting
+      // from scratch. Log a warn and record the answer as a free-form
+      // note so the next regeneration round can use it. The clarification
+      // still gets pruned by `pruneResolvedClarifications` because we
+      // keep the original paramPath in the resolutions list.
       const errMsg = err instanceof Error ? err.message : String(err);
       logger.warn(
         {
@@ -304,7 +319,7 @@ export function applyResolutions(
           err: errMsg,
           paramPath: r.paramPath,
         },
-        `setByDotPath failed for paramPath "${r.paramPath}"; recording "${r.value}" as a free-form note instead: ${errMsg}`
+        `setByDotPath failed for paramPath "${r.paramPath}"; recording "${r.value}" as a free-form note instead`
       );
       appendUserNote(draft, r.value);
       continue;

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -11,6 +11,7 @@
  * Kept out of `n8n-routes.ts` so the handlers stay focused on transport.
  */
 
+import { logger } from '@elizaos/core';
 import type {
   N8nClarificationRequest,
   N8nClarificationResolution,
@@ -141,14 +142,39 @@ export function parseParamPath(path: string): string[] {
 }
 
 /**
+ * Find the index of a named entry in an array of objects, matching against
+ * `.name` first then `.id`. Returns -1 if no match. Used by `setByDotPath`
+ * to resolve `nodes["My Node"]`-style segments — the LLM consistently
+ * addresses n8n nodes by their human name even though `workflow.nodes` is
+ * an array, so we map name → index here rather than rejecting the path.
+ */
+function findArrayIndexByNameOrId(arr: unknown[], key: string): number {
+  for (let i = 0; i < arr.length; i += 1) {
+    const entry = arr[i];
+    if (entry === null || typeof entry !== 'object') continue;
+    const obj = entry as Record<string, unknown>;
+    if (obj.name === key || obj.id === key) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Mutate `obj` so that its value at `paramPath` becomes `value`. Creates
  * intermediate plain objects as needed; never replaces an existing
  * non-object intermediate (those throw, since the path is invalid).
  *
- * Numeric segments index into arrays. If the segment expects an array but
- * the existing intermediate is a non-array object, we treat it as an
- * object key (n8n workflow shapes mix arrays and objects fairly freely;
- * we err on the side of preserving the existing structure).
+ * Segments that hit an array can be:
+ *   - numeric → direct index
+ *   - non-numeric (string) → looked up against the array's `.name` or `.id`
+ *     field. Common in LLM output for n8n workflows: the model writes
+ *     `nodes["Post to Slack"]` rather than `nodes[2]`. Treating that as a
+ *     hard failure forced every clarification resolution through a 400.
+ *
+ * If the segment expects an array but the existing intermediate is a non-
+ * array object, we treat it as an object key (n8n workflow shapes mix arrays
+ * and objects fairly freely; we err on the side of preserving structure).
  */
 export function setByDotPath(
   obj: Record<string, unknown>,
@@ -161,10 +187,17 @@ export function setByDotPath(
     const seg = segments[i];
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
-      if (!isArrayIndex) {
-        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
+      let idx: number;
+      if (isArrayIndex) {
+        idx = Number(seg);
+      } else {
+        idx = findArrayIndexByNameOrId(cur, seg);
+        if (idx < 0) {
+          throw new Error(
+            `paramPath segment "${seg}" did not match any element by name/id at depth ${i}`
+          );
+        }
       }
-      const idx = Number(seg);
       let next = cur[idx];
       if (next === undefined || next === null) {
         next = /^[0-9]+$/.test(segments[i + 1]) ? [] : {};
@@ -188,13 +221,46 @@ export function setByDotPath(
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
-    if (!/^[0-9]+$/.test(last)) {
-      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
+    if (/^[0-9]+$/.test(last)) {
+      cur[Number(last)] = value;
+      return;
     }
-    cur[Number(last)] = value;
+    const idx = findArrayIndexByNameOrId(cur, last);
+    if (idx < 0) {
+      throw new Error(
+        `paramPath terminal segment "${last}" did not match any element by name/id at array`
+      );
+    }
+    cur[idx] = value;
   } else {
     (cur as Record<string, unknown>)[last] = value;
   }
+}
+
+/**
+ * Append a free-form answer to `draft._meta.userNotes`. Used for
+ * clarifications with no `paramPath` AND as the fallback when
+ * `setByDotPath` can't resolve a paramPath against the current draft.
+ * Subsequent LLM regeneration rounds read these notes from `_meta` so the
+ * user's answer is preserved across the failure rather than discarded.
+ */
+function appendUserNote(draft: Record<string, unknown>, value: string): void {
+  const existingMeta = draft._meta;
+  const meta =
+    existingMeta && typeof existingMeta === 'object'
+      ? (existingMeta as Record<string, unknown>)
+      : {};
+  draft._meta = meta;
+
+  let notes: string[];
+  if (Array.isArray(meta.userNotes)) {
+    notes = meta.userNotes as string[];
+  } else {
+    notes =
+      meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
+    meta.userNotes = notes;
+  }
+  notes.push(value);
 }
 
 export function applyResolutions(
@@ -216,33 +282,32 @@ export function applyResolutions(
       // Free-form clarification with no field to wire into. Record the user's
       // answer under draft._meta.userNotes so subsequent LLM iterations can
       // consume the context, but don't mutate the workflow itself.
-      const draftRecord = draft as Record<string, unknown>;
-      const existingMeta = draftRecord._meta;
-      const meta =
-        existingMeta && typeof existingMeta === 'object'
-          ? (existingMeta as Record<string, unknown>)
-          : {};
-      draftRecord._meta = meta;
-
-      let notes: string[];
-      if (Array.isArray(meta.userNotes)) {
-        notes = meta.userNotes as string[];
-      } else {
-        notes =
-          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
-        meta.userNotes = notes;
-      }
-      notes.push(r.value);
+      appendUserNote(draft, r.value);
       continue;
     }
     try {
       setByDotPath(draft, r.paramPath, r.value);
     } catch (err) {
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-        paramPath: r.paramPath,
-      };
+      // The LLM occasionally emits a paramPath that references a node it
+      // didn't actually create (e.g. "Placeholder Notification") or points
+      // at a parent scope rather than a leaf field. Failing the whole
+      // resolution batch with a 400 is a dead-end — the user has no way to
+      // recover without re-prompting from scratch. Instead, log a warn and
+      // record the answer as a free-form note so the next regeneration
+      // round can use it. The clarification still gets pruned by
+      // `pruneResolvedClarifications` because we keep the original
+      // paramPath in the resolutions list.
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        {
+          src: 'plugin:n8n-workflow:clarification:applyResolutions',
+          err: errMsg,
+          paramPath: r.paramPath,
+        },
+        `setByDotPath failed for paramPath "${r.paramPath}"; recording "${r.value}" as a free-form note instead: ${errMsg}`
+      );
+      appendUserNote(draft, r.value);
+      continue;
     }
   }
   return { ok: true };


### PR DESCRIPTION
## Summary

Two LLM-emitted paramPath shapes were breaking clarification resolution with hard 400s, surfacing as raw error text in the Automations UI panel:

### 1. Name-keyed array indexing

The model writes `nodes[\"Post to Slack\"].parameters.channelId` — natural, since it addresses nodes by their human name. But `workflow.nodes` is an array, so the previous `setByDotPath` rejected any non-numeric segment with:

> paramPath segment \"Post to Slack\" is not a valid array index at depth 1

Resolve string segments against the array's `.name` field first, falling back to `.id`. Numeric segments still index directly.

### 2. Phantom node references

Sometimes the LLM asks a clarification (*\"How would you like to be notified?\"*) with a paramPath that points at a node it never actually created (`nodes[\"Placeholder Notification\"]`). Even with name resolution, the segment can't match. Previously this failed the whole batch with a 400 and the user had no recovery path.

Now `applyResolutions` catches the `setByDotPath` throw, logs a warn with the failing paramPath, and appends the user's answer to `draft._meta.userNotes` — the same sink the empty-paramPath free-form path already uses. The clarification gets pruned, the deploy proceeds, and the user's answer is preserved across the next regeneration round.

The userNotes-append logic is extracted into a reusable `appendUserNote` helper so both fallback paths (empty paramPath, failed paramPath) share one implementation.

## Test plan

- [x] **New test file** `__tests__/unit/n8n-clarification.test.ts` (11 tests):
  - numeric indexing (regression)
  - name-keyed indexing
  - id-keyed indexing
  - throws when no match (raw `setByDotPath` API contract)
  - dot identifiers still work
  - `applyResolutions` writes through name-keyed paths
  - `applyResolutions` falls back to userNotes on no-match
  - falls back to userNotes on descend-into-non-object
  - empty paramPath still goes to userNotes (regression)
  - mixed batch: real writes + userNote fallbacks coexist
  - non-string value still hard-fails (validation, not path bug)
- [x] 11/11 pass, 920 expect() calls across the plugin's unit suite (4 pre-existing failures elsewhere are unrelated — action/provider tests with module-not-found errors).
- [ ] Manual: click an Automations card with chained clarifications, type any value, click Apply — the panel should advance to the next clarification or deploy instead of showing a red \"not a valid array index\" error.

## Related

- Depends on #7506 (the route registration fix) for the resolve-clarification endpoint to be reachable in the first place.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two LLM-emitted `paramPath` shapes that caused hard 400 errors in the Automations UI: name-keyed array segments (`nodes["Post to Slack"]`) that `setByDotPath` previously rejected as non-numeric, and phantom node references that pointed at nodes the LLM never created. The fix adds `findArrayIndexByNameOrId` for name/id lookup in arrays, splits `applyResolutions` error handling into a structural pre-check (still a hard 400) and a lookup-time soft-fallback (routes the user's answer to `_meta.userNotes`), and extracts `appendUserNote` to share both fallback paths.

- `setByDotPath` now resolves bracketed string segments against array entries' `.name` then `.id`, so `nodes["Post to Slack"].parameters.channelId` writes to the correct node without requiring a numeric index.
- `applyResolutions` pre-validates path structure via `parseParamPath` (hard fail) then catches lookup failures separately, preserving the user's answer in `userNotes` and allowing the batch to succeed rather than returning a 400 the UI cannot recover from.
- 11 new unit tests cover numeric regression, name/id resolution, no-match throws, mixed batch behaviour, and the structural-error hard-fail contract.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-tested, the structural-error hard-fail contract is preserved, and the soft-fallback is intentionally scoped to lookup failures only.

The two changed code paths are covered by dedicated unit tests including regression cases. The structural/lookup error split is clean and the test for malformed paths confirms parse errors still surface as 400s. No existing functionality is removed, only extended.

No files require special attention; both changed files are self-contained and fully tested.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts | Adds name/id-keyed array resolution to `setByDotPath`, extracts `appendUserNote` helper, and splits `applyResolutions` catch logic into a pre-parse guard (hard 400) and a lookup-failure soft-fallback (userNotes). Design is sound; minor: raw user value appears in warn log message and `parseParamPath` is called twice per resolution. |
| plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts | New test file with 11 focused unit tests covering numeric indexing, name-keyed resolution, id-keyed resolution, no-match throws, fallback-to-userNotes paths, mixed batches, structural-error hard-fail, and non-string value validation. Good coverage of the changed code paths. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyResolutions called] --> B{r.paramPath empty?}
    B -- yes --> C[appendUserNote]
    B -- no --> D[parseParamPath pre-check]
    D -- throws --> E[return ok:false - structurally invalid 400]
    D -- ok --> F[setByDotPath]
    F -- success --> G[next resolution]
    F -- throws lookup failure --> H[logger.warn + appendUserNote]
    H --> G
    G --> I{more resolutions?}
    I -- yes --> B
    I -- no --> J[return ok:true]

    subgraph setByDotPath
        K[parseParamPath] --> L{segment hits array?}
        L -- numeric --> M[direct index]
        L -- string --> N[findArrayIndexByNameOrId - name then id]
        N -- idx >= 0 --> O[descend]
        N -- idx < 0 --> P[throw name/id mismatch]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts`, line 190-205 ([link](https://github.com/elizaos/eliza/blob/5b3c2a2ac544e9af77f819dcf8b26a22125c8532/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts#L190-L205)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Out-of-bounds numeric segment silently creates a sparse array**

   When the segment `isArrayIndex` is true, `idx = Number(seg)` is used without any bounds check. If the LLM emits `nodes[99].parameters.channelId` on a two-node workflow, `cur[99]` is `undefined`, the code creates a new object and assigns it to `cur[99]`, producing a sparse array with 98 `undefined` slots. The new name-keyed path adds a clean error for string mismatches but leaves numeric out-of-bounds silently mutating the draft in an unexpected way. The failure will likely only surface downstream when n8n rejects the malformed workflow JSON.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(n8n-workflow): split parse-error fro..."](https://github.com/elizaos/eliza/commit/414b18f6c0a8ad5793bd862f0ab2d5c33b1748cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31426407)</sub>

<!-- /greptile_comment -->