### PR TITLE
fix(n8n-workflow): include property description in missing-parameter clarification

### DIFF
--- a/plugins/plugin-n8n-workflow/__tests__/unit/workflow.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/workflow.test.ts
@@ -572,6 +572,50 @@ describe("validateNodeParameters", () => {
     const warnings = validateNodeParameters(workflow);
     expect(warnings).toEqual([]);
   });
+
+  test("includes the n8n property description so the user knows what the parameter governs", () => {
+    // Repro: clarification panel shows `missing required parameter "Name"`
+    // for the Discord node. "Name" alone tells the user nothing —
+    // n8n's UI shows a description tooltip but the Automations panel
+    // doesn't. Pull the description from the same catalog the
+    // validator reads and append it in parens.
+    //
+    // Discord's "Server" and "Channel" required parameters carry
+    // descriptions in the upstream node catalog, so use those to
+    // verify the formatting.
+    const workflow = {
+      name: "Discord notify",
+      nodes: [
+        {
+          name: "Post to Discord",
+          type: "n8n-nodes-base.discord",
+          typeVersion: 2,
+          position: [0, 0] as [number, number],
+          parameters: { resource: "message", operation: "send" },
+        },
+      ],
+      connections: {},
+    };
+    const warnings = validateNodeParameters(workflow);
+    const serverWarning = warnings.find((w) => w.includes('"Server"'));
+    expect(serverWarning).toBeDefined();
+    expect(serverWarning).toContain("(Select the server");
+  });
+
+  test("omits the parens suffix when the property has no description", () => {
+    // The default Gmail fixture's required `emailType` parameter has
+    // no description in the catalog. The warning string must stay
+    // tight in that case — no empty parens, no trailing whitespace.
+    const warnings = validateNodeParameters(createValidWorkflow());
+    const gmailWarning = warnings.find(
+      (w) => w.includes("Gmail") && w.includes("required parameter"),
+    );
+    expect(gmailWarning).toBeDefined();
+    expect(gmailWarning).not.toMatch(/\(\s*\)/);
+    expect(gmailWarning).toBe(
+      'Node "Gmail": missing required parameter "Email Type"',
+    );
+  });
 });
 
 // ============================================================================

--- a/plugins/plugin-n8n-workflow/__tests__/unit/workflow.test.ts
+++ b/plugins/plugin-n8n-workflow/__tests__/unit/workflow.test.ts
@@ -616,6 +616,31 @@ describe("validateNodeParameters", () => {
       'Node "Gmail": missing required parameter "Email Type"',
     );
   });
+
+  test("strips HTML tags from the catalog description", () => {
+    // The actionNetwork.tagId property (resource=personTag, operation=add)
+    // is required and its catalog description embeds an <a href="...">
+    // expression link. The clarification surface is plain text, so raw
+    // HTML must not leak through into the warning string.
+    const workflow = {
+      name: "Action Network Tag",
+      nodes: [
+        {
+          name: "Add Tag",
+          type: "n8n-nodes-base.actionNetwork",
+          typeVersion: 1,
+          position: [0, 0] as [number, number],
+          parameters: { resource: "personTag", operation: "add" },
+        },
+      ],
+      connections: {},
+    };
+    const warnings = validateNodeParameters(workflow);
+    const tagWarning = warnings.find((w) => w.includes('"Tag Name or ID"'));
+    expect(tagWarning).toBeDefined();
+    expect(tagWarning).toContain("specify an ID using an expression");
+    expect(tagWarning).not.toMatch(/<[^>]+>/);
+  });
 });
 
 // ============================================================================

--- a/plugins/plugin-n8n-workflow/src/utils/workflow.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/workflow.ts
@@ -174,7 +174,16 @@ export function validateNodeParameters(workflow: N8nWorkflow): string[] {
       const value = node.parameters?.[prop.name];
       if (value === undefined || value === null || value === '') {
         const label = prop.displayName || prop.name;
-        warnings.push(`Node "${node.name}": missing required parameter "${label}"`);
+        // Include the n8n property description in parentheses when present.
+        // The displayName alone is often opaque ("Name", "Type", "Mode")
+        // and the user has no way to know what the parameter actually
+        // governs. The description is the same hover-text n8n shows in
+        // its own UI, so it carries real semantic information.
+        const description = prop.description?.trim();
+        const detail = description ? ` (${description})` : '';
+        warnings.push(
+          `Node "${node.name}": missing required parameter "${label}"${detail}`,
+        );
       }
     }
   }

