### PR TITLE
fix(n8n-workflow): prefer sidecar-provisioned API key over stale env key

### DIFF
--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-api-key-resolver.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-api-key-resolver.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test";
+import { resolveN8nApiKey } from "../../src/services/n8n-workflow-service";
+
+const HOST = "http://127.0.0.1:5678";
+
+function probeReturning(map: Record<string, boolean>) {
+  return async (_host: string, key: string): Promise<boolean> => map[key] ?? false;
+}
+
+describe("resolveN8nApiKey", () => {
+  test("returns null when neither sidecar nor env has a key", async () => {
+    const result = await resolveN8nApiKey(HOST, null, {
+      getSidecarKey: () => null,
+      probe: probeReturning({}),
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns sidecar key when it is the only candidate", async () => {
+    const result = await resolveN8nApiKey(HOST, null, {
+      getSidecarKey: () => "sidecar-key",
+      probe: probeReturning({ "sidecar-key": true }),
+    });
+    expect(result).toBe("sidecar-key");
+  });
+
+  test("returns env key when no sidecar is registered", async () => {
+    const result = await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => null,
+      probe: probeReturning({ "env-key": true }),
+    });
+    expect(result).toBe("env-key");
+  });
+
+  test("prefers sidecar key over env when both are valid", async () => {
+    const result = await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => "sidecar-key",
+      probe: probeReturning({ "sidecar-key": true, "env-key": true }),
+    });
+    expect(result).toBe("sidecar-key");
+  });
+
+  test("falls back to env key when sidecar key fails the probe", async () => {
+    // The exact failure mode that broke the user's session: env has the
+    // stale key, sidecar has the fresh one. (Same shape, opposite outcome
+    // — we still want the working key.)
+    const result = await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => "stale-sidecar-key",
+      probe: probeReturning({ "env-key": true }),
+    });
+    expect(result).toBe("env-key");
+  });
+
+  test("falls back to sidecar key when env key fails the probe", async () => {
+    // The other half of the user's failure mode: env was stale, sidecar
+    // was fresh. After this PR: sidecar is preferred and validates clean.
+    const result = await resolveN8nApiKey(HOST, "stale-env-key", {
+      getSidecarKey: () => "sidecar-key",
+      probe: probeReturning({ "sidecar-key": true }),
+    });
+    expect(result).toBe("sidecar-key");
+  });
+
+  test("returns sidecar key when both fail (canonical source for diagnosis)", async () => {
+    const result = await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => "sidecar-key",
+      probe: probeReturning({}),
+    });
+    expect(result).toBe("sidecar-key");
+  });
+
+  test("returns env key when both fail and there is no sidecar", async () => {
+    const result = await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => null,
+      probe: probeReturning({}),
+    });
+    expect(result).toBe("env-key");
+  });
+
+  test("does not call probe at all when only one candidate is present", async () => {
+    let probed = 0;
+    const probe = async (): Promise<boolean> => {
+      probed += 1;
+      return true;
+    };
+    await resolveN8nApiKey(HOST, null, {
+      getSidecarKey: () => "sidecar-key",
+      probe,
+    });
+    expect(probed).toBe(0);
+
+    await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => null,
+      probe,
+    });
+    expect(probed).toBe(0);
+  });
+
+  test("when keys are identical, returns once without spurious diff log", async () => {
+    // Both sources happen to hold the same string (e.g. user copy-pasted
+    // the sidecar key into .env). Should still resolve cleanly.
+    const result = await resolveN8nApiKey(HOST, "shared-key", {
+      getSidecarKey: () => "shared-key",
+      probe: probeReturning({ "shared-key": true }),
+    });
+    expect(result).toBe("shared-key");
+  });
+});

--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-api-key-resolver.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-api-key-resolver.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "bun:test";
-import { resolveN8nApiKey } from "../../src/services/n8n-workflow-service";
+import {
+  pickRotatedSidecarKey,
+  resolveN8nApiKey,
+} from "../../src/services/n8n-workflow-service";
 
 const HOST = "http://127.0.0.1:5678";
 
