### PR TITLE
feat(shared): zod-typed routes round 5 — create + presence + run steering

### DIFF
--- a/packages/agent/src/api/apps-routes.ts
+++ b/packages/agent/src/api/apps-routes.ts
@@ -11,11 +11,15 @@ import {
   type AppSessionActionResult,
   createGeneratedAppHeroSvg,
   hasAppInterface,
+  PostCreateAppRequestSchema,
   PostInstallAppRequestSchema,
   PostLaunchAppRequestSchema,
   PostLoadFromDirectoryRequestSchema,
+  PostOverlayPresenceRequestSchema,
   PostRelaunchAppRequestSchema,
   PostReplaceFavoritesRequestSchema,
+  PostRunControlRequestSchema,
+  PostRunMessageRequestSchema,
   PostStopAppRequestSchema,
   PutAppPermissionsRequestSchema,
   PutFavoriteAppRequestSchema,
@@ -491,27 +495,6 @@ function parseCapturedBody(body: string): Record<string, unknown> | null {
   }
 }
 
-function readSteeringContent(
-  body: Record<string, unknown> | null,
-): string | null {
-  const content =
-    typeof body?.content === "string"
-      ? body.content
-      : typeof body?.message === "string"
-        ? body.message
-        : null;
-  const trimmed = content?.trim() ?? "";
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function readSteeringAction(
-  body: Record<string, unknown> | null,
-): "pause" | "resume" | null {
-  const action = typeof body?.action === "string" ? body.action.trim() : "";
-  if (action === "pause" || action === "resume") return action;
-  return null;
-}
-
 function isAppRunSummary(value: unknown): value is AppRunSummary {
   return (
     typeof value === "object" &&
@@ -871,11 +854,20 @@ export async function handleAppsRoutes(
 
   // Dashboard heartbeat for overlay apps (companion, etc.) — no AppManager run.
   if (method === "POST" && pathname === "/api/apps/overlay-presence") {
-    const body = await readJsonBody<{ appName?: string | null }>(req, res);
-    if (!body) return true;
-    const raw = body.appName;
-    const appName =
-      typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+    const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
+    if (rawBody === null || rawBody === undefined) return true;
+    const parsed = PostOverlayPresenceRequestSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const issuePath = issue?.path?.join(".") ?? "<root>";
+      error(
+        res,
+        `Invalid request body at ${issuePath}: ${issue?.message ?? "validation failed"}`,
+        400,
+      );
+      return true;
+    }
+    const { appName } = parsed.data;
     setOverlayAppPresence(appName);
     json(res, { ok: true, appName });
     return true;
@@ -946,29 +938,18 @@ export async function handleAppsRoutes(
         return true;
       }
 
-      const body =
+      const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
+      if (rawBody === null || rawBody === undefined) return true;
+      const parsed =
         subroute === "message"
-          ? await readJsonBody<{ content?: string }>(req, res)
-          : await readJsonBody<{ action?: "pause" | "resume" }>(req, res);
-      if (!body) return true;
-
-      const normalizedBody =
-        subroute === "message"
-          ? {
-              content: readSteeringContent(body),
-            }
-          : {
-              action: readSteeringAction(body),
-            };
-      if (
-        (subroute === "message" && !normalizedBody.content) ||
-        (subroute === "control" && !normalizedBody.action)
-      ) {
+          ? PostRunMessageRequestSchema.safeParse(rawBody)
+          : PostRunControlRequestSchema.safeParse(rawBody);
+      if (!parsed.success) {
+        const issue = parsed.error.issues[0];
+        const issuePath = issue?.path?.join(".") ?? "<root>";
         error(
           res,
-          subroute === "message"
-            ? "content is required"
-            : "action must be pause or resume",
+          `Invalid request body at ${issuePath}: ${issue?.message ?? "validation failed"}`,
           400,
         );
         return true;
@@ -978,7 +959,7 @@ export async function handleAppsRoutes(
         ctx,
         run,
         subroute,
-        normalizedBody as Record<string, unknown>,
+        parsed.data as Record<string, unknown>,
       );
       if (!result) {
         error(res, "Run steering failed", 500);
@@ -1530,16 +1511,20 @@ export async function handleAppsRoutes(
   }
 
   if (method === "POST" && pathname === "/api/apps/create") {
-    const body = await readJsonBody<{ intent?: string; editTarget?: string }>(
-      req,
-      res,
-    );
-    if (!body) return true;
-    const intent = body.intent?.trim() ?? "";
-    if (!intent) {
-      error(res, "intent is required");
+    const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
+    if (rawBody === null || rawBody === undefined) return true;
+    const parsed = PostCreateAppRequestSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      const issuePath = issue?.path?.join(".") ?? "<root>";
+      error(
+        res,
+        `Invalid request body at ${issuePath}: ${issue?.message ?? "validation failed"}`,
+        400,
+      );
       return true;
     }
+    const { intent, editTarget } = parsed.data;
 
     const runtimeWithActions = runtime as {
       actions?: Array<{
@@ -1583,11 +1568,11 @@ export async function handleAppsRoutes(
           parameters: {
             mode: "create",
             intent,
-            ...(body.editTarget ? { editTarget: body.editTarget } : {}),
+            ...(editTarget ? { editTarget } : {}),
           },
           mode: "create",
           intent,
-          ...(body.editTarget ? { editTarget: body.editTarget } : {}),
+          ...(editTarget ? { editTarget } : {}),
         },
         callback,
       )) as { success?: boolean; text?: string; data?: unknown } | undefined;

--- a/packages/agent/src/api/apps-routes.ts
+++ b/packages/agent/src/api/apps-routes.ts
@@ -799,7 +799,7 @@ export async function handleAppsRoutes(
 
     if (method === "PUT") {
       const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-      if (rawBody === null || rawBody === undefined) return true;
+      if (rawBody === null) return true;
       const parsed = PutFavoriteAppRequestSchema.safeParse(rawBody);
       if (!parsed.success) {
         const issue = parsed.error.issues[0];
@@ -828,7 +828,7 @@ export async function handleAppsRoutes(
       return true;
     }
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostReplaceFavoritesRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -855,7 +855,7 @@ export async function handleAppsRoutes(
   // Dashboard heartbeat for overlay apps (companion, etc.) — no AppManager run.
   if (method === "POST" && pathname === "/api/apps/overlay-presence") {
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostOverlayPresenceRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -939,7 +939,7 @@ export async function handleAppsRoutes(
       }
 
       const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-      if (rawBody === null || rawBody === undefined) return true;
+      if (rawBody === null) return true;
       const parsed =
         subroute === "message"
           ? PostRunMessageRequestSchema.safeParse(rawBody)
@@ -1005,7 +1005,7 @@ export async function handleAppsRoutes(
   if (method === "POST" && pathname === "/api/apps/launch") {
     try {
       const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-      if (rawBody === null || rawBody === undefined) return true;
+      if (rawBody === null) return true;
       const parsed = PostLaunchAppRequestSchema.safeParse(rawBody);
       if (!parsed.success) {
         const issue = parsed.error.issues[0];
@@ -1034,7 +1034,7 @@ export async function handleAppsRoutes(
   if (method === "POST" && pathname === "/api/apps/install") {
     try {
       const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-      if (rawBody === null || rawBody === undefined) return true;
+      if (rawBody === null) return true;
       const parsed = PostInstallAppRequestSchema.safeParse(rawBody);
       if (!parsed.success) {
         const issue = parsed.error.issues[0];
@@ -1098,7 +1098,7 @@ export async function handleAppsRoutes(
 
   if (method === "POST" && pathname === "/api/apps/stop") {
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostStopAppRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -1208,7 +1208,7 @@ export async function handleAppsRoutes(
 
   if (method === "POST" && pathname === "/api/apps/relaunch") {
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostRelaunchAppRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -1344,7 +1344,7 @@ export async function handleAppsRoutes(
     // the zod schema in @elizaos/shared so the wire shape is the
     // single source of truth (see contracts/app-permissions-routes.ts).
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PutAppPermissionsRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -1376,7 +1376,7 @@ export async function handleAppsRoutes(
     // The schema handles the required check, the absolute-path check,
     // and rejects extra unknown fields via .strict().
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostLoadFromDirectoryRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];
@@ -1512,7 +1512,7 @@ export async function handleAppsRoutes(
 
   if (method === "POST" && pathname === "/api/apps/create") {
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
-    if (rawBody === null || rawBody === undefined) return true;
+    if (rawBody === null) return true;
     const parsed = PostCreateAppRequestSchema.safeParse(rawBody);
     if (!parsed.success) {
       const issue = parsed.error.issues[0];

--- a/packages/shared/src/contracts/apps-lifecycle-routes.test.ts
+++ b/packages/shared/src/contracts/apps-lifecycle-routes.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  PostCreateAppRequestSchema,
   PostInstallAppRequestSchema,
   PostLaunchAppRequestSchema,
+  PostOverlayPresenceRequestSchema,
   PostRelaunchAppRequestSchema,
   PostStopAppRequestSchema,
 } from "./apps-lifecycle-routes.js";
@@ -163,6 +165,105 @@ describe("PostRelaunchAppRequestSchema", () => {
   it("rejects extra fields (strict)", () => {
     expect(() =>
       PostRelaunchAppRequestSchema.parse({ name: "x", force: true }),
+    ).toThrow();
+  });
+});
+
+describe("PostCreateAppRequestSchema", () => {
+  it("accepts intent only", () => {
+    const parsed = PostCreateAppRequestSchema.parse({ intent: "make a todo" });
+    expect(parsed).toEqual({ intent: "make a todo" });
+  });
+
+  it("accepts intent + editTarget", () => {
+    const parsed = PostCreateAppRequestSchema.parse({
+      intent: "tweak the colour",
+      editTarget: "companion",
+    });
+    expect(parsed).toEqual({
+      intent: "tweak the colour",
+      editTarget: "companion",
+    });
+  });
+
+  it("trims intent and editTarget", () => {
+    const parsed = PostCreateAppRequestSchema.parse({
+      intent: "  build me an app  ",
+      editTarget: "  companion  ",
+    });
+    expect(parsed).toEqual({
+      intent: "build me an app",
+      editTarget: "companion",
+    });
+  });
+
+  it("rejects missing intent", () => {
+    expect(() => PostCreateAppRequestSchema.parse({})).toThrow();
+  });
+
+  it("rejects empty intent", () => {
+    expect(() => PostCreateAppRequestSchema.parse({ intent: "" })).toThrow();
+  });
+
+  it("rejects empty editTarget (use omission)", () => {
+    expect(() =>
+      PostCreateAppRequestSchema.parse({ intent: "x", editTarget: "" }),
+    ).toThrow();
+  });
+
+  it("rejects extra fields (strict)", () => {
+    expect(() =>
+      PostCreateAppRequestSchema.parse({ intent: "x", scaffold: "v2" }),
+    ).toThrow();
+  });
+});
+
+describe("PostOverlayPresenceRequestSchema", () => {
+  it("accepts a string appName", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({
+      appName: "companion",
+    });
+    expect(parsed).toEqual({ appName: "companion" });
+  });
+
+  it("accepts explicit null", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({ appName: null });
+    expect(parsed).toEqual({ appName: null });
+  });
+
+  it("accepts omitted appName as null", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({});
+    expect(parsed).toEqual({ appName: null });
+  });
+
+  it("collapses empty string to null", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({ appName: "" });
+    expect(parsed).toEqual({ appName: null });
+  });
+
+  it("collapses whitespace-only string to null", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({
+      appName: "   \t  ",
+    });
+    expect(parsed).toEqual({ appName: null });
+  });
+
+  it("trims surrounding whitespace", () => {
+    const parsed = PostOverlayPresenceRequestSchema.parse({
+      appName: "  companion  ",
+    });
+    expect(parsed).toEqual({ appName: "companion" });
+  });
+
+  it("rejects non-string non-null appName", () => {
+    expect(() =>
+      PostOverlayPresenceRequestSchema.parse({ appName: 42 }),
+    ).toThrow();
+  });
+
+  it("rejects extra fields (strict)", () => {
+    expect(() =>
+      PostOverlayPresenceRequestSchema.parse({ appName: "x", focus: true }),
     ).toThrow();
   });
 });

--- a/packages/shared/src/contracts/apps-lifecycle-routes.ts
+++ b/packages/shared/src/contracts/apps-lifecycle-routes.ts
@@ -1,15 +1,17 @@
 /**
  * Zod schemas for the apps-lifecycle HTTP routes
- * (launch / install / stop). Third migration in the typed-routes
- * initiative — same template as
- * `./app-permissions-routes.ts` and `./apps-loading-routes.ts`:
- * schema in shared, safeParse on server, infer types on client.
+ * (launch / install / stop / relaunch / create / overlay-presence).
+ * Same template as the rest: schema in shared, safeParse on server,
+ * infer types on client.
  *
  * Routes covered:
- *   POST /api/apps/launch    body: { name }            → AppLaunchResult
- *   POST /api/apps/install   body: { name, version? }  → varies
- *   POST /api/apps/stop      body: { name?, runId? }   → AppStopResult
- *                             (at least one of name/runId required)
+ *   POST /api/apps/launch            body: { name }                  → AppLaunchResult
+ *   POST /api/apps/install           body: { name, version? }        → varies
+ *   POST /api/apps/stop              body: { name?, runId? }         → AppStopResult
+ *                                     (at least one of name/runId required)
+ *   POST /api/apps/relaunch          body: { name, runId?, verify? } → AppLaunchResult
+ *   POST /api/apps/create            body: { intent, editTarget? }   → APP-action result
+ *   POST /api/apps/overlay-presence  body: { appName?: string|null } → { ok, appName }
  *
  * Response shapes for these routes are not modelled here — they
  * delegate to handler-internal types (AppLaunchResult, AppStopResult,
@@ -109,9 +111,58 @@ export const PostRelaunchAppRequestSchema = z
       .strict(),
   );
 
+/**
+ * /create maps onto the unified APP action — the `intent` is the
+ * natural-language prompt the orchestrator hands to the spawned coding
+ * sub-agent, and `editTarget` (when present) names an existing app to
+ * edit instead of scaffolding a new one. The handler used to require a
+ * non-empty trimmed intent by hand; the schema now does that, plus
+ * trims `editTarget` so empty strings round-trip back to "missing".
+ */
+export const PostCreateAppRequestSchema = z
+  .object({
+    intent: z.string().min(1, "intent is required"),
+    editTarget: z.string().min(1).optional(),
+  })
+  .strict()
+  .transform((value) => ({
+    intent: value.intent.trim(),
+    ...(value.editTarget ? { editTarget: value.editTarget.trim() } : {}),
+  }))
+  .pipe(
+    z
+      .object({
+        intent: z.string().min(1, "intent is required"),
+        editTarget: z.string().min(1).optional(),
+      })
+      .strict(),
+  );
+
+/**
+ * /overlay-presence is the UI's "which app is currently visible" ping.
+ * The route accepts a string, an explicit `null`, or omission — all of
+ * the latter two clear presence. Empty/whitespace strings collapse to
+ * null too, matching the handler's prior `trim().length > 0 ? trim : null`
+ * normalisation.
+ */
+export const PostOverlayPresenceRequestSchema = z
+  .object({
+    appName: z.union([z.string(), z.null()]).optional(),
+  })
+  .strict()
+  .transform((value): { appName: string | null } => {
+    const raw = value.appName;
+    const trimmed = typeof raw === "string" ? raw.trim() : "";
+    return { appName: trimmed.length > 0 ? trimmed : null };
+  });
+
 export type PostLaunchAppRequest = z.infer<typeof PostLaunchAppRequestSchema>;
 export type PostInstallAppRequest = z.infer<typeof PostInstallAppRequestSchema>;
 export type PostStopAppRequest = z.infer<typeof PostStopAppRequestSchema>;
 export type PostRelaunchAppRequest = z.infer<
   typeof PostRelaunchAppRequestSchema
+>;
+export type PostCreateAppRequest = z.infer<typeof PostCreateAppRequestSchema>;
+export type PostOverlayPresenceRequest = z.infer<
+  typeof PostOverlayPresenceRequestSchema
 >;

--- a/packages/shared/src/contracts/apps-runs-routes.test.ts
+++ b/packages/shared/src/contracts/apps-runs-routes.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  PostRunControlRequestSchema,
+  PostRunMessageRequestSchema,
+} from "./apps-runs-routes.js";
+
+describe("PostRunMessageRequestSchema", () => {
+  it("accepts a content field", () => {
+    const parsed = PostRunMessageRequestSchema.parse({ content: "hello" });
+    expect(parsed).toEqual({ content: "hello" });
+  });
+
+  it("accepts a message alias", () => {
+    const parsed = PostRunMessageRequestSchema.parse({ message: "hello" });
+    expect(parsed).toEqual({ content: "hello" });
+  });
+
+  it("prefers content over message when both are present", () => {
+    const parsed = PostRunMessageRequestSchema.parse({
+      content: "from content",
+      message: "from message",
+    });
+    expect(parsed).toEqual({ content: "from content" });
+  });
+
+  it("trims surrounding whitespace", () => {
+    const parsed = PostRunMessageRequestSchema.parse({
+      content: "  hello  ",
+    });
+    expect(parsed).toEqual({ content: "hello" });
+  });
+
+  it("rejects empty body", () => {
+    expect(() => PostRunMessageRequestSchema.parse({})).toThrow(
+      /content is required/,
+    );
+  });
+
+  it("rejects whitespace-only content", () => {
+    expect(() =>
+      PostRunMessageRequestSchema.parse({ content: "   " }),
+    ).toThrow();
+  });
+
+  it("rejects extra fields (strict)", () => {
+    expect(() =>
+      PostRunMessageRequestSchema.parse({ content: "x", role: "user" }),
+    ).toThrow();
+  });
+});
+
+describe("PostRunControlRequestSchema", () => {
+  it("accepts pause", () => {
+    const parsed = PostRunControlRequestSchema.parse({ action: "pause" });
+    expect(parsed).toEqual({ action: "pause" });
+  });
+
+  it("accepts resume", () => {
+    const parsed = PostRunControlRequestSchema.parse({ action: "resume" });
+    expect(parsed).toEqual({ action: "resume" });
+  });
+
+  it("rejects unknown actions", () => {
+    expect(() =>
+      PostRunControlRequestSchema.parse({ action: "stop" }),
+    ).toThrow();
+  });
+
+  it("rejects missing action", () => {
+    expect(() => PostRunControlRequestSchema.parse({})).toThrow();
+  });
+
+  it("rejects non-string action", () => {
+    expect(() => PostRunControlRequestSchema.parse({ action: true })).toThrow();
+  });
+
+  it("rejects extra fields (strict)", () => {
+    expect(() =>
+      PostRunControlRequestSchema.parse({ action: "pause", reason: "idle" }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/contracts/apps-runs-routes.test.ts
+++ b/packages/shared/src/contracts/apps-runs-routes.test.ts
@@ -42,6 +42,12 @@ describe("PostRunMessageRequestSchema", () => {
     ).toThrow();
   });
 
+  it("rejects whitespace-only message alias", () => {
+    expect(() =>
+      PostRunMessageRequestSchema.parse({ message: "   " }),
+    ).toThrow();
+  });
+
   it("rejects extra fields (strict)", () => {
     expect(() =>
       PostRunMessageRequestSchema.parse({ content: "x", role: "user" }),

--- a/packages/shared/src/contracts/apps-runs-routes.ts
+++ b/packages/shared/src/contracts/apps-runs-routes.ts
@@ -1,0 +1,46 @@
+/**
+ * Zod schemas for the per-run steering HTTP routes:
+ *
+ *   POST /api/apps/runs/:runId/message   body: { content | message }
+ *   POST /api/apps/runs/:runId/control   body: { action: 'pause'|'resume' }
+ *
+ * The message route historically accepted either `content` or `message`
+ * as the field name (clients drifted, the handler tolerated both).
+ * The schema preserves that compatibility and normalises down to a
+ * single `content` field so the rest of the pipeline only sees one
+ * shape.
+ */
+
+import z from "zod";
+
+export const PostRunMessageRequestSchema = z
+  .object({
+    content: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .strict()
+  .transform((value) => {
+    const raw =
+      typeof value.content === "string"
+        ? value.content
+        : typeof value.message === "string"
+          ? value.message
+          : "";
+    return { content: raw.trim() };
+  })
+  .pipe(
+    z
+      .object({
+        content: z.string().min(1, "content is required"),
+      })
+      .strict(),
+  );
+
+export const PostRunControlRequestSchema = z
+  .object({
+    action: z.enum(["pause", "resume"]),
+  })
+  .strict();
+
+export type PostRunMessageRequest = z.infer<typeof PostRunMessageRequestSchema>;
+export type PostRunControlRequest = z.infer<typeof PostRunControlRequestSchema>;

--- a/packages/shared/src/contracts/index.ts
+++ b/packages/shared/src/contracts/index.ts
@@ -4,6 +4,7 @@ export * from "./apps.js";
 export * from "./apps-favorites-routes.js";
 export * from "./apps-lifecycle-routes.js";
 export * from "./apps-loading-routes.js";
+export * from "./apps-runs-routes.js";
 export * from "./awareness.js";
 export * from "./cloud-topology.js";
 export * from "./config.js";


### PR DESCRIPTION
## Summary

Round 5 of the zod-typed routes migration (continues #7557). Migrates the four remaining body-bearing apps HTTP routes:

- \`POST /api/apps/create\` — \`PostCreateAppRequestSchema\` (intent + optional editTarget; trims both)
- \`POST /api/apps/overlay-presence\` — \`PostOverlayPresenceRequestSchema\` (string | null | omitted; collapses empty/whitespace to null, matching prior hand-rolled normalisation)
- \`POST /api/apps/runs/:runId/message\` — \`PostRunMessageRequestSchema\` (preserves the historical \`content\`/\`message\` alias via \`.transform()\`)
- \`POST /api/apps/runs/:runId/control\` — \`PostRunControlRequestSchema\` (action: enum 'pause' | 'resume')

Drops the now-unused \`readSteeringContent\` and \`readSteeringAction\` helpers — fully subsumed by the schemas.

After this round, every body-bearing route in \`apps-routes.ts\` is schema-validated. Bodyless routes (\`/api/apps/refresh\`) and pure path-only GETs are not in scope.

## Module layout

- \`apps-lifecycle-routes.ts\` (existing) — gains \`PostCreateAppRequestSchema\` + \`PostOverlayPresenceRequestSchema\` (joins launch / install / stop / relaunch)
- \`apps-runs-routes.ts\` (new) — \`PostRunMessageRequestSchema\` + \`PostRunControlRequestSchema\` (run-level steering is a distinct domain from app-level lifecycle)

## Test plan

- [x] \`bun run test\` in \`@elizaos/shared\` — 11 files, 170 tests pass (28 new)
- [x] \`bun turbo run build --filter=@elizaos/shared\` — clean
- [x] Typecheck across changed files — no new errors
- [x] Biome lint clean
- [ ] Reviewer: spot-check the run-message alias semantics (\`{message: x}\` and \`{content: x}\` should both be accepted, with \`content\` taking precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes round 5 of the zod-typed routes migration, adding Zod schemas for the four remaining body-bearing `apps-routes.ts` handlers: `/api/apps/create`, `/api/apps/overlay-presence`, `/api/apps/runs/:runId/message`, and `/api/apps/runs/:runId/control`. It drops the now-superseded `readSteeringContent` and `readSteeringAction` helpers and introduces a new `apps-runs-routes.ts` contract file for run-level steering.

- **`PostCreateAppRequestSchema`** and **`PostOverlayPresenceRequestSchema`** are added to `apps-lifecycle-routes.ts`, following the established trim-then-pipe pattern; the presence schema normalises empty/whitespace strings and omitted `appName` to `null`, faithfully reproducing prior hand-rolled logic.
- **`PostRunMessageRequestSchema`** preserves the historical `content`/`message` alias via a transform, resolving to a single `content` field; **`PostRunControlRequestSchema`** wraps the `pause | resume` enum, and both are exported from a new `apps-runs-routes.ts` file.
- 28 new passing tests cover accept/reject paths, trim normalisation, and the alias precedence rule.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all four schema migrations faithfully reproduce prior hand-rolled normalisation, the new strict validation is a deliberate tightening, and 28 new tests confirm the expected accept/reject/alias behaviour.

The changes are a straightforward schema-lift of existing body-parsing logic with no control-flow restructuring. Each schema has been verified against the pre-zod handler behaviour and the accompanying tests exercise trim normalisation, alias precedence, strict-mode rejection, and all edge inputs. No functional regressions were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/contracts/apps-runs-routes.ts | New file — PostRunMessageRequestSchema (with content/message alias transform + pipe) and PostRunControlRequestSchema (enum strict); logic is correct and well-tested. |
| packages/shared/src/contracts/apps-lifecycle-routes.ts | Adds PostCreateAppRequestSchema (trim+pipe pattern) and PostOverlayPresenceRequestSchema (transform-only, no pipe re-validation); both schemas correctly replicate pre-zod handler logic. |
| packages/agent/src/api/apps-routes.ts | Replaces four hand-rolled body-parsing blocks with schema safeParse calls; removes dead readSteeringContent/readSteeringAction helpers and cleans up all remaining rawBody === undefined dead guards. |
| packages/shared/src/contracts/apps-runs-routes.test.ts | New test file with 14 cases covering both schemas, including alias precedence, trim, whitespace rejection, and strict-mode extra-field rejection. |
| packages/shared/src/contracts/apps-lifecycle-routes.test.ts | Adds 14 new test cases for PostCreateAppRequestSchema and PostOverlayPresenceRequestSchema; covers all expected accept/reject/normalisation paths. |
| packages/shared/src/contracts/index.ts | Adds apps-runs-routes.ts to the public contract barrel export; no issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant apps-routes.ts
    participant Schema as Zod Schema
    participant Handler as Route Handler Logic

    Client->>apps-routes.ts: "POST /api/apps/create { intent, editTarget? }"
    apps-routes.ts->>Schema: PostCreateAppRequestSchema.safeParse(rawBody)
    Schema-->>apps-routes.ts: "{ intent: trimmed, editTarget?: trimmed }"
    apps-routes.ts->>Handler: "{ intent, editTarget? }"

    Client->>apps-routes.ts: "POST /api/apps/overlay-presence { appName?: string|null }"
    apps-routes.ts->>Schema: PostOverlayPresenceRequestSchema.safeParse(rawBody)
    Schema-->>apps-routes.ts: "{ appName: string|null }"
    apps-routes.ts->>Handler: setOverlayAppPresence(appName)

    Client->>apps-routes.ts: "POST /api/apps/runs/:runId/message { content? | message? }"
    apps-routes.ts->>Schema: PostRunMessageRequestSchema.safeParse(rawBody)
    Schema-->>apps-routes.ts: "{ content: string }"
    apps-routes.ts->>Handler: proxyRunSteeringRequest

    Client->>apps-routes.ts: "POST /api/apps/runs/:runId/control { action }"
    apps-routes.ts->>Schema: PostRunControlRequestSchema.safeParse(rawBody)
    Schema-->>apps-routes.ts: "{ action: pause|resume }"
    apps-routes.ts->>Handler: proxyRunSteeringRequest
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: address greptile review on PR #75..."](https://github.com/elizaos/eliza/commit/2e12080ecc245350cf4ce2258690dc825eb0b84a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31523179)</sub>

<!-- /greptile_comment -->