### PR TITLE
fix(plugin-anthropic): rebuild ToolSet from tool.name when callers pass array

### DIFF
--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -223,25 +223,40 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
   if (!value) {
     return undefined;
   }
-  if (!Array.isArray(value)) {
-    return isRecord(value) ? (value as ToolSet) : undefined;
-  }
+
+  // Source can be either an array of ToolDefinition (each with .name) or a
+  // Record<string, ...>. ELIZAOS upstream sometimes passes the array as a
+  // Record with numeric keys (`{0: tool, 1: tool}`), which makes the AI SDK
+  // wire the tool name as "0" / "1" — the runtime parser then can't match
+  // the response against canonical names like HANDLE_RESPONSE / PLAN_ACTIONS.
+  // Walk both forms and rebuild keyed by tool.name when present.
+  const entries: Iterable<unknown> = Array.isArray(value)
+    ? value
+    : Object.values(value as Record<string, unknown>);
 
   const tools: Record<string, unknown> = {};
-  for (const rawTool of value) {
+  let sawNamedTool = false;
+  for (const rawTool of entries) {
     if (!isRecord(rawTool) || typeof rawTool.name !== "string") {
       continue;
     }
+    sawNamedTool = true;
     const schema = isRecord(rawTool.parameters)
       ? (rawTool.parameters as JSONSchema7)
-      : ({ type: "object" } satisfies JSONSchema7);
+      : isRecord(rawTool.input_schema)
+        ? (rawTool.input_schema as JSONSchema7)
+        : ({ type: "object" } satisfies JSONSchema7);
     tools[rawTool.name] = {
       ...(typeof rawTool.description === "string" ? { description: rawTool.description } : {}),
       inputSchema: jsonSchema(schema),
     };
   }
 
-  return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
+  if (sawNamedTool) {
+    return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
+  }
+  // Fall back to the original Record (already keyed by canonical names).
+  return !Array.isArray(value) && isRecord(value) ? (value as ToolSet) : undefined;
 }
 
 function readToolChoice(value: GenerateTextParams["toolChoice"]): ToolChoice<ToolSet> | undefined {


### PR DESCRIPTION
## What

`readToolSet()` in `plugins/plugin-anthropic/models/text.ts` builds the AI SDK `ToolSet` (a `Record<string, Tool>` keyed by tool name) from caller input. The previous logic only reconstructed when the input was an array; when callers passed something that JS already coerced into a `Record` with numeric keys (e.g. from `Object.fromEntries(arr.entries())` or just an array assigned to a `Record`-typed slot), the function passed the value straight through.

In the elizaOS runtime path that drives `@elizaos/plugin-anthropic` from the v5 message handler, this resulted in:

- caller passes `messageHandlerTools` as an array containing `createHandleResponseTool({...})`
- by the time `readToolSet` saw it, the array had been coerced to `{0: tool}`
- `readToolSet` returned that as-is
- the wire body sent to the Anthropic API contained `tools: [{name: "0", description: "Stage 1 — pick how to handle this turn..."}]`
- Anthropic accepted the request and the model called the tool by the name we gave it (`"0"`)
- the runtime parser at `packages/core/src/services/message.ts` only matches tool names against `HANDLE_RESPONSE` / `PLAN_ACTIONS` (`HANDLE_RESPONSE_TOOL_NAME`), so the response could not be parsed and the runtime threw `v5 messageHandler returned invalid MessageHandlerResult`

## Fix

Walk either the array or the record's values. If any entry has a string `name` field, rebuild the `Record` keyed by that name. If no entry has `.name` (the caller already gave us a properly named record), fall back to the original record so existing callers keep working.

Also accept `rawTool.input_schema` as a fallback when `rawTool.parameters` is missing — the elizaOS `HANDLE_RESPONSE` tool serializes its schema as `input_schema`.

## Validation

- `bunx @biomejs/biome format .` from `plugins/plugin-anthropic`: clean
- Live regression on Discord through the v5 message handler: simple, time, repo, btc, disk, image, app-build, pr-status — all replies clean, trajectory `status="finished"` with `toolCallFailures=0` and `evaluatorFailures=0`

## Diff size

51 lines, single function. No test or behavior change for callers that already pass a properly-keyed `ToolSet`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `readToolSet()` in `plugin-anthropic` to rebuild the AI SDK `ToolSet` from each entry's `.name` field when the caller passes an array (or a record with numeric keys coerced from an array). It also adds `input_schema` as a fallback when the elizaOS `HANDLE_RESPONSE` tool serialises its schema under that key instead of `parameters`.

- **Core fix**: `Object.values()` is now used for non-array input, and the record is rebuilt keyed by `tool.name` whenever any entry carries a string name — falling back to the original record if none do, preserving backward compatibility with callers that already supply a properly-keyed `ToolSet`.
- **Schema fallback**: `input_schema` is accepted when `parameters` is missing, resolving the `HANDLE_RESPONSE`/`PLAN_ACTIONS` matching failure in the v5 message handler.
- **Test coverage**: The two new branches (numeric-keyed rebuild and `input_schema` fallback) are not covered by unit tests; only a live Discord regression was used for validation.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the target bug scenario; the two new code paths have no unit-test coverage, leaving regressions dependent on live smoke testing.

The logic change is small, well-commented, and correctly handles the described numeric-key coercion. The sawNamedTool fallback preserves existing callers. The main gaps are unit tests for the new branches and a theoretical silent tool-drop when a mixed-format record is passed, but neither affects the production path described in the PR.

plugins/plugin-anthropic/models/text.ts — the new array-rebuild and input_schema paths are untested by the shape test suite.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-anthropic/models/text.ts | Fixes readToolSet() to rebuild ToolSet from tool.name when callers pass an array or a numerically-keyed record; adds input_schema as a fallback schema source. Logic is correct for the target bug scenario; two new code paths lack unit-test coverage, and a silent tool-drop can occur with mixed-format records. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readToolSet(value)"] --> B{value is falsy}
    B -- yes --> Z[return undefined]
    B -- no --> C{Array.isArray}
    C -- yes --> D["entries = value"]
    C -- no --> E["entries = Object.values(value)"]
    D --> F[Loop over entries]
    E --> F
    F --> G{isRecord AND name is string}
    G -- no --> H[skip entry]
    G -- yes --> I[sawNamedTool = true]
    I --> J{isRecord parameters}
    J -- yes --> K[schema = parameters]
    J -- no --> L{isRecord input_schema}
    L -- yes --> M[schema = input_schema]
    L -- no --> N["schema = {type: object}"]
    K --> O["tools[name] = rebuilt entry"]
    M --> O
    N --> O
    O --> F
    H --> F
    F --> P{sawNamedTool}
    P -- yes --> Q{tools non-empty}
    Q -- yes --> R[return rebuilt ToolSet]
    Q -- no --> Z
    P -- no --> S{not array AND isRecord}
    S -- yes --> T[return original record]
    S -- no --> Z
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-anthropic/models/text.ts`, line 222-259 ([link](https://github.com/elizaos/eliza/blob/5fd624f4e78a0f07f91d13326ea203562d290655/plugins/plugin-anthropic/models/text.ts#L222-L259)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **No unit tests for the two new code paths**

   The existing test suite passes pre-built `ToolSet` objects (e.g. `{ lookup: { description: "...", inputSchema: ... } }`) and relies on `call.tools === tools` identity checks — these never exercise the rebuilt-from-`name` branch. Two paths added by this PR have no coverage: (1) a record with numeric keys whose values carry a `.name` field (the exact bug scenario), and (2) the `input_schema` fallback when `parameters` is absent. The live Discord regression provides confidence for the happy path, but a future refactor could quietly break either branch with no test failure.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-anthropic): rebuild ToolSet f..."](https://github.com/elizaos/eliza/commit/5fd624f4e78a0f07f91d13326ea203562d290655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31468378)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->