### PR TITLE
fix(runtime): expose source-mode package boundaries

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -47,6 +47,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
+    "./api/*": "./src/api/*.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -110,9 +110,9 @@ import "@elizaos/app-vincent";
 import { useVincentState } from "@elizaos/app-vincent";
 import "@elizaos/app-vincent";
 // Side-effect: register the wallet UI plugin (route loader, /inventory shell
-// page, and chat sidebar wallet-status widget) with @elizaos/app-core
-// registries. Must precede the first shell render.
-import "@elizaos/app-wallet";
+// page, and chat sidebar wallet-status widget) with the app shell registries.
+// Must precede the first shell render.
+import "@elizaos/app-wallet/register";
 import { shouldUseCloudOnlyBranding } from "@elizaos/ui";
 import {
   APP_BRANDING_BASE,

--- a/plugins/app-wallet/package.json
+++ b/plugins/app-wallet/package.json
@@ -6,8 +6,108 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "bun": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./ui": {
+      "types": "./dist/ui.d.ts",
+      "bun": {
+        "types": "./src/ui.ts",
+        "import": "./src/ui.ts",
+        "default": "./src/ui.ts"
+      },
+      "import": "./dist/ui.js",
+      "default": "./dist/ui.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "bun": {
+        "types": "./src/plugin.ts",
+        "import": "./src/plugin.ts",
+        "default": "./src/plugin.ts"
+      },
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./register": {
+      "types": "./dist/register.d.ts",
+      "bun": {
+        "types": "./src/register.ts",
+        "import": "./src/register.ts",
+        "default": "./src/register.ts"
+      },
+      "import": "./dist/register.js",
+      "default": "./dist/register.js"
+    },
+    "./inventory/ChainIcon": {
+      "types": "./dist/inventory/ChainIcon.d.ts",
+      "bun": {
+        "types": "./src/inventory/ChainIcon.tsx",
+        "import": "./src/inventory/ChainIcon.tsx",
+        "default": "./src/inventory/ChainIcon.tsx"
+      },
+      "import": "./dist/inventory/ChainIcon.js",
+      "default": "./dist/inventory/ChainIcon.js"
+    },
+    "./inventory/TokenLogo": {
+      "types": "./dist/inventory/TokenLogo.d.ts",
+      "bun": {
+        "types": "./src/inventory/TokenLogo.tsx",
+        "import": "./src/inventory/TokenLogo.tsx",
+        "default": "./src/inventory/TokenLogo.tsx"
+      },
+      "import": "./dist/inventory/TokenLogo.js",
+      "default": "./dist/inventory/TokenLogo.js"
+    },
+    "./widgets/wallet-status": {
+      "types": "./dist/widgets/wallet-status.d.ts",
+      "bun": {
+        "types": "./src/widgets/wallet-status.tsx",
+        "import": "./src/widgets/wallet-status.tsx",
+        "default": "./src/widgets/wallet-status.tsx"
+      },
+      "import": "./dist/widgets/wallet-status.js",
+      "default": "./dist/widgets/wallet-status.js"
+    },
+    "./wallet-rpc": {
+      "types": "./dist/wallet-rpc.d.ts",
+      "bun": {
+        "types": "./src/wallet-rpc.ts",
+        "import": "./src/wallet-rpc.ts",
+        "default": "./src/wallet-rpc.ts"
+      },
+      "import": "./dist/wallet-rpc.js",
+      "default": "./dist/wallet-rpc.js"
+    },
+    "./state/*": {
+      "types": "./dist/state/*.d.ts",
+      "bun": {
+        "types": "./src/state/*.ts",
+        "import": "./src/state/*.ts",
+        "default": "./src/state/*.ts"
+      },
+      "import": "./dist/state/*.js",
+      "default": "./dist/state/*.js"
+    },
+    "./inventory/*": {
+      "types": "./dist/inventory/*.d.ts",
+      "bun": {
+        "types": "./src/inventory/*.ts",
+        "import": "./src/inventory/*.ts",
+        "default": "./src/inventory/*.ts"
+      },
+      "import": "./dist/inventory/*.js",
+      "default": "./dist/inventory/*.js"
+    },
+    "./*": {
+      "types": "./dist/*",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
     }
   },
   "dependencies": {

--- a/plugins/app-wallet/src/InventoryView.tsx
+++ b/plugins/app-wallet/src/InventoryView.tsx
@@ -9,13 +9,19 @@ import type {
   WalletTradingProfileResponse,
   WalletTradingProfileWindow,
 } from "@elizaos/shared";
+import type { InventoryChainFilters } from "@elizaos/ui";
 import {
+  type ActivityEvent,
+  AppPageSidebar,
   Button,
+  client,
   cn,
   PageLayout,
   SidebarContent,
   SidebarPanel,
   SidebarScrollRegion,
+  useActivityEvents,
+  useApp,
 } from "@elizaos/ui";
 import {
   Activity,
@@ -42,22 +48,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { client } from "@elizaos/ui";
-import {
-  type ActivityEvent,
-  useActivityEvents,
-} from "@elizaos/ui";
-import type { InventoryChainFilters } from "@elizaos/ui";
-import { useApp } from "@elizaos/ui";
-import { AppPageSidebar } from "@elizaos/ui";
-import { getNativeLogoUrl } from "./inventory/chainConfig";
+import { getNativeLogoUrl } from "./inventory/chainConfig.ts";
 import {
   formatBalance,
   type NftItem,
   type TokenRow,
-} from "./inventory/constants";
-import { TokenLogo } from "./inventory/TokenLogo";
-import { useInventoryData } from "./inventory/useInventoryData";
+} from "./inventory/constants.ts";
+import { TokenLogo } from "./inventory/TokenLogo.tsx";
+import { useInventoryData } from "./inventory/useInventoryData.ts";
 
 type DashboardWindow = "24h" | "7d" | "30d";
 type WalletRailTab = "tokens" | "defi" | "nfts";

--- a/plugins/app-wallet/src/index.ts
+++ b/plugins/app-wallet/src/index.ts
@@ -1,8 +1,7 @@
 // Re-exports for hosts that import directly from "@elizaos/app-wallet".
-export { walletAppPlugin } from "./plugin";
-export { InventoryView } from "./InventoryView";
-export { ChainIcon } from "./inventory/ChainIcon";
-export { TokenLogo } from "./inventory/TokenLogo";
+
+export { InventoryView } from "./InventoryView.tsx";
+export { ChainIcon } from "./inventory/ChainIcon.tsx";
 export {
   CHAIN_CONFIGS,
   type ChainConfig,
@@ -16,7 +15,7 @@ export {
   getStablecoinAddress,
   PRIMARY_CHAIN_KEYS,
   resolveChainKey,
-} from "./inventory/chainConfig";
+} from "./inventory/chainConfig.ts";
 export {
   BSC_GAS_READY_THRESHOLD,
   BSC_GAS_THRESHOLD,
@@ -26,16 +25,18 @@ export {
   type NftItem,
   type TokenRow,
   toNormalizedAddress,
-} from "./inventory/constants";
-export { useInventoryData } from "./inventory/useInventoryData";
-export { useWalletState } from "./state/useWalletState";
+} from "./inventory/constants.ts";
+export { TokenLogo } from "./inventory/TokenLogo.tsx";
+export { useInventoryData } from "./inventory/useInventoryData.ts";
+export { walletAppPlugin } from "./plugin.ts";
+export { useWalletState } from "./state/useWalletState.ts";
 export {
   buildWalletRpcUpdateRequest,
   resolveInitialWalletRpcSelections,
-} from "./wallet-rpc";
+} from "./wallet-rpc.ts";
 export {
-  WalletStatusSidebarWidget,
   WALLET_STATUS_WIDGET,
-} from "./widgets/wallet-status";
-export * from "./ui";
-export * from "./register";
+  WalletStatusSidebarWidget,
+} from "./widgets/wallet-status.tsx";
+export * from "./ui.ts";
+export * from "./register.ts";

