### PR TITLE
fix(plugin-app-control): retry VerificationRoomBridge attach to win the boot race against orchestrator

### DIFF
--- a/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
+++ b/plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts
@@ -1,0 +1,114 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { VerificationRoomBridgeService } from "../verification-room-bridge.ts";
+
+/**
+ * Minimal SwarmCoordinator-shaped stub. Only `subscribe` is exercised
+ * by the bridge.
+ */
+function makeCoordinator() {
+	const listeners = new Set<(event: unknown) => void>();
+	return {
+		subscribe: (listener: (event: unknown) => void) => {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		__emit: (event: unknown) => {
+			for (const l of listeners) l(event);
+		},
+		__listenerCount: () => listeners.size,
+	};
+}
+
+function makeRuntime(initialServices: Record<string, unknown>) {
+	const services = { ...initialServices };
+	return {
+		runtime: {
+			getService: vi.fn((name: string) => services[name] ?? null),
+			createMemory: vi.fn(async () => ({ id: "mem-stub" })),
+			agentId: "agent-1",
+			logger: {
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+			},
+		} as unknown as IAgentRuntime,
+		setService: (name: string, instance: unknown) => {
+			services[name] = instance;
+		},
+	};
+}
+
+describe("VerificationRoomBridgeService — boot-order retry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("attaches immediately when SwarmCoordinator is available at start()", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime } = makeRuntime({ SWARM_COORDINATOR: coordinator });
+
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		expect(coordinator.__listenerCount()).toBe(1);
+		await service.stop();
+		expect(coordinator.__listenerCount()).toBe(0);
+	});
+
+	it("retries until SwarmCoordinator is registered, then subscribes once", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime, setService } = makeRuntime({});
+
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		// First attach attempt failed — no service yet, no subscriber.
+		expect(coordinator.__listenerCount()).toBe(0);
+
+		// Service becomes available later; advance the retry timer.
+		setService("SWARM_COORDINATOR", coordinator);
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(coordinator.__listenerCount()).toBe(1);
+		await service.stop();
+	});
+
+	it("gives up quietly after ATTACH_MAX_RETRIES without binding twice", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime, setService } = makeRuntime({});
+
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		// Drain the entire retry budget: 60 retries × 500ms = 30s.
+		await vi.advanceTimersByTimeAsync(31_000);
+
+		// Service eventually shows up AFTER giving up. Bridge must NOT
+		// subscribe — the retry loop already terminated.
+		setService("SWARM_COORDINATOR", coordinator);
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(coordinator.__listenerCount()).toBe(0);
+
+		await service.stop();
+	});
+
+	it("stop() cancels a pending retry timer", async () => {
+		const coordinator = makeCoordinator();
+		const { runtime, setService } = makeRuntime({});
+
+		const service = await VerificationRoomBridgeService.start(runtime);
+
+		// Tear down BEFORE the service becomes available.
+		await service.stop();
+
+		// Now register the coordinator and advance time. A leaked timer
+		// would re-attach and increment the listener count; a proper
+		// cancel keeps it at zero.
+		setService("SWARM_COORDINATOR", coordinator);
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(coordinator.__listenerCount()).toBe(0);
+	});
+});

