### PR TITLE
fix(plugin-anthropic): preserve pre-built SDK Tool entries during readToolSet rebuild

### DIFF
--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -243,34 +243,44 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
   // Record with numeric keys (`{0: tool, 1: tool}`), which makes the AI SDK
   // wire the tool name as "0" / "1" — the runtime parser then can't match
   // the response against canonical names like HANDLE_RESPONSE / PLAN_ACTIONS.
-  // Walk both forms and rebuild keyed by tool.name when present.
-  const entries: Iterable<unknown> = Array.isArray(value)
-    ? value
-    : Object.values(value as Record<string, unknown>);
+  // Walk both forms and rebuild keyed by tool.name when present. Heterogeneous
+  // Records (raw ToolDefinitions mixed with already-built AI SDK Tool objects
+  // that lack `.name`) preserve the SDK Tool entries under their original key
+  // so we don't silently drop them.
+  const isArr = Array.isArray(value);
+  const entries: Iterable<[string, unknown]> = isArr
+    ? (value as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
+    : Object.entries(value as Record<string, unknown>);
 
   const tools: Record<string, unknown> = {};
   let sawNamedTool = false;
-  for (const rawTool of entries) {
-    if (!isRecord(rawTool) || typeof rawTool.name !== "string") {
+  for (const [origKey, rawTool] of entries) {
+    if (!isRecord(rawTool)) {
       continue;
     }
-    sawNamedTool = true;
-    const schema = isRecord(rawTool.parameters)
-      ? (rawTool.parameters as JSONSchema7)
-      : isRecord(rawTool.input_schema)
-        ? (rawTool.input_schema as JSONSchema7)
-        : ({ type: "object" } satisfies JSONSchema7);
-    tools[rawTool.name] = {
-      ...(typeof rawTool.description === "string" ? { description: rawTool.description } : {}),
-      inputSchema: jsonSchema(schema),
-    };
+    if (typeof rawTool.name === "string" && rawTool.name) {
+      sawNamedTool = true;
+      const schema = isRecord(rawTool.parameters)
+        ? (rawTool.parameters as JSONSchema7)
+        : isRecord(rawTool.input_schema)
+          ? (rawTool.input_schema as JSONSchema7)
+          : ({ type: "object" } satisfies JSONSchema7);
+      tools[rawTool.name] = {
+        ...(typeof rawTool.description === "string" ? { description: rawTool.description } : {}),
+        inputSchema: jsonSchema(schema),
+      };
+    } else if (!isArr) {
+      // Pre-built AI SDK Tool entry inside a Record — pass through under its
+      // original string key so heterogeneous callers don't lose tools.
+      tools[origKey] = rawTool;
+    }
   }
 
   if (sawNamedTool) {
     return Object.keys(tools).length > 0 ? (tools as ToolSet) : undefined;
   }
   // Fall back to the original Record (already keyed by canonical names).
-  return !Array.isArray(value) && isRecord(value) ? (value as ToolSet) : undefined;
+  return !isArr && isRecord(value) ? (value as ToolSet) : undefined;
 }
 
 function readToolChoice(value: GenerateTextParams["toolChoice"]): ToolChoice<ToolSet> | undefined {

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -246,11 +246,20 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
   // Walk both forms and rebuild keyed by tool.name when present. Heterogeneous
   // Records (raw ToolDefinitions mixed with already-built AI SDK Tool objects
   // that lack `.name`) preserve the SDK Tool entries under their original key
-  // so we don't silently drop them.
+  // so we don't silently drop them. Two passes so named-tool keys always win
+  // deterministically over an SDK passthrough at the same key, regardless of
+  // iteration order.
   const isArr = Array.isArray(value);
-  const entries: Iterable<[string, unknown]> = isArr
+  const entries: Array<[string, unknown]> = isArr
     ? (value as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
     : Object.entries(value as Record<string, unknown>);
+
+  const namedKeys = new Set<string>();
+  for (const [, rawTool] of entries) {
+    if (isRecord(rawTool) && typeof rawTool.name === "string" && rawTool.name) {
+      namedKeys.add(rawTool.name);
+    }
+  }
 
   const tools: Record<string, unknown> = {};
   let sawNamedTool = false;
@@ -269,9 +278,11 @@ function readToolSet(value: GenerateTextParams["tools"]): ToolSet | undefined {
         ...(typeof rawTool.description === "string" ? { description: rawTool.description } : {}),
         inputSchema: jsonSchema(schema),
       };
-    } else if (!isArr) {
+    } else if (!isArr && !namedKeys.has(origKey)) {
       // Pre-built AI SDK Tool entry inside a Record — pass through under its
-      // original string key so heterogeneous callers don't lose tools.
+      // original string key, but only if no named tool will claim that key
+      // later in the same pass; otherwise the named tool would silently
+      // overwrite (or be overwritten by) this entry depending on order.
       tools[origKey] = rawTool;
     }
   }


### PR DESCRIPTION
## What

Follow-up to #7525 (merged). Greptile's review on that PR flagged a P2 issue I didn't catch in time:

> When `value` is a Record that contains a mix of raw `ToolDefinition` objects (those with a `.name` string) alongside already-built AI SDK `Tool` objects (which have no `.name`), the loop sets `sawNamedTool = true` from the ToolDefinition entries but silently skips the SDK Tool entries via `continue`. The final returned record only contains the rebuilt tools, dropping any pre-built SDK tools that lacked a `.name` field.

This PR walks `Object.entries` instead of `Object.values` and passes any non-named Record entry through under its original key, so heterogeneous callers (raw ToolDefinitions + pre-built SDK Tool objects in one dict) keep all their tools instead of silently dropping the pre-built ones.

## Diff

- 1 file, +27 / -17 in `plugins/plugin-anthropic/models/text.ts`
- behaviour for the array-and-numeric-keyed-Record case (the original bug #7525 fixed) is unchanged
- behaviour for purely named-Record callers is unchanged
- only changes the heterogeneous-Record case from "silently drop" to "pass through"

## Why a follow-up rather than amend

The original landed before this fix could be tacked on. Keeping it as a small standalone PR so the diff is reviewable on its own.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a focused follow-up to #7525 that fixes silent dropping of pre-built AI SDK `Tool` objects in heterogeneous `Record` inputs to `readToolSet`. The function now uses `Object.entries` with a two-pass approach: the first pass collects all `ToolDefinition` `.name` values into a `namedKeys` set, and the second pass rebuilds named tools normally while passing SDK Tool entries through under their original keys (skipping any `origKey` already claimed by a named tool).

- The array path and purely named-Record path are behaviourally unchanged; only the heterogeneous-Record case is affected.
- The two-pass design ensures named-tool keys deterministically win over an SDK passthrough at the same key, regardless of iteration order.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-scoped, and only affects the heterogeneous-Record path that was previously broken.

The two-pass approach correctly handles all four input variants (array, named-only Record, SDK-only Record, heterogeneous Record) with no regression on the already-tested paths. The `namedKeys` pre-computation ensures deterministic collision resolution without depending on iteration order, and the `!isArr` guard keeps array-path behavior identical to before.

No files require special attention. The single changed file is well-commented and the logic is straightforward to follow.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-anthropic/models/text.ts | Refactors `readToolSet` to use `Object.entries` (two-pass) so pre-built SDK Tool objects in a heterogeneous Record are preserved under their original key instead of being silently dropped. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readToolSet(value)"] --> B{"value is array?"}
    B -- Yes --> C["Map to index-keyed entries"]
    B -- No --> D["Object.entries(value)"]
    C --> E["Pass 1: build namedKeys Set"]
    D --> E
    E --> F["Pass 2: iterate entries"]
    F --> G{"isRecord(rawTool)?"}
    G -- No --> H["skip"]
    G -- Yes --> I{"rawTool.name is string?"}
    I -- Yes --> J["sawNamedTool = true, rebuild under rawTool.name key"]
    I -- No --> K{"not array AND origKey not in namedKeys?"}
    K -- Yes --> L["Pass through SDK Tool under origKey"]
    K -- No --> M["skip - key claimed by NamedTool"]
    J --> N{"sawNamedTool?"}
    L --> N
    M --> N
    H --> N
    N -- Yes --> O["return assembled tools as ToolSet"]
    N -- No --> P{"not array AND isRecord?"}
    P -- Yes --> Q["return original value as ToolSet"]
    P -- No --> R["return undefined"]
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-anthropic): make named-tool /..."](https://github.com/elizaos/eliza/commit/acc9d454b015ba408db5a5b6990a6e43d633738e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31473060)</sub>

<!-- /greptile_comment -->