### PR TITLE
fix(core): downgrade evaluator FINISH to CONTINUE when messageToUser promises unexecuted work

### DIFF
--- a/packages/core/src/prompts/evaluator.ts
+++ b/packages/core/src/prompts/evaluator.ts
@@ -15,6 +15,7 @@ rules:
 - choose NEXT_RECOMMENDED only when one queued tool is still grounded; otherwise choose CONTINUE
 - you cannot call tools; never emit tool arguments, URL-open JSON, document JSON, or any JSON object except the single evaluator result
 - if the response would need any unexecuted tool/action side effect to be true, choose CONTINUE; do not imagine the missing result
+- never pair decision=FINISH with a forward-looking promise messageToUser (e.g. "on it", "kicking off", "i'll start", "spinning up", "about to", "will install/build/deploy", "will report back"); if you are promising work that has not happened yet, the work is not done, so choose CONTINUE
 - messageToUser is optional progress, diagnosis, question, or final output
 - messageToUser is shown directly to the user; never include internal thoughts, tool names, function syntax, JSON/tool-call attempts, or analysis
 - when decision is FINISH after tool use, include messageToUser with the concise user-facing answer or status grounded in the completed tool results

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -317,4 +317,166 @@ describe("v5 evaluator skeleton", () => {
 		expect(result.decision).toBe("FINISH");
 		expect(result.messageToUser).toContain("exit 2");
 	});
+
+	it("downgrades FINISH to CONTINUE when messageToUser promises 'Writing `/path` now...' but no tool wrote to that path", async () => {
+		// Live failure: bot ran READ + BASH + ATTACHMENT + multi-tool probing,
+		// landed on a correct diagnosis, then closed with
+		// 'Writing `/tmp/arxiv-grab-fixed.py` now...'. The latest tool (a
+		// debug BASH) succeeded, so the simple "last-tool-failed" guard
+		// missed it. The fix checks whether the promised path was actually
+		// written by any successful tool in the trajectory.
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Found bug. Should write fix.",
+  "messageToUser": "Found the bug — regex uses double quotes but HTML uses single. Writing \`/tmp/arxiv-grab-fixed.py\` now..."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: {
+							id: "t1",
+							name: "READ",
+							params: { file_path: "/tmp/arxiv-grab.py" },
+						},
+						result: { success: true, text: "...source..." },
+					},
+					{
+						toolCall: {
+							id: "t2",
+							name: "WRITE",
+							params: {
+								// Wrote to a DIFFERENT path (debug), not the promised path.
+								file_path: "/tmp/arxiv-debug.py",
+								content: "...",
+							},
+						},
+						result: { success: true, text: "wrote 1373 bytes" },
+					},
+					{
+						// Latest tool succeeds — original repair would have left FINISH alone.
+						toolCall: {
+							id: "t3",
+							name: "BASH",
+							params: { command: "curl -s arxiv.org | head" },
+						},
+						result: { success: true, text: "exit 0" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+		expect(result.success).toBe(false);
+	});
+
+	it("leaves FINISH alone when the promised 'Writing `/path` now' file WAS written by a tool", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Wrote the fix.",
+  "messageToUser": "Writing \`/tmp/arxiv-grab-fixed.py\` now... done. 38 lines, syntax checks pass."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: {
+							id: "t1",
+							name: "WRITE",
+							params: {
+								file_path: "/tmp/arxiv-grab-fixed.py",
+								content: "...fix...",
+							},
+						},
+						result: { success: true, text: "wrote 1200 bytes" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		// Promise is grounded — the file WAS written, so FINISH stands.
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("done.");
+	});
+
+	it("accepts a BASH-style write (cat > /path / tee /path / > /path) as fulfilling the path promise", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Wrote it via tee.",
+  "messageToUser": "Writing \`/tmp/script.sh\` now. Done."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: {
+							id: "t1",
+							name: "BASH",
+							params: { command: "echo 'hi' | tee /tmp/script.sh" },
+						},
+						result: { success: true, text: "hi" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		// The BASH command mentions /tmp/script.sh and succeeded, so the
+		// promise is considered fulfilled.
+		expect(result.decision).toBe("FINISH");
+	});
 });

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -479,4 +479,85 @@ describe("v5 evaluator skeleton", () => {
 		// promise is considered fulfilled.
 		expect(result.decision).toBe("FINISH");
 	});
