### PR TITLE
fix(distro-android): add RECEIVE_BOOT_COMPLETED + SYSTEM_ALERT_WINDOW to ANDROID_PERMISSIONS

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -600,6 +600,8 @@ const ANDROID_PERMISSIONS = [
   "FOREGROUND_SERVICE_SPECIAL_USE",
   "POST_NOTIFICATIONS",
   "WAKE_LOCK",
+  "RECEIVE_BOOT_COMPLETED",
+  "SYSTEM_ALERT_WINDOW",
   // PACKAGE_USAGE_STATS is granted via the privapp-permissions whitelist;
   // MANAGE_APP_OPS_MODES is what ElizaBootReceiver actually needs to
   // reflectively flip the GET_USAGE_STATS appop to ALLOWED at boot.


### PR DESCRIPTION
## Summary

\`scripts/distro-android/validate.mjs\` (and \`packages/app-core/scripts/aosp/validate.mjs\`) require both \`RECEIVE_BOOT_COMPLETED\` and \`SYSTEM_ALERT_WINDOW\` in the APK \`uses-permission\` set, but the manifest-merge step in \`packages/app-core/scripts/run-mobile-build.mjs\` does not inject either. Every freshly built privileged APK fails validation:

\`\`\`
[aosp:validate] APK badging is missing uses-permission:
  name='android.permission.RECEIVE_BOOT_COMPLETED'
\`\`\`

then after fixing that one:

\`\`\`
[aosp:validate] APK badging is missing uses-permission:
  name='android.permission.SYSTEM_ALERT_WINDOW'
\`\`\`

Both permissions are real product needs:

- \`RECEIVE_BOOT_COMPLETED\` — \`ElizaBootReceiver\` listens for \`ACTION_BOOT_COMPLETED\` to flip the \`GET_USAGE_STATS\` appop and start the agent service on cold boot.
- \`SYSTEM_ALERT_WINDOW\` — needed for the agent's overlay/notification surfaces.

This adds them to \`ANDROID_PERMISSIONS\` so the build pipeline injects them into the merged \`AndroidManifest.xml\`, and the validator's required-permissions contract is satisfied.

## Test plan

- [x] \`bun run miladyos:validate\` passes against the resulting privileged APK
- [x] \`m -j6\` of \`milady_cf_x86_64_phone-trunk_staging-userdebug\` succeeds with the new APK staged via \`vendor/milady\`
- [x] Booted in Cuttlefish and confirmed: \`adb shell cmd role get-role-holders\` returns \`ai.milady.milady\` for HOME, DIALER, SMS, ASSISTANT, and BROWSER, with no manifest validation errors at any step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a build-time validation failure by adding `RECEIVE_BOOT_COMPLETED` and `SYSTEM_ALERT_WINDOW` to the `ANDROID_PERMISSIONS` array in the manifest-merge step, aligning it with what both `validate.mjs` scripts already require.

- Both permissions were listed as required in `requiredApkPermissions` in both `packages/app-core/scripts/aosp/validate.mjs` and `scripts/distro-android/validate.mjs`, but the build script never injected them, causing every fresh privileged APK build to fail validation.
- The two-line addition follows the existing idempotent injection pattern (skip if already present in the XML), so there is no risk of duplicate entries.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix with no functional risk.

Two permission strings are added to an array that feeds an idempotent manifest-injection loop. The injection logic already skips entries already present in the XML, so there is no risk of duplicate entries. Both permissions are independently confirmed as required by the existing validator contracts in both validator files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/run-mobile-build.mjs | Added RECEIVE_BOOT_COMPLETED and SYSTEM_ALERT_WINDOW to ANDROID_PERMISSIONS so the manifest-merge step injects them, satisfying the contract checked by both validator scripts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Build as run-mobile-build.mjs
    participant Manifest as AndroidManifest.xml
    participant Validator as validate.mjs

    Build->>Build: Iterate ANDROID_PERMISSIONS[]
    Note over Build: Now includes RECEIVE_BOOT_COMPLETED<br/>and SYSTEM_ALERT_WINDOW
    loop For each permission not already in manifest
        Build->>Manifest: "Inject uses-permission for {PERM}"
    end
    Manifest-->>Validator: APK badging output
    Validator->>Validator: Check requiredApkPermissions[]
    Note over Validator: RECEIVE_BOOT_COMPLETED ✓<br/>SYSTEM_ALERT_WINDOW ✓
    Validator-->>Build: Validation passes
```

<sub>Reviews (1): Last reviewed commit: ["fix(distro-android): add RECEIVE\_BOOT\_CO..."](https://github.com/elizaos/eliza/commit/00ab917c0b4bd6835b8232c0c08392a3db7b3594) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31465127)</sub>

<!-- /greptile_comment -->