### PR TITLE
fix(core): emit AI SDK v6 message shape for tool turns

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
@@ -105,18 +105,30 @@ describe("planner-loop message stacking regression", () => {
 			expect(JSON.stringify(msgs2[i])).toBe(JSON.stringify(msgs1[i]));
 		}
 
-		// The new messages added in call 2 must be assistant + tool pair
+		// The new messages added in call 2 must be assistant + tool pair (AI SDK v6 shape:
+		// tool calls live inside `content` as `ToolCallPart`, tool results inside `content`
+		// as `ToolResultPart`).
 		const added = msgs2.slice(msgs1.length);
 		expect(added.length).toBe(2);
 		expect(added[0].role).toBe("assistant");
-		expect(added[0].toolCalls).toBeDefined();
-		expect(added[0].toolCalls).toHaveLength(1);
-		expect(added[1].role).toBe("tool");
-		expect(added[1].toolCallId).toBeDefined();
+		const assistantContent = added[0].content;
+		expect(Array.isArray(assistantContent)).toBe(true);
+		const toolCallPart = (assistantContent as Array<{ type: string }> | undefined)?.find(
+			(part) => part.type === "tool-call",
+		) as { type: "tool-call"; toolCallId: string } | undefined;
+		expect(toolCallPart).toBeDefined();
+		expect(toolCallPart?.toolCallId).toBeDefined();
 
-		// The assistant message's tool call id must match the tool message's toolCallId
-		const assistantToolCallId = added[0].toolCalls?.[0]?.id;
-		expect(added[1].toolCallId).toBe(assistantToolCallId);
+		expect(added[1].role).toBe("tool");
+		const toolContent = added[1].content;
+		expect(Array.isArray(toolContent)).toBe(true);
+		const toolResultPart = (toolContent as Array<{ type: string }> | undefined)?.find(
+			(part) => part.type === "tool-result",
+		) as { type: "tool-result"; toolCallId: string } | undefined;
+		expect(toolResultPart).toBeDefined();
+
+		// The assistant message's tool-call id must match the tool message's tool-result id
+		expect(toolResultPart?.toolCallId).toBe(toolCallPart?.toolCallId);
 	});
 
 	it("planner never appends a standalone trajectory JSON dump as the LAST message", async () => {
@@ -329,9 +341,14 @@ describe("planner-loop message stacking regression", () => {
 		if (added.length >= 2) {
 			const assistantMsg = added[0];
 			const toolMsg = added[1];
-			const tcId = assistantMsg?.toolCalls?.[0]?.id;
+			const tcId = (assistantMsg?.content as Array<{ type: string }> | undefined)
+				?.find((part) => part.type === "tool-call")
+				?.toolCallId;
+			const trId = (toolMsg?.content as Array<{ type: string }> | undefined)
+				?.find((part) => part.type === "tool-result")
+				?.toolCallId;
 			expect(tcId).toBeDefined();
-			expect(toolMsg?.toolCallId).toBe(tcId);
+			expect(trId).toBe(tcId);
 		}
 	});
 });

