### PR TITLE
fix(android): qualify ByteArrayOutputStream import to unblock the build

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -16,7 +16,7 @@ import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
-import ByteArrayOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
## Summary

\`dc9674b789\` added a \`ByteArrayOutputStream\`-backed line buffer to the agent stream pump but the import line was written without the package qualifier:

\`\`\`java
import ByteArrayOutputStream;
\`\`\`

That is not valid Java syntax — javac reports \`ElizaAgentService.java:19: error: '.' expected\` and \`compileDebugJavaWithJavac\` fails on every Android build off develop since the merge.

## Fix

\`\`\`java
import java.io.ByteArrayOutputStream;
\`\`\`

Resolves to the same standard-library class the body already uses at line ~1116 (\`new ByteArrayOutputStream(256)\`).

## Test plan

- [x] \`./gradlew assembleDebug -PelizaAospBuild=true\` succeeds (was failing on type-check before this commit)
- [x] No other changes — the stream pump's behavior is identical
- [x] Verified by rebasing this branch on latest develop and re-running gradle on a Moto G Play 2024 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken Java import that has been blocking Android builds since `dc9674b789` was merged into `develop`. The unqualified `import ByteArrayOutputStream;` is invalid Java syntax and caused `compileDebugJavaWithJavac` to fail with a `'.' expected` error.

- Replaces `import ByteArrayOutputStream;` with the fully-qualified `import java.io.ByteArrayOutputStream;` — a single-line, zero-behavior-change fix that restores a compilable state for all Android builds off `develop`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a single-line build-fix with no logic changes.

The change corrects an invalid Java import that was preventing the Android project from compiling. Adding the `java.io.` qualifier has no effect on runtime behavior; the class resolved at the call site is identical. The surrounding import block is alphabetically consistent, and no other files are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java | Single-line import fix: adds `java.io.` package qualifier to `ByteArrayOutputStream` import; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["dc9674b789 merged\n(added ByteArrayOutputStream line buffer)"] --> B["import ByteArrayOutputStream;\n(invalid — no package qualifier)"]
    B --> C["javac: '.' expected error\ncompileDebugJavaWithJavac fails"]
    C --> D["Android build broken for all\ndevelop-based branches"]
    D --> E["This PR: import java.io.ByteArrayOutputStream;"]
    E --> F["Build succeeds ✅\nStream pump behavior unchanged"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(android): qualify ByteArrayOutputStr..."](https://github.com/elizaos/eliza/commit/1bc5edcddcf028e56cff94e286d022c729224c32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31514494)</sub>

<!-- /greptile_comment -->