### PR TITLE
feat(mobile-build): inject useLegacyPackaging for stock-Android local agent

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -720,6 +720,56 @@ export function injectNoCompressTarGz(content) {
 }
 
 /**
+ * Inject `packaging.jniLibs.useLegacyPackaging = true` so the JNI-staged
+ * bun runtime (libeliza_bun.so + libeliza_ld_musl_<abi>.so + libeliza_stdcpp.so
+ * + libeliza_gcc_s.so) is materialized on disk under <nativeLibraryDir> at
+ * install time. AGP 9.x defaults this to false, which keeps native libs as
+ * mmap-only entries inside the APK — fine for `dlopen`, but ProcessBuilder
+ * cannot fork-exec a path inside a zip. On stock Android (`untrusted_app`
+ * SELinux domain) the only path that allows `execute_no_trans` for the bun
+ * binary is the `system_data_file`-labeled native-library dir; anything we
+ * extract into `files/agent/<abi>/` lives in `app_data_file` and gets denied.
+ * Switching this back to legacy-packaging materializes the libs on disk so
+ * `ElizaAgentService.preferPackagedExecutable()` can resolve them.
+ *
+ * Idempotent: re-runs are no-ops once the block is present.
+ */
+export function injectUseLegacyJniPackaging(content) {
+  if (/useLegacyPackaging\s*=\s*true/.test(content)) return content;
+  const block =
+    `\n    // Extract native libs to <nativeLibraryDir> at install time so the bun\n` +
+    `    // binary + musl loader can be fork-exec'd by ElizaAgentService. AGP 9.x\n` +
+    `    // defaults useLegacyPackaging to false, which keeps the libs as mmap-only\n` +
+    `    // entries inside the APK — perfect for dlopen, but ProcessBuilder cannot\n` +
+    `    // fork-exec a path inside a zip. The musl loader path under \`lib/<abi>/\`\n` +
+    `    // (system_data_file SELinux context) is the only path the untrusted_app\n` +
+    `    // domain can execute, so the libs MUST be on disk for the local agent to\n` +
+    `    // start. Mirrors platforms/android/app/build.gradle.\n` +
+    `    packaging {\n` +
+    `        jniLibs {\n` +
+    `            useLegacyPackaging = true\n` +
+    `            keepDebugSymbols += ["**/libimage_processing_util_jni.so"]\n` +
+    `        }\n` +
+    `    }\n`;
+  const androidOpen = content.search(/\n\s*android\s*\{/);
+  if (androidOpen < 0) return content;
+  let depth = 0;
+  let i = content.indexOf("{", androidOpen);
+  while (i < content.length) {
+    const ch = content[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return content.slice(0, i) + block + content.slice(i);
+      }
+    }
+    i += 1;
+  }
+  return content;
+}
+
+/**
  * Inject an optional app-thinning hook for `assets/agent/`.
  *
  * Local mode on stock Capacitor APKs now depends on the staged bun runtime,
@@ -2063,6 +2113,7 @@ function patchAndroidGradle() {
     );
     patched = injectBuildConfigAospField(patched);
     patched = injectNoCompressTarGz(patched);
+    patched = injectUseLegacyJniPackaging(patched);
     patched = injectAospAssetThinning(patched);
     patched = injectCopyForkLlamaLibTask(patched);
     if (patched !== current) {


### PR DESCRIPTION
## Summary

- Adds `injectUseLegacyJniPackaging` to the `patchAndroidGradle` chain so every `bun run build:android` writes `packaging.jniLibs.useLegacyPackaging = true` into `apps/app/android/app/build.gradle`
- Mirrors the AOSP system-app template's existing block at `platforms/android/app/build.gradle:93-97`
- Idempotent — re-runs are a no-op once the block is present

## Why

ElizaAgentService spawns the on-device agent by `ProcessBuilder.start()`-ing the bun binary against the JNI-staged `libeliza_bun.so` + matching musl loader. AGP 9.x defaults `packaging.jniLibs.useLegacyPackaging` to false, which keeps native libs as mmap-only entries **inside the APK** — fine for `dlopen`, but `ProcessBuilder` cannot fork-exec a path inside a zip.

On stock Android the app runs in the `untrusted_app` SELinux domain. That domain grants `execute_no_trans` only on `system_data_file`-labeled paths, which means the binary has to live under `<nativeLibraryDir>` (extracted to `/data/app/.../lib/<abi>/` at install time). Anything we extract into `files/agent/<abi>/` ends up `app_data_file`-labeled and the kernel denies the execve:

```
avc: denied { execute_no_trans } for path="/data/data/<pkg>/files/agent/arm64-v8a/ld-musl-aarch64.so.1"
  scontext=u:r:untrusted_app:s0 tcontext=u:object_r:app_data_file:s0 tclass=file permissive=0
java.io.IOException: Cannot run program "...ld-musl-aarch64.so.1": error=13, Permission denied
  at ai.elizaos.app.ElizaAgentService.startAgentProcess(ElizaAgentService.java:993)
```

Without legacy packaging the libs never hit disk in the first place — `<nativeLibraryDir>` is empty even though the APK contains `lib/arm64-v8a/libeliza_*.so`. So even with the renamed JNI staging the agent silently dies in `startAgentProcess()`.

Switching to legacy packaging materializes the libs on install. The existing `ElizaAgentService.preferPackagedExecutable()` and `linkPackagedRuntimeLibrary()` helpers then resolve the correct paths and the agent boots normally.

## Test plan

- [x] Built debug APK on Moto G Play 2024 (`untrusted_app`, SELinux enforcing) with `bun run build:android && ./gradlew assembleDebug -PelizaAospBuild=true`
- [x] After install, `<nativeLibraryDir>/lib/arm64/libeliza_bun.so` is present (was missing before the fix)
- [x] ElizaAgentService.startAgentProcess() no longer throws `error=13, Permission denied`
- [x] The bun process actually launches; agent.log shows `Using local AI configuration`, `CACHE_DIR not set`, `[eliza] PGlite data dir: ... (created)` instead of dying at the SELinux denial
- [x] Idempotent (re-running `bun run build:android` does NOT inject the block twice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `Permission denied` (`error=13`) crash in `ElizaAgentService.startAgentProcess()` on stock Android by ensuring JNI-staged native libs are extracted to disk at install time. It adds `injectUseLegacyJniPackaging` to the `patchAndroidGradle` chain, which appends `packaging { jniLibs { useLegacyPackaging = true } }` to `apps/app/android/app/build.gradle`.

- **Core fix**: Overrides AGP 9.x's default of keeping native libs as mmap-only APK entries so `ProcessBuilder` can fork-exec the bun binary from the `system_data_file`-labeled `<nativeLibraryDir>` path required by the `untrusted_app` SELinux domain.
- **Style concern**: The injected block also includes `keepDebugSymbols += [\"**/libimage_processing_util_jni.so\"]`, which is an AOSP-specific debug symbol rule unrelated to stock Capacitor builds.
- **Idempotency gap**: The guard `/useLegacyPackaging\\s*=\\s*true/` only short-circuits when the value is already `true`; a file with `useLegacyPackaging = false` would accumulate a duplicate `packaging` block on each build run.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly addresses the SELinux native-lib execution problem and non-breaking minor issues don't affect build correctness.

The core logic is sound and mirrors the existing `injectNoCompressTarGz` pattern. The unrelated `keepDebugSymbols` entry and the incomplete idempotency guard are both non-breaking but worth cleaning up before the pattern is copy-pasted further.

packages/app-core/scripts/run-mobile-build.mjs — the injected block content and idempotency guard in `injectUseLegacyJniPackaging`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/run-mobile-build.mjs | Adds `injectUseLegacyJniPackaging` to the Gradle patch chain; mirrors the brace-counting approach used by `injectNoCompressTarGz`. Two minor concerns: injected block includes an unrelated `keepDebugSymbols` line, and the idempotency guard only checks for `true`, leaving a gap when `useLegacyPackaging = false` is already present. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(mobile-build): inject useLegacyPack..."](https://github.com/elizaos/eliza/commit/b104336a725613f98268fe47a1d8b4b13ce889c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31492962)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->