@@ -41,9 +44,9 @@ describe("resolveN8nApiKey", () => {
   });
 
   test("falls back to env key when sidecar key fails the probe", async () => {
-    // The exact failure mode that broke the user's session: env has the
-    // stale key, sidecar has the fresh one. (Same shape, opposite outcome
-    // — we still want the working key.)
+    // Sidecar key is stale (e.g. provisioned against a now-reset n8n
+    // instance) while the env key still passes. The resolver should detect
+    // the sidecar probe failure and return the working env key.
     const result = await resolveN8nApiKey(HOST, "env-key", {
       getSidecarKey: () => "stale-sidecar-key",
       probe: probeReturning({ "env-key": true }),
@@ -104,5 +107,55 @@ describe("resolveN8nApiKey", () => {
       probe: probeReturning({ "shared-key": true }),
     });
     expect(result).toBe("shared-key");
+  });
+
+  test("probes both candidates concurrently when both are present", async () => {
+    // Caps the worst-case startup wait at one probe interval rather than
+    // two when n8n is slow or unreachable. Verifies both probes are
+    // in-flight before either resolves.
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const probe = async (_host: string, _key: string): Promise<boolean> => {
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 10));
+      inFlight -= 1;
+      return false;
+    };
+    await resolveN8nApiKey(HOST, "env-key", {
+      getSidecarKey: () => "sidecar-key",
+      probe,
+    });
+    expect(peakInFlight).toBe(2);
+  });
+});
+
+describe("pickRotatedSidecarKey", () => {
+  test("returns null when sidecar has no key", () => {
+    expect(pickRotatedSidecarKey(null, null)).toBeNull();
+    expect(pickRotatedSidecarKey(null, "stale-x")).toBeNull();
+  });
+
+  test("refuses to rotate to the exact start-time stale key (the P1 fix)", () => {
+    // n8n was reset; the sidecar's cached key is now revoked, the env key
+    // is known to work. getClient must not flip the apiClient back to the
+    // stale value on every request.
+    expect(pickRotatedSidecarKey("stale-sidecar-key", "stale-sidecar-key")).toBeNull();
+  });
+
+  test("rotates when the sidecar value differs from the start-time stale key", () => {
+    // Sidecar has reprovisioned a fresh key after the start-time probe
+    // failure — pick it up so subsequent requests use the canonical
+    // source again.
+    expect(pickRotatedSidecarKey("fresh-sidecar-key", "stale-sidecar-key")).toBe(
+      "fresh-sidecar-key",
+    );
+  });
+
+  test("returns the sidecar value when there was no start-time stale key", () => {
+    // Healthy path: start-time resolver chose the sidecar key (or there
+    // was no sidecar at start). Live-refresh continues to follow the
+    // sidecar.
+    expect(pickRotatedSidecarKey("sidecar-key", null)).toBe("sidecar-key");
   });
 });

--- a/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
+++ b/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
@@ -245,6 +245,17 @@ export class N8nWorkflowService extends Service {
     if (!this.apiClient) {
       throw new Error('N8n Workflow Service not initialized');
     }
+    // Live-refresh from the sidecar. The plugin's service typically starts
+    // BEFORE the n8n autostart provisions its API key, so the start-time
+    // resolver may have fallen back to the env value when no sidecar key
+    // was registered yet. Once the sidecar is ready, prefer its key — it
+    // is the freshest and is rotated by the sidecar itself. peekN8nSidecar
+    // is O(1); getApiKey returns a cached string, so this is microsecond
+    // overhead per request.
+    const sidecarKey = peekN8nSidecar()?.getApiKey();
+    if (sidecarKey) {
+      this.apiClient.setApiKey(sidecarKey);
+    }
     return this.apiClient;
   }
 

