### PR TITLE
fix(shared): restore channel-plugin-map + embedding-presets re-exports

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,11 +21,13 @@ export * from "./config/boot-config.js";
 // This keeps node-side benchmark / agent boot paths React-free.
 export * from "./config/boot-config-store.js";
 export * from "./config/branding.js";
+export * from "./config/channel-plugin-map.js";
 export * from "./config/cloud-only.js";
 export * from "./config/config.js";
 export * from "./config/config-catalog.js";
 export * from "./config/config-paths.js";
 export * from "./config/distribution-profile.js";
+export * from "./config/embedding-presets.js";
 export * from "./config/env-vars.js";
 export * from "./config/plugin-auto-enable.js";
 export * from "./config/plugin-manifest.js";


### PR DESCRIPTION
## Bug

Live consumers in `packages/agent/src/runtime`, `packages/app-core/src/runtime`, and the plugin resolver pull `CHANNEL_PLUGIN_MAP` and `EMBEDDING_PRESETS` from `@elizaos/shared`, but the barrel doesn't re-export them. Bun fails the import on boot, blocking the API.

## Repro

```
SyntaxError: export 'CHANNEL_PLUGIN_MAP' not found in '@elizaos/shared'
  at loadAndEvaluateModule
```

## Fix

Both source files exist and are part of the build:
- `packages/shared/src/config/channel-plugin-map.ts`
- `packages/shared/src/config/embedding-presets.ts`

Just add the two missing `export * from "./config/<name>.js"` lines back to `packages/shared/src/index.ts`.

## Diff

- 1 file, +2 / -0 in `packages/shared/src/index.ts`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two missing `export *` lines to `packages/shared/src/index.ts` to restore `CHANNEL_PLUGIN_MAP` and `EMBEDDING_PRESETS` on the `@elizaos/shared` barrel, aiming to fix a boot-time `SyntaxError` when consumers import those names.

- The source files the new re-exports point to (`packages/shared/src/config/channel-plugin-map.ts` and `packages/shared/src/config/embedding-presets.ts`) do not exist in the repository; the actual implementations live in `packages/app-core/src/runtime/` and `packages/agent/src/runtime/`, making this fix incomplete and still boot-breaking.
- The PR needs to either create the target source files in `packages/shared/src/config/`, move/copy the implementations there, or change the re-export paths to the correct locations.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — the two re-export targets don't exist in the shared package, so the barrel will fail to resolve at build time just as it does today.

The re-exported module paths (`./config/channel-plugin-map.js` and `./config/embedding-presets.js`) have no corresponding source files in `packages/shared/src/config/`. The actual implementations are in `packages/app-core/src/runtime/` and `packages/agent/src/runtime/`. Merging this would swap one boot-blocking error for a different one, leaving the API broken.

packages/shared/src/index.ts — both newly added re-export lines reference missing source files; cannot be resolved until the implementation files are created or moved into the shared package.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/shared/src/index.ts | Adds two barrel re-exports for channel-plugin-map and embedding-presets, but neither source file exists in packages/shared/src/config/ — the build will fail to resolve both modules. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@elizaos/shared barrel\n(packages/shared/src/index.ts)"] -->|"export * from './config/channel-plugin-map.js'"| B["packages/shared/src/config/\nchannel-plugin-map.ts\n❌ FILE DOES NOT EXIST"]
    A -->|"export * from './config/embedding-presets.js'"| C["packages/shared/src/config/\nembedding-presets.ts\n❌ FILE DOES NOT EXIST"]
    D["packages/app-core/src/runtime/\nchannel-plugin-map.ts\n✅ EXISTS"] -->|"actual location"| E["CHANNEL_PLUGIN_MAP"]
    F["packages/app-core/src/runtime/\nembedding-presets.ts\n✅ EXISTS"] -->|"actual location"| G["EMBEDDING_PRESETS"]
    H["packages/agent/src/runtime/\nembedding-presets.ts\n✅ EXISTS"] -->|"actual location"| G
    B -.->|"build fails:\nCannot find module"| I["💥 Boot failure\n(same as before fix)"]
    C -.->|"build fails:\nCannot find module"| I
```

<sub>Reviews (1): Last reviewed commit: ["fix(shared): restore channel-plugin-map ..."](https://github.com/elizaos/eliza/commit/302ce41fd2428f39be647638418ae745f4922427) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475573)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->