### PR TITLE
fix(core): cap FACTS provider embedding call to 3s so a hung backend doesn't burn the 30s state-composition budget per turn

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime, Memory, State } from "../../../types/index";
+import { factsProvider } from "./facts.ts";
+
+function makeRuntime(
+	useModelImpl: () => Promise<unknown>,
+): Pick<
+	IAgentRuntime,
+	"useModel" | "getMemories" | "searchMemories" | "character" | "logger"
+> {
+	return {
+		character: { name: "TestAgent" } as IAgentRuntime["character"],
+		useModel: vi.fn(useModelImpl) as unknown as IAgentRuntime["useModel"],
+		getMemories: vi.fn(async () => [
+			{
+				id: "m1",
+				entityId: "user-1",
+				roomId: "room-1",
+				content: { text: "hello world" },
+			} as Memory,
+		]),
+		searchMemories: vi.fn(async () => []),
+		logger: {
+			debug: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+		} as unknown as IAgentRuntime["logger"],
+	};
+}
+
+function makeMessage(): Memory {
+	return {
+		id: "msg-1",
+		entityId: "user-1",
+		roomId: "room-1",
+		content: { text: "what's up" },
+	} as Memory;
+}
+
+describe("FACTS provider — embedding-timeout degradation", () => {
+	it("returns empty facts well under the 30s outer timeout when the embedding hangs", async () => {
+		const runtime = makeRuntime(
+			() =>
+				new Promise<never>(() => {
+					/* never resolves — simulates a broken local embedding binding */
+				}),
+		);
+
+		const start = Date.now();
+		const result = await factsProvider.get!(
+			runtime as unknown as IAgentRuntime,
+			makeMessage(),
+			{} as State,
+		);
+		const elapsed = Date.now() - start;
+
+		// EMBEDDING_TIMEOUT_MS is 3000ms; provider must bail within ~3.5s, not 30s.
+		expect(elapsed).toBeLessThan(4000);
+		expect(result.values?.facts).toBe("");
+		expect(result.text).toBe("No facts available.");
+	}, 8000);
+
+	it("returns empty facts when the embedding call throws", async () => {
+		const runtime = makeRuntime(async () => {
+			throw new Error("embedding backend offline");
+		});
+
+		const result = await factsProvider.get!(
+			runtime as unknown as IAgentRuntime,
+			makeMessage(),
+			{} as State,
+		);
+
+		expect(result.values?.facts).toBe("");
+		expect(result.text).toBe("No facts available.");
+		expect(result.data?.error).toContain("offline");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -37,6 +37,43 @@ const DEFAULT_FACT_CONFIDENCE = 0.6;
 const CANDIDATE_POOL_PER_SEARCH = 20;
 const TOP_PER_KIND = 6;
 
+/**
+ * Internal timeout for the embedding seed that drives FACTS retrieval. The
+ * provider runtime gives every provider 30s for its full state-composition
+ * pass; if `useModel(TEXT_EMBEDDING, ...)` hangs (e.g. the local llama.cpp
+ * embedding backend failed to build or the remote embedding endpoint is
+ * unreachable) we burn the full 30s on every turn waiting for the outer
+ * cut. Race the embedding call against a much shorter internal limit and
+ * fall through to the `catch` block (which returns empty facts) so the
+ * provider degrades to "no facts" instead of "30s of dead air per turn".
+ *
+ * 3s is comfortably above a healthy embedding round-trip (warm local
+ * bge-small-en-v1.5 returns in ~50-150ms; warm cloud endpoint in
+ * ~100-400ms) and well below the 30s outer cut.
+ */
+const EMBEDDING_TIMEOUT_MS = 3000;
+
+async function withTimeout<T>(
+	promise: Promise<T>,
+	ms: number,
+	label: string,
+): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(
+					() => reject(new Error(`${label} timed out after ${ms}ms`)),
+					ms,
+				);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
 function readFactMetadata(memory: Memory): FactMetadata {
 	const meta = memory.metadata;
 	if (!meta || typeof meta !== "object" || Array.isArray(meta)) return {};
@@ -230,9 +267,13 @@ const factsProvider: Provider = {
 			lastMessageLines.reverse();
 			const last5Messages = lastMessageLines.join("\n");
 
-			const embedding = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
-				text: last5Messages,
-			});
+			const embedding = await withTimeout(
+				runtime.useModel(ModelType.TEXT_EMBEDDING, {
+					text: last5Messages,
+				}),
+				EMBEDDING_TIMEOUT_MS,
+				"FACTS provider: embedding call",
+			);
 
 			// Two parallel searches, one room-scoped and one entity-scoped, both
 			// over the `facts` table. We over-fetch so that the in-memory kind


### PR DESCRIPTION
## Summary

The FACTS provider seeds memory retrieval with `useModel(TEXT_EMBEDDING, ...)`. When the embedding backend is unhealthy — local `node-llama-cpp` binding failed to build (recent upstream rename of `cpu_get_num_math` is one live example), or a remote embedding endpoint is unreachable — the call **hangs**, it doesn't throw. The provider's outer 30s state-composition timeout eventually cuts it, but every turn pays the full 30s of dead air first.

## Repro

On a live deployment whose local `node-llama-cpp` binding fails to compile:

```
AddonContext.cpp:400:41: error: 'cpu_get_num_math' was not declared in this scope; did you mean 'common_cpu_get_num_math'?
```

bot.log shows:

```
Error  [AGENT] Provider timed out during state composition (provider=FACTS, timeoutMs=30000)
```

**42 occurrences in a single bot session.** Every Discord turn waits 30s for FACTS before proceeding.

## Fix

Race the embedding call against a 3s internal timeout, then let the existing `catch` branch return empty facts. 3s is comfortably above a healthy round-trip (local bge-small ~50-150ms warm, cloud ~100-400ms) and well below the 30s outer cut, so the happy path is unchanged.

```ts
const embedding = await withTimeout(
  runtime.useModel(ModelType.TEXT_EMBEDDING, { text: last5Messages }),
  EMBEDDING_TIMEOUT_MS, // 3000
  "FACTS provider: embedding call",
);
```

Provider now degrades from `"30s of dead air per turn"` to `"No facts available."` in ~3s.

## Test plan

- [x] New `packages/core/src/features/advanced-capabilities/providers/facts.test.ts` with two cases:
  - embedding hangs forever → provider bails in <4s with empty facts
  - embedding throws → provider returns empty facts, surfaces error in `data.error`
- [x] 2/2 tests pass: `bunx vitest run src/features/advanced-capabilities/providers/facts.test.ts`
- [x] Verified on the live bot — same prompt that previously hit the FACTS 30s timeout now composes state in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 3-second internal timeout around the `TEXT_EMBEDDING` call in the FACTS provider, preventing a hung embedding backend from consuming the full 30-second state-composition budget on every agent turn. When the embedding call exceeds 3 s the provider degrades gracefully to "No facts available." via the existing `catch` block.

- A new `withTimeout` helper races the `useModel` promise against a `setTimeout`-based rejection, clearing the timer in a `finally` block to avoid a dangling timer on the happy path.
- Two new Vitest tests cover the "embedding never resolves" and "embedding throws immediately" paths; the first uses an 8 s test-level timeout to give the 3 s internal limit room to fire.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is narrowly scoped to the FACTS provider's embedding call, the happy path is unaffected, and graceful degradation to empty facts is well-exercised by the new tests.

The fix correctly races the embedding promise against a short internal deadline and lets the existing catch block handle the timeout error. No data is mutated, no side-effects are skipped on the happy path, and the worst-case outcome (cold-start false positive) results in a single turn with no facts rather than any data loss or corruption.

No files require special attention beyond the cold-start timeout trade-off noted in facts.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/features/advanced-capabilities/providers/facts.ts | Adds EMBEDDING_TIMEOUT_MS constant, a local withTimeout helper, and wraps the useModel call; core logic is correct but the 3 s limit may cause false-positive timeouts on cold-start model loads. |
| packages/core/src/features/advanced-capabilities/providers/facts.test.ts | New test file covering "embedding hangs" and "embedding throws immediately"; missing coverage for the "hangs then rejects" real-world path. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Runtime (30 s outer budget)
    participant FP as factsProvider.get
    participant WT as withTimeout (3 s)
    participant EM as useModel(TEXT_EMBEDDING)

    R->>FP: get(runtime, message, state)
    FP->>EM: "runtime.useModel(TEXT_EMBEDDING, {text})"
    FP->>WT: race(embeddingPromise, 3 s timer)

    alt "Healthy backend (< 3 s)"
        EM-->>WT: embedding vector
        WT-->>FP: embedding vector
        FP->>R: searchMemories + ranked facts
    else "Backend hangs / unreachable (> 3 s)"
        WT-->>FP: throws TimeoutError (~3 s)
        Note over EM: original promise still running (no handler)
        FP->>R: "{ text: "No facts available." }"
    else Backend throws immediately
        EM-->>WT: Error
        WT-->>FP: re-throws Error
        FP->>R: "{ text: "No facts available.", data.error }"
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(core): cap FACTS provider embedding ..."](https://github.com/elizaos/eliza/commit/41d5800175b87e2e216eb0f1b8c899b2e8259e0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31574171)</sub>

<!-- /greptile_comment -->