### PR TITLE
fix(core): emit fallback messageToUser when planner loop hits iteration cap

### DIFF
--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -466,6 +466,33 @@ export async function runPlannerLoop(
 			finalMessage,
 		};
 	}
+	// Iteration cap reached without a synthesised user-facing message. Without a
+	// fallback the connector has nothing to send and the user sees silence — the
+	// same trajectory shows planner→tool→evaluation iterating with no progress.
+	// Prefer the planner's last explicit `messageToUser` if present; otherwise
+	// emit a deterministic, honest failure reply so the user knows what happened.
+	if (!evaluator.messageToUser) {
+		const cappedMessage =
+			lastPlannerExplicitMessageToUser ??
+			"I tried several steps but couldn't finish that. Try rephrasing the request or breaking it into smaller pieces.";
+		params.runtime.logger?.warn?.(
+			{
+				maxPlannerIterations: config.maxPlannerIterations,
+				steps: trajectory.steps.length,
+				usedExplicitPlannerMessage: typeof lastPlannerExplicitMessageToUser === "string",
+			},
+			"Planner loop reached iteration cap without a synthesised reply; emitting fallback messageToUser",
+		);
+		return {
+			status: "continued",
+			trajectory,
+			evaluator: {
+				...evaluator,
+				messageToUser: cappedMessage,
+			},
+			finalMessage: cappedMessage,
+		};
+	}
 	return {
 		status: "continued",
 		trajectory,


### PR DESCRIPTION
## What

`runPlannerLoop()` in `packages/core/src/runtime/planner-loop.ts` exits silently when it reaches `config.maxPlannerIterations` without an explicit `messageToUser`. The connector then has nothing to send and the user sees no reply, even though the trajectory is marked `status: "finished"`. Trajectory metrics for these turns end with `finalDecision: null` and `evaluator.messageToUser` undefined.

Repro: a turn where the model gets stuck calling the same non-terminal tool repeatedly (e.g. native `BASH mkdir`) without making progress. The loop reaches the iteration cap, the existing branch at the bottom of the function only emits a `finalMessage` when `requireNonTerminalToolCall && !hasExecutedNonTerminalTool(trajectory)`, and otherwise returns the cap-default `evaluator` (which has no `messageToUser`).

## Fix

Add a fallback at the cap-exit path: if `evaluator.messageToUser` is missing, prefer the planner's last explicit `messageToUser` (`lastPlannerExplicitMessageToUser` is already tracked in the loop), otherwise emit a deterministic honest reply explaining the runtime gave up. Log at `logger.warn` with the iteration count and a flag indicating whether the explicit planner field was used, so the failure mode is observable.

## Why this matters

Without this, certain v5 turns disappear into the void from the user's perspective — there's no UI signal that the runtime did anything. The fallback restores the contract that every `RESPOND` turn produces a user-facing message, even when the planner couldn't finish the work.

## Diff size

A single conditional block at the cap-exit, plus the existing `requireNonTerminalToolCall` branch is unchanged. No new exports, no new types.

## Validation

- `bun run --cwd packages/core build:node` clean (node + types).
- Live Discord regression after applying: previously-broken Discord-reply prompts that triggered the BASH-loop now produce graceful fallback replies instead of going silent. Clean direct-mention prompts (which already routed correctly) continue to behave the same — the patch is defensive and only fires at the iteration cap.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fallback at the iteration-cap exit of `runPlannerLoop` so that turns exhausting `maxPlannerIterations` without a synthesised `evaluator.messageToUser` always produce a user-visible reply — either the planner's last explicit `messageToUser` or a hard-coded honest failure string — instead of silently returning nothing to the connector.

- **Fallback message selection**: prefers `lastPlannerExplicitMessageToUser` (already tracked per-iteration) over a deterministic hard-coded string, with a `logger.warn` recording iteration count and which path was taken.
- **Scope**: the new block sits after the existing `requireNonTerminalToolCall` guard and before the final `return { status: "continued" }`, so it only fires when both that guard and a clean evaluator message are absent.

<h3>Confidence Score: 3/5</h3>

Safe to merge after adding the isUnsafeUserVisibleText guard; without it the BASH-loop scenario can surface raw tool-call syntax to users in the fallback message.

Every other call site that surfaces lastPlannerExplicitMessageToUser to the user runs the value through isUnsafeUserVisibleText before exposing it. The new fallback skips this check, so a planner whose last iteration emitted a messageToUser containing function-call fragments would forward that internal text to the connector instead of the safe hard-coded string.

packages/core/src/runtime/planner-loop.ts — specifically the new if (!evaluator.messageToUser) block around line 474.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-loop.ts | Adds an iteration-cap fallback that emits a user-facing message when the evaluator has none; `lastPlannerExplicitMessageToUser` is used without the `isUnsafeUserVisibleText` guard applied by every other call site that surfaces this value. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): emit fallback messageToUser w..."](https://github.com/elizaos/eliza/commit/4f1b10203cb3bcef77e3f3516db9cf1ef949863f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31469493)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->