### PR TITLE
fix(core): lazy-import document extractors to keep browser bundle clean

### DIFF
--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -627,6 +627,14 @@ const browserExternals = [
 	"node:diagnostics_channel", // Node.js built-in module
 	"node:async_hooks", // Node.js built-in module
 	"fs-extra", // Node-only fs library; host bundlers stub this for browser/Capacitor
+	// Document extractors are Node-only (mammoth uses fs.readFile.bind, unpdf
+	// pulls in Node fs/util internals). Reachable from
+	// features/documents/utils.ts which is dynamic-imported lazily — but
+	// Bun's `target: "node"` build still inlines dynamic imports unless the
+	// module is declared external. Hosts that need DOCX/PDF extraction load
+	// these at runtime via dynamic import on the Node side.
+	"mammoth",
+	"unpdf",
 ];
 
 // Node-specific externals (native modules and node-specific packages)

--- a/packages/core/src/features/documents/utils.ts
+++ b/packages/core/src/features/documents/utils.ts
@@ -1,8 +1,14 @@
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import * as mammoth from "mammoth";
-import { extractText } from "unpdf";
 import { v5 as uuidv5 } from "uuid";
+
+// mammoth and unpdf are heavy Node-side document extractors that pull
+// fs/util/path internals into the bundle. They are only reachable from
+// extractTextFromFileBuffer / convertPdfToTextFromBuffer, both of which
+// are document-ingestion entry points exclusive to Node-side flows.
+// Lazy-import via dynamic `import()` so Bun's bundler tree-shakes them
+// out of the @elizaos/core browser bundle (where they crash on first
+// access — see commit message for the exact failure modes).
 
 const PLAIN_TEXT_CONTENT_TYPES = [
 	"application/typescript",
@@ -32,7 +38,8 @@ export async function extractTextFromFileBuffer(
 		"application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 	) {
 		try {
-			const result = await mammoth.extractRawText({ buffer: fileBuffer });
+			const { extractRawText } = await import("mammoth");
+			const result = await extractRawText({ buffer: fileBuffer });
 			return result.value;
 		} catch (docxError) {
 			const errorMessage =
@@ -96,6 +103,7 @@ export async function convertPdfToTextFromBuffer(
 			),
 		);
 
+		const { extractText } = await import("unpdf");
 		const result = await extractText(uint8Array, {
 			mergePages: true,
 		});


### PR DESCRIPTION
## Summary

`mammoth` and `unpdf` are heavy Node-side document extractors that pull `fs`/`util`/`path` internals into the bundle. The static `import * as mammoth from "mammoth"` and `import { extractText } from "unpdf"` in `packages/core/src/features/documents/utils.ts` are inlined into `@elizaos/core`'s browser bundle, where they crash on first access in browser/Capacitor consumers (no `node:fs`).

## Change

Two surgical changes in `packages/core`:

- **`src/features/documents/utils.ts`**: switch the two callsites (`extractTextFromFileBuffer` for DOCX, `convertPdfToTextFromBuffer` for PDF) to dynamic `import()` so the modules are only resolved when document ingestion actually runs.
- **`build.ts`**: add `mammoth` and `unpdf` to `browserExternals` so Bun's `target: "node"` build doesn't inline the dynamic-imported modules through its loader.

DOCX/PDF extraction is exercised at runtime, not at module load — Node-side flows stay unchanged.

## Test plan
- [ ] Verify `bun run build` produces a `@elizaos/core` browser bundle that no longer references `mammoth` or `unpdf` directly
- [ ] Confirm DOCX/PDF extraction still works on the Node side via `extractTextFromFileBuffer` / `convertPdfToTextFromBuffer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts two static top-level imports of `mammoth` and `unpdf` in `packages/core/src/features/documents/utils.ts` to dynamic `import()` calls, and adds both packages to `browserExternals` in `build.ts` so Bun's bundler treats them as external for browser and edge builds.

- **`utils.ts`**: `extractTextFromFileBuffer` (DOCX) and `convertPdfToTextFromBuffer` (PDF) now lazy-import their respective libraries at call time instead of at module load, preventing Node-only fs/util internals from crashing browser/Capacitor consumers.
- **`build.ts`**: `mammoth` and `unpdf` added to `browserExternals`, which is used by both the browser build (`dist/browser`) and the edge build (`dist/edge`); the Node build (`dist/node`) intentionally omits them from its `nodeExternals` so Bun bundles them inline for Node-side consumers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — two surgical changes with no logic alterations; browser/edge builds are fixed and Node-side extraction is unaffected.

The diff is minimal: two dynamic-import swaps that preserve the exact call signatures of extractRawText and extractText, and two entries added to browserExternals. The Node build intentionally leaves the packages out of nodeExternals so they continue to be bundled inline for server-side consumers. No error-handling paths, public APIs, or type signatures changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/features/documents/utils.ts | Replaces two static top-level imports with inline dynamic import() calls inside each extractor function; logic and error handling are unchanged. |
| packages/core/build.ts | Adds mammoth and unpdf to browserExternals (consumed by both browser and edge builds) so Bun does not inline these CJS modules into the browser/edge bundles even when they appear only in dynamic imports. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module Load] -->|Before PR| B[Static import mammoth\nStatic import unpdf]
    A -->|After PR| C[No top-level imports]

    D[extractTextFromFileBuffer called\nwith DOCX content-type] --> E["await import('mammoth')"]
    E --> F[extractRawText runs\nNode-side only]

    G[convertPdfToTextFromBuffer called] --> H["await import('unpdf')"]
    H --> I[extractText runs\nNode-side only]

    J[Bun browser build] -->|browserExternals| K[mammoth & unpdf marked external\nNot bundled into dist/browser]
    J -->|browserExternals| L[mammoth & unpdf marked external\nNot bundled into dist/edge]

    M[Bun node build] -->|nodeExternals — no change| N[mammoth & unpdf bundled inline\ninto dist/node]
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): lazy-import document extracto..."](https://github.com/elizaos/eliza/commit/98453b03b4d17a5347cfcdca5ca47cea49851f4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31472263)</sub>

<!-- /greptile_comment -->