### PR TITLE
fix(plugin-discord): use curly quotes around reply-context quote

### DIFF
--- a/plugins/plugin-discord/inbound-envelope.ts
+++ b/plugins/plugin-discord/inbound-envelope.ts
@@ -118,8 +118,11 @@ export async function formatInboundEnvelope(
 			// classifier toward the quoted topic, which broke routing for turns
 			// where the user replied to a long bot message and asked for something
 			// unrelated (e.g. an app build after a tech-debt status update).
+			// Use typographic curly quotes as outer delimiters so embedded straight
+			// `"` characters in the quoted content don't visually break the wrapper
+			// or confuse an LLM classifier reading the result.
 			replyContext = truncated
-				? `\n(in reply to @${refAuthor}: "${truncated}")`
+				? `\n(in reply to @${refAuthor}: “${truncated}”)`
 				: `\n(in reply to @${refAuthor})`;
 		} catch {
 			// Reply context is best-effort only.


### PR DESCRIPTION
## What

Follow-up to #7527 (merged). Greptile's review on that PR flagged a P2 issue I didn't catch in time:

> Unescaped double quotes in the quoted content can break the parenthetical wrapper. If the replied-to message contains double quotes (e.g. \`he said "hello"\`), the output becomes \`(in reply to @author: "he said "hello"")\`, which is visually ambiguous and may confuse an LLM classifier treating the outer quotes as delimiters.

This PR switches the outer delimiters from straight ASCII \`"\` to typographic curly quotes (U+201C / U+201D) so embedded straight quotes in the quoted content can never collide with the wrapper.

Result for a quoted message containing a quote:
- before: \`(in reply to @x: "he said "hello"")\` — ambiguous
- after: \`(in reply to @x: "he said "hello"")\` — clean

## Diff

- 1 file, +4 / -1 in `plugins/plugin-discord/inbound-envelope.ts`
- no behaviour change for messages without embedded quotes

## Why a follow-up rather than amend

The original landed before this fix could be tacked on.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted follow-up to #7527 that swaps the straight ASCII double-quote delimiters (`"`) around the Discord reply-context snippet for typographic curly quotes (`"` / `"`, U+201C / U+201D), preventing visual ambiguity when the quoted message itself contains straight quotes.

- **Single-line template change** in `inbound-envelope.ts`: the `replyContext` string on the truthy branch now wraps `${truncated}` with `"…"` instead of `"…"`, accompanied by an explanatory comment.
- **No behavioural change** for messages without embedded quotes; the only observable difference is the delimiter characters used in the formatted envelope string.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single template-string character swap with no logic alterations.

The diff touches exactly one line of one file, replacing two ASCII quote characters with their Unicode typographic equivalents. The surrounding logic (truncation, author lookup, error handling) is untouched. The curly quotes are distinct code points and cannot collide with embedded straight quotes in user content, which is precisely the defect being addressed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/inbound-envelope.ts | Replaces straight ASCII double quotes with typographic curly quotes (U+201C/U+201D) around the reply-context snippet, and adds a clarifying comment explaining the rationale. Change is isolated to one template string on line 125. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Discord as Discord Message
    participant IE as inbound-envelope.ts
    participant LLM as LLM Classifier

    Discord->>IE: message with reference (reply)
    IE->>Discord: fetchReference()
    Discord-->>IE: refMessage (author + content)
    IE->>IE: truncate content to 200 chars
    alt truncated content exists
        IE->>IE: wrap in curly quotes
    else no content
        IE->>IE: omit quote wrapper
    end
    IE->>LLM: formattedContent with unambiguous reply context
    LLM-->>IE: classification result
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-discord): use curly quotes ar..."](https://github.com/elizaos/eliza/commit/3d23cb6f3c0c1ba39c5f582e23af8d022d7646c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31473062)</sub>

<!-- /greptile_comment -->