### PR TITLE
refactor(message): extract failure-reply helpers from buildStructuredFailureReply

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1235,6 +1235,16 @@ interface StrategyResult {
 	mode: StrategyMode;
 }
 
+/**
+ * Outcome of attempting the fallback model loop in
+ * `buildStructuredFailureReply`. `noProvider` means a model call surfaced
+ * `NoModelProviderConfiguredError`; the caller must short-circuit to
+ * `buildNoModelProviderReply` instead of continuing the loop.
+ */
+type FailureReplyAttempt =
+	| { kind: "text"; value: string }
+	| { kind: "noProvider" };
+
 export type V5MessageRuntimeStage1Result =
 	| {
 			kind: "terminal";
@@ -9141,6 +9151,82 @@ export class DefaultMessageService implements IMessageService {
 		return processedAttachments;
 	}
 
+	private resolveRecentMessagesForFailureReply(
+		state: State,
+		message: Memory,
+	): string {
+		if (
+			typeof state.values?.recentMessages === "string" &&
+			state.values.recentMessages.trim().length > 0
+		) {
+			return state.values.recentMessages;
+		}
+		if (typeof state.text === "string" && state.text.trim().length > 0) {
+			return state.text;
+		}
+		if (typeof message.content.text === "string") {
+			return message.content.text;
+		}
+		return "(unavailable)";
+	}
+
+	private async generateFailureReplyText(
+		runtime: IAgentRuntime,
+		prompt: string,
+		stage: string,
+	): Promise<FailureReplyAttempt> {
+		for (const modelType of [
+			ModelType.TEXT_LARGE,
+			ModelType.RESPONSE_HANDLER,
+			ModelType.TEXT_SMALL,
+			ModelType.TEXT_NANO,
+		] as const) {
+			try {
+				const response = await runtime.useModel(modelType, { prompt });
+				if (typeof response !== "string") {
+					continue;
+				}
+
+				const cleaned = response
+					.replace(/<think>[\s\S]*?<\/think>/g, "")
+					.trim();
+				const looksStructuredReply =
+					cleaned.startsWith("{") && cleaned.includes("}");
+				const parsed = looksStructuredReply
+					? parseJSONObjectFromText(cleaned)
+					: null;
+				const replyText =
+					typeof parsed?.text === "string" && parsed.text.trim().length > 0
+						? parsed.text.trim()
+						: cleaned;
+				if (replyText) {
+					return { kind: "text", value: replyText };
+				}
+			} catch (error) {
+				// If the runtime reports no LLM provider is configured at all,
+				// no further model attempts will succeed. Surface the actionable
+				// hint instead of the generic transient-failure message. See
+				// elizaOS/eliza#7203.
+				if (
+					error instanceof Error &&
+					error.name === "NoModelProviderConfiguredError"
+				) {
+					return { kind: "noProvider" };
+				}
+				runtime.logger.warn(
+					{
+						src: "service:message",
+						stage,
+						modelType,
+						error: error instanceof Error ? error.message : String(error),
+					},
+					"Structured failure reply generation failed for model",
+				);
+			}
+		}
+		return { kind: "text", value: "" };
+	}
+
 	private async buildStructuredFailureReply(
 		runtime: IAgentRuntime,
 		message: Memory,
@@ -9162,15 +9248,10 @@ export class DefaultMessageService implements IMessageService {
 			);
 		}
 
-		const recentMessages =
-			typeof state.values?.recentMessages === "string" &&
-			state.values.recentMessages.trim().length > 0
-				? state.values.recentMessages
-				: typeof state.text === "string" && state.text.trim().length > 0
-					? state.text
-					: typeof message.content.text === "string"
-						? message.content.text
-						: "(unavailable)";
+		const recentMessages = this.resolveRecentMessagesForFailureReply(
+			state,
+			message,
+		);
 		const failurePrompt = [
 			"You hit a transient model error and have to send a short user-facing reply.",
 			"Write a one or two sentence reply in plain language.",
@@ -9197,65 +9278,22 @@ export class DefaultMessageService implements IMessageService {
 			"Reply:",
 		].join("\n");
 
-		let replyText = "";
-		for (const modelType of [
-			ModelType.TEXT_LARGE,
-			ModelType.RESPONSE_HANDLER,
-			ModelType.TEXT_SMALL,
-			ModelType.TEXT_NANO,
-		] as const) {
-			try {
-				const response = await runtime.useModel(modelType, {
-					prompt: failurePrompt,
-				});
-				if (typeof response !== "string") {
-					continue;
-				}
-
-				const cleaned = response
-					.replace(/<think>[\s\S]*?<\/think>/g, "")
-					.trim();
-				const looksStructuredReply =
-					cleaned.startsWith("{") && cleaned.includes("}");
-				const parsed = looksStructuredReply
-					? parseJSONObjectFromText(cleaned)
-					: null;
-				replyText =
-					typeof parsed?.text === "string" && parsed.text.trim().length > 0
-						? parsed.text.trim()
-						: cleaned;
-				if (replyText) {
-					break;
-				}
-			} catch (error) {
-				// If the runtime reports no LLM provider is configured at all,
-				// no further model attempts will succeed. Surface the actionable
-				// hint instead of the generic transient-failure message. See
-				// elizaOS/eliza#7203.
-				if (
-					error instanceof Error &&
-					error.name === "NoModelProviderConfiguredError"
-				) {
-					return this.buildNoModelProviderReply(
-						runtime,
-						message,
-						state,
-						responseId,
-						stage,
-					);
-				}
-				runtime.logger.warn(
-					{
-						src: "service:message",
-						stage,
-						modelType,
-						error: error instanceof Error ? error.message : String(error),
-					},
-					"Structured failure reply generation failed for model",
-				);
-			}
+		const attempt = await this.generateFailureReplyText(
+			runtime,
+			failurePrompt,
+			stage,
+		);
+		if (attempt.kind === "noProvider") {
+			return this.buildNoModelProviderReply(
+				runtime,
+				message,
+				state,
+				responseId,
+				stage,
+			);
 		}
 
+		let replyText = attempt.value;
 		if (!replyText) {
 			// Last-ditch fallback when every model call above also failed.
 			// Voice-neutral so any character can ship this default; characters


### PR DESCRIPTION
## Summary

Pure code-motion extraction inside `MessageService.buildStructuredFailureReply` in [packages/core/src/services/message.ts](https://github.com/elizaOS/eliza/blob/develop/packages/core/src/services/message.ts). The method previously held three concerns inline; this PR breaks them into named private helpers without touching any logic.

**Before** — one 153-line method, cyclomatic complexity 19, three concerns inline:
1. Tri-fallback resolver for "recent conversation" text
2. Four-model fallback loop with `NoModelProviderConfiguredError` short-circuit
3. Response-content / `StrategyResult` assembly

**After** — three methods + one private discriminated-union type:
- `resolveRecentMessagesForFailureReply(state, message): string`
- `generateFailureReplyText(runtime, prompt, stage): Promise<FailureReplyAttempt>`
- `buildStructuredFailureReply(...)` — now short-circuit check, prompt build, delegate to helper, assemble result

`FailureReplyAttempt = { kind: \"text\"; value: string } | { kind: \"noProvider\" }` lets the inner loop signal the no-provider short-circuit upward cleanly instead of `throw`-from-loop or shared mutable state.

## Behavior

Zero change. Verified by inspection:

| Behavior | Preserved |
|---|---|
| Model order: `TEXT_LARGE → RESPONSE_HANDLER → TEXT_SMALL → TEXT_NANO` | Yes |
| \`<think>…</think>\` stripping before parse | Yes |
| Structured-JSON \`{ ... }\` parse + \`parsed.text\` extraction | Yes |
| Per-model \`warn\` log on failure | Yes |
| \`NoModelProviderConfiguredError\` short-circuit to \`buildNoModelProviderReply\` | Yes |
| Final \`character.templates.transientFailureReply\` fallback | Yes |
| Final 2000-char truncate via \`truncateToCompleteSentence\` | Yes |
| Returned \`StrategyResult\` shape (\`mode: \"simple\"\`, \`actions: [\"REPLY\"]\`, \`simple: true\`, etc.) | Yes |

## Verification

- `bun run typecheck` in `packages/core` — clean
- 12 message-touching vitest suites — **95/95 passing**:
  - `message-runtime-stage1`, `message-action-dedupe`, `planner-happy-path`, `planner-loop`
  - `message-benchmark-integration.contract`, `tiered-action-surface`, `stress-compaction`
  - `message-routing-live-regression`, `message-stage1-context-catalog`
  - `message-handler-output`, `message-handler`, `response-handler-evaluators`

## Follow-ups (separate PRs)

`message.ts` has three other high-complexity methods that warrant extraction (`processAttachments` cc 53, `handleMessage` cc 22, `processMessage` cc 102). Each is too large to bundle into one review-able diff, so they will land as their own PRs after this one settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR performs a pure code-motion refactoring of `buildStructuredFailureReply` in `packages/core/src/services/message.ts`, extracting three inline concerns into two named private helpers (`resolveRecentMessagesForFailureReply`, `generateFailureReplyText`) and a module-scoped discriminated union type (`FailureReplyAttempt`). No logic is changed.

- **`resolveRecentMessagesForFailureReply`** converts the original tri-fallback ternary chain into explicit `if` branches with identical precedence (`state.values.recentMessages` → `state.text` → `message.content.text` → `"(unavailable)"`).
- **`generateFailureReplyText`** hoists the four-model fallback loop; the previous `break`-on-success becomes `return { kind: "text", value }` and the `NoModelProviderConfiguredError` early return becomes `return { kind: "noProvider" }`, letting the caller dispatch without needing shared mutable state or catching re-thrown errors.
- **`buildStructuredFailureReply`** is now a thin coordinator: short-circuit check, prompt assembly, delegate to helper, assemble `StrategyResult`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is a mechanical extraction with no behavioral delta.

Every code path in the original `buildStructuredFailureReply` is faithfully reproduced: the tri-fallback resolver preserves source-priority order, the model loop uses the same four types in the same order, `NoModelProviderConfiguredError` still short-circuits to `buildNoModelProviderReply`, the template fallback and `truncateToCompleteSentence` call are untouched, and the returned `StrategyResult` shape is identical. The discriminated union is a clean alternative to the former `break`/shared-mutable-variable approach. No regressions are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Pure extraction refactor: `buildStructuredFailureReply` split into `resolveRecentMessagesForFailureReply`, `generateFailureReplyText`, and a `FailureReplyAttempt` discriminated union. All original behavior is preserved — model loop order, `<think>` stripping, JSON parse, warn logging, `NoModelProviderConfiguredError` short-circuit, template fallback, and `truncateToCompleteSentence` — with no logic changes. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildStructuredFailureReply] -->|!hasTextGenerationHandler| B[buildNoModelProviderReply]
    A -->|has provider| C[resolveRecentMessagesForFailureReply\nstate.values.recentMessages\n→ state.text\n→ message.content.text\n→ unavailable]
    C --> D[build failurePrompt]
    D --> E[generateFailureReplyText\nTEXT_LARGE → RESPONSE_HANDLER\n→ TEXT_SMALL → TEXT_NANO]
    E -->|kind: noProvider| B
    E -->|kind: text, value: empty| F{replyText empty?}
    E -->|kind: text, value: non-empty| G[truncateToCompleteSentence 2000]
    F -->|yes| H[character.templates.transientFailureReply\nor static fallback]
    H --> G
    G --> I[assemble StrategyResult\nmode: simple, actions: REPLY]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/launch-qa/run.mjs`, line 53-65 ([link](https://github.com/elizaos/eliza/blob/d1a43967a7b959d2feb65257547f61e8cc8b710c/scripts/launch-qa/run.mjs#L53-L65)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent removal of cloud-auth and persistence tests from QA suite**

   `client-cloud-direct-auth.test.ts` and `persistence-cloud-active-server.test.ts` are removed from both the vitest run arguments and `requiredFiles`, but neither file appears in this diff — they still exist at their original paths. After this PR, those tests are simply never executed by the QA task runner, silently dropping CI coverage for cloud auth and active-server persistence without any explanation in the PR description. Similarly, `packages/agent/src/actions/search.test.ts` disappears from the `agent-focused` task with no replacement.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Flaunch-qa%2Frun.mjs%0ALine%3A%2053-65%0A%0AComment%3A%0A**Silent%20removal%20of%20cloud-auth%20and%20persistence%20tests%20from%20QA%20suite**%0A%0A%60client-cloud-direct-auth.test.ts%60%20and%20%60persistence-cloud-active-server.test.ts%60%20are%20removed%20from%20both%20the%20vitest%20run%20arguments%20and%20%60requiredFiles%60%2C%20but%20neither%20file%20appears%20in%20this%20diff%20%E2%80%94%20they%20still%20exist%20at%20their%20original%20paths.%20After%20this%20PR%2C%20those%20tests%20are%20simply%20never%20executed%20by%20the%20QA%20task%20runner%2C%20silently%20dropping%20CI%20coverage%20for%20cloud%20auth%20and%20active-server%20persistence%20without%20any%20explanation%20in%20the%20PR%20description.%20Similarly%2C%20%60packages%2Fagent%2Fsrc%2Factions%2Fsearch.test.ts%60%20disappears%20from%20the%20%60agent-focused%60%20task%20with%20no%20replacement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=elizaos%2Feliza&pr=7579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22wip%2Fmessage-pipeline-extractions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22wip%2Fmessage-pipeline-extractions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Flaunch-qa%2Frun.mjs%0ALine%3A%2053-65%0A%0AComment%3A%0A**Silent%20removal%20of%20cloud-auth%20and%20persistence%20tests%20from%20QA%20suite**%0A%0A%60client-cloud-direct-auth.test.ts%60%20and%20%60persistence-cloud-active-server.test.ts%60%20are%20removed%20from%20both%20the%20vitest%20run%20arguments%20and%20%60requiredFiles%60%2C%20but%20neither%20file%20appears%20in%20this%20diff%20%E2%80%94%20they%20still%20exist%20at%20their%20original%20paths.%20After%20this%20PR%2C%20those%20tests%20are%20simply%20never%20executed%20by%20the%20QA%20task%20runner%2C%20silently%20dropping%20CI%20coverage%20for%20cloud%20auth%20and%20active-server%20persistence%20without%20any%20explanation%20in%20the%20PR%20description.%20Similarly%2C%20%60packages%2Fagent%2Fsrc%2Factions%2Fsearch.test.ts%60%20disappears%20from%20the%20%60agent-focused%60%20task%20with%20no%20replacement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Flaunch-qa%2Frun.mjs%0ALine%3A%2053-65%0A%0AComment%3A%0A**Silent%20removal%20of%20cloud-auth%20and%20persistence%20tests%20from%20QA%20suite**%0A%0A%60client-cloud-direct-auth.test.ts%60%20and%20%60persistence-cloud-active-server.test.ts%60%20are%20removed%20from%20both%20the%20vitest%20run%20arguments%20and%20%60requiredFiles%60%2C%20but%20neither%20file%20appears%20in%20this%20diff%20%E2%80%94%20they%20still%20exist%20at%20their%20original%20paths.%20After%20this%20PR%2C%20those%20tests%20are%20simply%20never%20executed%20by%20the%20QA%20task%20runner%2C%20silently%20dropping%20CI%20coverage%20for%20cloud%20auth%20and%20active-server%20persistence%20without%20any%20explanation%20in%20the%20PR%20description.%20Similarly%2C%20%60packages%2Fagent%2Fsrc%2Factions%2Fsearch.test.ts%60%20disappears%20from%20the%20%60agent-focused%60%20task%20with%20no%20replacement.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=7579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (27): Last reviewed commit: ["refactor(message): extract failure-reply..."](https://github.com/elizaos/eliza/commit/d182a8cefd376e607a28e3614f05d0fd430a605e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31561108)</sub>

<!-- /greptile_comment -->