### PR TITLE
fix(plugin-anthropic): accept null content on assistant tool-call messages

### DIFF
--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -208,12 +208,26 @@ function isModelMessage(value: unknown): value is ModelMessage {
     case "system":
       return typeof value.content === "string";
     case "user":
-    case "assistant":
     case "tool":
-      // Accept string or array content. Eliza runtime synthesizes tool / assistant
-      // messages with string content (see buildStageChatMessages); the AI SDK
-      // accepts these and the underlying provider normalizes them.
+      // Eliza runtime synthesizes tool / user messages with string content
+      // (see buildStageChatMessages); the AI SDK accepts these and the
+      // underlying provider normalizes them.
       return typeof value.content === "string" || Array.isArray(value.content);
+    case "assistant":
+      // Assistant messages emitted by `trajectoryStepsToMessages` carry a tool
+      // call with `content: step.thought ?? null`. The OpenAI/Anthropic spec
+      // allows `content: null` on assistant messages that carry tool calls —
+      // dropping the message here turns `readModelMessages` into `undefined`
+      // and the AI SDK silently falls back to a prompt-only call, blinding
+      // the evaluator to the entire tool history. Accept null content when
+      // a tool call is attached so the evaluator actually sees its turn.
+      if (typeof value.content === "string" || Array.isArray(value.content)) {
+        return true;
+      }
+      if (value.content === null || value.content === undefined) {
+        return Array.isArray(value.toolCalls) && value.toolCalls.length > 0;
+      }
+      return false;
     default:
       return false;
   }


### PR DESCRIPTION
## Bug

The OpenAI / Anthropic chat-message spec allows assistant messages that carry a tool call to set `content: null` (the tool call itself is the turn's payload). `trajectoryStepsToMessages` in `@elizaos/core` emits exactly that shape:

```ts
messages.push({
  role: "assistant",
  content: step.thought ?? null,        // ← null when planner returns no thought
  toolCalls: [{ id, type: "function", name, arguments }],
});
```

`isModelMessage` in `plugins/plugin-anthropic/models/text.ts` rejected such messages because `null` is neither a string nor an array:

```ts
case "user":
case "assistant":
case "tool":
  return typeof value.content === "string" || Array.isArray(value.content);
```

`readModelMessages` then returned `undefined` for the entire messages array, so the AI SDK silently fell back to a prompt-only call — the evaluator (and any other downstream model call) lost the entire assistant+tool history of the current planner-loop turn.

## Real-world impact

This is the root cause of an evaluator-blindness loop on every shell-tool turn. Repro:

```
> df -h / what is the disk usage
[planner picks BASH] → [tool runs successfully, exit 0]
[evaluator: "no tool has been executed yet" → CONTINUE]
[loop 16 times]
[trajectory limit exceeded → structured failure fallback to user]
```

Trace from a real trajectory's evaluator stage:
```json
{
  "role": "assistant",
  "content": null,                 // ← rejected
  "toolCalls": [{ "id": "tool-1-0", "name": "BASH", ... }]
}
```

After this fix the evaluator sees the assistant turn and the paired tool result, so it can FINISH with the disk numbers instead of looping.

## Fix

Accept `content: null` (or missing) on assistant messages when at least one tool call is attached — matches the OpenAI/Anthropic spec and the AI SDK's own `AssistantContent` typing. The user/tool cases still require string-or-array content (those never carry tool calls).

## Diff

- 1 file, +18 / -4 in `plugins/plugin-anthropic/models/text.ts`
- additive only — string/array assistant content still accepted unchanged
- new behaviour only kicks in for the specific null-content + toolCalls shape that `trajectoryStepsToMessages` emits

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an evaluator-blindness loop caused by `isModelMessage` rejecting assistant messages with `content: null` — a valid shape emitted by `trajectoryStepsToMessages` when the planner returns no thought text. Because `readModelMessages` returns `undefined` on the first failing message (dropping the whole array), the AI SDK silently fell back to a prompt-only call and the evaluator never saw tool-call history.

- **Core fix**: the `\"assistant\"` switch case now accepts `null`/`undefined` content when `toolCalls` is a non-empty array, while preserving the existing string/array acceptance unchanged.
- **User and tool cases** are left untouched — they correctly still require string-or-array content.
- The fix is consistent with the `ChatMessage` type in `@elizaos/core`, which already declares `content?: string | ChatMessageContentPart[] | null`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is additive and tightly scoped to assistant messages with null content and attached tool calls, leaving all other message shapes unchanged.

The fix correctly addresses the documented evaluator-blindness loop. The ChatMessage core type already declares content as nullable, the fix matches the OpenAI/Anthropic spec, and the change is additive. The only open question is whether individual toolCalls items should also be shape-validated before the cast to ModelMessage, but that is a pre-existing gap in the guard rather than a regression introduced here.

No files require special attention beyond the single changed guard in plugins/plugin-anthropic/models/text.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-anthropic/models/text.ts | Splits the assistant/user/tool switch case to handle null content on assistant messages that carry tool calls; one minor nit on toolCall item shape validation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-anthropic): accept null conte..."](https://github.com/elizaos/eliza/commit/268af9a2be1180550bf0f19be389ec38cdfa23cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31531968)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->