### PR TITLE
fix(mobile-signals): gate iOS 26 AuthorizationStatus case behind compiler check

### DIFF
--- a/packages/native-plugins/mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
+++ b/packages/native-plugins/mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
@@ -115,8 +115,13 @@ enum ScreenTimeSupport {
             switch AuthorizationCenter.shared.authorizationStatus {
             case .approved:
                 return "approved"
+            #if compiler(>=6.2)
+            // .approvedWithDataAccess shipped in iOS 26 (Xcode 26 / Swift 6.2).
+            // Older Xcode/SDK combinations don't know the case at all, so it
+            // has to be guarded at compile time, not via #available.
             case .approvedWithDataAccess:
                 return "approved"
+            #endif
             case .denied:
                 return "denied"
             case .notDetermined:


### PR DESCRIPTION
## Summary

\`FamilyControls.AuthorizationStatus.approvedWithDataAccess\` was added in iOS 26 (Xcode 26 / Swift 6.2). Xcode 16.4 — what mobile-build-smoke uses — ships with the iOS 18.5 SDK, where the case literally does not exist on the enum. The switch fails to compile with:

\`\`\`
ScreenTimeSupport.swift:118:19: error: type 'AuthorizationStatus' has no member 'approvedWithDataAccess'
\`\`\`

\`#available\` doesn't help because the type member is missing from the SDK at compile time, not just at runtime. The fix is a compile-time \`#if compiler(>=6.2)\` gate.

## Behavior

- Newer toolchains (Xcode 26+) keep the case mapped to \`"approved"\` exactly as before.
- Older toolchains skip the case entirely and fall through to \`@unknown default\` → \`"unavailable"\`. Harmless because no iOS 18 device can return that case at runtime.

## Impact

Restores the \`iOS Simulator Build\` job that's been red on every PR since the file was introduced in \`ff6de92d8 chore: restore current develop tree\` (May 5).

## Test plan

- [ ] CI: \`Mobile Build Smoke Test > iOS Simulator Build\` passes
- [ ] CI: \`Mobile Build Smoke Test > Android Debug Build\` still passes (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a compile-time build failure caused by referencing `FamilyControls.AuthorizationStatus.approvedWithDataAccess`, an enum case that exists only in the iOS 26 SDK (Xcode 26 / Swift 6.2) but not in the iOS 18.5 SDK used by the CI smoke-test job.

- **Root cause & fix**: `#available` is insufficient here because the case is absent from the SDK at compile time, not just at runtime. The PR wraps the case in a `#if compiler(>=6.2)` block, which is the idiomatic Swift solution for this class of SDK gap.
- **Behavioral correctness**: Under older toolchains the case is simply absent from the switch; the existing `@unknown default` branch correctly handles any future or unknown cases, and no iOS 18 device can ever return `approvedWithDataAccess` at runtime, so the fallback to `"unavailable"` is harmless.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted compile-time guard that unblocks CI without altering any runtime behavior on shipping devices.

The fix is a single, well-understood Swift preprocessor directive. The `#if compiler(>=6.2)` block correctly isolates the SDK-missing enum case at compile time, the existing `@unknown default` branch provides a safe fallback, and no runtime logic is altered for any currently-shipping iOS version.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/native-plugins/mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift | Wraps the `.approvedWithDataAccess` enum case in a `#if compiler(>=6.2)` guard so the file compiles under Xcode 16.4 / Swift < 6.2, where the case does not exist in the SDK. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[authorizationStatusString called] --> B{"#if compiler(>=6.2)?"}
    B -- Swift 6.2+ --> C[Full switch on AuthorizationStatus]
    B -- Swift lt 6.2 --> D[Switch without approvedWithDataAccess]

    C --> C1[".approved"] --> R1["'approved'"]
    C --> C2[".approvedWithDataAccess"] --> R2["'approved'"]
    C --> C3[".denied"] --> R3["'denied'"]
    C --> C4[".notDetermined"] --> R4["'not-determined'"]
    C --> C5["unknown default"] --> R5["'unavailable'"]

    D --> D1[".approved"] --> S1["'approved'"]
    D --> D3[".denied"] --> S3["'denied'"]
    D --> D4[".notDetermined"] --> S4["'not-determined'"]
    D --> D5["unknown default"] --> S5["'unavailable'"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into fix/ios-scre..."](https://github.com/elizaos/eliza/commit/65b2c27076dd89e5381309a9d4c7240798760a10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31527433)</sub>

<!-- /greptile_comment -->