### PR TITLE
fix(ci): export advanced-memory evaluator types + biome-format plugin-shell/plugin-sql

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -46,17 +46,17 @@ const longTermMemorySchema: JSONSchema = {
 	additionalProperties: false,
 };
 
-interface SummaryOutput {
+export interface SummaryOutput {
 	text: string;
 	topics: string[];
 	keyPoints: string[];
 }
 
-interface LongTermMemoryOutput {
+export interface LongTermMemoryOutput {
 	memories: MemoryExtraction[];
 }
 
-interface SummaryPrepared {
+export interface SummaryPrepared {
 	memoryService: MemoryService;
 	allDialogueMessages: Memory[];
 	summarizationMessages: Memory[];
@@ -68,7 +68,7 @@ interface SummaryPrepared {
 	canSummarize: boolean;
 }
 
-interface LongTermMemoryPrepared {
+export interface LongTermMemoryPrepared {
 	memoryService: MemoryService;
 	recentMessages: Memory[];
 	existingMemories: string;

--- a/plugins/plugin-shell/services/shellService.ts
+++ b/plugins/plugin-shell/services/shellService.ts
@@ -136,9 +136,11 @@ export class ShellService extends Service {
   }
 
   private getSandboxManager(): RuntimeSandboxManager | null {
-    const candidate = (this.runtime as unknown as {
-      getSandboxManager?: () => RuntimeSandboxManager | null;
-    }).getSandboxManager?.();
+    const candidate = (
+      this.runtime as unknown as {
+        getSandboxManager?: () => RuntimeSandboxManager | null;
+      }
+    ).getSandboxManager?.();
     return candidate ?? null;
   }
 
@@ -155,7 +157,7 @@ export class ShellService extends Service {
     command: string,
     workdir: string,
     timeoutMs: number,
-    env?: Record<string, string>,
+    env?: Record<string, string>
   ): Promise<CommandResult> {
     const sandboxManager = this.getSandboxManager();
     if (!sandboxManager) {

--- a/plugins/plugin-shell/utils/executionMode.ts
+++ b/plugins/plugin-shell/utils/executionMode.ts
@@ -19,7 +19,7 @@ function normalizeMode(value: unknown): RuntimeExecutionMode | null {
 }
 
 export function resolveRuntimeExecutionMode(
-  runtime?: Pick<IAgentRuntime, "getSetting"> | null,
+  runtime?: Pick<IAgentRuntime, "getSetting"> | null
 ): RuntimeExecutionMode {
   const candidates: unknown[] = [
     runtime?.getSetting?.("ELIZA_RUNTIME_MODE"),
@@ -37,20 +37,18 @@ export function resolveRuntimeExecutionMode(
 }
 
 export function resolveLocalExecutionMode(
-  runtime?: Pick<IAgentRuntime, "getSetting"> | null,
+  runtime?: Pick<IAgentRuntime, "getSetting"> | null
 ): LocalExecutionMode {
   const mode = resolveRuntimeExecutionMode(runtime);
   return mode === "local-safe" ? "local-safe" : "local-yolo";
 }
 
 export function shouldUseSandboxExecution(
-  runtime?: Pick<IAgentRuntime, "getSetting"> | null,
+  runtime?: Pick<IAgentRuntime, "getSetting"> | null
 ): boolean {
   return resolveRuntimeExecutionMode(runtime) === "local-safe";
 }
 
-export function isCloudExecutionMode(
-  runtime?: Pick<IAgentRuntime, "getSetting"> | null,
-): boolean {
+export function isCloudExecutionMode(runtime?: Pick<IAgentRuntime, "getSetting"> | null): boolean {
   return resolveRuntimeExecutionMode(runtime) === "cloud";
 }

--- a/plugins/plugin-shell/utils/processQueue.ts
+++ b/plugins/plugin-shell/utils/processQueue.ts
@@ -131,7 +131,7 @@ export async function runCommandWithTimeout(
   }
   if (mode === "local-safe") {
     throw new Error(
-      "[shell] runCommandWithTimeout cannot route through SandboxManager from this code path; use the runtime-aware shell action.",
+      "[shell] runCommandWithTimeout cannot route through SandboxManager from this code path; use the runtime-aware shell action."
     );
   }
 

--- a/plugins/plugin-sql/src/build.ts
+++ b/plugins/plugin-sql/src/build.ts
@@ -125,10 +125,7 @@ await writeFile(
 // resolve to a runtime JS file. Emit a small shim that re-exports the
 // schema from the bundled root so the consumer doesn't need to know the
 // internal layout.
-await writeFile(
-  join(DIST, "schema", "index.js"),
-  `export * from '../node/index.node.js';\n`
-);
+await writeFile(join(DIST, "schema", "index.js"), `export * from '../node/index.node.js';\n`);
 await appendFile(
   join(DIST, "index.node.d.ts"),
   `\nexport * from './schema/index.js';\nexport type { DrizzleDatabase } from './types.js';\n`


### PR DESCRIPTION
Post-merge CI cleanup after #7528, #7530, #7531, #7532, #7533 landed.

## What

Two unrelated CI fixes bundled together (both blocking develop):

### 1. TS4023 in advanced-memory evaluators

\`packages/core/src/features/advanced-memory/evaluators/memory-items.ts\` declares four interfaces (\`SummaryOutput\`, \`LongTermMemoryOutput\`, \`SummaryPrepared\`, \`LongTermMemoryPrepared\`) without \`export\`, then uses them as the type parameters of the exported \`summaryEvaluator\` and \`longTermMemoryEvaluator\` constants. tsc -d cannot name the public type of those exports without the underlying interfaces being exported, so declaration emit fails with:

\`\`\`
src/features/advanced-memory/evaluators/index.ts(13,14): error TS4023:
  Exported variable 'longTermMemoryEvaluator' has or is using name 'LongTermMemoryOutput'
  from external module ".../memory-items" but cannot be named.
\`\`\`

This is the trailing failure on the \"Build production Docker image (+ smoke boot)\" check on every recent develop push (\`exit code 1\` at \`build.ts --node-only\`). Adding \`export\` to the four interfaces clears the emit and unblocks Docker smoke.

### 2. biome format on plugin-shell + plugin-sql

\`bun run format:check\` was failing on develop with three errors in \`plugins/plugin-shell\` (\`services/shellService.ts\`, \`utils/executionMode.ts\`, \`utils/processQueue.ts\`) and one in \`plugins/plugin-sql/src/build.ts\` — recent edits left lines slightly above biome's preferred wrapping. Auto-format applied with \`bunx @biomejs/biome format --write\`. No semantic change.

## Test plan

- [x] \`bun run --cwd packages/core build.ts --node-only\` — clean (was failing on TS4023)
- [x] \`bun run format:check\` — 66/66 packages green

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted CI cleanup PR that bundles two unrelated fixes blocking the `develop` branch. The changes are minimal and mechanical with no runtime behavior changes.

- **TS4023 fix**: Adds `export` to four interfaces in `memory-items.ts` (`SummaryOutput`, `LongTermMemoryOutput`, `SummaryPrepared`, `LongTermMemoryPrepared`) so tsc declaration emit can name the public types of `summaryEvaluator` and `longTermMemoryEvaluator`. These interfaces remain unchanged structurally.
- **Biome formatting**: Auto-formats `plugin-shell` (3 files) and `plugin-sql/src/build.ts` to satisfy `bun run format:check` — trailing commas removed and a few expressions reflowed; strictly cosmetic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the interface exports are a purely additive TypeScript change with no runtime effect, and the biome-format changes are cosmetic rewrites verified by `format:check`.

Both fixes are narrow and low-risk: exporting the four interfaces adds new public API surface only at the type level (zero runtime impact), and the formatter changes are semantically identical to what they replace. The PR description includes a clear test plan that covers both failure modes that were being fixed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/features/advanced-memory/evaluators/memory-items.ts | Adds `export` to four previously private interfaces (SummaryOutput, LongTermMemoryOutput, SummaryPrepared, LongTermMemoryPrepared) to satisfy tsc declaration emit (TS4023). |
| plugins/plugin-shell/services/shellService.ts | Pure biome formatting: reformats a cast expression to multi-line and removes a trailing comma from a function parameter — no semantic change. |
| plugins/plugin-shell/utils/executionMode.ts | Pure biome formatting: removes trailing commas from three function signatures and collapses `isCloudExecutionMode` to a single line — no semantic change. |
| plugins/plugin-shell/utils/processQueue.ts | Pure biome formatting: removes a trailing comma inside a string argument — no semantic change. |
| plugins/plugin-sql/src/build.ts | Pure biome formatting: collapses a multi-line `writeFile` call to a single line — no semantic change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[memory-items.ts] -->|exports| B[SummaryOutput]
    A -->|exports| C[LongTermMemoryOutput]
    A -->|exports| D[SummaryPrepared]
    A -->|exports| E[LongTermMemoryPrepared]
    B --> F[summaryEvaluator]
    C --> G[longTermMemoryEvaluator]
    D --> F
    E --> G
    F -->|re-exported via| H[evaluators/index.ts]
    G -->|re-exported via| H
    H -->|tsc -d succeeds| I[Declaration emit ✅]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): export advanced-memory evaluato..."](https://github.com/elizaos/eliza/commit/d8c97fd62df08ed8276fe83f7bc3e4b0f54ffca7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31474785)</sub>

<!-- /greptile_comment -->