### PR TITLE
fix(shared): export ./config/allowed-hosts subpath

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,6 +61,7 @@
     "./themes/presets": "./dist/themes/presets.js",
     "./contracts/wallet": "./dist/contracts/wallet.js",
     "./config": "./dist/config/types.js",
+    "./config/allowed-hosts": "./dist/config/allowed-hosts.js",
     "./config/types.agent-defaults": "./dist/config/types.agent-defaults.js",
     "./config/types.agents": "./dist/config/types.agents.js",
     "./config/types.eliza": "./dist/config/types.eliza.js",


### PR DESCRIPTION
## Summary

The P1A refactor (5a6f5f337) moved `allowed-hosts.ts` from `app-core` into `shared/src/config/`, but `packages/shared/package.json` exports map was not updated. Consumers that try to import `@elizaos/shared/config/allowed-hosts` fail at module-resolution time:

```
[plugin: externalize-deps] Missing "./config/allowed-hosts" specifier in "@elizaos/shared" package
```

This blocks downstream consumers — concretely, milady-ai/milady#2125 switches `apps/app/vite.config.ts` from the (now-defunct) `@elizaos/app-core/config/allowed-hosts` to `@elizaos/shared/config/allowed-hosts`, and CI fails on that import.

## Change

One line in `packages/shared/package.json`:

```diff
     "./config": "./dist/config/types.js",
+    "./config/allowed-hosts": "./dist/config/allowed-hosts.js",
     "./config/types.agent-defaults": "./dist/config/types.agent-defaults.js",
```

Same shape as the surrounding `./config/types.*` entries. No build config change needed — `build:dist` (`tsc -p tsconfig.build.json`) already compiles `src/config/allowed-hosts.ts` to `dist/config/allowed-hosts.js` because `tsconfig.build.json` includes `src/`.

## Test plan
- [ ] CI green
- [ ] Verify `dist/config/allowed-hosts.js` and `.d.ts` produced after `cd packages/shared && bun run build`
- [ ] Verify a Node-ESM consumer can `import "@elizaos/shared/config/allowed-hosts"` without "Missing specifier" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single missing subpath export (`./config/allowed-hosts`) to `packages/shared/package.json` so that consumers importing `@elizaos/shared/config/allowed-hosts` no longer get a "Missing specifier" error at module-resolution time.

- **Root cause fixed**: The P1A refactor moved `allowed-hosts.ts` into `packages/shared/src/config/` but forgot to register the new subpath in the `exports` map; this PR closes that gap.
- **Shape is correct**: The new entry `\"./config/allowed-hosts\": \"./dist/config/allowed-hosts.js\"` exactly mirrors the surrounding `./config/types.*` entries, and the source file `src/config/allowed-hosts.ts` is already included in the `tsconfig.build.json` compilation scope, so `dist/config/allowed-hosts.js` and its `.d.ts` are produced without any further build changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line addition that restores a missing export entry, with no logic changes and no risk of breaking existing consumers.

The fix is minimal and surgical: one line in the exports map of `packages/shared/package.json`. The source file it references (`src/config/allowed-hosts.ts`) already exists and is already compiled by the `build:dist` step. The new entry is identical in shape to every surrounding `./config/*` entry. No existing exports are modified, no build config is touched, and there is nothing that can regress.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/shared/package.json | Adds the missing `./config/allowed-hosts` export entry pointing to `./dist/config/allowed-hosts.js`, matching the shape of all other `./config/*` subpath entries. The source file `src/config/allowed-hosts.ts` exists and is already compiled by the `build:dist` step. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer: import '@elizaos/shared/config/allowed-hosts'"] --> B{Export Map Lookup}
    B -- "Before PR\n(entry missing)" --> C["❌ Missing specifier error\nat module-resolution time"]
    B -- "After PR\n(entry added)" --> D["✅ Resolves to dist/config/allowed-hosts.js"]
    D --> E["src/config/allowed-hosts.ts\n(compiled by tsc -p tsconfig.build.json)"]
    E --> F["Exports: AllowedHostPattern\nparseAllowedHostEnv\ntoViteAllowedHosts\ntoCapacitorAllowNavigation"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(shared): export ./config/allowed-hos..."](https://github.com/elizaos/eliza/commit/49782dc7e08cf8d2b30caa5c1da23beca59e99ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31440349)</sub>

<!-- /greptile_comment -->