--- a/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
+++ b/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
@@ -115,11 +115,17 @@ export async function resolveN8nApiKey(
   if (!envKey && sidecarKey) return sidecarKey;
   if (!sidecarKey && envKey) return envKey;
 
-  // Both present. Prefer the sidecar key, but fall through to env if it
-  // does not validate (e.g. sidecar still provisioning, or its host
-  // differs from the configured N8N_HOST so the cached key doesn't apply).
-  if (sidecarKey && (await probe(host, sidecarKey))) {
-    if (envKey && envKey !== sidecarKey) {
+  // Both present. Probe both candidates concurrently to bound the
+  // worst-case startup wait at one probe interval (5 s) instead of two
+  // (10 s) when n8n is slow or unreachable. Preference order is unchanged
+  // — sidecar wins when it validates; env wins otherwise; both-fail falls
+  // through to the sidecar canonical-source rule below.
+  const [sidecarOk, envOk] = await Promise.all([
+    probe(host, sidecarKey),
+    probe(host, envKey),
+  ]);
+  if (sidecarOk) {
+    if (envKey !== sidecarKey) {
       logger.info(
         { src: 'plugin:n8n-workflow:service:main' },
         'Using sidecar-provisioned N8N_API_KEY; the env-configured key did not match',
@@ -127,13 +133,35 @@ export async function resolveN8nApiKey(
     }
     return sidecarKey;
   }
-  if (envKey && (await probe(host, envKey))) {
+  if (envOk) {
     return envKey;
   }
-  // Neither validated. Return the sidecar key if we have it (it is the
-  // canonical source); otherwise fall back to env so the upstream error
-  // has *something* to report.
-  return sidecarKey ?? envKey;
+  // Neither validated. Return the sidecar key (canonical source); the
+  // upstream error path produces a real diagnostic instead of a missing-
+  // config error.
+  return sidecarKey;
+}
+
+/**
+ * Choose the next sidecar key to apply to the apiClient.
+ *
+ * Returns the new key when the sidecar has rotated to a value different
+ * from the one that was already known to fail at start-time. Returns null
+ * when the apiClient should keep its current key — either because there
+ * is no sidecar key right now, or because the sidecar still holds the
+ * exact key that lost the start-time probe (e.g. n8n was reset and the
+ * sidecar's cached key is now revoked, but the env key is known to work).
+ *
+ * Without this guard, `getClient()` would unconditionally clobber the
+ * probe-selected env key with the stale sidecar key on every request.
+ */
+export function pickRotatedSidecarKey(
+  currentSidecarKey: string | null,
+  staleSidecarKey: string | null,
+): string | null {
+  if (!currentSidecarKey) return null;
+  if (currentSidecarKey === staleSidecarKey) return null;
+  return currentSidecarKey;
 }
 
 /**
@@ -151,6 +179,9 @@ export class N8nWorkflowService extends Service {
 
   private apiClient: N8nApiClient | null = null;
   private serviceConfig: N8nWorkflowServiceConfig | null = null;
+  // The sidecar key that lost the start-time probe (if any). getClient()
+  // refuses to auto-rotate back to this exact value — see pickRotatedSidecarKey.
+  private staleSidecarKey: string | null = null;
 
   static async start(runtime: IAgentRuntime): Promise<N8nWorkflowService> {
     logger.info({ src: 'plugin:n8n-workflow:service:main' }, 'Starting N8n Workflow Service...');
@@ -168,6 +199,12 @@ export class N8nWorkflowService extends Service {
     if (!apiKey) {
       throw new Error('N8N_API_KEY is required in settings');
     }
+    // If the start-time resolver fell back to env because the sidecar's
+    // current key failed its probe, remember that exact sidecar value so
+    // getClient() does not auto-rotate back to it on every request.
+    const startSidecarKey = peekN8nSidecar()?.getApiKey() ?? null;
+    const staleSidecarKey =
+      startSidecarKey && startSidecarKey !== apiKey ? startSidecarKey : null;
 
     // Get optional pre-configured credentials from character.settings.workflows
     // Note: runtime.getSetting() only returns primitives — nested objects must be read directly
@@ -185,6 +222,7 @@ export class N8nWorkflowService extends Service {
 
     // Initialize API client
     service.apiClient = new N8nApiClient(host, apiKey);
+    service.staleSidecarKey = staleSidecarKey;
 
     logger.info(
       { src: 'plugin:n8n-workflow:service:main' },
@@ -209,6 +247,7 @@ export class N8nWorkflowService extends Service {
     logger.info({ src: 'plugin:n8n-workflow:service:main' }, 'Stopping N8n Workflow Service...');
     this.apiClient = null;
     this.serviceConfig = null;
+    this.staleSidecarKey = null;
     logger.info({ src: 'plugin:n8n-workflow:service:main' }, 'N8n Workflow Service stopped');
   }
 
@@ -247,14 +286,19 @@ export class N8nWorkflowService extends Service {
     }
     // Live-refresh from the sidecar. The plugin's service typically starts
     // BEFORE the n8n autostart provisions its API key, so the start-time
-    // resolver may have fallen back to the env value when no sidecar key
-    // was registered yet. Once the sidecar is ready, prefer its key — it
-    // is the freshest and is rotated by the sidecar itself. peekN8nSidecar
-    // is O(1); getApiKey returns a cached string, so this is microsecond
-    // overhead per request.
-    const sidecarKey = peekN8nSidecar()?.getApiKey();
-    if (sidecarKey) {
-      this.apiClient.setApiKey(sidecarKey);
+    // resolver may have fallen back to the env value when the sidecar was
+    // not yet ready or its cached key failed the probe. Once the sidecar
+    // rotates to a different key, prefer its value — it is the freshest
+    // and is rotated by the sidecar itself. pickRotatedSidecarKey skips
+    // the override when the sidecar still holds the exact stale key that
+    // lost the start-time probe (avoids clobbering a known-working env
+    // key with a known-broken sidecar key on every request).
+    const next = pickRotatedSidecarKey(
+      peekN8nSidecar()?.getApiKey() ?? null,
+      this.staleSidecarKey,
+    );
+    if (next) {
+      this.apiClient.setApiKey(next);
     }
     return this.apiClient;
   }

--- a/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
+++ b/plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts
@@ -1,4 +1,5 @@
 import { type IAgentRuntime, logger, Service } from '@elizaos/core';
+import { peekN8nSidecar } from '@elizaos/app-core/services/n8n-sidecar';
 import { N8nApiClient } from '../utils/api';
 import { searchNodes, filterNodesByIntegrationSupport } from '../utils/catalog';
 import { getUserTagName } from '../utils/context';
@@ -55,6 +56,87 @@ export interface N8nWorkflowServiceConfig {
 }
 
 /**
+ * Probe a candidate API key against `${host}/api/v1/workflows?limit=1`.
+ * Returns true on 2xx, false on 401/403/network error.
+ */
+async function probeApiKey(host: string, key: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${host.replace(/\/$/, '')}/api/v1/workflows?limit=1`, {
+      method: 'GET',
+      headers: { 'X-N8N-API-KEY': key },
+      signal: AbortSignal.timeout(5_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pick the API key the workflow service should use.
+ *
+ * The local n8n sidecar provisions a fresh API key at every boot and
+ * persists it under `${stateDir}/api-key` (see
+ * `@elizaos/app-core/services/n8n-sidecar`). The plugin's settings
+ * `N8N_API_KEY` is read from `.env` / config and can drift independently
+ * — e.g. a previous sidecar instance was reset, or the user copied a key
+ * from a stale install. When both are set but disagree, the env value
+ * wins by default and every deploy gets 401 from n8n until someone
+ * rewrites `.env` by hand.
+ *
+ * Resolution order:
+ *   1. If a sidecar service is registered AND has provisioned a key, prefer
+ *      that key — it is the freshest and is rotated by the sidecar itself.
+ *   2. Otherwise fall back to the env / config value.
+ *   3. If the chosen candidate fails a probe but the other candidate
+ *      passes, use the working one.
+ *   4. If both fail (or only one is present and it fails), return the
+ *      best-available so the existing failure path produces a real
+ *      diagnostic instead of a missing-config error.
+ *
+ * Returns null only when no candidates exist at all.
+ */
+export async function resolveN8nApiKey(
+  host: string,
+  envKey: string | null,
+  deps: {
+    getSidecarKey?: () => string | null;
+    probe?: (host: string, key: string) => Promise<boolean>;
+  } = {},
+): Promise<string | null> {
+  const getSidecarKey = deps.getSidecarKey ?? (() => peekN8nSidecar()?.getApiKey() ?? null);
+  const probe = deps.probe ?? probeApiKey;
+
+  const sidecarKey = getSidecarKey();
+
+  if (!sidecarKey && !envKey) return null;
+
+  // Single-candidate fast path: nothing to disambiguate.
+  if (!envKey && sidecarKey) return sidecarKey;
+  if (!sidecarKey && envKey) return envKey;
+
+  // Both present. Prefer the sidecar key, but fall through to env if it
+  // does not validate (e.g. sidecar still provisioning, or its host
+  // differs from the configured N8N_HOST so the cached key doesn't apply).
+  if (sidecarKey && (await probe(host, sidecarKey))) {
+    if (envKey && envKey !== sidecarKey) {
+      logger.info(
+        { src: 'plugin:n8n-workflow:service:main' },
+        'Using sidecar-provisioned N8N_API_KEY; the env-configured key did not match',
+      );
+    }
+    return sidecarKey;
+  }
+  if (envKey && (await probe(host, envKey))) {
+    return envKey;
+  }
+  // Neither validated. Return the sidecar key if we have it (it is the
+  // canonical source); otherwise fall back to env so the upstream error
+  // has *something* to report.
+  return sidecarKey ?? envKey;
+}
+
+/**
  * N8n Workflow Service - Orchestrates the RAG pipeline for workflow generation.
  *
  * generateWorkflowDraft(): keywords → node search → LLM generation → validation → positioning
@@ -74,15 +156,17 @@ export class N8nWorkflowService extends Service {
     logger.info({ src: 'plugin:n8n-workflow:service:main' }, 'Starting N8n Workflow Service...');
 
     // Validate configuration
-    const apiKey = runtime.getSetting('N8N_API_KEY');
     const host = runtime.getSetting('N8N_HOST');
-
-    if (!apiKey || typeof apiKey !== 'string') {
-      throw new Error('N8N_API_KEY is required in settings');
-    }
-
     if (!host || typeof host !== 'string') {
       throw new Error('N8N_HOST is required in settings (e.g., https://your.n8n.cloud)');
+    }
+
+    const envKeySetting = runtime.getSetting('N8N_API_KEY');
+    const envKey =
+      typeof envKeySetting === 'string' && envKeySetting.length > 0 ? envKeySetting : null;
+    const apiKey = await resolveN8nApiKey(host, envKey);
+    if (!apiKey) {
+      throw new Error('N8N_API_KEY is required in settings');
     }
 
     // Get optional pre-configured credentials from character.settings.workflows

--- a/plugins/plugin-n8n-workflow/src/utils/api.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/api.ts
@@ -89,6 +89,16 @@ export class N8nApiClient {
     this.apiKey = apiKey;
   }
 
+  /**
+   * Update the API key used for subsequent requests. The workflow service
+   * calls this on every getClient() to live-refresh from the sidecar after
+   * it provisions, since the sidecar typically boots after the plugin's
+   * service starts.
+   */
+  setApiKey(apiKey: string): void {
+    this.apiKey = apiKey;
+  }
+
   // ============================================================================
   // WORKFLOWS
   // ============================================================================


### PR DESCRIPTION
## Summary

The local n8n sidecar provisions a fresh API key at every boot via n8n's owner-setup → login → `/rest/api-keys` flow, persists it under `\${stateDir}/api-key`, and caches it on the singleton. The plugin's workflow service reads `N8N_API_KEY` from `runtime.getSetting` which sources from `.env` / config. The two values can drift independently:

- A previous sidecar instance was reset → the env value points at a revoked key, the file/sidecar holds the new one.
- The user copied a key from a stale install into `.env` → same shape.
- Multiple Milady installs share the same `.env` via dotfile sync but each has its own sidecar DB.

Today the env value wins unconditionally. Every workflow deploy then hits n8n with the wrong key, gets HTTP 401, and the route propagates `unauthorized` to the Automations UI clarification panel — a dead end the user has no way to recover from short of manually rewriting `.env`.

I reproduced this on my own dev box this session. Two divergent keys:

| Source | Suffix | n8n response |
|--------|--------|--------------|
| `.env` `N8N_API_KEY` (what the plugin reads today) | `…Pt0` | HTTP 401 |
| `~/.eliza/n8n/api-key` (sidecar's persisted key) | `…PIe` | HTTP 200 |

## Fix

Add a `resolveN8nApiKey` helper used at service start. Resolution order:

1. If the sidecar service is registered AND has provisioned a key, prefer that key — it is the freshest and the sidecar self-rotates.
2. Otherwise fall back to the env / config value.
3. If the chosen candidate fails a `/api/v1/workflows?limit=1` probe but the other candidate passes, use the working one.
4. If both fail, return the best-available so the existing failure path produces a real diagnostic.
5. Returns `null` only when no candidates exist at all.

Dependencies (sidecar lookup, probe) are injectable for testing — the runtime caller defaults to `peekN8nSidecar()` and a fetch-backed probe with a 5s timeout.

## Test plan

- [x] **New test file** `__tests__/unit/n8n-api-key-resolver.test.ts` (10 tests) covers all 6 disambiguation branches plus the no-probe-needed fast paths and the identical-key edge case. 10/10 pass.
- [x] Existing plugin suite: 327 pass / 4 pre-existing failures (action/provider tests with module-not-found errors, unrelated to this change).
- [ ] Manual: with a stale `.env` `N8N_API_KEY` pointing at a revoked key and the local sidecar holding a fresh key, deploy a workflow through the Automations UI — should succeed instead of returning `unauthorized`.

## Related

Pairs with #7506 (route registration) and #7507 (tolerant paramPaths) — together those three PRs unblock the Automations UI clarification flow end-to-end. This PR specifically fixes the deploy step that runs after a clarification is resolved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a key-precedence bug where a stale `.env` `N8N_API_KEY` would win over a freshly-provisioned sidecar key, causing every workflow deploy to return HTTP 401. The fix introduces `resolveN8nApiKey` (concurrent dual-probe, sidecar-preferred) at service start and `pickRotatedSidecarKey` for live key refresh on each `getClient()` call.

- **`resolveN8nApiKey`**: probes both keys concurrently at startup, prefers the sidecar key when valid, falls back to env, and returns the best-available on total failure so the existing error path produces a real diagnostic.
- **`pickRotatedSidecarKey`**: guards live-refresh in `getClient()` against re-applying a key that was already known to fail the start-time probe, preventing the env-fallback from being clobbered back to a broken sidecar key on every request.
- **Test coverage**: 14 new unit tests cover all disambiguation branches, the concurrent-probe property, the identical-key edge case, and the stale-key rotation guard.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core key-selection logic is correct and well-tested with two non-blocking refinements worth considering.

The key-resolution and live-rotation logic is sound and addresses the described failure mode. Two small gaps exist: identical keys cause two redundant probe requests at startup, and serviceConfig.apiKey drifts silently after a live rotation in getClient(). Neither causes incorrect behavior today, but the latter is a latent inconsistency.

The getClient() method in n8n-workflow-service.ts — specifically how it updates apiClient without updating serviceConfig — warrants a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/services/n8n-workflow-service.ts | Adds resolveN8nApiKey and pickRotatedSidecarKey, wires both into start() and getClient(); minor: identical-key double-probe and serviceConfig.apiKey drift after rotation. |
| plugins/plugin-n8n-workflow/__tests__/unit/n8n-api-key-resolver.test.ts | Comprehensive unit tests for both new helpers covering all disambiguation branches, single-candidate fast paths, identical-key edge case, and concurrent-probe verification. |
| plugins/plugin-n8n-workflow/src/utils/api.ts | Adds setApiKey method to N8nApiClient to support live key rotation from the sidecar; straightforward and safe. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(n8n-workflow): keep probe-selected e..."](https://github.com/elizaos/eliza/commit/b6860d8b3811c1ad9b74810255b4eef11ec3937c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31427514)</sub>

<!-- /greptile_comment -->