+	it("downgrades FINISH to CONTINUE for 'running X now' gerund promise after a non-executing tool", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "About to run grep.",
+  "messageToUser": "File exists (656 lines) — running a grep count now for 'sanitize'."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: {
+							id: "t1",
+							name: "READ",
+							params: { file_path: "/some/file.ts" },
+						},
+						result: { success: true, text: "file contents" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
+
+	it("downgrades FINISH to CONTINUE for 'let me run/check' command-form when latest tool failed", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": false,
+  "decision": "FINISH",
+  "thought": "Probe failed.",
+  "messageToUser": "Initial probe didn't return useful output. Let me run a quick check on the file structure."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "t1", name: "SHELL", params: { command: "ls" } },
+						result: { success: false, text: "" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
 });

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -560,4 +560,47 @@ describe("v5 evaluator skeleton", () => {
 		expect(result.decision).toBe("CONTINUE");
 		expect(result.messageToUser).toBeUndefined();
 	});
+	it("does not false-positive on bare 'results' word — 'Got results but ... let me check' must still CONTINUE", async () => {
+		// Live regression: bot said "Got results but rootMessage field path
+		// is off — let me check the actual schema." The previous
+		// COMPLETION_INDICATORS regex had a too-broad `results?` that
+		// matched on the bare word and let the gerund slip through.
+		// Tightened to `results?:` (must be followed by colon).
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Probe came back wrong, will retry with corrected schema.",
+  "messageToUser": "Got results but rootMessage field path is off — let me check the actual schema."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "t1", name: "BASH", params: { command: "jq ..." } },
+						result: { success: true, text: "..." },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
 });

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -195,4 +195,126 @@ describe("v5 evaluator skeleton", () => {
 		expect(result.decision).toBe("FINISH");
 		expect(result.success).toBe(true);
 	});
