### PR TITLE
fix(app-core): use explicit .ts extension on steward-sidecar barrel re-export

### DIFF
--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -30,7 +30,13 @@ export * from "./services/auth-store";
 export * from "./services/github-credentials";
 export * from "./services/plugin-installer";
 export * from "./services/steward-credentials";
-export * from "./services/steward-sidecar";
+// Explicit .ts extension on steward-sidecar.ts disambiguates from the
+// sibling steward-sidecar/ directory: `tsc --rewriteRelativeImportExtensions`
+// emits `./services/steward-sidecar.js` in dist, which Node ESM can resolve
+// without falling through to the directory and crashing on the missing
+// dist/services/steward-sidecar/index.json fallback (the Docker production
+// smoke regression observed on PR #7528 / #7530).
+export * from "./services/steward-sidecar.ts";
 export * from "./services/steward-sidecar/helpers";
 export * from "./services/vault-bootstrap";
 export * from "./services/vault-mirror";


### PR DESCRIPTION
## Summary

Docker production smoke (`Dockerfile.ci`) has been crashing on container start since the steward-sidecar refactor that introduced both a parent `services/steward-sidecar.ts` file and a sibling `services/steward-sidecar/` directory of helpers:

```
[eliza-autonomous] Failed to start: Error [ERR_MODULE_NOT_FOUND]:
Cannot find module '/app/packages/app-core/dist/services/steward-sidecar/index.json'
imported from /app/packages/app-core/dist/index.js
```

Currently surfacing as the persistent "Build production Docker image (+ smoke boot)" failure on PRs #7528, #7530, and any other PR that triggers a fresh Docker smoke run.

## Cause

`packages/app-core/src/index.ts:33` had:

```ts
export * from "./services/steward-sidecar";
```

That path is ambiguous on disk:
- `packages/app-core/src/services/steward-sidecar.ts` (the parent module — the file we want)
- `packages/app-core/src/services/steward-sidecar/` (a sibling directory: `helpers.ts`, `health-check.ts`, `process-management.ts`, `types.ts`, `wallet-setup.ts`, but **no `index.ts`**)

`tsc` source-mode resolution picks the file (typecheck stays green) but does NOT rewrite an extensionless relative import. So the compiled `dist/index.js` ships `export * from "./services/steward-sidecar";` unchanged. At runtime in the Docker image, Node ESM sees both `dist/services/steward-sidecar.js` and `dist/services/steward-sidecar/` on disk and falls through to a directory-style index lookup that doesn't exist — the import throws, the container exits before the smoke probe binds, the CI step fails.

## Fix

One-character change: explicit `.ts` source extension. The repo already has `allowImportingTsExtensions: true` + `rewriteRelativeImportExtensions: true` in `packages/app-core/tsconfig.build.json`, so `tsc` rewrites the import to `./services/steward-sidecar.js` in dist:

```diff
-export * from "./services/steward-sidecar";
+export * from "./services/steward-sidecar.ts";
```

Verified locally:

```
$ bun run build:dist  # in packages/app-core
$ grep steward-sidecar dist/index.js | head -2
38:export * from "./services/steward-sidecar.js";
39:export * from "./services/steward-sidecar/helpers";
```

The dist output now has the explicit `.js` extension that Node ESM can resolve unambiguously to the file.

## Test plan
- [ ] CI green on `Build production Docker image (+ smoke boot)` (the previously-stuck check)
- [ ] Repository typecheck still passes
- [ ] No semantic change — same module exported under same name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Docker production boot crash caused by an ambiguous extensionless re-export in the `app-core` barrel file. Adding `.ts` explicitly lets `tsc` (with `rewriteRelativeImportExtensions: true`) emit the correct `.js`-suffixed path in `dist/index.js`, removing the Node ESM fallback that was resolving to a nonexistent directory index.

- **Root cause confirmed by `tsconfig.build.json`**: both `allowImportingTsExtensions` and `rewriteRelativeImportExtensions` are enabled, so the explicit `.ts` suffix is valid TypeScript and will be reliably rewritten to `.js` on emit.
- **Scope is minimal**: only the one ambiguous barrel export is touched; the sibling `steward-sidecar/helpers` sub-export (already an explicit subdirectory path) is unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-character extension change that fixes a confirmed Docker boot crash with no semantic impact on exported types or values.

The change is a single targeted token in a barrel file. Both `allowImportingTsExtensions` and `rewriteRelativeImportExtensions` are confirmed active in `tsconfig.build.json`, so the explicit `.ts` suffix is valid source and will be correctly rewritten to `.js` on emit. The existing `steward-sidecar/helpers` sub-export is unaffected. No logic, types, or runtime behavior change beyond fixing the broken import path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/index.ts | Adds explicit `.ts` extension to the `steward-sidecar` re-export so tsc's `rewriteRelativeImportExtensions` emits `.js` in dist, resolving Node ESM ambiguity between the sibling file and directory at runtime. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant src as src/index.ts
    participant tsc as tsc (rewriteRelativeImportExtensions)
    participant dist as dist/index.js
    participant node as Node ESM (Docker)

    Note over src: Before fix
    src->>tsc: "export * from "./services/steward-sidecar""
    tsc->>dist: "export * from "./services/steward-sidecar" (unchanged)"
    dist->>node: resolve "./services/steward-sidecar"
    node-->>dist: ambiguous: file.js vs dir/ falls through to dir/index.json ERR_MODULE_NOT_FOUND

    Note over src: After fix
    src->>tsc: "export * from "./services/steward-sidecar.ts""
    tsc->>dist: "export * from "./services/steward-sidecar.js""
    dist->>node: resolve "./services/steward-sidecar.js"
    node-->>dist: resolves unambiguously to the .js file
```

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): use explicit .ts extensio..."](https://github.com/elizaos/eliza/commit/2124c2806a228b1c15bfaa7c5dc0e925e2025fb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31474164)</sub>

<!-- /greptile_comment -->