--- a/plugins/app-wallet/src/inventory/ChainIcon.tsx
+++ b/plugins/app-wallet/src/inventory/ChainIcon.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { resolveChainKey } from "./chainConfig";
+import { resolveChainKey } from "./chainConfig.ts";
 
 export type ChainIconSize = "sm" | "md" | "lg";
 

--- a/plugins/app-wallet/src/inventory/TokenLogo.tsx
+++ b/plugins/app-wallet/src/inventory/TokenLogo.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { getContractLogoUrl, getNativeLogoUrl } from "./chainConfig";
-import { chainIcon } from "./constants";
-import { normalizeInventoryImageUrl } from "./media-url";
+import { getContractLogoUrl, getNativeLogoUrl } from "./chainConfig.ts";
+import { chainIcon } from "./constants.ts";
+import { normalizeInventoryImageUrl } from "./media-url.ts";
 
 export function tokenLogoUrl(
   chain: string,

--- a/plugins/app-wallet/src/inventory/index.ts
+++ b/plugins/app-wallet/src/inventory/index.ts
@@ -11,7 +11,7 @@ export {
   getStablecoinAddress,
   PRIMARY_CHAIN_KEYS,
   resolveChainKey,
-} from "./chainConfig";
+} from "./chainConfig.ts";
 export {
   BSC_GAS_READY_THRESHOLD,
   BSC_GAS_THRESHOLD,
@@ -21,6 +21,6 @@ export {
   type NftItem,
   type TokenRow,
   toNormalizedAddress,
-} from "./constants";
-export { TokenLogo } from "./TokenLogo";
-export { useInventoryData } from "./useInventoryData";
+} from "./constants.ts";
+export { TokenLogo } from "./TokenLogo.tsx";
+export { useInventoryData } from "./useInventoryData.ts";

