### PR TITLE
fix(ci): local-inference-matrix prepare-matrix reads inputs from wrong context

### DIFF
--- a/.github/workflows/local-inference-matrix.yml
+++ b/.github/workflows/local-inference-matrix.yml
@@ -71,7 +71,7 @@ jobs:
           script: |
             const ev = context.eventName;
             const pr = context.payload.pull_request;
-            const inputs = github.event.inputs ?? {};
+            const inputs = context.payload.inputs ?? {};
 
             const hasGpuLabel =
               ev === "pull_request" &&


### PR DESCRIPTION
## Summary

One-line fix to [.github/workflows/local-inference-matrix.yml:74](https://github.com/elizaOS/eliza/blob/develop/.github/workflows/local-inference-matrix.yml#L74). The `prepare-matrix` job crashes on every PR that touches local-inference paths with:

```
TypeError: Cannot read properties of undefined (reading 'inputs')
    at eval (eval at callAsyncFunction ...)
```

## Cause

`github.event.inputs` is undefined inside an `actions/github-script@v7` step — `github` is the Octokit API client, not the event payload. The base `github.event` itself is `undefined`, so the `??` fallback can't save it.

The idiomatic path is `context.payload.inputs`. It matches the existing pattern in the same script:

```js
const pr = context.payload.pull_request;  // already used on the line above
const inputs = github.event.inputs ?? {}; // wrong — this line
```

`context.payload.inputs` is correctly populated by `workflow_dispatch` and is harmlessly undefined on `pull_request` events (where the `??` then provides the empty object the downstream code expects).

## Blast radius

Shipped with [`082412ca5`](https://github.com/elizaOS/eliza/commit/082412ca5) (the May 9 prepare-matrix rebuild). Since then, every PR touching `packages/app-core/src/services/local-inference/**`, `scripts/local-inference-*`, or `.github/workflows/local-inference-matrix.yml` has had a red `prepare-matrix` check.

## Scope

This PR has been reset to its original 1-line scope. Bundled CI fixes that previously rode along (background-runner, kernel smoke flag, connector-deeplink, format sweeps, lockfile bump, etc.) have been dropped to keep this PR reviewable and unblockable. Those fixes can land in separate PRs against develop on their own merit.
