### PR TITLE
fix(dev-ui): return absolute path for stealth preload imports

### DIFF
--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -433,8 +433,14 @@ function formatRelativeImportPath(relativePath) {
 
 function resolveStealthImportPath(devCwd, candidatePaths) {
   for (const candidatePath of candidatePaths) {
-    if (existsSync(path.join(devCwd, candidatePath))) {
-      return formatRelativeImportPath(candidatePath);
+    const absPath = path.join(devCwd, candidatePath);
+    if (existsSync(absPath)) {
+      // Return the absolute path so the value stays valid regardless of
+      // which cwd the API child gets spawned in. The API child is anchored
+      // at the eliza/ submodule (see apiSpawnCwd below), so a path computed
+      // relative to the outer milady cwd would resolve to a non-existent
+      // `eliza/eliza/...` from the child's perspective.
+      return absPath;
     }
   }
   return null;


### PR DESCRIPTION
## Bug

When dev-ui's API child cwd is anchored at the `eliza/` submodule (for workspace lookup — see `apiSpawnCwd` further down in `dev-ui.mjs`), `resolveStealthImportPath` was returning a path relative to the outer caller's cwd. A candidate like `eliza/packages/agent/src/auth/claude-code-stealth-preload.ts` then resolved against the child's `eliza/` cwd as `eliza/eliza/packages/...`, which doesn't exist, and the API restart-loops with `preload not found`.

## Repro

In a milady-style outer repo (cwd contains an `eliza/` submodule) with `ELIZA_ENABLE_CLAUDE_STEALTH=1`:

```
$ bun run dev
[milady] Stealth imports enabled: ./eliza/packages/agent/src/auth/claude-code-stealth-preload.ts
error: preload not found "./eliza/packages/agent/src/auth/claude-code-stealth-preload.ts"
[milady] API exited with code 1 — relaunching (attempt 1/5)…
```

## Fix

Return the absolute path of the resolved candidate instead — bun's `--preload` accepts absolute paths and the value stays valid no matter which cwd the API child runs in.

## Diff

- 1 file, +8 / -2 in `packages/app-core/scripts/dev-ui.mjs`
- behaviour change is invisible to anyone running dev-ui from the eliza repo directly (no submodule layout) — both relative and absolute paths resolve there
- only fixes the broken case where the outer repo embeds `eliza/` as a submodule

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a path resolution bug in `dev-ui.mjs` where stealth preload files were passed to the API child process as paths relative to the outer repo's cwd, causing Bun to fail to locate them when the child was spawned with a different cwd (`eliza/` submodule root).

- **Root cause fixed**: `resolveStealthImportPath` now returns the absolute path (`path.join(devCwd, candidatePath)`) instead of a `./`-prefixed relative path, so the `--preload` value remains valid regardless of what cwd the API child process inherits.
- **Scope**: The change is a one-liner in the resolution function; behavior is unchanged for users running dev-ui directly from the eliza repo (no submodule layout), and `formatRelativeImportPath` is left as dead code now that its only call site is gone.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a one-liner fix with no impact on the non-submodule code path.

The fix is minimal, well-scoped, and directly addresses the described failure mode. The only leftover artifact is `formatRelativeImportPath`, which is now unreachable dead code — harmless but worth cleaning up.

packages/app-core/scripts/dev-ui.mjs — `formatRelativeImportPath` is now dead code and can be removed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/dev-ui.mjs | Returns absolute path from `resolveStealthImportPath` instead of a relative one, fixing `--preload` resolution when the API child is spawned with a different cwd. `formatRelativeImportPath` is now dead code. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DevUI as dev-ui.mjs (outer cwd)
    participant Resolver as resolveStealthImportPath
    participant APIChild as API Child Process (cwd: eliza/)

    DevUI->>Resolver: candidatePaths[], devCwd (outer repo root)
    Note over Resolver: path.join(devCwd, candidatePath) → absPath
    Resolver-->>DevUI: absPath (absolute)

    DevUI->>APIChild: "spawn(cmd, ["--preload", absPath], { cwd: "eliza/" })"
    Note over APIChild: Absolute path resolves correctly regardless of spawned cwd
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/scripts/dev-ui.mjs`, line 429-434 ([link](https://github.com/elizaos/eliza/blob/570c1264401f1e4b48d30e5e3d1a8850e7326350/packages/app-core/scripts/dev-ui.mjs#L429-L434)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> `formatRelativeImportPath` is now unreachable — the only call site was inside `resolveStealthImportPath`, which now returns `absPath` directly. The function can be removed to avoid confusion.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(dev-ui): return absolute path for st..."](https://github.com/elizaos/eliza/commit/570c1264401f1e4b48d30e5e3d1a8850e7326350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475006)</sub>

<!-- /greptile_comment -->