### PR TITLE
feat(android): enable chrome://inspect on debug builds

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -6,6 +6,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.webkit.WebSettings;
+import android.webkit.WebView;
 
 import androidx.core.content.ContextCompat;
 
@@ -58,6 +59,12 @@ public class MainActivity extends BridgeActivity {
     protected void onCreate(Bundle savedInstanceState) {
         registerPlugin(AgentPlugin.class);
         super.onCreate(savedInstanceState);
+
+        // chrome://inspect access for debug builds. Off in release.
+        // BuildConfig is gradle-generated per package; the import is implicit.
+        if (BuildConfig.DEBUG) {
+            WebView.setWebContentsDebuggingEnabled(true);
+        }
 
         // The Capacitor WebView serves the renderer at https://localhost
         // (its default secure-context origin); the on-device Eliza agent


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer)
>
> - **Depends on:** nothing.
> - **Unblocks:** nothing else.
> - **CI status:** the failing `Android Debug Build` and `iOS Simulator Build` checks are an **upstream regression** in the eliza repo's mobile build, not caused by this PR. The same failures are reproducing on multiple recent unrelated PRs (#7548, #7546). Root cause: vite's `externalize-deps` plugin can't resolve `@elizaos/shared`'s entry, suggesting `packages/shared` isn't being prebuilt before the `packages/app` mobile build runs in those CI lanes. This 1-line change to `MainActivity.java` cannot affect that.
> - **PR-side checks (Plugin/Client/Server Tests, Docker smoke, label-pr) all pass.**

## Summary

- Adds a one-line `WebView.setWebContentsDebuggingEnabled(true)` call inside `MainActivity.onCreate`, gated on `BuildConfig.DEBUG`
- Lets developers `chrome://inspect` into the renderer on Capacitor debug builds without rebuilding from source
- Off in release — remote debugging stays locked down for shipping APKs

## Why

Without this, there's no way to inspect the WebView on a debug Capacitor build short of rebuilding the WebView itself. This blocks every common dev-loop investigation: \"why does the runtime picker show the wrong tiles\", \"what's the state of `Capacitor.Preferences`\", \"why is the bridge `Promise` hanging\". Each one ends up debugged through `Capacitor/Console` logcat lines instead of devtools, which is much slower than just opening Chrome's inspector.

`WebView.setWebContentsDebuggingEnabled` is a global flag (it affects every WebView in the process), so it has to be called once on the main activity. Gating on `BuildConfig.DEBUG` makes it auto-track the build variant — debug builds get devtools, release builds don't.

## Test plan

- [x] Built debug APK on Moto G Play 2024 (`./gradlew assembleDebug`)
- [x] `adb forward tcp:9222 localabstract:webview_devtools_remote_<pid>` works
- [x] `chrome://inspect` lists the milady WebView page and lets me attach
- [x] Release build (`./gradlew assembleRelease`) does NOT expose the devtools socket
- [x] No effect on Cuttlefish AOSP system-app build path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Chrome DevTools remote debugging for the Capacitor WebView on Android debug builds by adding a single `WebView.setWebContentsDebuggingEnabled(true)` call gated behind `BuildConfig.DEBUG` in `MainActivity.onCreate`. The change is additive, has no effect on release APKs, and is a standard pattern for Capacitor/Android WebView development workflows.

- Adds `android.webkit.WebView` import and a `BuildConfig.DEBUG`-guarded `setWebContentsDebuggingEnabled(true)` call after `super.onCreate()` in `MainActivity.java`.
- `BuildConfig.DEBUG` is a compile-time constant, so R8/ProGuard will dead-strip the block entirely in release builds — no runtime overhead or surface-area change in production.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line addition is debug-only, compile-time stripped in release, and follows standard Android WebView tooling practice.

The change is a single static method call wrapped in a BuildConfig.DEBUG guard. Release APKs are unaffected because the constant is resolved at compile time by R8/ProGuard. No production logic, permissions, or data paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java | Adds a DEBUG-gated `WebView.setWebContentsDebuggingEnabled(true)` call and the `WebView` import; no logic changes to release builds. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Gradle as Gradle Build
    participant App as MainActivity.onCreate()
    participant BridgeActivity as BridgeActivity (super)
    participant WebView as Capacitor WebView
    participant Chrome as chrome://inspect

    Gradle->>App: "assembleDebug → BuildConfig.DEBUG = true"
    App->>BridgeActivity: registerPlugin(AgentPlugin)
    App->>BridgeActivity: super.onCreate() [creates WebView]
    BridgeActivity->>WebView: "instantiate & attach"
    App->>WebView: setWebContentsDebuggingEnabled(true) [DEBUG only]
    WebView-->>Chrome: exposes devtools socket
    Chrome-->>App: developer can inspect renderer

    Note over Gradle,Chrome: Release build path
    Gradle->>App: "assembleRelease → BuildConfig.DEBUG = false"
    App->>BridgeActivity: super.onCreate()
    Note over App,WebView: setWebContentsDebuggingEnabled never called → no devtools socket
```

<sub>Reviews (3): Last reviewed commit: ["feat(app-core/android): enable chrome://..."](https://github.com/elizaos/eliza/commit/56f7f14350cdd0cd8a48366158001aae03d0ec99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31491917)</sub>

<!-- /greptile_comment -->