### PR TITLE
fix(agent): restore relationships-graph public re-exports from @elizaos/core

### DIFF
--- a/packages/agent/src/services/relationships-graph.ts
+++ b/packages/agent/src/services/relationships-graph.ts
@@ -1,7 +1,39 @@
 /**
  * Agent-side wiring for the merged relationships graph in `@elizaos/core`.
  * Import graph types and helpers from `@elizaos/core` directly.
+ *
+ * Compatibility shim — the relationships-graph service has been merged into
+ * `RelationshipsService` in `@elizaos/core`. This module re-exports the
+ * public surface from the new core location so existing barrel imports
+ * (e.g. `packages/agent/src/index.ts`) continue to resolve. New code should
+ * import from `@elizaos/core` directly.
  */
+
+export {
+  type ClusterMemoriesQuery,
+  type ClusterSearchQuery,
+  createNativeRelationshipsGraphService,
+  getMemoriesForCluster,
+  type RelationshipsConversationMessage,
+  type RelationshipsConversationSnippet,
+  type RelationshipsFactExtractedInformation,
+  type RelationshipsFactProvenance,
+  type RelationshipsGraphEdge,
+  type RelationshipsGraphQuery,
+  type RelationshipsGraphSnapshot,
+  type RelationshipsGraphStats,
+  type RelationshipsIdentityEdge,
+  type RelationshipsIdentityHandle,
+  type RelationshipsIdentitySummary,
+  type RelationshipsMergeCandidate,
+  type RelationshipsPersonDetail,
+  type RelationshipsPersonFact,
+  type RelationshipsPersonSummary,
+  type RelationshipsProfile,
+  type RelationshipsRelevantMemory,
+  type RelationshipsUserPersonalityPreference,
+  searchMemoriesForCluster,
+} from "@elizaos/core";
 
 import type {
   IAgentRuntime,


### PR DESCRIPTION
## Bug

The `.d.ts` for `packages/agent/src/services/relationships-graph.ts` declares a 22-symbol re-export from `@elizaos/core` (`createNativeRelationshipsGraphService`, `getMemoriesForCluster`, `searchMemoriesForCluster`, plus the cohort of `Relationships*` types), and `packages/agent/src/index.ts` imports many of them from this module. The current `.ts` source dropped the re-export block, leaving only `resolveRelationshipsGraphService`, so the API restart-loops on boot.

## Repro

```
SyntaxError: export 'getMemoriesForCluster' not found in
'./services/relationships-graph.ts'
```

## Fix

Restore the re-export block so the source matches the existing `.d.ts` contract. All re-exported names already exist on `@elizaos/core`; this PR doesn't add new exports anywhere — it just re-surfaces existing ones through the historical agent-side path so the barrel keeps working.

## Diff

- 1 file, +32 / -0 in `packages/agent/src/services/relationships-graph.ts`
- only adds the re-export block; the existing `resolveRelationshipsGraphService` function is unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR attempts to restore a re-export block in `packages/agent/src/services/relationships-graph.ts` that the author believed had been dropped, causing an agent boot-loop. However, the base branch already contains the complete re-export block; the PR adds a redundant second block, creating 23 duplicate export identifiers that will cause TypeScript to refuse to compile the `packages/agent` package entirely.

- The original file at `77f56a92` already exports all 23 symbols (`ClusterMemoriesQuery`, `createNativeRelationshipsGraphService`, `getMemoriesForCluster`, `searchMemoriesForCluster`, and 19 `Relationships*` types) from `@elizaos/core` via the block beginning at line 14 of the pre-PR file — plus `RelationshipsGraphService` and `RelationshipsServiceLike` which the new block omits.
- The entire newly-added block (lines 12-36 in the post-PR file) should be reverted; no net change is needed to restore the export surface, since the existing block already satisfies the `.d.ts` contract.

<h3>Confidence Score: 1/5</h3>

Not safe to merge — the change introduces duplicate exports that prevent the package from compiling.

The re-export block being 'restored' already existed in the base branch. Adding it a second time causes TypeScript to emit duplicate-identifier errors for all 23 shared symbols, replacing a claimed boot-loop with a definite build failure across the entire packages/agent package. The PR needs to be reverted rather than merged.

packages/agent/src/services/relationships-graph.ts is the only changed file and the source of the compilation-breaking duplicate exports.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/services/relationships-graph.ts | Adds a duplicate re-export block that duplicates 23 symbols already re-exported by the pre-existing block, causing TypeScript compilation failure. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["@elizaos/core\n(RelationshipsService + all types)"] -->|"re-exports (pre-existing block)"| B["relationships-graph.ts\nlines 14-40 of original"]
    A -->|"re-exports (newly added block — DUPLICATE)"| C["relationships-graph.ts\nlines 12-36 of post-PR file"]
    B --> D["TypeScript compiler"]
    C --> D
    D -->|"TS2308: Duplicate identifier"| E["❌ Build failure\n23 duplicate symbols"]
    B -.->|"Without this PR, already exports all 23 symbols"| F["index.ts barrel"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent): restore relationships-graph ..."](https://github.com/elizaos/eliza/commit/e63bd438b134920ffb9cce24e75dee4dccb996d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475609)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->