### PR TITLE
fix(agent): drop dead export of removed runtime/restart.ts

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -144,7 +144,6 @@ export {
 } from "./runtime/plugin-resolver.ts";
 export * from "./runtime/plugin-types.ts";
 export * from "./runtime/release-plugin-policy.ts";
-export * from "./runtime/restart.ts";
 export * from "./runtime/trajectory-internals.ts";
 export * from "./runtime/trajectory-persistence.ts";
 export * from "./runtime/trajectory-query.ts";


### PR DESCRIPTION
## Summary

Commit `de48c6c569` ("cleanups") removed `packages/agent/src/runtime/restart.ts` but didn't remove the matching `export * from "./runtime/restart.ts"` from `packages/agent/src/index.ts:147`.

Bun's module resolver fails the import: `Cannot find module './runtime/restart.ts'` — which kills `bun run dev` (the milady host-side Vite + API orchestrator) at API-server boot, and breaks any consumer that imports `@elizaos/agent` via source.

`@elizaos/agent`'s packaged dist tolerates the dangling re-export silently because tsc emits a CommonJS export with a non-existent module specifier that only blows up at runtime if anyone tries to access a member of it. Bun's loader aborts up-front.

One-line removal of the dead line.

## Test plan

- [x] `bun run dev` from the milady root no longer crash-loops on API-server boot
- [x] Confirmed via grep that `runtime/restart` has no other source references in the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the stale re-export of `./runtime/restart.ts` from `packages/agent/src/index.ts` that was left behind when the file itself was deleted in a prior cleanup commit. Bun's module resolver aborts early on the missing specifier, crashing `bun run dev` at API-server boot.

- One-line deletion of `export * from \"./runtime/restart.ts\"` (line 147); the backing file is confirmed absent and no other source in the package references it.
- No functional change beyond eliminating the dangling export — consumers compiled via `tsc` to CommonJS were silently unaffected until they accessed a member of the module at runtime.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line removal of a dead export whose backing file is confirmed absent from the repository.

The deleted line pointed to a file that no longer exists anywhere in the package. Removing it restores correct behavior for Bun users without touching any live code paths. No other source in packages/agent/src references runtime/restart, so there is no risk of a partial removal leaving a dangling dependency elsewhere.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/index.ts | Removes dead `export * from "./runtime/restart.ts"` whose backing file no longer exists, fixing a hard Bun module-resolution crash at startup. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["bun run dev / import @elizaos/agent"] --> B["packages/agent/src/index.ts"]
    B --> C{"export * from './runtime/restart.ts'"}
    C -->|"Before fix"| D["❌ Bun: Cannot find module\n'./runtime/restart.ts'\nProcess crashes at boot"]
    C -->|"After fix (line removed)"| E["✅ Module resolves normally\nbun run dev starts successfully"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent): drop dead export of removed ..."](https://github.com/elizaos/eliza/commit/6162f3df0bfb97535ca5ec33b7fc58173c722996) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475332)</sub>

<!-- /greptile_comment -->