### PR TITLE
fix(agent): expose ./services/* + ./security/* subpath exports

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -48,7 +48,37 @@
   "exports": {
     ".": "./src/index.ts",
     "./package.json": "./package.json",
-    "./config/plugin-auto-enable": "./src/config/plugin-auto-enable.ts"
+    "./config/plugin-auto-enable": "./src/config/plugin-auto-enable.ts",
+    "./services/app-session-gate": {
+      "types": "./src/services/app-session-gate.d.ts",
+      "bun": {
+        "types": "./src/services/app-session-gate.ts",
+        "import": "./src/services/app-session-gate.ts",
+        "default": "./src/services/app-session-gate.ts"
+      },
+      "import": "./dist/services/app-session-gate.js",
+      "default": "./dist/services/app-session-gate.js"
+    },
+    "./security/*": {
+      "types": "./src/security/*.d.ts",
+      "bun": {
+        "types": "./src/security/*.ts",
+        "import": "./src/security/*.ts",
+        "default": "./src/security/*.ts"
+      },
+      "import": "./dist/security/*.js",
+      "default": "./dist/security/*.js"
+    },
+    "./services/*": {
+      "types": "./src/services/*.d.ts",
+      "bun": {
+        "types": "./src/services/*.ts",
+        "import": "./src/services/*.ts",
+        "default": "./src/services/*.ts"
+      },
+      "import": "./dist/services/*.js",
+      "default": "./dist/services/*.js"
+    }
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Bug

Plugins like `@elizaos/app-companion` runtime-import paths such as `@elizaos/agent/services/app-session-gate` and `@elizaos/agent/security/access`. Without matching subpath entries in `packages/agent/package.json#exports`, bun's package resolver rejects those subpaths and the plugin fails to load.

## Repro

```
[eliza] Failed to load core plugin @elizaos/app-companion: ResolveMessage:
Cannot find module '@elizaos/agent/services/app-session-gate' from
'/.../app-companion/dist/plugin.js'
```

## Fix

Add wildcard `./services/*` and `./security/*` exports plus an explicit `./services/app-session-gate` (the most common subpath import in the ecosystem). Each entry uses the same `bun:` source-condition pattern as the root `.` export so source-mode resolves the `.ts` and packaged consumers continue to use the compiled `.js` under `dist/`.

## Diff

- 1 file, +31 / -1 in `packages/agent/package.json`
- additive only — no existing exports changed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `./services/*` and `./security/*` wildcard subpath exports to `packages/agent/package.json`, along with an explicit `./services/app-session-gate` entry, so that plugins like `@elizaos/app-companion` can import those subpaths without bun's resolver rejecting them at runtime.

- The outer `types` condition in all three new export blocks points to `.d.ts` files under `src/` (e.g. `./src/services/app-session-gate.d.ts`), which do not exist — TypeScript writes declaration files to `dist/` per `tsconfig.build.json`. Non-bun TypeScript consumers will fail to resolve types for these subpaths.
- The explicit `./services/app-session-gate` entry is redundant because the `./services/*` wildcard added immediately after already covers that path; the wildcard alone would suffice.

<h3>Confidence Score: 3/5</h3>

The bun runtime fix works as intended, but the types condition across all new exports points to files that will never exist in src/, which will break TypeScript type checking for any non-bun consumer of these subpaths.

All three new export entries declare a `types` condition resolving to `.d.ts` files in `src/` that are never generated there — TypeScript emits declarations to `dist/` per the build config. This is a present defect for any TypeScript consumer not running under the bun condition, and it affects every newly exported subpath.

packages/agent/package.json — specifically the `types` condition values in the three new export entries

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/package.json | Adds ./services/* and ./security/* wildcard subpath exports plus an explicit ./services/app-session-gate entry; the outer `types` condition in all three new entries points to .d.ts files in src/ that don't exist — declaration files land in dist/ — which will break type resolution for non-bun consumers. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer imports\n@elizaos/agent/services/app-session-gate"] --> B{Resolver condition}
    B -->|bun condition| C["✅ src/services/app-session-gate.ts\n(source mode)"]
    B -->|import / default| D["✅ dist/services/app-session-gate.js\n(compiled)"]
    B -->|types condition| E["❌ src/services/app-session-gate.d.ts\n(does not exist)"]
    E --> F["TypeScript type resolution fails\nfor non-bun consumers"]
    D --> G["Expected: dist/services/app-session-gate.d.ts\n(generated by tsc with declaration:true)"]

    H["Consumer imports\n@elizaos/agent/security/access"] --> I{Resolver condition}
    I -->|bun condition| J["✅ src/security/access.ts"]
    I -->|import / default| K["✅ dist/security/access.js"]
    I -->|types condition| L["❌ src/security/access.d.ts\n(does not exist)"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent): expose ./services/\* + ./secu..."](https://github.com/elizaos/eliza/commit/2912d2886e0e353343af3c804a58c912c0a88865) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475564)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->