--- a/plugins/app-wallet/src/inventory/inventory-chain-filters.ts
+++ b/plugins/app-wallet/src/inventory/inventory-chain-filters.ts
@@ -1,6 +1,6 @@
 import type { InventoryChainFilters } from "@elizaos/ui";
-import type { ChainKey } from "./chainConfig";
-import { resolveChainKey } from "./chainConfig";
+import type { ChainKey } from "./chainConfig.ts";
+import { resolveChainKey } from "./chainConfig.ts";
 
 export type PrimaryInventoryChainKey = keyof InventoryChainFilters;
 

--- a/plugins/app-wallet/src/inventory/useInventoryData.ts
+++ b/plugins/app-wallet/src/inventory/useInventoryData.ts
@@ -5,20 +5,20 @@ import type {
   WalletConfigStatus,
   WalletNftsResponse,
 } from "@elizaos/shared";
-import { useMemo } from "react";
 import type { InventoryChainFilters } from "@elizaos/ui";
+import { useMemo } from "react";
 import {
   CHAIN_CONFIGS,
   type ChainKey,
   PRIMARY_CHAIN_KEYS,
   resolveChainKey,
-} from "./chainConfig";
-import { isBscChainName, type NftItem, type TokenRow } from "./constants";
+} from "./chainConfig.ts";
+import { isBscChainName, type NftItem, type TokenRow } from "./constants.ts";
 import {
   computeSingleChainFocus,
   matchesInventoryChainFilter,
   type PrimaryInventoryChainKey,
-} from "./inventory-chain-filters";
+} from "./inventory-chain-filters.ts";
 
 export interface InventoryDataInput {
   walletBalances: WalletBalancesResponse | null;

--- a/plugins/app-wallet/src/register-routes.ts
+++ b/plugins/app-wallet/src/register-routes.ts
@@ -8,10 +8,10 @@
 
 import { registerAppRoutePluginLoader } from "@elizaos/core";
 import { registerAppShellPage, registerBuiltinWidgets } from "@elizaos/ui";
-import { InventoryView } from "./InventoryView";
+import { InventoryView } from "./InventoryView.tsx";
 
 registerAppRoutePluginLoader("@elizaos/app-wallet", async () => {
-  const { walletAppPlugin } = await import("./plugin");
+  const { walletAppPlugin } = await import("./plugin.ts");
   return walletAppPlugin;
 });
 
@@ -27,7 +27,9 @@ registerAppShellPage({
 
 queueMicrotask(async () => {
   try {
-    const { WALLET_STATUS_WIDGET } = await import("./widgets/wallet-status");
+    const { WALLET_STATUS_WIDGET } = await import(
+      "./widgets/wallet-status.tsx"
+    );
     registerBuiltinWidgets([WALLET_STATUS_WIDGET]);
   } catch {
     // Widget registration is best-effort; route registration above is the critical path.

--- a/plugins/app-wallet/src/register.ts
+++ b/plugins/app-wallet/src/register.ts
@@ -1,1 +1,1 @@
-import "./register-routes";
+import "./register-routes.ts";

--- a/plugins/app-wallet/src/ui.ts
+++ b/plugins/app-wallet/src/ui.ts
@@ -1,6 +1,5 @@
-export { InventoryView } from "./InventoryView";
-export { ChainIcon } from "./inventory/ChainIcon";
-export { TokenLogo } from "./inventory/TokenLogo";
+export { InventoryView } from "./InventoryView.tsx";
+export { ChainIcon } from "./inventory/ChainIcon.tsx";
 export {
   CHAIN_CONFIGS,
   type ChainConfig,
@@ -14,7 +13,7 @@ export {
   getStablecoinAddress,
   PRIMARY_CHAIN_KEYS,
   resolveChainKey,
-} from "./inventory/chainConfig";
+} from "./inventory/chainConfig.ts";
 export {
   BSC_GAS_READY_THRESHOLD,
   BSC_GAS_THRESHOLD,
@@ -24,14 +23,15 @@ export {
   type NftItem,
   type TokenRow,
   toNormalizedAddress,
-} from "./inventory/constants";
-export { useInventoryData } from "./inventory/useInventoryData";
-export { useWalletState } from "./state/useWalletState";
+} from "./inventory/constants.ts";
+export { TokenLogo } from "./inventory/TokenLogo.tsx";
+export { useInventoryData } from "./inventory/useInventoryData.ts";
+export { useWalletState } from "./state/useWalletState.ts";
 export {
   buildWalletRpcUpdateRequest,
   resolveInitialWalletRpcSelections,
-} from "./wallet-rpc";
+} from "./wallet-rpc.ts";
 export {
-  WalletStatusSidebarWidget,
   WALLET_STATUS_WIDGET,
-} from "./widgets/wallet-status";
+  WalletStatusSidebarWidget,
+} from "./widgets/wallet-status.tsx";

--- a/plugins/app-wallet/src/widgets/wallet-status.tsx
+++ b/plugins/app-wallet/src/widgets/wallet-status.tsx
@@ -1,20 +1,16 @@
-import { Check, Copy, Wallet } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-import { useApp } from "@elizaos/ui";
-import {
-  EmptyWidgetState,
-  WidgetSection,
-} from "@elizaos/ui";
 import type {
   ChatSidebarWidgetDefinition,
   ChatSidebarWidgetProps,
 } from "@elizaos/ui";
+import { EmptyWidgetState, useApp, WidgetSection } from "@elizaos/ui";
+import { Check, Copy, Wallet } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import {
   type ChainKey,
   getNativeLogoUrl,
   resolveChainKey,
-} from "../inventory/chainConfig";
-import { normalizeInventoryImageUrl } from "../inventory/media-url";
+} from "../inventory/chainConfig.ts";
+import { normalizeInventoryImageUrl } from "../inventory/media-url.ts";
 
 const DUST_THRESHOLD_USD = 0.01;
 const COPY_FEEDBACK_MS = 1200;

--- a/plugins/plugin-browser/package.json
+++ b/plugins/plugin-browser/package.json
@@ -10,6 +10,56 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./contracts": {
+      "types": "./dist/contracts.d.ts",
+      "bun": {
+        "types": "./src/contracts.ts",
+        "import": "./src/contracts.ts",
+        "default": "./src/contracts.ts"
+      },
+      "import": "./dist/contracts.js",
+      "default": "./dist/contracts.js"
+    },
+    "./packaging": {
+      "types": "./dist/packaging.d.ts",
+      "bun": {
+        "types": "./src/packaging.ts",
+        "import": "./src/packaging.ts",
+        "default": "./src/packaging.ts"
+      },
+      "import": "./dist/packaging.js",
+      "default": "./dist/packaging.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin.d.ts",
+      "bun": {
+        "types": "./src/plugin.ts",
+        "import": "./src/plugin.ts",
+        "default": "./src/plugin.ts"
+      },
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "bun": {
+        "types": "./src/schema.ts",
+        "import": "./src/schema.ts",
+        "default": "./src/schema.ts"
+      },
+      "import": "./dist/schema.js",
+      "default": "./dist/schema.js"
+    },
+    "./workspace": {
+      "types": "./dist/workspace/index.d.ts",
+      "bun": {
+        "types": "./src/workspace/index.ts",
+        "import": "./src/workspace/index.ts",
+        "default": "./src/workspace/index.ts"
+      },
+      "import": "./dist/workspace/index.js",
+      "default": "./dist/workspace/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- expose source-mode Bun export conditions for app-wallet root and documented runtime subpaths while preserving dist fallbacks
- import the wallet registration side effect through `@elizaos/app-wallet/register` so app-shell startup uses the explicit package boundary
- expose `@elizaos/agent/api/*` and documented plugin-browser subpaths needed by source-mode runtime/app-route imports

## Validation

- `bunx biome check --write packages/app/src/main.tsx packages/agent/package.json plugins/app-wallet/package.json plugins/app-wallet/src/index.ts plugins/app-wallet/src/InventoryView.tsx plugins/app-wallet/src/inventory/ChainIcon.tsx plugins/app-wallet/src/inventory/TokenLogo.tsx plugins/app-wallet/src/inventory/index.ts plugins/app-wallet/src/inventory/inventory-chain-filters.ts plugins/app-wallet/src/inventory/useInventoryData.ts plugins/app-wallet/src/register-routes.ts plugins/app-wallet/src/register.ts plugins/app-wallet/src/ui.ts plugins/app-wallet/src/widgets/wallet-status.tsx plugins/plugin-browser/package.json`
- `git diff --cached --check -- . ':(exclude)*.patch'`
- Bun `import.meta.resolve` smoke for app-wallet, agent API, and plugin-browser subpaths, verifying each new source-mode subpath resolves to the intended `src` file
- `bun run --cwd packages/core build:node`
- `bun run --cwd packages/shared build`
- `bun run --cwd plugins/app-wallet build:js`
- `bun run --cwd plugins/plugin-browser build:js`

Note: in a fresh current-develop worktree, full package declaration builds for app-wallet/plugin-browser still hit existing workspace declaration/bootstrap gaps outside this diff. The JS bundles and source-condition package resolution pass for the changed boundaries.

## CI note

Current `develop` at `f33f724c0f` is already red on the broad `Quality (Extended)`, `Tests`, and `Docker CI Smoke` workflows. The matching #7519 failures are in unrelated baseline areas (`plugin-twitch` formatting, `plugin-ngrok` missing test deps, agent/UI package-resolution baselines, mobile smoke). The changed package-boundary files are covered by the focused local validation above.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR exposes source-mode Bun package boundaries for `app-wallet`, `plugin-browser`, and `agent/api` by adding `bun` export conditions pointing to `src/` files, and switches `main.tsx` to import the wallet registration side effect via the explicit `@elizaos/app-wallet/register` subpath rather than the root barrel. Relative imports across `app-wallet` are updated to include explicit `.ts`/`.tsx` file extensions, required for Bun's source-mode module resolution.

- **`plugins/app-wallet/package.json`** gains 10 new named subpath exports with `bun`/`import`/`default` conditions, plus a `./*` catch-all fallback missing a `bun` condition; the `./inventory/*` wildcard bun condition uses `*.ts` which won't match the directory's `.tsx` files — the named `./inventory/ChainIcon` and `./inventory/TokenLogo` entries appear first and cover these today, but the wildcard is a footgun for future additions.
- **`plugins/app-wallet/src/index.ts`** preserves `export * from \"./register.ts\"` (which triggers registration side effects) alongside the new explicit `/register` import path, and duplicates all `ui.ts` exports through `export * from \"./ui.ts\"` after already listing them individually.
- **`plugins/plugin-browser/package.json`** and **`packages/agent/package.json`** add well-formed subpath exports for their respective `src/` modules, all backed by verified source files.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the package boundary changes are additive and the source files they reference all exist.

The core change — adding Bun source-mode conditions to app-wallet, plugin-browser, and agent subpath exports — is mechanically correct and all referenced source files were verified to exist. The ./inventory/* wildcard bun condition would silently fail for future .tsx additions not covered by specific entries, and the ./* catch-all lacks a bun condition entirely. The index.ts barrel still carries registration side effects despite the stated goal of separating them into /register, and its export * from './ui.ts' duplicates every explicitly listed export. None of these cause runtime breakage today, but they leave the package boundary design partially inconsistent with the PR's own stated intent.

plugins/app-wallet/package.json (wildcard bun conditions and missing catch-all bun entry) and plugins/app-wallet/src/index.ts (redundant re-exports and preserved registration side effects in the root barrel)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/app-wallet/package.json | Adds 10 new subpath exports with bun source-mode conditions; the ./inventory/* wildcard uses *.ts glob but the directory contains ChainIcon.tsx and TokenLogo.tsx (covered by prior named entries); the ./* catch-all has no bun condition. |
| plugins/app-wallet/src/index.ts | Extensions updated to explicit .ts/.tsx; export * from './ui.ts' duplicates every named export already listed explicitly; export * from './register.ts' preserves registration side-effects in the root barrel despite moving to explicit /register import. |
| packages/agent/package.json | Adds ./api/* wildcard subpath pointing directly to ./src/api/*.ts without conditions; consistent with the existing . export pattern; src/api/ directory verified to exist. |
| packages/app/src/main.tsx | Switches wallet registration import from root barrel @elizaos/app-wallet to explicit @elizaos/app-wallet/register; semantically cleaner and consistent with the new subpath boundary. |
| plugins/plugin-browser/package.json | Adds 5 new subpath exports (contracts, packaging, plugin, schema, workspace) with bun source-mode conditions; all referenced source files verified to exist. |
| plugins/app-wallet/src/register-routes.ts | Import paths updated to include explicit .ts/.tsx extensions; logic unchanged; registration side-effects fire at module load time as before. |
| plugins/app-wallet/src/ui.ts | Import paths updated to explicit .ts/.tsx extensions; TokenLogo re-export added to match the symbols available in index.ts. |
| plugins/app-wallet/src/InventoryView.tsx | Consolidates scattered @elizaos/ui imports into single import statements; updates relative import paths to explicit .ts/.tsx extensions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["main.tsx\nimport '@elizaos/app-wallet/register'"] --> B["app-wallet/package.json\n./register export"]
    B --> C["src/register.ts\nimport './register-routes.ts'"]
    C --> D["src/register-routes.ts\nregisterAppRoutePluginLoader\nregisterAppShellPage\nqueueMicrotask → registerBuiltinWidgets"]

    E["import '@elizaos/app-wallet'\n(root barrel)"] --> F["src/index.ts\nexport * from './register.ts'"]
    F --> C

    G["agent/package.json\n'./api/*' → src/api/*.ts"] --> H["packages/agent/src/api/"]

    I["app-wallet/package.json\n'./inventory/*'"] -->|"bun: *.ts"| J["src/inventory/*.ts ✓"]
    I -->|"bun: *.ts (NO MATCH)"| K["src/inventory/ChainIcon.tsx\nsrc/inventory/TokenLogo.tsx"]
    L["app-wallet/package.json\n'./inventory/ChainIcon'\n'./inventory/TokenLogo'\n(named, higher priority)"] -->|"bun: *.tsx ✓"| K

    style K fill:#ffe0e0
    style L fill:#d4edda
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): expose source-mode package..."](https://github.com/elizaos/eliza/commit/1ee2cf0332dab7497bbe35f4016f90b078ceb34a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31441491)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->