### PR TITLE
fix(ui): route stale-bearer 401 straight to login gate

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -352,9 +352,30 @@ export async function runPollingBackend(
         dispatch({ type: "BACKEND_REACHED", onboardingComplete: true });
         return;
       }
+      if (
+        ae?.status === 401 &&
+        client.hasToken() &&
+        latestAuth.required &&
+        latestAuth.authenticated === false
+      ) {
+        // Stale bearer: token is in storage and we've already seen
+        // /api/auth/status report `required:true, authenticated:false`.
+        // Server is definitively rejecting this session — retrying every
+        // 250-1000ms for 15s won't change that, it just dead-ends on
+        // BACKEND_TIMEOUT with the last 401 detail. Route straight to the
+        // pairing/login gate so the user can re-pair or sign in.
+        deps.setAuthRequired(true);
+        deps.setPairingEnabled(latestAuth.pairingEnabled);
+        deps.setPairingExpiresAt(latestAuth.expiresAt);
+        deps.setOnboardingLoading(false);
+        dispatch({ type: "BACKEND_AUTH_REQUIRED" });
+        return;
+      }
       if (ae?.status === 401 && client.hasToken()) {
-        // 401-with-token but auth/status hasn't confirmed we're authenticated
-        // yet — port race / pre-bearer endpoint window. Fall through to retry.
+        // 401-with-token but auth/status hasn't confirmed authenticated:true
+        // OR authenticated:false yet — port race / pre-bearer endpoint
+        // window before the first auth/status poll completes. Fall through
+        // to retry.
       }
       if (ae?.status === 404) {
         deps.setStartupError(describeBackendFailure(err, false));


### PR DESCRIPTION
## Summary

When a paired bearer token in storage is rejected by the server (vault rotation, session expiry, server reset, etc.), `runPollingBackend` retries `/api/onboarding/status` against the rejected bearer for 15 s and then dead-ends on a `BACKEND_TIMEOUT` overlay with the trailing 401 as the only context. The user sees "Startup failed: Backend Timeout / `/api/onboarding/status` — HTTP 401 — Unauthorised" with no actionable recovery beyond clearing app data.

Reproduced on the Solana Seeker (Capacitor APK):
- App had a paired bearer from a prior session
- VPS server state changed under it (vault hydration), so the bearer is now invalid
- Boot → `/api/auth/status` returns `{required:true, authenticated:false, pairingEnabled:true}`
- `getOnboardingStatus()` 401s → existing 401-with-token branch is a comment-only fall-through → retry loop → 15 s timeout → "Backend Timeout"

## Why the existing branches don't catch this

`packages/ui/src/state/startup-phase-poll.ts`'s outer catch handles three 401-with-token shapes:

| line | condition | action |
|---|---|---|
| 328 | `401 && !hasToken()` | route to LoginView ✓ |
| 336 | `(401 \|\| 429) && hasToken() && latestAuth.authenticated === true` | bearer-only path, advance to "ready" so the auth gate renders LoginView ✓ |
| 355 | `401 && hasToken()` | comment-only no-op — falls through to retry ⚠️ |

The third branch was meant to ride out a port-race window before `/api/auth/status` completes. But it also catches the *definitive-rejection* state (`latestAuth.required && latestAuth.authenticated === false`), where retrying changes nothing.

## Fix

Add a 4th branch *before* the port-race fall-through: if `latestAuth` already told us `required:true && authenticated === false`, the session is gone — dispatch `BACKEND_AUTH_REQUIRED` immediately (with the correct `pairingEnabled` / `expiresAt` from the last poll) so the user lands on the pairing/login gate instead of the timeout overlay.

The existing `latestAuth.authenticated === true` branch (line 336) is unchanged. The existing port-race fall-through (now line 374) is unchanged — it still applies when `latestAuth.authenticated` is `undefined`, i.e. before the first auth/status response.

## Test plan
- [ ] Repro pre-fix on a paired Capacitor build with a stale bearer in storage (or simulate by rotating vault) — confirm "Startup failed: Backend Timeout" overlay
- [ ] Apply this PR + rebuild APK → confirm app routes to PairingView/LoginView on next boot instead of the timeout overlay
- [ ] Regression: confirm a *fresh* bearer (just paired, valid) still advances normally — line 336 path
- [ ] Regression: confirm port-race window (auth/status reachable before app endpoints) still retries via the unchanged fall-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to fix a stale-bearer flow where a rejected token would exhaust the 15-second polling timeout and land the user on a `BACKEND_TIMEOUT` overlay instead of the pairing/login gate. It adds a new early-exit branch in `runPollingBackend`'s outer catch block that checks `latestAuth.authenticated === false` and dispatches `BACKEND_AUTH_REQUIRED`.

- The new catch-block branch is unreachable: `latestAuth.authenticated` is set only by a successful `getAuthStatus()` call returning `authenticated:false`, but at that point the existing try-block guard at line 207 (`auth.required && !auth.authenticated && client.hasToken()`) fires first, returns, and the catch block is never entered with that state.
- `getAuthStatus()` internally converts a 401 response to `{ required: true, pairingEnabled: false }` (omitting `authenticated`), so the `=== false` strict check also never matches the synthetic return value.
- The root handling path for the described scenario remains line 207, which dispatches `BACKEND_REACHED` with `setAuthRequired(false)` \u2014 routing the stale-bearer case to \"ready\" rather than the pairing gate.

<h3>Confidence Score: 2/5</h3>

The change introduces new code in the catch block that cannot execute in the described scenario, leaving the reported user-facing bug unresolved.

The new guard checks `latestAuth.authenticated === false` strictly, but that value is never false when the outer catch block runs. When `getAuthStatus()` encounters a server 401 it internally swallows it and returns a synthetic object without the `authenticated` field (undefined). When the server does return `authenticated:false`, the try-block guard at line 207 fires and returns before `getOnboardingStatus()` is called — the catch block is never entered with that state. The stale-bearer path the PR aims to fix still routes through line 207 to `BACKEND_REACHED` rather than `BACKEND_AUTH_REQUIRED`.

packages/ui/src/state/startup-phase-poll.ts — the fix is in the wrong code path; the try-block guard at line 207 handles the same auth-state but routes to the wrong outcome.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/state/startup-phase-poll.ts | New catch-block branch checks `latestAuth.authenticated === false`, but this value can never be false when the catch block executes — the try-block guard at line 207 returns first whenever getAuthStatus() resolves with authenticated:false, and getAuthStatus() itself swallows 401s and returns undefined for authenticated. The reported stale-bearer → BACKEND_TIMEOUT bug remains unfixed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[start polling iteration] --> B[getAuthStatus call]
    B --> C{server 401?}
    C -->|Yes| D[internal catch: return required=true, pairingEnabled=false]
    C -->|No| E[use server response]
    D --> F{line 207}
    E --> F
    F -->|required and not-authenticated and hasBearer| G[BACKEND_REACHED dispatched\nfunction returns here]
    F -->|authenticated truthy or required false| H[getOnboardingStatus call]
    H --> I{throws 401?}
    I -->|Yes| J[catch block]
    J --> K{new branch\nlatestAuth.authenticated strictly false?}
    K -->|always undefined or truthy here| L[retry loop]
    I -->|No| M[success]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): route stale-bearer 401 straight..."](https://github.com/elizaos/eliza/commit/37d5c2487b8c43ec3474835bb7b8c40694c50174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31474036)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->