### PR TITLE
fix(core): externalise mammoth/unpdf/@ai-sdk/gateway/@vercel/oidc from browser bundle

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -627,6 +627,22 @@ const browserExternals = [
 	"node:diagnostics_channel", // Node.js built-in module
 	"node:async_hooks", // Node.js built-in module
 	"fs-extra", // Node-only fs library; host bundlers stub this for browser/Capacitor
+	// Document extractors are Node-only (mammoth uses fs.readFile.bind, unpdf
+	// pulls in Node fs/util internals). Reachable from
+	// features/documents/utils.ts; with `target: "node"` Bun inlines these
+	// even when only used inside Node-side flows. Mark as external so the
+	// host bundler resolves them only on the Node side.
+	"mammoth",
+	"unpdf",
+	// Vercel AI SDK gateway has a transitive `@vercel/oidc` import that
+	// touches `os.platform()`/`os.arch()`/`os.hostname()` at module-load
+	// to build a User-Agent string. That throws in the browser even when
+	// host bundlers stub `os`, because the call site uses
+	// `(0, os.platform)()` after a destructured re-binding, which loses the
+	// Proxy chaining. Externalise the gateway and its transitive sentinel
+	// so the browser bundle never invokes the call.
+	"@ai-sdk/gateway",
+	"@vercel/oidc",
 ];
 
 // Node-specific externals (native modules and node-specific packages)


### PR DESCRIPTION
## Summary

`@elizaos/core@2.0.0-alpha.537`'s `dist/browser/index.browser.js` ships with three Node-only library fragments inlined that crash on first access in any browser/WebView environment, killing every consumer that imports `@elizaos/core` from a Vite/rolldown app. Adding 4 packages to \`browserExternals\` in \`packages/core/build.ts\` makes Bun emit them as runtime-resolved externals instead.

The 3 crash-on-import problems found by attaching chrome-devtools to a Capacitor WebView running the milady privileged-system APK in Cuttlefish:

1. **fs-extra** (already in \`browserExternals\`, but Bun's \`target: "node"\` was inlining it anyway via a transitive ESM chain). Crashed with \`Cannot read properties of undefined (reading 'native')\` at \`fs.realpath.native\` access.
2. **mammoth + unpdf**. Crashed with \`Cannot read properties of undefined (reading 'bind')\` at \`util.promisify(fs.readFile.bind(fs))\` in mammoth's module init.
3. **@ai-sdk/gateway → @vercel/oidc** (transitive via \`ai\`). Crashed with \`(0 , u.platform) is not a function\` because \`@vercel/oidc\` calls \`(0, os.platform)()\` at module-load to build a User-Agent string. The destructured re-binding form defeats the host \`os\` Proxy stub.

## Bundle delta

| | Before | After |
|---|---|---|
| \`dist/browser/index.browser.js\` | 8.05 MB | **2.94 MB** (~64% smaller) |
| \`grep -c 'fs-extra-WARN'\` | 5 | 0 |
| \`grep -c 'could not find external image'\` | 1 | 0 |
| \`grep -c '@vercel/oidc'\` | 1 | 0 |

## Test plan

- [x] \`bun run build\` in \`packages/core\` produces a 2.94 MB browser bundle with zero references to the 4 externalised packages
- [x] Built the milady privileged Android APK against the new bundle, flashed to a Cuttlefish device with \`milady_cf_x86_64_phone-trunk_staging-userdebug\`
- [x] Attached chrome-devtools to the Capacitor WebView (\`adb forward tcp:9222 localabstract:webview_devtools_remote_*\`); confirmed \`document.getElementById('root').children.length\` goes from 0 to 1, React renders the milady "CONNECTING TO BACKEND…" loader + brand art, no thrown exceptions

## Notes

Hosts that need DOCX/PDF extraction or AI SDK gateway resolution should import them via dynamic \`import()\` on the Node side; the browser variant of \`@elizaos/core\` is no longer self-sufficient for those flows, but it never functioned for them in the browser anyway — the inlined code crashed at load before any of these features could run.

This pairs with https://github.com/elizaOS/eliza/pull/7523 — that one fixed the validator/build permission contract on the AOSP path; this one fixes module-load crashes on the React side. Both are needed end-to-end for a Capacitor host to consume \`@elizaos/core\` cleanly from a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four Node-only packages (`mammoth`, `unpdf`, `@ai-sdk/gateway`, `@vercel/oidc`) to the `browserExternals` list in `packages/core/build.ts`, preventing Bun from inlining them into the browser and edge bundles where they crash at module load time.

- **Browser crash fixes**: `mammoth` and `unpdf` call `fs.readFile.bind(fs)` and pull in Node `fs`/`util` at load, while `@ai-sdk/gateway` transitively imports `@vercel/oidc`, which invokes `(0, os.platform)()` at load — both patterns throw in browser/WebView environments even with `os` stubbed.
- **Bundle size**: Externalising these packages reduces `dist/browser/index.browser.js` from ~8.05 MB to ~2.94 MB (~64%). The same `browserExternals` array is shared with `buildEdge()`, so the edge bundle also drops these Node-only inlines.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to the browser/edge external list in the build script, directly fixes confirmed crash-on-load behaviour, and has no impact on Node builds.

Only one file changed, and the change is an additive append to an existing allow-list. The packages being externalised were already crashing at import in browser environments, so removing them from the bundle cannot regress any currently working functionality. The edge build shares the same browserExternals array, which is also correct since edge runtimes lack Node.js fs/os APIs.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/build.ts | Adds mammoth, unpdf, @ai-sdk/gateway, and @vercel/oidc to browserExternals so they are not inlined into the browser/edge bundle, fixing module-load crashes on those targets. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(core): externalise mammoth/unpdf/@ai..."](https://github.com/elizaos/eliza/commit/060e2024b368eced23864f4283e33606a4d47995) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31472104)</sub>

<!-- /greptile_comment -->