+
+	it("downgrades FINISH to CONTINUE when messageToUser promises unexecuted work after a failed tool", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": false,
+  "decision": "FINISH",
+  "thought": "SHELL returned empty. I need to spawn a task agent. Let me inform the channel.",
+  "messageToUser": "On it — kicking off a build task now. Will install Android SDK if needed and report back."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "t1", name: "SHELL", params: { command: "ls" } },
+						result: { success: false, text: "" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+		expect(result.success).toBe(false);
+	});
+
+	it("leaves FINISH alone when messageToUser is grounded in a successful tool result", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Build succeeded.",
+  "messageToUser": "On it — wait, actually it's done. APK at /tmp/out.apk."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "t1", name: "BUILD", params: {} },
+						result: { success: true, text: "Built." },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		// Grounded FINISH: even forward-looking words pass through because the
+		// most recent tool result was successful (the work was actually done).
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("APK at /tmp/out.apk");
+	});
+
+	it("leaves non-promise messageToUser alone after a failed tool", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": false,
+  "decision": "FINISH",
+  "thought": "Tool failed; user needs to retry.",
+  "messageToUser": "The command failed with exit 2. Try again with the right path."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "t1", name: "SHELL", params: { command: "ls" } },
+						result: { success: false, text: "exit 2" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		// Diagnostic messageToUser (no future-tense promise) stays as FINISH so
+		// the user gets the explanation instead of an empty replan.
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("exit 2");
+	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -446,7 +446,7 @@ function trajectoryWroteToPath(
  * then I did it, here's the result").
  */
 const COMPLETION_INDICATORS =
-	/\b(?:done|completed|finished|verified|confirmed|here['']?s\s+(?:the|what|how)|here\s+is|result:|results?\b|output:|wrote\s+\d|saved\s+\d|exit\s+0|✓|all\s+(?:passed|set)|success(?:ful(?:ly)?)?:)\b/i;
+	/\b(?:done|completed|finished|verified|confirmed|here['']?s\s+(?:the|what|how)|here\s+is|results?:|output:|wrote\s+\d|saved\s+\d|exit\s+0|✓|all\s+(?:passed|set)|success(?:ful(?:ly)?)?:)\b/i;
 
 function repairForwardLookingFinish(
 	output: EvaluatorOutput,

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -105,8 +105,11 @@ export async function runEvaluator(
 		params.provider,
 	);
 	const endedAt = Date.now();
-	const output = repairMissingEvaluatorSuccess(
-		parseEvaluatorOutput(raw),
+	const output = repairForwardLookingFinish(
+		repairMissingEvaluatorSuccess(
+			parseEvaluatorOutput(raw),
+			params.trajectory,
+		),
 		params.trajectory,
 	);
 	const streamingContext = getStreamingContext();
@@ -338,6 +341,59 @@ function repairMissingEvaluatorSuccess(
 	return {
 		...output,
 		success: true,
+	};
+}
+
+const FORWARD_LOOKING_PROMISE_PATTERNS: RegExp[] = [
+	/^\s*(?:on it|got it|sure|okay|kk)[,!.\s-]/i,
+	/\b(?:i'?ll|i\s+will|i'?m\s+(?:going to|about to|gonna))\s+(?:install|build|deploy|create|spawn|kick(?:ing)?\s+off|start|launch|run|do|handle|fix|update|generate|set\s+up|put|drop|grab|pull|push|send|write|make|add)/i,
+	/\b(?:kick(?:ing)?\s+off|spinning\s+up|spawning|starting(?:\s+it)?(?:\s+now)?|launching|firing\s+off)\s+(?:a\s+|the\s+|task|agent|build|job|process|now)/i,
+	/\bwill\s+(?:install|build|deploy|create|spawn|kick\s+off|start|launch|run|generate|fix|update|report\s+back)\b/i,
+	/\babout\s+to\s+(?:install|build|deploy|create|spawn|kick|start|launch|run|generate|fix)/i,
+	/\bwill\s+report\s+back\b/i,
+];
+
+function isForwardLookingPromise(text: string): boolean {
+	return FORWARD_LOOKING_PROMISE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+/**
+ * Repair the failure mode where the evaluator picks `FINISH` but the
+ * `messageToUser` is a forward-looking promise about work that hasn't been
+ * executed yet (e.g. "On it — kicking off a build task now"). The prompt
+ * already says "if the response would need any unexecuted tool/action side
+ * effect to be true, choose CONTINUE; do not imagine the missing result",
+ * but LLMs ignore that rule often enough that we enforce it server-side.
+ *
+ * Trigger conditions (ALL must hold):
+ *   - decision === "FINISH"
+ *   - messageToUser is a non-empty string
+ *   - the trajectory's most-recent tool result was NOT a successful execution
+ *     (so the LLM is promising something that hasn't happened yet)
+ *   - messageToUser matches a forward-looking promise pattern
+ *
+ * When triggered, downgrade decision to "CONTINUE" and drop the hallucinated
+ * messageToUser so the planner gets another turn to actually emit the
+ * follow-up action.
+ */
+function repairForwardLookingFinish(
+	output: EvaluatorOutput,
+	trajectory: PlannerTrajectory,
+): EvaluatorOutput {
+	if (output.decision !== "FINISH") return output;
+	if (typeof output.messageToUser !== "string") return output;
+	const trimmed = output.messageToUser.trim();
+	if (!trimmed) return output;
+	const latestStep = [...trajectory.steps]
+		.reverse()
+		.find((step) => step.toolCall && step.result);
+	if (latestStep?.result?.success === true) return output;
+	if (!isForwardLookingPromise(trimmed)) return output;
+	return {
+		...output,
+		decision: "CONTINUE",
+		messageToUser: undefined,
+		success: false,
 	};
 }
 

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -355,6 +355,61 @@ function isForwardLookingPromise(text: string): boolean {
 }
 
 /**
+ * Match the present-continuous file-write promise pattern, e.g.
+ *   "Writing `/tmp/arxiv-grab-fixed.py` now..."
+ *   "writing /tmp/X now"
+ *   "Writing (bold-md-wrapped) /tmp/file now ..."
+ *
+ * Captures the inner path so we can cross-check it against what the
+ * trajectory actually wrote. The path is unwrapped from backticks,
+ * bold-markdown wrappers, or appears bare.
+ */
+const WRITING_PATH_NOW_PATTERN =
+	/\b(?:writing|saving)\s+(?:`([^`]+)`|\*\*([^*]+?)\*\*|((?:[/~]|\.{1,2}\/)[^\s`*"'<>]+))\s+now\b/i;
+
+function extractPromisedWritePath(text: string): string | null {
+	const match = text.match(WRITING_PATH_NOW_PATTERN);
+	if (!match) return null;
+	const captured = match[1] ?? match[2] ?? match[3];
+	if (!captured) return null;
+	const trimmed = captured.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Look at every tool call in the trajectory and return true if any of
+ * them either:
+ *   - has `args.file_path` / `args.path` matching the promised path, OR
+ *   - has `args.command` whose text contains the promised path (which
+ *     covers `BASH` writes like `cat > /tmp/x <<EOF`, `tee /tmp/x`, or
+ *     `> /tmp/x` redirects), AND succeeded.
+ *
+ * We only count successful tool results — a `BASH` that mentioned the
+ * path but errored out doesn't satisfy the promise.
+ */
+function trajectoryWroteToPath(
+	trajectory: PlannerTrajectory,
+	path: string,
+): boolean {
+	for (const step of trajectory.steps) {
+		const result = step.result;
+		if (!result || result.success !== true) continue;
+		const toolArgs =
+			(step.toolCall as { params?: Record<string, unknown> } | undefined)
+				?.params ?? {};
+		const filePath = toolArgs.file_path ?? toolArgs.path;
+		if (typeof filePath === "string" && filePath.trim() === path) {
+			return true;
+		}
+		const command = toolArgs.command;
+		if (typeof command === "string" && command.includes(path)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
  * Repair the failure mode where the evaluator picks `FINISH` but the
  * `messageToUser` is a forward-looking promise about work that hasn't been
  * executed yet (e.g. "On it — kicking off a build task now"). The prompt
@@ -381,6 +436,29 @@ function repairForwardLookingFinish(
 	if (typeof output.messageToUser !== "string") return output;
 	const trimmed = output.messageToUser.trim();
 	if (!trimmed) return output;
+
+	// Case A: messageToUser names a specific path the LLM is "writing now"
+	// but no successful tool call in the trajectory actually wrote to that
+	// path. This catches the failure mode where the planner runs a bunch
+	// of probing tools (some succeed, some fail), forms a diagnosis, and
+	// then closes the turn with "Writing `/path/to/fix.py` now..." without
+	// ever emitting the WRITE itself. The previous "latest tool failed"
+	// guard misses this because the latest tool (typically a debug BASH)
+	// did succeed — the unfulfilled promise is about a DIFFERENT action.
+	const promisedPath = extractPromisedWritePath(trimmed);
+	if (promisedPath && !trajectoryWroteToPath(trajectory, promisedPath)) {
+		return {
+			...output,
+			decision: "CONTINUE",
+			messageToUser: undefined,
+			success: false,
+		};
+	}
+
+	// Case B: latest tool failed and messageToUser is a generic
+	// forward-looking promise (e.g. "On it — kicking off..."). The
+	// original failure mode from the upstream-merged version of this
+	// repair.
 	const latestStep = [...trajectory.steps]
 		.reverse()
 		.find((step) => step.toolCall && step.result);

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -106,10 +106,7 @@ export async function runEvaluator(
 	);
 	const endedAt = Date.now();
 	const output = repairForwardLookingFinish(
-		repairMissingEvaluatorSuccess(
-			parseEvaluatorOutput(raw),
-			params.trajectory,
-		),
+		repairMissingEvaluatorSuccess(parseEvaluatorOutput(raw), params.trajectory),
 		params.trajectory,
 	);
 	const streamingContext = getStreamingContext();

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -348,6 +348,16 @@ const FORWARD_LOOKING_PROMISE_PATTERNS: RegExp[] = [
 	/\bwill\s+(?:install|build|deploy|create|spawn|kick\s+off|start|launch|run|generate|fix|update|report\s+back)\b/i,
 	/\babout\s+to\s+(?:install|build|deploy|create|spawn|kick|start|launch|run|generate|fix)/i,
 	/\bwill\s+report\s+back\b/i,
+	// Present-continuous "(verb-ing) ... now" pattern. The LLM frequently
+	// closes a turn with "File exists (656 lines) — running a grep count
+	// now" or "checking it now" or "computing the result now" — describing
+	// work it CLAIMS to be doing this instant but never actually invoked
+	// a tool for. Treat any of those gerund verbs followed by "...now" as
+	// an unfulfilled promise unless the prior tool actually executed it.
+	/\b(?:running|fetching|checking|computing|loading|grabbing|reading|writing|saving|searching|processing|fixing|building|installing|deploying|verifying|counting|grepping|inspecting|scanning|querying|pulling|pushing|sending)\s+[^.!?\n]{0,80}?\bnow\b/i,
+	// "let me run/check/grep ..." — first-person command-form that the
+	// LLM uses to imply "I'm about to do this" without actually doing it.
+	/\blet\s+me\s+(?:run|check|grep|fetch|read|write|save|search|count|verify|inspect|scan|query|do|try|look|kick|spawn|start|launch|build|deploy)\b/i,
 ];
 
 function isForwardLookingPromise(text: string): boolean {
@@ -428,6 +438,16 @@ function trajectoryWroteToPath(
  * messageToUser so the planner gets another turn to actually emit the
  * follow-up action.
  */
+/**
+ * Words that signal the work is ACTUALLY done within the message
+ * (vs. a forward-looking promise). If a message contains both a
+ * forward-looking phrase AND one of these markers, treat it as a
+ * legitimate FINISH (the LLM is narrating "I was about to do X,
+ * then I did it, here's the result").
+ */
+const COMPLETION_INDICATORS =
+	/\b(?:done|completed|finished|verified|confirmed|here['']?s\s+(?:the|what|how)|here\s+is|result:|results?\b|output:|wrote\s+\d|saved\s+\d|exit\s+0|✓|all\s+(?:passed|set)|success(?:ful(?:ly)?)?:)\b/i;
+
 function repairForwardLookingFinish(
 	output: EvaluatorOutput,
 	trajectory: PlannerTrajectory,
@@ -437,39 +457,43 @@ function repairForwardLookingFinish(
 	const trimmed = output.messageToUser.trim();
 	if (!trimmed) return output;
 
-	// Case A: messageToUser names a specific path the LLM is "writing now"
-	// but no successful tool call in the trajectory actually wrote to that
-	// path. This catches the failure mode where the planner runs a bunch
-	// of probing tools (some succeed, some fail), forms a diagnosis, and
-	// then closes the turn with "Writing `/path/to/fix.py` now..." without
-	// ever emitting the WRITE itself. The previous "latest tool failed"
-	// guard misses this because the latest tool (typically a debug BASH)
-	// did succeed — the unfulfilled promise is about a DIFFERENT action.
-	const promisedPath = extractPromisedWritePath(trimmed);
-	if (promisedPath && !trajectoryWroteToPath(trajectory, promisedPath)) {
-		return {
-			...output,
-			decision: "CONTINUE",
-			messageToUser: undefined,
-			success: false,
-		};
-	}
-
-	// Case B: latest tool failed and messageToUser is a generic
-	// forward-looking promise (e.g. "On it — kicking off..."). The
-	// original failure mode from the upstream-merged version of this
-	// repair.
-	const latestStep = [...trajectory.steps]
-		.reverse()
-		.find((step) => step.toolCall && step.result);
-	if (latestStep?.result?.success === true) return output;
-	if (!isForwardLookingPromise(trimmed)) return output;
-	return {
+	const downgrade: EvaluatorOutput = {
 		...output,
 		decision: "CONTINUE",
 		messageToUser: undefined,
 		success: false,
 	};
+
+	// Case A: messageToUser names a specific path the LLM is "writing now"
+	// but no successful tool call in the trajectory actually wrote to that
+	// path. This catches the failure mode where the planner runs a bunch
+	// of probing tools (some succeed, some fail), forms a diagnosis, and
+	// then closes the turn with "Writing `/path/to/fix.py` now..." without
+	// ever emitting the WRITE itself. Specific-path promises ignore the
+	// completion-indicator gate because we have ground truth (the actual
+	// trajectory tool calls) to check against.
+	const promisedPath = extractPromisedWritePath(trimmed);
+	if (promisedPath && !trajectoryWroteToPath(trajectory, promisedPath)) {
+		return downgrade;
+	}
+
+	// Case B: messageToUser matches a generic forward-looking pattern
+	// (gerund "running X now", "let me run", "on it — kicking off",
+	// "i'll start", etc.) AND has no completion indicator suggesting
+	// the work actually happened. We fire regardless of which tool was
+	// most recent — the live failure that motivated this guard had a
+	// successful READ as the latest tool, but the promised grep never
+	// ran. The completion-indicator check prevents false-positives like
+	// "Writing /tmp/x.py now. Done." or "On it — wait, actually it's
+	// done. APK at /tmp/out.apk."
+	if (
+		isForwardLookingPromise(trimmed) &&
+		!COMPLETION_INDICATORS.test(trimmed)
+	) {
+		return downgrade;
+	}
+
+	return output;
 }
 
 export async function applyEvaluatorEffects(


### PR DESCRIPTION
## Summary

When the evaluator picks `decision: FINISH` but the `messageToUser` is a forward-looking promise ("On it — kicking off the build now", "I'll install X", "will report back"), the planner-loop closes the trajectory without ever invoking the follow-up action the LLM said it was going to take. The user is left waiting for work that never happens.

The prompt already says:
- *"if a planner terminal message merely narrates remaining work [...] choose CONTINUE and do not reuse that text as messageToUser"*
- *"if the response would need any unexecuted tool/action side effect to be true, choose CONTINUE; do not imagine the missing result"*

But LLMs ignore those rules with some regularity. Empirical example from a live trajectory (`tj-cb9e83bd6b2692`):

```jsonc
// after a SHELL probe came back with success:false / empty text:
{
  "decision": "FINISH",
  "thought": "...I need to spawn a task agent... Let me inform the channel I'm kicking off the build task and spawn it.",
  "messageToUser": "On it — kicking off a build task now. Will install Android SDK if needed, build a debug APK from .../milady-fork, and drop it at nubilio.org/apps. ... Will report back."
}
```

Nothing was actually kicked off; the trajectory closed and the user was ghosted.

## Fix

Two-part defense-in-depth:

1. **Prompt** (`packages/core/src/prompts/evaluator.ts`): adds a concrete forbidden-phrasing rule
   > never pair `decision=FINISH` with a forward-looking promise messageToUser (e.g. "on it", "kicking off", "i'll start", "spinning up", "about to", "will install/build/deploy", "will report back"); if you are promising work that has not happened yet, the work is not done, so choose CONTINUE

2. **Server-side repair** (`packages/core/src/runtime/evaluator.ts`): adds `repairForwardLookingFinish` to enforce the rule when the LLM still violates it. Triggers only when ALL of the following hold:
   - `decision === "FINISH"`
   - `messageToUser` is a non-empty string
   - the trajectory's most-recent tool result is NOT `success === true` (so the LLM is promising work that hasn't actually happened)
   - `messageToUser` matches one of a conservative set of forward-looking promise regexes

   When triggered, decision drops to `CONTINUE`, `messageToUser` is cleared, and `success` is forced to `false`. The planner gets another turn to actually emit the follow-up action.

## Test plan

- [x] Three new tests in `packages/core/src/runtime/__tests__/evaluator.test.ts`:
  - `downgrades FINISH to CONTINUE when messageToUser promises unexecuted work after a failed tool` — verifies the repair fires
  - `leaves FINISH alone when messageToUser is grounded in a successful tool result` — verifies a successful tool turn lets FINISH stand even if the message contains forward-looking words
  - `leaves non-promise messageToUser alone after a failed tool` — verifies a diagnostic message (e.g. "the command failed with exit 2, try again") still surfaces as FINISH
- [x] 8/8 evaluator tests pass on a clean branch off develop
- [x] Verified live in a Discord-connected runtime: same "can you install android sdk and build the apk" prompt that previously produced an "On it — kicking off..." hallucination now produces a grounded "A few blockers before I can do this: 1. No Android build files found — I already checked..."

## Notes

Pairs with #7574 (`fix(core): match ACTION_ROLE_POLICY against action similes`) — that PR fixes the gate path that made SHELL silently fail; this PR fixes the evaluator surface area that turned the silent failure into a user-facing lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a two-layer defense against evaluators that emit `FINISH` with a forward-looking promise (`messageToUser`) for work that was never executed: a new prompt rule in `evaluator.ts` and a server-side `repairForwardLookingFinish` function that pattern-matches and downgrades hallucinated FINISH decisions to CONTINUE.

- **Prompt hardening** (`packages/core/src/prompts/evaluator.ts`): one new concrete forbidden-phrasing rule covering the exact `decision=FINISH + future-tense messageToUser` failure mode.
- **Server-side repair** (`packages/core/src/runtime/evaluator.ts`): `repairForwardLookingFinish` is inserted into the output pipeline and checks two cases \u2014 a specific \"writing `/path` now\" promise vs. the trajectory's actual tool calls (Case A), and a broader set of forward-looking phrase patterns gated by `COMPLETION_INDICATORS` (Case B).
- **Test coverage** (`packages/core/src/runtime/__tests__/evaluator.test.ts`): 8 new test cases for the repair function, though all happy-path tests rely on \"done\"/\"Done.\" which masks the `\\b`-after-colon breakage in `COMPLETION_INDICATORS` and the gerund false-positive gap.

<h3>Confidence Score: 3/5</h3>

The repair function has two defects in the main evaluation hot-path that can cause grounded FINISH responses to be incorrectly downgraded to CONTINUE, creating spurious planner loops and silently dropping valid user-facing output.

The trailing `\b` after colon-terminated alternatives in `COMPLETION_INDICATORS` makes `results?:`, `output:`, and `success:` unreachable for the normal colon-followed-by-space form, so messages like "Fetching data now — output: 42 rows" bypass the completion gate and are wrongly downgraded. Pattern 7's gerund match also fires on retrospective narration whose completion phrasing (e.g. "found", "received", "got") is absent from the COMPLETION_INDICATORS vocabulary. Both defects are in the evaluation hot-path and are unexercised by the test suite because every happy-path fixture uses "done"/"Done." to satisfy the indicators.

packages/core/src/runtime/evaluator.ts — the COMPLETION_INDICATORS regex and Pattern 7 in FORWARD_LOOKING_PROMISE_PATTERNS need attention before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/evaluator.ts | Adds `repairForwardLookingFinish` with two real issues: the trailing `\b` after colon-terminated COMPLETION_INDICATORS patterns makes them effectively inert in the common "results: …" form, and Pattern 7 fires on grounded retrospective messages whose completion phrasing falls outside the narrow COMPLETION_INDICATORS vocabulary, causing false-positive CONTINUE downgrades. |
| packages/core/src/runtime/__tests__/evaluator.test.ts | Adds 8 new test cases covering the core repair scenarios; all happy-path messages use "done"/"Done." which masks the `\b`-after-colon bug and the missing completion-word gap in COMPLETION_INDICATORS. |
| packages/core/src/prompts/evaluator.ts | Adds one concrete forbidden-phrasing rule to the evaluator system prompt; accurate, appropriately scoped, and consistent with surrounding rule style. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM returns EvaluatorOutput] --> B[repairMissingEvaluatorSuccess]
    B --> C[repairForwardLookingFinish]
    C --> D{decision === FINISH\nand messageToUser set?}
    D -- No --> Z[Return output unchanged]
    D -- Yes --> E{Extract promised\nwrite path - Case A}
    E -- Path found --> F{trajectoryWroteToPath?}
    F -- No --> DOWNGRADE[Downgrade to CONTINUE\nclear messageToUser\nsuccess = false]
    F -- Yes --> G{Case B:\nisForwardLookingPromise?}
    E -- No path --> G
    G -- No --> Z
    G -- Yes --> H{COMPLETION_INDICATORS\nmatches?}
    H -- Yes --> Z
    H -- No --> DOWNGRADE
    DOWNGRADE --> I[Planner gets another turn]
```

<sub>Reviews (6): Last reviewed commit: ["fix(core): narrow COMPLETION\_INDICATORS ..."](https://github.com/elizaos/eliza/commit/183ee4845153a2c06a3d4ffc020edb1440c3c9ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31554772)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->