### PR TITLE
fix(shared): dedupe RuntimeExecutionModeConfigSource interface

### DIFF
--- a/packages/shared/src/config/runtime-mode.ts
+++ b/packages/shared/src/config/runtime-mode.ts
@@ -14,11 +14,6 @@ export interface RuntimeModeConfig {
   executionMode?: RuntimeExecutionMode;
 }
 
-export interface RuntimeExecutionModeConfigSource {
-  runtime?: unknown;
-  deploymentTarget?: unknown;
-}
-
 export interface RuntimeExecutionModeDefinition {
   mode: RuntimeExecutionMode;
   local: boolean;


### PR DESCRIPTION
## Bug

`packages/shared/src/config/runtime-mode.ts` ships two declarations of `RuntimeExecutionModeConfigSource` (currently lines 17 and 90), which is a duplicate-identifier error in TypeScript.

## Repro

```
$ bun run build  # in packages/shared
src/config/runtime-mode.ts: error TS2300: Duplicate identifier 'RuntimeExecutionModeConfigSource'.
```

## Fix

Drop the early lazy-typed version (`{ runtime?: unknown; deploymentTarget?: unknown }`). The precise declaration further down — `{ runtime?: RuntimeModeConfig | Record<string, unknown> | null; deploymentTarget?: DeploymentTargetConfig | null }` — is the one `readRuntimeExecutionModeConfig` actually relies on (it reads `config?.runtime?.executionMode` and passes `config?.deploymentTarget` through `normalizeDeploymentTargetConfig`).

## Diff

- 1 file, +0 / -5 in `packages/shared/src/config/runtime-mode.ts`
- the surviving declaration is unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the early, weakly-typed duplicate declaration of `RuntimeExecutionModeConfigSource` (which used `unknown` for both fields) to fix a `TS2300: Duplicate identifier` build error in `packages/shared`.

- The deleted interface at the old line 17 used `{ runtime?: unknown; deploymentTarget?: unknown }`, while the surviving one at line 85 uses the precise `RuntimeModeConfig | Record<string, unknown> | null` / `DeploymentTargetConfig | null` types that `readRuntimeExecutionModeConfig` actually depends on.
- No callsites or exports change; only the redundant, less-typed declaration is dropped.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely removes a duplicate declaration that was causing a build failure, with no behaviour changes.

The only change is deleting a redundant interface whose weaker `unknown`-typed fields were not used anywhere in the codebase. The surviving declaration, the function bodies, and all exports remain identical to the base branch.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/shared/src/config/runtime-mode.ts | Removes 5 lines — the early weakly-typed duplicate of `RuntimeExecutionModeConfigSource`; the surviving declaration and all function bodies are untouched. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readRuntimeExecutionModeConfig(config)"] --> B{"isPlainObject(config.runtime)?"}
    B -- yes --> C["normalizeRuntimeExecutionMode(runtimeConfig.executionMode)"]
    B -- no --> E["runtimeExecutionModeForDeploymentTarget(...)"]
    C --> D{"explicitMode set?"}
    D -- yes --> F["return explicitMode"]
    D -- no --> E
    E --> G["normalizeDeploymentTargetConfig(config.deploymentTarget)"]
    G --> H["return cloud | local-safe"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(shared): dedupe RuntimeExecutionMode..."](https://github.com/elizaos/eliza/commit/6c9e57c013a66421776cd5f6586d9e252b757ef0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31475990)</sub>

<!-- /greptile_comment -->