### PR TITLE
fix(android): byte-level stream pump preserves last bun output before crash

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -16,12 +16,10 @@ import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -988,6 +986,14 @@ public class ElizaAgentService extends Service {
 
             env.putAll(agentEnv);
 
+            // Merge stderr into stdout so a single pump captures both streams
+            // and one failure mode — bun crashing mid-write before the buffered
+            // stderr line is flushed — can't lose the diagnostic. The previous
+            // BufferedReader.readLine() pump silently dropped any partial line
+            // that wasn't terminated with a newline, which is exactly what
+            // happens when a panic interrupts a Logger call mid-string.
+            pb.redirectErrorStream(true);
+
             Process started;
             try {
                 started = pb.start();
@@ -1002,7 +1008,9 @@ public class ElizaAgentService extends Service {
             agentProcess = started;
             File logFile = new File(root, AGENT_LOG_NAME);
             stdoutPump = startStreamPump(started.getInputStream(), logFile, "out");
-            stderrPump = startStreamPump(started.getErrorStream(), logFile, "err");
+            // stderrPump intentionally null — redirectErrorStream(true) merges
+            // both streams into getInputStream() so one pump captures everything.
+            stderrPump = null;
             currentStatus = "running";
             updateNotification();
             Log.i(TAG, "Agent process started (pid=" + safePid(started) + ").");
@@ -1096,20 +1104,34 @@ public class ElizaAgentService extends Service {
      */
     private Thread startStreamPump(InputStream stream, File logFile, String label) {
         Thread t = new Thread(() -> {
-            try (
-                BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
-                FileOutputStream logOut = new FileOutputStream(logFile, true)
-            ) {
-                String line;
-                while ((line = reader.readLine()) != null) {
+            byte[] buf = new byte[4096];
+            try (FileOutputStream logOut = new FileOutputStream(logFile, true)) {
+                StringBuilder lineBuf = new StringBuilder();
+                int n;
+                while ((n = stream.read(buf)) >= 0) {
                     if (Thread.currentThread().isInterrupted()) break;
-                    String stamped = "[" + label + "] " + line + "\n";
-                    logOut.write(stamped.getBytes());
-                    if ("err".equals(label)) {
-                        Log.w(TAG, line);
-                    } else {
-                        Log.i(TAG, line);
+                    // Mirror raw bytes to the log immediately so a mid-write
+                    // panic in the agent doesn't lose its last diagnostic.
+                    // BufferedReader.readLine() dropped partial lines on
+                    // crash; the byte-level pump captures everything.
+                    logOut.write(buf, 0, n);
+                    logOut.flush();
+                    // For logcat readability, accumulate complete lines and
+                    // emit them tagged. The post-loop drain below handles the
+                    // unterminated tail when the stream closes mid-line.
+                    for (int i = 0; i < n; i += 1) {
+                        char c = (char) (buf[i] & 0xFF);
+                        if (c == '\n') {
+                            String line = lineBuf.toString();
+                            lineBuf.setLength(0);
+                            if (!line.isEmpty()) Log.i(TAG, line);
+                        } else if (c != '\r') {
+                            lineBuf.append(c);
+                        }
                     }
+                }
+                if (lineBuf.length() > 0) {
+                    Log.w(TAG, lineBuf + " <eof — no trailing newline>");
                 }
             } catch (IOException error) {
                 if (!shuttingDown) {


### PR DESCRIPTION
> ## Merge sequencing (for the maintainer)
>
> - **Depends on:** nothing.
> - **Unblocks:** nothing else.
> - **Status:** rebased onto current `develop` so the only commit on this branch is the meaningful 1-file fix to `ElizaAgentService.java` (37+ / 15-). Title corrected from `fix(app-core/android):` (which fails the convention regex on `/`) to `fix(android):`. Biome format check passes locally on current `develop`.
> - **Pre-existing CI noise on this PR:** `Format Check (biome)` was failing on `@elizaos/plugin-local-inference` — that's a develop-side fix that landed after the original PR push; the rebase brings it in. `Android Debug Build` and `iOS Simulator Build` reds are an upstream `@elizaos/shared` package-entry resolution issue affecting multiple recent unrelated PRs (#7548, #7546, #7550), not caused by this 1-file Java change.

## Summary

- Drops `BufferedReader.readLine()` from the agent's stream pump in favor of raw byte reads with immediate `flush()`
- Adds `pb.redirectErrorStream(true)` so stderr merges into stdout — one pump, one stream
- Logcat output stays line-oriented (StringBuilder accumulates between `\n` boundaries); the on-disk log captures every byte
- Trailing unterminated tail is logged with an `<eof — no trailing newline>` suffix so an operator can tell whether the agent ended cleanly or crashed mid-write

## Why

Hit on a Moto G Play 2024 today: the agent boots through PGlite init, then exits silently. agent.log truncates at the last newline-terminated line and the actual panic line (`logger.error("...some panic...")`) never makes it to disk because `BufferedReader.readLine()` discarded the partial buffer when the stream closed.

The doc at `packages/docs/agent-on-mobile.md:22` already calls out that the agent shells out to ~20 system binaries that don't exist on Android — at least one of those `child_process.spawn` calls is firing post-PGlite without an Android guard. We can't see which one because the diagnostic is being eaten by the line-buffered pump.

## What this is NOT

- Not a behavior change for a healthy agent — `Log.i(TAG, line)` per newline still happens
- Not a new dependency or ABI change
- Not Android-only in concept (the ProcessBuilder semantics are identical on every JVM), but the file is `platforms/android/.../ElizaAgentService.java` so this only ships in the Android agent path

## Test plan

- [x] Built and ran on Moto G Play 2024; agent.log now captures every byte until the crash, including unterminated tails
- [x] Confirmed `Log.i` line-tagging still works for normal (newline-terminated) bun output
- [x] No imports leftover (BufferedReader / InputStreamReader removed since they're no longer used)
- [x] No regression on Cuttlefish x86_64 — same code path, just a different I/O strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the line-buffered `BufferedReader.readLine()` stream pump with a raw byte-read loop that writes to disk immediately, fixing a real crash-diagnosis loss on Android where the last (unterminated) panic line was silently dropped. `redirectErrorStream(true)` collapses the two-pump design to one.

- The core fix is correct: removing `BufferedReader` eliminates the Java-level line buffer that swallowed partial writes on crash. Bytes now land in the log file as fast as the OS delivers them.
- `stderrPump` is permanently `null` after this change; the field and the `errPump` interrupt path in `stopAgentProcess()` are now dead code that could be cleaned up in a follow-up.
- The logcat path retains line-oriented output via `StringBuilder`, though the byte-to-char conversion (`(char)(buf[i] & 0xFF)`) treats each byte as Latin-1, which fragments multi-byte UTF-8 sequences in logcat (the on-disk file is unaffected).

<h3>Confidence Score: 4/5</h3>

The on-disk crash capture improvement is real and correct, but two unresolved issues in the pump loop limit confidence in the overall change.

The byte-pump approach correctly eliminates the BufferedReader line-buffer that swallowed unterminated crash lines. However, the interrupt check still sits between stream.read() and logOut.write(), so a graceful-shutdown interrupt can drop the last chunk of data already read from the OS. The Latin-1 cast also makes logcat unusable for any non-ASCII agent output, reducing diagnostic value on production devices.

ElizaAgentService.java — specifically the interrupt-check ordering and the byte-to-char conversion in the logcat accumulation loop of startStreamPump.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java | Stream pump rewritten from BufferedReader to raw byte reads; `redirectErrorStream(true)` merges stderr into stdout. Two pre-existing issues flagged in review comments (interrupt-check ordering and UTF-8 logcat corruption) remain unaddressed in the current diff. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProcessBuilder] -->|redirectErrorStream true| B[Single InputStream stdout + stderr merged]
    B --> C[startStreamPump byte buf 4096]
    C --> D{stream.read buf}
    D -->|n >= 0| E{isInterrupted?}
    E -->|yes| F[break bytes in buf discarded]
    E -->|no| G[logOut.write buf 0 n + flush no-op]
    G --> H[for each byte buf i AND 0xFF]
    H -->|char == newline| I[Log.i TAG line]
    H -->|char != CR| J[lineBuf.append c Latin-1 cast]
    H --> D
    D -->|n == -1 EOF| K{lineBuf.length > 0?}
    K -->|yes| L[Log.w TAG eof no trailing newline]
    K -->|no| M[close FileOutputStream]
    L --> M
```

<sub>Reviews (2): Last reviewed commit: ["fix(app-core/android): byte-level stream..."](https://github.com/elizaos/eliza/commit/d509493fa53d3a1befeb3517f8317d426a07b2ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31493765)</sub>

<!-- /greptile_comment -->