### PR TITLE
fix(plugin-sql): add bun-source condition on ./schema export

### DIFF
--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -34,6 +34,11 @@
     },
     "./schema": {
       "types": "./src/dist/schema/index.d.ts",
+      "bun": {
+        "types": "./src/schema/index.ts",
+        "import": "./src/schema/index.ts",
+        "default": "./src/schema/index.ts"
+      },
       "import": "./src/dist/schema/index.js",
       "default": "./src/dist/schema/index.js"
     }


### PR DESCRIPTION
## Bug

The `./schema` export currently points only at the compiled `./src/dist/schema/index.{js,d.ts}` path. When a workspace consumer runs in source mode (no compiled dist for plugin-sql) — common in milady-style outer repos and during fresh workspace bootstraps — bun cannot resolve `@elizaos/plugin-sql/schema` and the API restart-loops.

## Repro

```
error: Cannot find module '@elizaos/plugin-sql/schema' from
'/.../packages/app-core/src/services/auth-store.ts'
```

## Fix

Add a `bun:` condition that points at the `.ts` source so source-mode resolves correctly while compiled consumers continue to use `dist/`. Matches the pattern already on the root "." and "./drizzle" exports in this same file.

## Diff

- 1 file, +5 / -0 in `plugins/plugin-sql/package.json`
- additive only — compiled consumers unaffected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `bun` source-mode condition to the `./schema` export in `plugins/plugin-sql/package.json`, mirroring the pattern already present on the root `.` export so that workspace consumers running without a compiled `dist/` can resolve `@elizaos/plugin-sql/schema` under Bun.

- **`./schema` export** now includes a `bun` condition pointing to `./src/schema/index.ts`, which exists in the repo and matches the root `.` export's structure.
- **`./drizzle` export** is left without a `bun` condition despite the PR description claiming parity with it — workspace consumers importing `@elizaos/plugin-sql/drizzle` in source mode will still fail.
- **`files` array** does not include `src/schema`, so the new `bun` condition only works for monorepo workspace consumers, not published-package consumers using Bun.

<h3>Confidence Score: 4/5</h3>

Safe to merge for workspace consumers; the change is additive and compiled consumers are unaffected.

The change correctly fixes the reported source-mode resolution failure for `./schema` under Bun, but the `./drizzle` export is left without the same treatment despite the PR description claiming parity, and the `src/schema` source tree is absent from the `files` array so published-package bun consumers gain no benefit.

plugins/plugin-sql/package.json — the `./drizzle` export and the `files` array both warrant a follow-up look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-sql/package.json | Adds a `bun` condition to the `./schema` export so Bun can resolve the TypeScript source when `dist/` is absent; consistent with the existing root `.` export pattern, but `./drizzle` is still missing the same treatment. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer imports @elizaos/plugin-sql/schema"] --> B{Runtime?}
    B -->|Bun| C{dist/ present?}
    B -->|Node| F["dist/schema/index.js"]
    B -->|Browser| F
    C -->|"No (source mode)"| D["src/schema/index.ts ✅ (new bun condition)"]
    C -->|"Yes (compiled)"| E["src/dist/schema/index.js"]
    F --> G[Compiled output used]
    D --> H[TypeScript source used directly]
    E --> G
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plugins/plugin-sql/package.json`, line 30-34 ([link](https://github.com/elizaos/eliza/blob/ab8cd502268b52448c661bd80e6fb706435865f1/plugins/plugin-sql/package.json#L30-L34)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`./drizzle` still lacks a `bun` condition**

   The PR description states this fix "matches the pattern already on the root '.' and './drizzle' exports," but `./drizzle` does not actually have a `bun` condition — it only resolves to `./src/dist/drizzle/index.js`. Any workspace consumer that imports `@elizaos/plugin-sql/drizzle` in source mode (no compiled `dist/`) under Bun will hit the same restart-loop described in the bug report. If `./schema` needs source-mode support, `./drizzle` almost certainly does too.


2. `plugins/plugin-sql/package.json`, line 46-50 ([link](https://github.com/elizaos/eliza/blob/ab8cd502268b52448c661bd80e6fb706435865f1/plugins/plugin-sql/package.json#L46-L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`src/schema` source files excluded from published package**

   The `files` array includes only `src/dist`, `README.md`, and `dist`. The newly-added `bun` condition points to `./src/schema/index.ts`, which will not be present in the published npm artifact. Any consumer installing this package from the registry (rather than using it as a workspace dependency) and running under Bun will fail to resolve `@elizaos/plugin-sql/schema` via the `bun` condition — the same failure mode the PR intends to fix. The same gap already exists for the root `.` export's `bun` path (`./src/index.ts`), so this is a pre-existing pattern, but extending it here without addressing the `files` gap may surprise non-workspace consumers.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-sql): add bun-source conditio..."](https://github.com/elizaos/eliza/commit/ab8cd502268b52448c661bd80e6fb706435865f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475584)</sub>

<!-- /greptile_comment -->