### PR TITLE
chore(ci): mobile-build-smoke triggers on packages/native-plugins changes too

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -8,6 +8,7 @@ on:
       - "packages/app/**"
       - "packages/app-core/**"
       - "packages/core/**"
+      - "packages/native-plugins/**"
       - "packages/shared/**"
       - "plugins/plugin-sql/**"
       - ".github/workflows/mobile-build-smoke.yml"


### PR DESCRIPTION
## Summary

The Capacitor iOS app builds in the bundled native plugins under \`packages/native-plugins/*\` (camera, location, mobile-signals, screencapture, swabble, talkmode, ...). Changes to those Swift sources can break the iOS Simulator Build, but the workflow's \`paths\` filter didn't include them.

That's how the iOS Swift compile regression in \`packages/native-plugins/mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift\` (fixed in #7562) slipped through to develop and stayed there. By the time a PR touched a watched path, it showed up as a "develop is broken" symptom on every open PR rather than getting caught at PR review on the original change.

## Diff

One-line addition.

\`\`\`diff
       - "packages/core/**"
+      - "packages/native-plugins/**"
       - "packages/shared/**"
\`\`\`

## Test plan

- [ ] CI: this PR triggers the Mobile Build Smoke Test workflow (touching the workflow file always triggers it)
- [ ] After merge: a future PR touching only a native-plugin Swift file will run the iOS/Android jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `packages/native-plugins/**` to the `paths` trigger of the Mobile Build Smoke Test workflow so that changes to any of the bundled Capacitor native plugins (Swift, Kotlin, or TypeScript sources) automatically run the iOS and Android build jobs on PRs.

- The new glob matches the verified `packages/native-plugins/` directory, which contains Swift/Kotlin Capacitor plugins for camera, location, mobile-signals, screen-capture, etc.
- Inserted alphabetically between `packages/core/**` and `packages/shared/**`, keeping the list consistent with the existing ordering.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line glob addition to a CI paths filter with no effect on runtime code.

The change touches only the workflow trigger configuration. The added glob `packages/native-plugins/**` correctly matches the existing directory (confirmed in the repo), is inserted in alphabetical order consistent with the surrounding entries, and uses standard GitHub Actions glob syntax. There are no logic changes, no new jobs, and no modifications to build steps.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/mobile-build-smoke.yml | Adds `packages/native-plugins/**` to the workflow's path filter so changes to Swift/Kotlin native plugin sources trigger the iOS Simulator and Android Debug build jobs. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened / pushed to main or develop] --> B{Changed files match paths filter?}
    B -- "packages/agent/**\npackages/app/**\npackages/app-core/**\npackages/core/**\npackages/shared/**\nplugins/plugin-sql/**\n.github/workflows/..." --> C[Trigger workflow]
    B -- "packages/native-plugins/** (NEW)" --> C
    B -- No match --> D[Skip workflow]
    C --> E[iOS Simulator Build\nmacos-15]
    C --> F[Android Debug Build\nubuntu-24.04]
    E --> G[Verify .app + bundle ID\n+ Info.plist keys\n+ Fastlane config]
    F --> H[Verify APK exists\n+ Upload artifact]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci(mobile-build-smoke): trigger on packa..."](https://github.com/elizaos/eliza/commit/8e35b32cd117a6eaf786062c688d67dd52016f7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31528445)</sub>

<!-- /greptile_comment -->