--- a/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts
@@ -113,18 +113,22 @@ describe("planner-loop message stacking regression", () => {
 		expect(added[0].role).toBe("assistant");
 		const assistantContent = added[0].content;
 		expect(Array.isArray(assistantContent)).toBe(true);
-		const toolCallPart = (assistantContent as Array<{ type: string }> | undefined)?.find(
-			(part) => part.type === "tool-call",
-		) as { type: "tool-call"; toolCallId: string } | undefined;
+		const toolCallPart = (
+			assistantContent as Array<{ type: string }> | undefined
+		)?.find((part) => part.type === "tool-call") as
+			| { type: "tool-call"; toolCallId: string }
+			| undefined;
 		expect(toolCallPart).toBeDefined();
 		expect(toolCallPart?.toolCallId).toBeDefined();
 
 		expect(added[1].role).toBe("tool");
 		const toolContent = added[1].content;
 		expect(Array.isArray(toolContent)).toBe(true);
-		const toolResultPart = (toolContent as Array<{ type: string }> | undefined)?.find(
-			(part) => part.type === "tool-result",
-		) as { type: "tool-result"; toolCallId: string } | undefined;
+		const toolResultPart = (
+			toolContent as Array<{ type: string }> | undefined
+		)?.find((part) => part.type === "tool-result") as
+			| { type: "tool-result"; toolCallId: string }
+			| undefined;
 		expect(toolResultPart).toBeDefined();
 
 		// The assistant message's tool-call id must match the tool message's tool-result id
@@ -341,12 +345,12 @@ describe("planner-loop message stacking regression", () => {
 		if (added.length >= 2) {
 			const assistantMsg = added[0];
 			const toolMsg = added[1];
-			const tcId = (assistantMsg?.content as Array<{ type: string }> | undefined)
-				?.find((part) => part.type === "tool-call")
-				?.toolCallId;
-			const trId = (toolMsg?.content as Array<{ type: string }> | undefined)
-				?.find((part) => part.type === "tool-result")
-				?.toolCallId;
+			const tcId = (
+				assistantMsg?.content as Array<{ type: string }> | undefined
+			)?.find((part) => part.type === "tool-call")?.toolCallId;
+			const trId = (
+				toolMsg?.content as Array<{ type: string }> | undefined
+			)?.find((part) => part.type === "tool-result")?.toolCallId;
 			expect(tcId).toBeDefined();
 			expect(trId).toBe(tcId);
 		}

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "../types/model";
+import type { ChatMessage, ChatMessageContentPart } from "../types/model";
 import type { JsonValue } from "../types/primitives.ts";
 import { stringifyForModel } from "./json-output";
 import type { PlannerStep, PlannerToolResult } from "./planner-types";
@@ -14,6 +14,19 @@ import {
  * for native tool-calling. Skips steps that lack a toolCall or result (e.g.
  * terminal-only steps). The resulting array grows append-only across planner
  * iterations, which keeps the prefix byte-identical for cache hits.
+ *
+ * Emits AI SDK v6's `AssistantModelMessage` / `ToolModelMessage` shape — tool
+ * calls live inside `content` as `ToolCallPart`, tool results inside `content`
+ * as `ToolResultPart`. The legacy OpenAI v0.x shape (`assistant` with a
+ * top-level `toolCalls` array + `tool` with `toolCallId`/`name` siblings) is
+ * silently ignored by AI SDK v6's message conversion: `AssistantContent` only
+ * understands `string | Array<TextPart | FilePart | ReasoningPart |
+ * ToolCallPart | ToolResultPart | ToolApprovalRequest>` and has no top-level
+ * `toolCalls` field. Emitting the legacy shape leaves the evaluator's
+ * downstream model call with no view of the tool history, so the LLM keeps
+ * routing CONTINUE under the belief that no tool has been executed yet — the
+ * planner-loop then iterates until `TrajectoryLimitExceeded` on every
+ * shell-tool turn.
  */
 export function trajectoryStepsToMessages(steps: PlannerStep[]): ChatMessage[] {
 	const messages: ChatMessage[] = [];
@@ -22,24 +35,33 @@ export function trajectoryStepsToMessages(steps: PlannerStep[]): ChatMessage[] {
 			continue;
 		}
 		const toolCallId = stableToolCallId(step);
-		// The model's prior decision: assistant message with a tool call.
-		messages.push({
-			role: "assistant",
-			content: step.thought ?? null,
-			toolCalls: [
-				{
-					id: toolCallId,
-					type: "function",
-					name: step.toolCall.name,
-					arguments: JSON.stringify(step.toolCall.params ?? {}),
-				},
-			],
+
+		const assistantContent: ChatMessageContentPart[] = [];
+		const thought = (step.thought ?? "").trim();
+		if (thought) {
+			assistantContent.push({ type: "text", text: thought });
+		}
+		assistantContent.push({
+			type: "tool-call",
+			toolCallId,
+			toolName: step.toolCall.name,
+			input: (step.toolCall.params ?? {}) as Record<string, unknown>,
 		});
 		messages.push({
+			role: "assistant",
+			content: assistantContent,
+		});
+
+		messages.push({
 			role: "tool",
-			toolCallId,
-			name: step.toolCall.name,
-			content: toolMessageContent(step.result),
+			content: [
+				{
+					type: "tool-result",
+					toolCallId,
+					toolName: step.toolCall.name,
+					output: { type: "text", value: toolMessageContent(step.result) },
+				},
+			],
 		});
 	}
 	return messages;

--- a/plugins/plugin-anthropic/models/text.ts
+++ b/plugins/plugin-anthropic/models/text.ts
@@ -208,12 +208,25 @@ function isModelMessage(value: unknown): value is ModelMessage {
     case "system":
       return typeof value.content === "string";
     case "user":
-    case "assistant":
     case "tool":
-      // Accept string or array content. Eliza runtime synthesizes tool / assistant
-      // messages with string content (see buildStageChatMessages); the AI SDK
-      // accepts these and the underlying provider normalizes them.
+      // Eliza runtime synthesizes tool / user messages with string or array
+      // content (see buildStageChatMessages); the AI SDK accepts these and
+      // the underlying provider normalizes them.
       return typeof value.content === "string" || Array.isArray(value.content);
+    case "assistant":
+      // Most callers emit string-or-array content. Defensively also accept
+      // assistant messages with `content: null` when a tool call is attached
+      // — the OpenAI v0.x / legacy shape that some callers still produce.
+      // Without this, `readModelMessages` returns `undefined` and the AI SDK
+      // silently drops the entire conversation, blinding any downstream model
+      // call to the tool history.
+      if (typeof value.content === "string" || Array.isArray(value.content)) {
+        return true;
+      }
+      if (value.content === null || value.content === undefined) {
+        return Array.isArray(value.toolCalls) && value.toolCalls.length > 0;
+      }
+      return false;
     default:
       return false;
   }


### PR DESCRIPTION
## TL;DR

The evaluator (and any other downstream model call after a tool turn) is blind to the entire planner tool history. The LLM keeps routing `CONTINUE` under the belief that no tool has been executed yet, and the planner-loop iterates until `TrajectoryLimitExceeded` on every shell-tool prompt.

## Repro (before)

```
> what is the disk usage of /
[planner picks BASH] → [tool runs successfully, exit 0, real df output]
[evaluator: "no tool has been executed yet" → CONTINUE]
[loop 16 times]
[trajectory limit exceeded → structured failure fallback to user]

Bot reply: "something flaked, try once more in a moment."
```

## After

```
> what is the disk usage of / on this host
[planner picks BASH] → [tool runs successfully]
[evaluator sees the tool turn → FINISH]

Bot reply: "387G total, 195G used, 192G free (51% used) on /dev/sda1."
```

Verified end-to-end on a live agent with `claude-sonnet-4-6` — trajectory went from 51 stages / 17 iterations / errored to 5 stages / 1 iteration / FINISH.

## Root cause

`packages/core/src/runtime/planner-rendering.ts:trajectoryStepsToMessages` emits OpenAI v0.x legacy message shape:

```ts
{ role: "assistant", content: step.thought ?? null,
  toolCalls: [{ id, type:"function", name, arguments }] }
{ role: "tool", toolCallId, name, content: "text: ..." }
```

AI SDK v6's `AssistantModelMessage`/`ToolModelMessage` only understand content as:

```ts
type AssistantContent = string | Array<TextPart | FilePart | ReasoningPart | ToolCallPart | ToolResultPart | ToolApprovalRequest>
```

There is no top-level `toolCalls` field, and `content: null` is not a valid `AssistantContent`. The provider-anthropic plugin's `isModelMessage` rejected the assistant message, `readModelMessages` returned `undefined` for the whole array, and the AI SDK silently fell back to a prompt-only call.

## Fix

1. **`trajectoryStepsToMessages`** emits AI SDK v6 content arrays:
   - assistant: `[{type:"text",text:thought?}, {type:"tool-call",toolCallId,toolName,input}]`
   - tool: `[{type:"tool-result",toolCallId,toolName,output:{type:"text",value:...}}]`

2. **`plugin-anthropic/models/text.ts:isModelMessage`** defensively accepts `content: null` on assistant messages that carry a tool call — for any other caller that still emits the legacy shape. Without this second change, even one stale caller would re-trigger the same silent-drop. String/array assistant content is unchanged.

## Diff

- `packages/core/src/runtime/planner-rendering.ts` (+33 / -12)
- `plugins/plugin-anthropic/models/text.ts` (+18 / -4)

Supersedes #7567 — same bug, this is the complete root-cause fix.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the planner-loop evaluator being blind to completed tool turns by migrating `trajectoryStepsToMessages` from the OpenAI v0.x legacy message shape (top-level `toolCalls` array, `content: null`) to the AI SDK v6 content-array format that Anthropic's provider actually understands. A secondary shim in `plugin-anthropic`'s `isModelMessage` defensively accepts legacy-shaped assistant messages from any remaining callers that haven't been updated.

- **`planner-rendering.ts`**: `trajectoryStepsToMessages` now emits `AssistantModelMessage` with a `ToolCallPart` in `content` and `ToolModelMessage` with a `ToolResultPart` in `content`. The `ToolResultPart.output` field is correctly named, but the `ToolCallPart` uses `input` instead of the AI SDK v6–required `args` field, silently dropping all tool-call arguments from the reconstructed history.
- **`plugin-anthropic/models/text.ts`**: `isModelMessage` is extended to also return `true` for assistant messages with `content: null/undefined` when `toolCalls` is present; these messages are forwarded to the AI SDK via an `as ModelMessage` cast, which may crash rather than degrade gracefully since `null` is not a valid `AssistantContent`.
- **`planner-loop-message-stacking.test.ts`**: Tests updated to assert the new content-array shape and `toolCallId` linkage, but do not verify the `args` field of the `ToolCallPart`, leaving the field-name bug undetected.

<h3>Confidence Score: 3/5</h3>

The infinite-loop fix is structurally correct, but tool-call arguments are silently dropped from the reconstructed history on every tool turn due to a wrong field name.

The main loop-forever bug is addressed by switching to content arrays, and `ToolResultPart.output` is correctly named. However, the `ToolCallPart` field for arguments is `input` in the code but `args` in the AI SDK v6 spec — every tool call in the conversation history reaches the evaluator LLM with its arguments silently absent. The test suite does not assert on this field, so the discrepancy was not caught during authoring.

packages/core/src/runtime/planner-rendering.ts — the `ToolCallPart` emission at line 44 uses `input` instead of `args`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-rendering.ts | Migrates trajectory-step message encoding to AI SDK v6 content-array shape; `ToolResultPart.output` is correctly named but `ToolCallPart` uses `input` instead of the required `args` field, silently dropping tool arguments from the reconstructed conversation history. |
| plugins/plugin-anthropic/models/text.ts | Adds a defensive shim in `isModelMessage` to accept legacy-shape assistant messages with `content: null`; the shim passes these messages to the AI SDK as-is via cast, which may crash rather than degrade gracefully. The primary code path avoids this branch entirely. |
| packages/core/src/runtime/__tests__/planner-loop-message-stacking.test.ts | Tests updated to assert on the new AI SDK v6 content-array shape and `toolCallId` linkage, but do not assert on the `args`/`input` field of the `ToolCallPart`, so the field-name bug goes undetected. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PL as Planner Loop
    participant TR as trajectoryStepsToMessages
    participant RM as readModelMessages (plugin-anthropic)
    participant AI as AI SDK v6 generateText
    participant EV as Evaluator LLM

    Note over PL,EV: Before fix — legacy shape silently dropped
    PL->>TR: steps[]
    TR-->>PL: "[{role:assistant, content:null, toolCalls:[...]}]"
    PL->>RM: messages[]
    RM-->>PL: undefined (isModelMessage rejected content:null)
    PL->>AI: prompt-only call (no tool history)
    AI->>EV: no tool context
    EV-->>PL: CONTINUE (thinks no tool ran)
    PL->>PL: loop x16 → TrajectoryLimitExceeded

    Note over PL,EV: After fix — AI SDK v6 shape accepted
    PL->>TR: steps[]
    TR-->>PL: "[{role:assistant, content:[ToolCallPart]}, {role:tool, content:[ToolResultPart]}]"
    PL->>RM: messages[]
    RM-->>PL: ModelMessage[] (array content accepted)
    PL->>AI: messages + tool history
    AI->>EV: tool call + result visible
    EV-->>PL: FINISH
```

<sub>Reviews (3): Last reviewed commit: ["chore(core): biome-format planner-loop-m..."](https://github.com/elizaos/eliza/commit/3e75b5eb99de67ad8d9c34bf1f8d3880c0b3fdfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31532349)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->