--- a/plugins/plugin-n8n-workflow/src/utils/workflow.ts
+++ b/plugins/plugin-n8n-workflow/src/utils/workflow.ts
@@ -179,7 +179,13 @@ export function validateNodeParameters(workflow: N8nWorkflow): string[] {
         // and the user has no way to know what the parameter actually
         // governs. The description is the same hover-text n8n shows in
         // its own UI, so it carries real semantic information.
-        const description = prop.description?.trim();
+        // n8n catalog descriptions sometimes contain raw HTML
+        // (e.g. <a href="...">expression</a>) sourced from the upstream
+        // node-types definitions; strip tags before interpolation so the
+        // clarification surfaces in plain-text contexts cleanly.
+        const description = prop.description
+          ?.replace(/<[^>]*>/g, '')
+          .trim();
         const detail = description ? ` (${description})` : '';
         warnings.push(
           `Node "${node.name}": missing required parameter "${label}"${detail}`,


### PR DESCRIPTION
## Summary

The catalog-validation clarification panel currently surfaces messages like:

> Node \"Post to Discord\": missing required parameter \"Name\" — please provide this value or clarify your requirements

\"Name\" alone tells the user nothing about what the field actually governs (display name to post as? a recipient name? an attachment label?). n8n's own UI shows the property description in a tooltip, but the Automations clarification panel only sees the `displayName`.

## Fix

Append the n8n property `description` (when present) in parentheses after the displayName. The result for the Discord case becomes:

> Node \"Post to Discord\": missing required parameter \"Server\" (Select the server (guild) that your bot is connected to) — please provide this value or clarify your requirements

That matches what n8n itself shows on hover, so it carries real semantic information without requiring any new catalog work.

Properties whose `description` is undefined in the catalog (e.g. Gmail's `emailType`) keep the original short form — no empty parens, no trailing whitespace.

## Test plan

- [x] **Extend** `__tests__/unit/workflow.test.ts` with two cases:
  - Discord's \"Server\" required property exposes its description in the warning string
  - Gmail's \"Email Type\" (no description in the catalog) keeps the short form unchanged
- [x] 58/58 pass.
- [ ] Manual: trigger a workflow generation that leaves a Discord/Slack required field unset — the clarification panel should now show the parameter's purpose, not just its label.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the clarification panel for the n8n workflow plugin by appending the n8n property `description` (stripped of HTML) to missing-required-parameter warning messages, matching what n8n's own UI shows on hover. Three new tests cover the description-present path, the no-description path, and the HTML-stripping path.

- **`workflow.ts`**: In `validateNodeParameters`, the warning string now optionally appends `(description)` using the catalog's `description` field, with a regex to strip HTML tags before interpolation.
- **`workflow.test.ts`**: Three test cases added — Discord \"Server\" (description present), Gmail \"Email Type\" (no description), and actionNetwork \"Tag Name or ID\" (HTML in description).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to a single string-formatting path in the validator and cannot affect workflow execution or data integrity.

The fix is a small, additive string interpolation guarded by an optional-chaining expression; it cannot throw, cannot alter validated values, and degrades gracefully to the old short form when the catalog property has no description. The HTML-stripping regex addresses the previously noted concern, and three targeted tests cover the three distinct code branches.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-n8n-workflow/src/utils/workflow.ts | Appends catalog description (HTML-stripped) to missing-parameter warnings; logic is clean and guards against undefined/empty values. |
| plugins/plugin-n8n-workflow/__tests__/unit/workflow.test.ts | Three new test cases cover description-present, no-description, and HTML-stripping scenarios; all align with the new behavior in workflow.ts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateNodeParameters] --> B{prop.required?}
    B -- No --> C[skip]
    B -- Yes --> D{isPropertyVisible?}
    D -- No --> C
    D -- Yes --> E{value missing?}
    E -- No --> C
    E -- Yes --> F[label = displayName or prop.name]
    F --> G{prop.description defined?}
    G -- Yes --> H[Strip HTML tags and trim]
    H --> I{Non-empty after strip?}
    I -- Yes --> J[detail = space + description in parens]
    I -- No --> K[detail = empty string]
    G -- No --> K
    J --> L[Push warning with label and detail]
    K --> L
```

<sub>Reviews (2): Last reviewed commit: ["fix(n8n-workflow): strip HTML tags from ..."](https://github.com/elizaos/eliza/commit/58b0502cf13ae984a4010d8cc3d65c07a648c778) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31428346)</sub>

<!-- /greptile_comment -->