--- a/plugins/plugin-app-control/src/services/verification-room-bridge.ts
+++ b/plugins/plugin-app-control/src/services/verification-room-bridge.ts
@@ -53,6 +53,19 @@ const VERIFY_PLUGIN_METHOD = "verifyPlugin";
 const VERDICT_DEDUPE_TTL_MS = 10 * 60 * 1000;
 
 /**
+ * How often we re-check for the SwarmCoordinator service when it was not
+ * registered yet during the first `attach()` call. Plugin start ordering
+ * is not deterministic, so we retry on a fixed interval until the
+ * coordinator shows up or `ATTACH_MAX_RETRIES` is reached.
+ *
+ * 500ms interval × 60 retries = 30 seconds of patience — long enough to
+ * cover slow plugin-loading on cold boots while still bounding the
+ * dangling-timer window after `stop()` to 0.5s.
+ */
+const ATTACH_RETRY_INTERVAL_MS = 500;
+const ATTACH_MAX_RETRIES = 60;
+
+/**
  * Minimal shape of the SwarmCoordinator service surface this bridge
  * depends on. We only need `subscribe`; declared locally so we don't
  * pull in plugin-agent-orchestrator as a hard dependency just for
@@ -190,6 +203,8 @@ export class VerificationRoomBridgeService extends Service {
 		"Posts the AppVerificationService verdict back into the originating chat room when the orchestrator's custom-validator branch fires task_complete / escalation events.";
 
 	private unsubscribe: (() => void) | null = null;
+	private attachRetryTimer: ReturnType<typeof setTimeout> | null = null;
+	private attachRetryAttempts = 0;
 
 	/**
 	 * Dedupe map: `${sessionId}:${verdict}` -> expiresAt epoch ms. Drops
@@ -209,6 +224,12 @@ export class VerificationRoomBridgeService extends Service {
 	}
 
 	override async stop(): Promise<void> {
+		// Cancel any pending attach retry before tearing down so a late retry
+		// can't subscribe to a coordinator after stop() returned.
+		if (this.attachRetryTimer) {
+			clearTimeout(this.attachRetryTimer);
+			this.attachRetryTimer = null;
+		}
 		const unsub = this.unsubscribe;
 		// Always clear the field first so a retry of stop() can't double-call.
 		this.unsubscribe = null;
@@ -236,14 +257,20 @@ export class VerificationRoomBridgeService extends Service {
 			"SWARM_COORDINATOR",
 		) as SwarmCoordinatorLike | null;
 		if (!coordinator || typeof coordinator.subscribe !== "function") {
-			// Orchestrator plugin isn't loaded or is on an older surface that
-			// doesn't expose subscribe(). plugin-app-control still works for
-			// non-create flows without the bridge; log at debug since this
-			// fires every boot when the orchestrator isn't enabled.
-			logger.debug(
-				"[VerificationRoomBridge] SWARM_COORDINATOR service has no subscribe(); bridge inactive. Verification verdicts will not be posted back to chat.",
-			);
+			// Orchestrator plugin isn't loaded yet — but plugin start ordering
+			// is not deterministic, so the orchestrator may register its
+			// SwarmCoordinator after we ran. Retry on a backoff up to
+			// `ATTACH_MAX_RETRIES` so the bridge ends up wired whenever the
+			// orchestrator IS in the plugin set. After the retry budget
+			// expires we give up quietly — `plugin-app-control` still works
+			// for non-create flows without the bridge.
+			this.scheduleAttachRetry();
 			return;
+		}
+		// Clear any pending retry timer — we succeeded on this pass.
+		if (this.attachRetryTimer) {
+			clearTimeout(this.attachRetryTimer);
+			this.attachRetryTimer = null;
 		}
 		this.unsubscribe = coordinator.subscribe((event) => {
 			this.handleEvent(event).catch((err) => {
@@ -253,8 +280,30 @@ export class VerificationRoomBridgeService extends Service {
 			});
 		});
 		logger.info(
-			"[VerificationRoomBridge] subscribed to SWARM_COORDINATOR event stream",
+			`[VerificationRoomBridge] subscribed to SWARM_COORDINATOR event stream${
+				this.attachRetryAttempts > 0
+					? ` (after ${this.attachRetryAttempts} retr${this.attachRetryAttempts === 1 ? "y" : "ies"})`
+					: ""
+			}`,
 		);
+	}
+
+	private scheduleAttachRetry(): void {
+		if (this.attachRetryAttempts >= ATTACH_MAX_RETRIES) {
+			// Final attempt exhausted — log once at debug level so this is
+			// silent in deployments that genuinely don't have the
+			// orchestrator plugin enabled (the common case for non-create
+			// agent deployments) while still being grep-able.
+			logger.debug(
+				`[VerificationRoomBridge] SWARM_COORDINATOR service still has no subscribe() after ${ATTACH_MAX_RETRIES} retries; bridge inactive. Verification verdicts will not be posted back to chat.`,
+			);
+			return;
+		}
+		this.attachRetryAttempts += 1;
+		this.attachRetryTimer = setTimeout(() => {
+			this.attachRetryTimer = null;
+			this.attach();
+		}, ATTACH_RETRY_INTERVAL_MS);
 	}
 
 	private async handleEvent(event: SwarmEventLike): Promise<void> {


### PR DESCRIPTION
## Summary

When plugin-app-control's `VerificationRoomBridgeService` boots before plugin-agent-orchestrator's `SwarmCoordinator` registers, the bridge's one-shot `attach()` call finds no service, logs once, and never tries again. Custom-validator verdicts (APP create / PLUGIN create verification pass/fail) are silently dropped instead of posted back to the originating chat room.

Plugin start order is not deterministic — a workspace where plugin-app-control wins the start race against plugin-agent-orchestrator hits this on every boot. Live evidence from one such deployment:

```
Warn  [VerificationRoomBridge] SWARM_COORDINATOR service has no subscribe(); bridge inactive. Verification verdicts will not be posted back to chat.
```

Then a few seconds later, the orchestrator does register:

```
Info  [SwarmCoordinator] SwarmCoordinator started
Info  [SwarmCoordinator] Chat callback wired
```

But the bridge already gave up.

## Fix

Retry `attach()` on a 500ms cadence up to 60 attempts (30s total budget). Once `SwarmCoordinator` shows up the bridge wires its listener exactly once. `stop()` clears any pending retry timer so a late retry can't subscribe after teardown.

```ts
const ATTACH_RETRY_INTERVAL_MS = 500;
const ATTACH_MAX_RETRIES = 60;
```

## Test plan

Four new vitest cases using `vi.useFakeTimers()`:

- [x] `attaches immediately when SwarmCoordinator is available at start()` — happy path
- [x] `retries until SwarmCoordinator is registered, then subscribes once` — race fix
- [x] `gives up quietly after ATTACH_MAX_RETRIES without binding twice` — budget cap
- [x] `stop() cancels a pending retry timer` — no dangling timer post-teardown

All 4/4 pass: `bunx vitest run src/services/__tests__/verification-room-bridge.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a boot-order race condition in `VerificationRoomBridgeService`: when the bridge's one-shot `attach()` ran before `SwarmCoordinator` was registered, verdicts were silently dropped forever. The fix retries `attach()` every 500 ms for up to 60 attempts (30 s) and properly cancels any pending timer on `stop()`.

- **`verification-room-bridge.ts`**: Adds `attachRetryTimer` / `attachRetryAttempts` fields, a `scheduleAttachRetry()` private method, and timer cancellation in `stop()`. The retry budget (60 × 500 ms) is well-chosen and bounds the dangling-timer window to at most 0.5 s after teardown.
- **`verification-room-bridge.test.ts`**: Four new vitest cases using `vi.useFakeTimers()` cover the happy path, the retry path, budget exhaustion, and `stop()` timer cancellation — providing good behavioural coverage of the new retry loop.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the retry loop is bounded, teardown correctly cancels pending timers, and the four new tests exercise all branching paths.

The change is narrowly scoped: it adds a retry timer with proper cleanup and four tests that directly exercise the new code paths. No existing behaviour is altered for deployments where SwarmCoordinator is available immediately. Timer cancellation in stop() is correct and race-condition-safe given JavaScript's single-threaded event loop.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-app-control/src/services/verification-room-bridge.ts | Adds deterministic retry loop for SwarmCoordinator attach; teardown and timer cancellation logic is correct. |
| plugins/plugin-app-control/src/services/__tests__/verification-room-bridge.test.ts | Four new vitest cases with fake timers covering happy path, retry, budget exhaustion, and stop-cancellation; coverage is solid. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Start as start()
    participant Bridge as VerificationRoomBridgeService
    participant Timer as setTimeout
    participant Runtime as IAgentRuntime
    participant SC as SwarmCoordinator

    Start->>Bridge: new VerificationRoomBridgeService(runtime)
    Start->>Bridge: attach()
    Bridge->>Runtime: getService("SWARM_COORDINATOR")
    Runtime-->>Bridge: null (not yet registered)
    Bridge->>Bridge: scheduleAttachRetry() [attempt 1..60]
    Bridge->>Timer: setTimeout(500ms)

    note over Timer: (coordinator registers later)

    Timer-->>Bridge: callback fires
    Bridge->>Bridge: attach()
    Bridge->>Runtime: getService("SWARM_COORDINATOR")
    Runtime-->>Bridge: coordinator found
    Bridge->>SC: subscribe(listener)
    SC-->>Bridge: unsubscribe fn
    Bridge->>Bridge: store unsubscribe

    note over Bridge: on stop()
    Bridge->>Timer: clearTimeout(attachRetryTimer)
    Bridge->>SC: unsubscribe()
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-app-control): retry Verificat..."](https://github.com/elizaos/eliza/commit/310f1916e81489f5742676f6137c44590633628c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31574983)</sub>

<!-- /greptile_comment -->