### PR TITLE
fix(plugin-discord): place reply quote after user content for cleaner stage 1 routing

### DIFF
--- a/plugins/plugin-discord/inbound-envelope.ts
+++ b/plugins/plugin-discord/inbound-envelope.ts
@@ -112,9 +112,15 @@ export async function formatInboundEnvelope(
 			const refContent = refMessage.content ?? "";
 			const truncated =
 				refContent.length > 200 ? `${refContent.slice(0, 200)}...` : refContent;
+			// Put the reply quote AFTER the user's actual message so Stage 1
+			// classification weights the user's current intent first. The previous
+			// order ("replying to @x:\n> <quote>\n<userText>") biased the
+			// classifier toward the quoted topic, which broke routing for turns
+			// where the user replied to a long bot message and asked for something
+			// unrelated (e.g. an app build after a tech-debt status update).
 			replyContext = truncated
-				? ` replying to @${refAuthor}:\n> ${truncated}\n`
-				: ` replying to @${refAuthor}:\n`;
+				? `\n(in reply to @${refAuthor}: "${truncated}")`
+				: `\n(in reply to @${refAuthor})`;
 		} catch {
 			// Reply context is best-effort only.
 		}
@@ -122,9 +128,7 @@ export async function formatInboundEnvelope(
 
 	const header = `[Discord ${channelLabel}] @${senderName} (${timestamp})`;
 	return {
-		formattedContent: replyContext
-			? `${header}${replyContext}${rawContent}`
-			: `${header}: ${rawContent}`,
+		formattedContent: `${header}: ${rawContent}${replyContext}`,
 		chatType,
 	};
 }


### PR DESCRIPTION
## What

When a Discord message has a `message_reference` (a Discord reply), `formatInboundEnvelope` in `plugins/plugin-discord/inbound-envelope.ts` injects the quoted reply BEFORE the user's actual message text:

```
[Discord <chan>] @<user> (<time>) replying to @<refAuthor>:
> <truncated quoted message>
<user's actual message>
```

In Eliza v5, Stage 1 (`HANDLE_RESPONSE`) classifies the turn's `plan.contexts` from the full user-message string. Putting the quote first biases that classifier toward the quoted topic — so a user replying to a long technical message and then asking for an unrelated app build can land in `general` instead of `apps`, which routes the planner to native `BASH` rather than `SPAWN_AGENT`. That makes the orchestrator's configured workdir routes (and any `apps`-context tooling) invisible to the model, and the planner can spin until the iteration cap.

## Fix

Place the quote AFTER the user's message and demote it to a parenthetical context note rather than a Markdown blockquote:

```
[Discord <chan>] @<user> (<time>): <user's actual message>
(in reply to @<refAuthor>: "<truncated quoted message>")
```

Same information, but Stage 1 sees the user's intent first and the quote is clearly framed as context rather than content. This is independent of the v5 planner-loop iteration-cap fallback (#7526) — that one is the safety net; this one is the actual cure for the most common reply-context misroute.

## Validation

- `bunx @biomejs/biome format .` from `plugins/plugin-discord`: clean
- Live live test: a Discord reply asking for an app build now routes through `SPAWN_AGENT` to the configured `agent-home` workdir instead of falling into BASH-direct mode

## Diff size

A single function in one file. No new exports, no new types, no behavior change for non-reply Discord messages (they keep the existing `${header}: ${rawContent}` shape).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reorders the Discord reply-context in `formatInboundEnvelope` so the user's own message appears first and the quoted reply is demoted to a trailing parenthetical, fixing Stage 1 classifier misrouting when a user replies to a long message and asks something unrelated.

- **Routing fix**: Moving `replyContext` after `rawContent` ensures the LLM classifier weights the user's current intent before the quoted context, preventing topic-bleed that incorrectly landed `apps`-category turns in `general`.
- **Format simplification**: The reply/non-reply conditional in `formattedContent` is collapsed into a single expression; non-reply messages are unaffected.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is confined to a single string-formatting function and does not affect non-reply messages.

The reordering logic is correct and the non-reply code path is unchanged. The only open question is whether double-quote characters inside a quoted message could produce a malformed parenthetical that slightly undermines the classifier improvement the PR aims for.

plugins/plugin-discord/inbound-envelope.ts — specifically the new double-quote delimiters around the truncated reply content.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/inbound-envelope.ts | Moves the Discord reply quote from a leading Markdown blockquote to a trailing parenthetical; unifies the reply/non-reply formatting branch. One minor issue: double-quotes wrapping the truncated content can collide with double-quotes inside the quoted message text. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant D as Discord Message
    participant FIE as formatInboundEnvelope
    participant S1 as Stage 1 Classifier

    Note over D,S1: Before (broken routing)
    D->>FIE: message with reply reference
    FIE->>S1: "[Discord #chan] @user (time) replying to @bot: long tech quote - Build me an app"
    S1-->>FIE: classifies as general (biased by quote topic)

    Note over D,S1: After (this PR)
    D->>FIE: message with reply reference
    FIE->>S1: "[Discord #chan] @user (time): Build me an app - in reply to @bot: truncated quote"
    S1-->>FIE: classifies as apps (user intent seen first)
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-discord): place reply quote a..."](https://github.com/elizaos/eliza/commit/65f2144bb8ebef2e3119b3c27cc9d9d0c878165a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31471258)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->