### PR TITLE
fix(ui): align auto-download-recommended test with renamed catalog tier

### DIFF
--- a/packages/ui/src/onboarding/auto-download-recommended.test.ts
+++ b/packages/ui/src/onboarding/auto-download-recommended.test.ts
@@ -87,7 +87,7 @@ describe("autoDownloadRecommendedLocalModelInBackground", () => {
     );
 
     expect(mockClient.startLocalInferenceDownload).toHaveBeenCalledWith(
-      "eliza-1-mobile-1_7b",
+      "eliza-1-1_7b",
     );
   });
 });


### PR DESCRIPTION
## Summary

Catalog model IDs were renamed in [\`5c5eb75de more inference optmization and testing\`](https://github.com/elizaOS/eliza/commit/5c5eb75de) — \`eliza-1-mobile-1_7b\` became plain \`eliza-1-1_7b\` (and the other tiers dropped their \`desktop-\` / \`pro-\` / \`lite-\` prefixes similarly). The auto-download recommendation test still asserted the old name and has been failing on every Tests run since.

For the iOS simulator scenario in this test (\`mobile.platform: 'ios'\`, \`appleSilicon: true\`, 5 GB available RAM), the recommendation engine classifies as \`mobile\` and walks the TEXT_LARGE ladder \`['eliza-1-1_7b', 'eliza-1-0_6b']\`. With nothing installed, the first pick is \`eliza-1-1_7b\` — the new equivalent of the old \`eliza-1-mobile-1_7b\`.

## Diff

One-line update to the assertion. No production code changes.

## Test plan

- [x] Local: \`vitest run src/onboarding/auto-download-recommended.test.ts\` → \`Test Files 1 passed (1), Tests 1 passed (1)\`
- [ ] CI: \`Tests > Client Tests\` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates a single test assertion to match the renamed catalog model ID introduced in commit `5c5eb75de`, where `eliza-1-mobile-1_7b` was simplified to `eliza-1-1_7b`. No production code is changed.

- `auto-download-recommended.test.ts`: the expected argument to `startLocalInferenceDownload` is updated from `\"eliza-1-mobile-1_7b\"` to `\"eliza-1-1_7b\"`, which is the correct tier ID in the current `MODEL_CATALOG` for the iOS-simulator / 5 GB RAM scenario tested.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — one test assertion corrected, no production code touched.

The change is a single string update in a test file. The replacement value `eliza-1-1_7b` is confirmed present in `MODEL_CATALOG` and is designated as the `FIRST_RUN_DEFAULT_MODEL_ID` for the iOS mobile tier. The surrounding test setup (hardware snapshot, mocks, assertions) is unchanged and remains coherent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/onboarding/auto-download-recommended.test.ts | Single assertion updated from old `eliza-1-mobile-1_7b` to current catalog ID `eliza-1-1_7b`; no logic changes, catalog confirms the new ID exists. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["autoDownloadRecommendedLocalModelInBackground()"] --> B{Marker already set?}
    B -- Yes --> Z[Return early]
    B -- No --> C[waitForLocalAgent]
    C -- Timeout --> Z
    C -- Ready --> D[getLocalInferenceHub snapshot]
    D -- Error --> Z
    D -- OK --> E{Already has eliza-download model?}
    E -- Yes --> F[writeMarker + return]
    E -- No --> G["pickRecommendedModel(snapshot)\nTEXT_LARGE slot, hardware=iOS/arm64/5GB"]
    G --> H{"Model found?\n(eliza-1-1_7b renamed from eliza-1-mobile-1_7b)"}
    H -- None --> F
    H -- Found --> I["startLocalInferenceDownload('eliza-1-1_7b')"]
    I -- Success --> J[writeMarker]
    I -- Error --> Z
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): align auto-download-recommended..."](https://github.com/elizaos/eliza/commit/4f621df439d8e37e1532d4b16a1e7183e31e81c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31527631)</sub>

<!-- /greptile_comment -->