### PR TITLE
fix(n8n-workflow): refuse to overwrite parameters object with non-object value

### DIFF
--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
@@ -54,6 +54,45 @@ describe("setByDotPath", () => {
     setByDotPath(obj, "a.b.c", 42);
     expect((obj.a as any).b.c).toBe(42);
   });
+
+  test("refuses to overwrite an object with a non-object value (object case)", () => {
+    // The LLM sometimes points paramPath at a parent scope. Without this
+    // guard, the assignment silently replaces the parameters object with
+    // a string and n8n rejects the deploy with `parameters must be object`.
+    const obj: Record<string, unknown> = {
+      nodes: [{ name: "Trigger", parameters: { existing: "field" } }],
+    };
+    expect(() =>
+      setByDotPath(obj, 'nodes["Trigger"].parameters', "discord"),
+    ).toThrow(/refusing to overwrite with non-object value/);
+    // Original parameters object is untouched.
+    expect((obj.nodes as any)[0].parameters).toEqual({ existing: "field" });
+  });
+
+  test("refuses to overwrite an object inside an array (array case)", () => {
+    const obj: Record<string, unknown> = {
+      items: [{ a: 1 }, { b: 2 }],
+    };
+    expect(() => setByDotPath(obj, "items.0", "string")).toThrow(
+      /refusing to overwrite with non-object value/,
+    );
+  });
+
+  test("allows replacing a primitive with another primitive", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [{ name: "T", parameters: { hour: 9 } }],
+    };
+    setByDotPath(obj, 'nodes["T"].parameters.hour', 10);
+    expect((obj.nodes as any)[0].parameters.hour).toBe(10);
+  });
+
+  test("allows replacing an object with another object", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [{ name: "T", parameters: { old: "x" } }],
+    };
+    setByDotPath(obj, 'nodes["T"].parameters', { new: "y" });
+    expect((obj.nodes as any)[0].parameters).toEqual({ new: "y" });
+  });
 });
 
 describe("applyResolutions", () => {
@@ -94,6 +133,26 @@ describe("applyResolutions", () => {
     // Workflow nodes untouched.
     expect((draft.nodes as any).length).toBe(1);
     expect((draft.nodes as any)[0].name).toBe("Hourly Trigger");
+  });
+
+  test("falls back to userNotes when paramPath points at a parent object scope", () => {
+    // The exact LLM failure the user hit: clarification asked for a
+    // notification channel but paramPath was `nodes["Trigger"].parameters`
+    // — the parameters object itself, not a leaf field. Old behavior
+    // overwrote parameters with the string "discord" and broke deploy.
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "Hourly Trigger", parameters: { mode: "everyHour" } }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Hourly Trigger"].parameters',
+        value: "discord",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft as any)._meta.userNotes).toEqual(["discord"]);
+    // The parameters object survives untouched.
+    expect((draft.nodes as any)[0].parameters).toEqual({ mode: "everyHour" });
   });
 
   test("falls back to userNotes when paramPath descends into a non-object", () => {

--- a/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts
@@ -1,0 +1,156 @@
+import { describe, test, expect } from "bun:test";
+import {
+  setByDotPath,
+  applyResolutions,
+} from "../../src/lib/n8n-clarification";
+
+describe("setByDotPath", () => {
+  test("writes through a numeric array index (existing behavior)", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { name: "A", parameters: {} },
+        { name: "B", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, "nodes[1].parameters.channelId", "C-123");
+    expect((obj.nodes as any)[1].parameters.channelId).toBe("C-123");
+    expect((obj.nodes as any)[0].parameters).toEqual({});
+  });
+
+  test("resolves a string array segment by entry .name (n8n nodes)", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { name: "Webhook", parameters: { path: "/in" } },
+        { name: "Post to Slack", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, 'nodes["Post to Slack"].parameters.channelId', "C-42");
+    expect((obj.nodes as any)[1].parameters.channelId).toBe("C-42");
+    // Other nodes untouched
+    expect((obj.nodes as any)[0].parameters.path).toBe("/in");
+  });
+
+  test("resolves a string array segment by entry .id when name does not match", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [
+        { id: "uuid-slack", name: "Post to Slack", parameters: {} },
+      ],
+    };
+    setByDotPath(obj, 'nodes["uuid-slack"].parameters.channelId', "C-99");
+    expect((obj.nodes as any)[0].parameters.channelId).toBe("C-99");
+  });
+
+  test("throws when string segment matches no element by name or id", () => {
+    const obj: Record<string, unknown> = {
+      nodes: [{ name: "Webhook", parameters: {} }],
+    };
+    expect(() =>
+      setByDotPath(obj, 'nodes["Placeholder Notification"].parameters.x', "y"),
+    ).toThrow(/did not match any element by name\/id/);
+  });
+
+  test("dot identifiers still work end-to-end", () => {
+    const obj: Record<string, unknown> = { a: { b: { c: 1 } } };
+    setByDotPath(obj, "a.b.c", 42);
+    expect((obj.a as any).b.c).toBe(42);
+  });
+});
+
+describe("applyResolutions", () => {
+  test("applies a name-keyed paramPath to the matching node", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [
+        { name: "Hourly Trigger", parameters: { rule: "everyHour" } },
+        { name: "Notify", parameters: {} },
+      ],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Notify"].parameters.channelId',
+        value: "discord-channel-1",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft.nodes as any)[1].parameters.channelId).toBe(
+      "discord-channel-1",
+    );
+  });
+
+  test("falls back to userNotes when paramPath references a non-existent node", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "Hourly Trigger", parameters: {} }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Placeholder Notification"].parameters',
+        value: "discord",
+      },
+    ]);
+    // Resolution doesn't fail the batch — the user's answer is preserved.
+    expect(result.ok).toBe(true);
+    const meta = (draft as any)._meta;
+    expect(meta).toBeDefined();
+    expect(meta.userNotes).toEqual(["discord"]);
+    // Workflow nodes untouched.
+    expect((draft.nodes as any).length).toBe(1);
+    expect((draft.nodes as any)[0].name).toBe("Hourly Trigger");
+  });
+
+  test("falls back to userNotes when paramPath descends into a non-object", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "X", parameters: "this is a string not an object" }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["X"].parameters.channelId',
+        value: "C-1",
+      },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft as any)._meta.userNotes).toEqual(["C-1"]);
+  });
+
+  test("empty paramPath stores answer as userNote (existing behavior)", () => {
+    const draft: Record<string, unknown> = { nodes: [], connections: {} };
+    const result = applyResolutions(draft, [
+      { paramPath: "", value: "use email" },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft as any)._meta.userNotes).toEqual(["use email"]);
+  });
+
+  test("multiple resolutions can mix successful path writes and userNote fallbacks", () => {
+    const draft: Record<string, unknown> = {
+      nodes: [{ name: "Real Node", parameters: {} }],
+    };
+    const result = applyResolutions(draft, [
+      {
+        paramPath: 'nodes["Real Node"].parameters.target',
+        value: "ok",
+      },
+      {
+        paramPath: 'nodes["Imaginary Node"].parameters.target',
+        value: "fallback",
+      },
+      { paramPath: "", value: "free-form note" },
+    ]);
+    expect(result.ok).toBe(true);
+    expect((draft.nodes as any)[0].parameters.target).toBe("ok");
+    expect((draft as any)._meta.userNotes).toEqual([
+      "fallback",
+      "free-form note",
+    ]);
+  });
+
+  test("non-string value still rejects the batch (validation, not path failure)", () => {
+    const draft: Record<string, unknown> = { nodes: [] };
+    const result = applyResolutions(draft, [
+      // @ts-expect-error — testing runtime guard
+      { paramPath: "x", value: 42 },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("must be a string");
+    }
+  });
+});

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -175,6 +175,15 @@ function findArrayIndexByNameOrId(arr: unknown[], key: string): number {
  * If the segment expects an array but the existing intermediate is a non-
  * array object, we treat it as an object key (n8n workflow shapes mix arrays
  * and objects fairly freely; we err on the side of preserving structure).
+ *
+ * Terminal-segment guard: refuses to overwrite an existing object with a
+ * non-object value. The LLM sometimes emits a paramPath that points at a
+ * parent scope rather than a leaf (e.g.
+ * `nodes["Hourly Trigger"].parameters` for a question whose answer is a
+ * channel name); naively writing the string there replaces the entire
+ * `parameters` object and n8n then rejects the workflow with `parameters
+ * must be object`. Throwing here gives `applyResolutions` a chance to
+ * fall back to the userNotes path.
  */
 export function setByDotPath(
   obj: Record<string, unknown>,
@@ -220,19 +229,35 @@ export function setByDotPath(
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
+  const isExistingObject = (v: unknown): boolean =>
+    v !== null && typeof v === 'object';
+  const isObjectValue = (v: unknown): boolean =>
+    v !== null && typeof v === 'object';
   if (Array.isArray(cur)) {
+    let idx: number;
     if (/^[0-9]+$/.test(last)) {
-      cur[Number(last)] = value;
-      return;
+      idx = Number(last);
+    } else {
+      idx = findArrayIndexByNameOrId(cur, last);
+      if (idx < 0) {
+        throw new Error(
+          `paramPath terminal segment "${last}" did not match any element by name/id at array`
+        );
+      }
     }
-    const idx = findArrayIndexByNameOrId(cur, last);
-    if (idx < 0) {
+    if (isExistingObject(cur[idx]) && !isObjectValue(value)) {
       throw new Error(
-        `paramPath terminal segment "${last}" did not match any element by name/id at array`
+        `paramPath terminal "${last}" currently holds an object; refusing to overwrite with non-object value (path likely points at a parent scope rather than a leaf field)`
       );
     }
     cur[idx] = value;
   } else {
+    const existing = (cur as Record<string, unknown>)[last];
+    if (isExistingObject(existing) && !isObjectValue(value)) {
+      throw new Error(
+        `paramPath terminal "${last}" currently holds an object; refusing to overwrite with non-object value (path likely points at a parent scope rather than a leaf field)`
+      );
+    }
     (cur as Record<string, unknown>)[last] = value;
   }
 }

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -229,9 +229,7 @@ export function setByDotPath(
     cur = next as Record<string, unknown> | unknown[];
   }
   const last = segments[segments.length - 1];
-  const isExistingObject = (v: unknown): boolean =>
-    v !== null && typeof v === 'object';
-  const isObjectValue = (v: unknown): boolean =>
+  const isNonNullObject = (v: unknown): boolean =>
     v !== null && typeof v === 'object';
   if (Array.isArray(cur)) {
     let idx: number;
@@ -245,7 +243,7 @@ export function setByDotPath(
         );
       }
     }
-    if (isExistingObject(cur[idx]) && !isObjectValue(value)) {
+    if (isNonNullObject(cur[idx]) && !isNonNullObject(value)) {
       throw new Error(
         `paramPath terminal "${last}" currently holds an object; refusing to overwrite with non-object value (path likely points at a parent scope rather than a leaf field)`
       );
@@ -253,7 +251,7 @@ export function setByDotPath(
     cur[idx] = value;
   } else {
     const existing = (cur as Record<string, unknown>)[last];
-    if (isExistingObject(existing) && !isObjectValue(value)) {
+    if (isNonNullObject(existing) && !isNonNullObject(value)) {
       throw new Error(
         `paramPath terminal "${last}" currently holds an object; refusing to overwrite with non-object value (path likely points at a parent scope rather than a leaf field)`
       );

--- a/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
+++ b/plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts
@@ -11,6 +11,7 @@
  * Kept out of `n8n-routes.ts` so the handlers stay focused on transport.
  */
 
+import { logger } from '@elizaos/core';
 import type {
   N8nClarificationRequest,
   N8nClarificationResolution,
@@ -141,14 +142,39 @@ export function parseParamPath(path: string): string[] {
 }
 
 /**
+ * Find the index of a named entry in an array of objects, matching against
+ * `.name` first then `.id`. Returns -1 if no match. Used by `setByDotPath`
+ * to resolve `nodes["My Node"]`-style segments — the LLM consistently
+ * addresses n8n nodes by their human name even though `workflow.nodes` is
+ * an array, so we map name → index here rather than rejecting the path.
+ */
+function findArrayIndexByNameOrId(arr: unknown[], key: string): number {
+  for (let i = 0; i < arr.length; i += 1) {
+    const entry = arr[i];
+    if (entry === null || typeof entry !== 'object') continue;
+    const obj = entry as Record<string, unknown>;
+    if (obj.name === key || obj.id === key) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Mutate `obj` so that its value at `paramPath` becomes `value`. Creates
  * intermediate plain objects as needed; never replaces an existing
  * non-object intermediate (those throw, since the path is invalid).
  *
- * Numeric segments index into arrays. If the segment expects an array but
- * the existing intermediate is a non-array object, we treat it as an
- * object key (n8n workflow shapes mix arrays and objects fairly freely;
- * we err on the side of preserving the existing structure).
+ * Segments that hit an array can be:
+ *   - numeric → direct index
+ *   - non-numeric (string) → looked up against the array's `.name` or `.id`
+ *     field. Common in LLM output for n8n workflows: the model writes
+ *     `nodes["Post to Slack"]` rather than `nodes[2]`. Treating that as a
+ *     hard failure forced every clarification resolution through a 400.
+ *
+ * If the segment expects an array but the existing intermediate is a non-
+ * array object, we treat it as an object key (n8n workflow shapes mix arrays
+ * and objects fairly freely; we err on the side of preserving structure).
  */
 export function setByDotPath(
   obj: Record<string, unknown>,
@@ -161,10 +187,17 @@ export function setByDotPath(
     const seg = segments[i];
     const isArrayIndex = /^[0-9]+$/.test(seg);
     if (Array.isArray(cur)) {
-      if (!isArrayIndex) {
-        throw new Error(`paramPath segment "${seg}" is not a valid array index at depth ${i}`);
+      let idx: number;
+      if (isArrayIndex) {
+        idx = Number(seg);
+      } else {
+        idx = findArrayIndexByNameOrId(cur, seg);
+        if (idx < 0) {
+          throw new Error(
+            `paramPath segment "${seg}" did not match any element by name/id at depth ${i}`
+          );
+        }
       }
-      const idx = Number(seg);
       let next = cur[idx];
       if (next === undefined || next === null) {
         next = /^[0-9]+$/.test(segments[i + 1]) ? [] : {};
@@ -188,13 +221,46 @@ export function setByDotPath(
   }
   const last = segments[segments.length - 1];
   if (Array.isArray(cur)) {
-    if (!/^[0-9]+$/.test(last)) {
-      throw new Error(`paramPath terminal segment "${last}" must be numeric at array`);
+    if (/^[0-9]+$/.test(last)) {
+      cur[Number(last)] = value;
+      return;
     }
-    cur[Number(last)] = value;
+    const idx = findArrayIndexByNameOrId(cur, last);
+    if (idx < 0) {
+      throw new Error(
+        `paramPath terminal segment "${last}" did not match any element by name/id at array`
+      );
+    }
+    cur[idx] = value;
   } else {
     (cur as Record<string, unknown>)[last] = value;
   }
+}
+
+/**
+ * Append a free-form answer to `draft._meta.userNotes`. Used for
+ * clarifications with no `paramPath` AND as the fallback when
+ * `setByDotPath` can't resolve a paramPath against the current draft.
+ * Subsequent LLM regeneration rounds read these notes from `_meta` so the
+ * user's answer is preserved across the failure rather than discarded.
+ */
+function appendUserNote(draft: Record<string, unknown>, value: string): void {
+  const existingMeta = draft._meta;
+  const meta =
+    existingMeta && typeof existingMeta === 'object'
+      ? (existingMeta as Record<string, unknown>)
+      : {};
+  draft._meta = meta;
+
+  let notes: string[];
+  if (Array.isArray(meta.userNotes)) {
+    notes = meta.userNotes as string[];
+  } else {
+    notes =
+      meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
+    meta.userNotes = notes;
+  }
+  notes.push(value);
 }
 
 export function applyResolutions(
@@ -216,33 +282,32 @@ export function applyResolutions(
       // Free-form clarification with no field to wire into. Record the user's
       // answer under draft._meta.userNotes so subsequent LLM iterations can
       // consume the context, but don't mutate the workflow itself.
-      const draftRecord = draft as Record<string, unknown>;
-      const existingMeta = draftRecord._meta;
-      const meta =
-        existingMeta && typeof existingMeta === 'object'
-          ? (existingMeta as Record<string, unknown>)
-          : {};
-      draftRecord._meta = meta;
-
-      let notes: string[];
-      if (Array.isArray(meta.userNotes)) {
-        notes = meta.userNotes as string[];
-      } else {
-        notes =
-          meta.userNotes !== null && meta.userNotes !== undefined ? [String(meta.userNotes)] : [];
-        meta.userNotes = notes;
-      }
-      notes.push(r.value);
+      appendUserNote(draft, r.value);
       continue;
     }
     try {
       setByDotPath(draft, r.paramPath, r.value);
     } catch (err) {
-      return {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-        paramPath: r.paramPath,
-      };
+      // The LLM occasionally emits a paramPath that references a node it
+      // didn't actually create (e.g. "Placeholder Notification") or points
+      // at a parent scope rather than a leaf field. Failing the whole
+      // resolution batch with a 400 is a dead-end — the user has no way to
+      // recover without re-prompting from scratch. Instead, log a warn and
+      // record the answer as a free-form note so the next regeneration
+      // round can use it. The clarification still gets pruned by
+      // `pruneResolvedClarifications` because we keep the original
+      // paramPath in the resolutions list.
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.warn(
+        {
+          src: 'plugin:n8n-workflow:clarification:applyResolutions',
+          err: errMsg,
+          paramPath: r.paramPath,
+        },
+        `setByDotPath failed for paramPath "${r.paramPath}"; recording "${r.value}" as a free-form note instead: ${errMsg}`
+      );
+      appendUserNote(draft, r.value);
+      continue;
     }
   }
   return { ok: true };


### PR DESCRIPTION
## Summary

Reproducible LLM failure mode in the Automations clarification flow:

```json
{
  \"kind\": \"value\",
  \"platform\": \"notification\",
  \"question\": \"How would you like to be notified?\",
  \"paramPath\": \"nodes[\\\"Hourly Trigger\\\"].parameters\"
}
```

When the user types `\"discord\"`, `setByDotPath` walks the path and silently writes the string `\"discord\"` at `nodes[0].parameters`, **replacing the entire parameters object with a string**. n8n then rejects the deploy with:

> request/body/nodes/1/parameters must be object

The previous tolerant-paths fix (#7507) only catches paramPaths that *throw* during resolution. This case doesn't throw — it just writes to the wrong scope and breaks the workflow shape silently.

## Fix

Add a terminal-segment guard in `setByDotPath`: if the slot at the final segment currently holds an object AND the new value is a primitive, throw. The existing `applyResolutions` catch block then records the user's answer in `_meta.userNotes` (same recovery path as phantom-node and descend-into-non-object failures), the clarification gets pruned by paramPath match, and the deploy proceeds with the workflow shape intact.

The guard fires for both branches of the terminal step (object key + array index by name/numeric).

## Test plan

- [x] **Extend** `__tests__/unit/n8n-clarification.test.ts` with 5 new cases:
  - `setByDotPath` throws when overwriting an object with a string at an object-keyed terminal
  - `setByDotPath` throws when overwriting an object with a string at an array-numeric terminal
  - `setByDotPath` still allows primitive→primitive replacement
  - `setByDotPath` still allows object→object replacement
  - `applyResolutions` falls back to userNotes when paramPath points at a parent scope (the exact user-reported repro)
- [x] 16/16 pass (added 5 new on top of the 11 from #7507).

## Related

Stacked on #7507 — extends the same userNotes-fallback machinery to also handle the silent-clobber case. Together with #7506, #7508, #7509 the clarification flow now handles:

| Failure mode | Catcher |
|--------------|---------|
| Route 404'd | #7506 |
| Name-keyed array segments | #7507 |
| Phantom-node references | #7507 |
| Parent-scope paramPath (silent overwrite) | **this PR** |
| Stale env API key | #7508 |
| Channel-before-server clarification order | #7509 |

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a terminal-segment guard to `setByDotPath` that refuses to silently overwrite an existing object with a non-object value, fixing a silent-clobber bug where the LLM emits a `paramPath` pointing at a parent scope (`nodes["Trigger"].parameters`) rather than a leaf field — causing n8n to reject the deploy with `parameters must be object`. The `applyResolutions` catch block is extended to cover this new throw, falling back to `appendUserNote` (the same recovery path used for phantom-node and descend-into-non-object failures) instead of returning a hard `{ ok: false }`.

- The guard fires symmetrically in both the object-key branch and the array-index branch of the terminal step, and `appendUserNote` is extracted into a shared helper to eliminate the repeated inline logic.
- Five new tests extend the suite to cover: object-key guard, array-index guard, primitive→primitive allowed, object→object allowed, and the exact user-reported repro through `applyResolutions`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is narrowly scoped to the terminal-write step of setByDotPath and the fallback path in applyResolutions, with no changes to transport or workflow-generation logic.

The guard condition is correct and conservative: it only fires when an existing object would be silently replaced by a primitive, leaving all other write cases unaffected. The recovery path mirrors the already-tested phantom-node fallback, and the five new tests cover both guard branches plus the exact user-reported repro end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/lib/n8n-clarification.ts | Adds terminal-segment guard in `setByDotPath`, extracts `appendUserNote` helper, and converts the `applyResolutions` catch block from a hard failure into a warn-and-fallback. Logic is sound and guard conditions are correct. |
| plugins/plugin-n8n-workflow/__tests__/unit/n8n-clarification.test.ts | New test file covering all setByDotPath and applyResolutions paths; the 5 new cases directly exercise the guard and the fallback in the exact failure scenario from the bug report. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(n8n-workflow): collapse duplicate is..."](https://github.com/elizaos/eliza/commit/945ace99cf13f5f153175b2051ed4593eaa9fac9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31428093)</sub>

<!-- /greptile_comment -->