### PR TITLE
fix(core): match ACTION_ROLE_POLICY against action similes

### DIFF
--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -330,6 +330,32 @@ describe("executePlannedToolCall", () => {
 			expect(handler).toHaveBeenCalledOnce();
 		});
 
+		it("matches a policy entry against the action's similes when canonical name is absent", async () => {
+			process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "NONE" });
+			_resetActionRolePolicyCacheForTests();
+			const handler = vi.fn(async () => ({ success: true }));
+			const action = makeAction({
+				name: "SHELL",
+				similes: ["BASH", "EXEC", "RUN_COMMAND"],
+				contextGate: { anyOf: ["code", "terminal", "automation"] },
+				roleGate: { minRole: "OWNER" },
+				handler,
+			});
+
+			const result = await executePlannedToolCall(
+				makeRuntime([action]),
+				{
+					message: makeMessage(),
+					activeContexts: ["general"],
+					userRoles: ["GUEST"],
+				},
+				{ name: "SHELL", params: {} },
+			);
+
+			expect(result.success).toBe(true);
+			expect(handler).toHaveBeenCalledOnce();
+		});
+
 		it("ignores policy entries with unrecognized roles instead of granting access", async () => {
 			process.env.ACTION_ROLE_POLICY = JSON.stringify({ GATED: "MODERATOR" });
 			_resetActionRolePolicyCacheForTests();

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -367,7 +367,16 @@ function getGateFailure(
 	action: Action,
 	ctx: ExecutePlannedToolCallContext,
 ): string | undefined {
-	const policyRole = readActionRolePolicy()[action.name];
+	const policy = readActionRolePolicy();
+	let policyRole = policy[action.name];
+	if (!policyRole && Array.isArray(action.similes)) {
+		for (const simile of action.similes) {
+			if (typeof simile === "string" && policy[simile]) {
+				policyRole = policy[simile];
+				break;
+			}
+		}
+	}
 	if (policyRole) {
 		return satisfiesRoleGate(ctx.userRoles, { minRole: policyRole })
 			? undefined


### PR DESCRIPTION
## Summary

`getGateFailure` in `packages/core/src/runtime/execute-planned-tool-call.ts` looks up the `ACTION_ROLE_POLICY` env-var override by `action.name` only. When an operator sets a policy like `{"BASH":"NONE"}` they reasonably expect it to cover the action whose handler `BASH` aliases — most notably the plugin-coding-tools `shellAction` which is registered as:

```ts
name: "SHELL",
similes: ["BASH", "EXEC", "RUN_COMMAND"],
contextGate: { anyOf: ["code", "terminal", "automation"] },
roleGate: { minRole: "OWNER" },
```

Today, when the planner emits `"SHELL"` (the canonical name), the lookup `readActionRolePolicy()["SHELL"]` misses, so the executor falls through to the strict context+role gates. Outside the three allow-listed contexts the action silently fails (and the failure message gets mangled into an empty-text result on the way to the trajectory, which compounds the surprise).

## Fix

Walk `action.similes` when the canonical-name policy lookup misses, so a single policy entry covers an action and every alias it advertises.

## Repro before the fix

Bot deployed with `ACTION_ROLE_POLICY={"BASH":"NONE",...}` in a Discord channel whose `activeContexts` is `["general"]`. User asks the agent to run a shell command. Planner emits `{name:"SHELL", args:{command:"..."}}`. Trajectory records:

```json
{"success":false,"text":"","data":{"actionName":"SHELL"}}
```

Evaluator decides FINISH and replies with a hallucinated `"On it — kicking off a task now..."` because the SHELL probe came back as a no-op the LLM can't reason about. No tool actually ran.

## After the fix

Same prompt, same deployment, planner emits the same `{name:"SHELL"}`. Trajectory records the proper:

```
$ ls /home/milady/projects/milady-fork/apps/
[exit 0] (cwd=..., took=15ms)
--- stdout ---
app
homepage
```

## Test plan

- [x] Added `matches a policy entry against the action's similes when canonical name is absent` to `packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts` — sets `ACTION_ROLE_POLICY={"BASH":"NONE"}`, defines an action `name:"SHELL", similes:["BASH","EXEC","RUN_COMMAND"]` with a strict `roleGate:"OWNER"` + `contextGate:["admin"]`, asserts the GUEST caller's `general`-context call still hits the handler.
- [x] Existing 13 `executePlannedToolCall` tests continue to pass (14/14 in `bunx vitest run src/runtime/__tests__/execute-planned-tool-call.test.ts`).
- [x] Verified live in a Discord-connected runtime: pre-fix produced the empty-text trajectory, post-fix produces the expected stdout result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `getGateFailure` in `execute-planned-tool-call.ts` to walk `action.similes` when the canonical action name is absent from the `ACTION_ROLE_POLICY` env-var map, so a policy entry like `{"BASH":"NONE"}` correctly covers a `SHELL`-named action and all its registered aliases.

- **Core fix**: `getGateFailure` now iterates `action.similes` after a canonical-name miss, picking up the first matching policy entry and using it to evaluate role access — bypassing the stricter `contextGate`/`roleGate` as intended.
- **Test added**: A new test verifies that a GUEST caller in a `general` context can invoke `SHELL` when `{"BASH":"NONE"}` is set, covering the allow path through simile matching.
- **Gap remaining**: `isActionAllowedByRolePolicy` in `action-role-policy.ts` — called from `sub-planner.ts` to build the child-action list — still only looks up `child.name` and never walks similes, leaving the sub-planner path with the same bug this PR targets in the top-level executor.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the top-level executor path, but the sub-planner child-action filtering has the same simile-lookup gap and will silently exclude policy-whitelisted actions by alias.

The fix in `getGateFailure` is correct and well-tested for the allow path. However, `isActionAllowedByRolePolicy` in `action-role-policy.ts` — which feeds the sub-planner's child-action list — still only looks up the canonical name, so any action whose policy entry is keyed to an alias will remain invisible to the sub-planner even after this PR lands.

`packages/core/src/runtime/action-role-policy.ts` (`isActionAllowedByRolePolicy`) and `packages/core/src/runtime/sub-planner.ts` (line 199) need the same simile-walking treatment applied to `getGateFailure`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/execute-planned-tool-call.ts | Adds simile-walking to `getGateFailure` so a policy entry like `{"BASH":"NONE"}` covers a `SHELL`-named action; the logic is correct and well-guarded, but only one of two policy-lookup sites was updated. |
| packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts | Adds a test covering the simile-match allow case (`"NONE"` policy bypasses strict gates); the restricting direction (simile-matched policy should block access) is not covered. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executePlannedToolCall] --> B[getGateFailure]
    B --> C{policy lookup by action.name}
    C -- found --> D[satisfiesRoleGate]
    C -- miss --> E{has similes?}
    E -- no --> G[check contextGate and roleGate]
    E -- yes --> F{walk similes: find policy match}
    F -- found --> D
    F -- no match --> G
    D -- passes --> H[run handler OK]
    D -- fails --> I[gate failure]
    G -- passes --> H
    G -- fails --> I
    J[runSubPlanner] --> K[isActionAllowedByRolePolicy uses child.name only]
    K --> L{policy lookup by child.name}
    L -- miss --> M[child excluded - similes not walked]
    L -- found --> N[child included OK]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/core/src/runtime/action-role-policy.ts`, line 73-82 ([link](https://github.com/elizaos/eliza/blob/9b821250062eaade8503df0b4146a333477d559e/packages/core/src/runtime/action-role-policy.ts#L73-L82)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Incomplete fix — sub-planner path still skips similes**

   `isActionAllowedByRolePolicy` is called from `sub-planner.ts` (line 199) to decide which child actions are exposed to the sub-planner when context-gating alone would exclude them. It only looks up `child.name` in the policy — it never walks `action.similes`. So a policy entry like `{"BASH":"NONE"}` will still silently fail to include a `SHELL`-named child action in the sub-planner's allowed list, exactly the same bug the PR fixes in `getGateFailure`.

   The PR description even notes: *"Lookup is honored in two places: `executePlannedToolCall` (top-level planner picks) and `runSubPlanner` (sub-planner child action list)"* — but only the first path received the simile-walking logic. The sub-planner path remains broken for any action whose canonical name differs from its policy-listed alias.

2. `packages/core/src/runtime/action-role-policy.ts`, line 73-82 ([link](https://github.com/elizaos/eliza/blob/98aad9116c6666c48b82b42c3f2e865cf73b8088/packages/core/src/runtime/action-role-policy.ts#L73-L82)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Sub-planner path still skips simile lookup**

   `isActionAllowedByRolePolicy` looks up only `actionName` in the policy and never walks the action's `similes`. It is called from `sub-planner.ts` (line 199) as `isActionAllowedByRolePolicy(child.name, params.ctx.userRoles)` to decide which child actions are exposed when context-gating alone would exclude them. A policy entry like `{"BASH":"NONE"}` will therefore fail to include a `SHELL`-named child action in the sub-planner's allowed list — the same bug this PR fixed in `getGateFailure`. The module docstring (lines 14–17) explicitly states the policy is honored in both `executePlannedToolCall` and `runSubPlanner`, but only the first path received the simile-walking logic.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(core): match ACTION\_ROLE\_POLICY agai..."](https://github.com/elizaos/eliza/commit/98aad9116c6666c48b82b42c3f2e865cf73b8088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31553939)</sub>

<!-- /greptile_comment -->