### PR TITLE
fix(plugin-agent-orchestrator): consult MILADY_API_PORT/ELIZA_API_PORT when resolving sub-agent hook URL

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/pty-service-server-port.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/pty-service-server-port.test.ts
@@ -1,0 +1,53 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { resolveServerPort } from "../../src/services/pty-service.ts";
+
+function makeRuntime(settings: Record<string, string | number | undefined>) {
+  return {
+    getSetting: vi.fn((key: string) => settings[key]),
+  } as unknown as IAgentRuntime;
+}
+
+describe("resolveServerPort", () => {
+  it("prefers explicit SERVER_PORT override over deployment env vars", () => {
+    const runtime = makeRuntime({
+      SERVER_PORT: "9999",
+      MILADY_API_PORT: "47831",
+      ELIZA_API_PORT: "31337",
+    });
+    expect(resolveServerPort(runtime)).toBe("9999");
+  });
+
+  it("falls back to MILADY_API_PORT when SERVER_PORT is not set", () => {
+    const runtime = makeRuntime({
+      MILADY_API_PORT: "47831",
+      ELIZA_API_PORT: "31337",
+    });
+    expect(resolveServerPort(runtime)).toBe("47831");
+  });
+
+  it("falls back to ELIZA_API_PORT when only that is set", () => {
+    const runtime = makeRuntime({
+      ELIZA_API_PORT: "31337",
+    });
+    expect(resolveServerPort(runtime)).toBe("31337");
+  });
+
+  it("returns the dev-UI default 2138 only when nothing else is configured", () => {
+    const runtime = makeRuntime({});
+    expect(resolveServerPort(runtime)).toBe("2138");
+  });
+
+  it("accepts numeric port settings", () => {
+    const runtime = makeRuntime({ MILADY_API_PORT: 47831 });
+    expect(resolveServerPort(runtime)).toBe("47831");
+  });
+
+  it("ignores empty-string settings and walks to the next key", () => {
+    const runtime = makeRuntime({
+      SERVER_PORT: "   ",
+      MILADY_API_PORT: "47831",
+    });
+    expect(resolveServerPort(runtime)).toBe("47831");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/pty-service.ts
@@ -354,10 +354,32 @@ function prependWorkspaceLockToTask(
   return `${workspaceLock} ${task}`;
 }
 
-function resolveServerPort(runtime: IAgentRuntime): string {
-  const raw = runtime.getSetting("SERVER_PORT");
-  if (typeof raw === "number" && Number.isFinite(raw)) return String(raw);
-  if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+/**
+ * Setting keys consulted to locate the parent agent's HTTP API. Order
+ * matters: we prefer the explicit override (`SERVER_PORT`) over deployment
+ * env vars (`MILADY_API_PORT`, `ELIZA_API_PORT`). The fallback `2138`
+ * targets the dev-UI (Vite) port, which does NOT serve
+ * `/api/coding-agents/*` — that lives on the API server. The dev-UI
+ * port answer was correct only for the legacy single-port topology
+ * where the dev orchestrator put UI + API on the same port; modern
+ * deployments split them and a sub-agent POSTing hook telemetry to
+ * `:2138` gets HTTP 404 instead of hitting the parent's hook endpoint
+ * (`/api/coding-agents/hooks`). That silently drops PreToolUse / Stop
+ * hooks so the parent never sees the sub-agent's lifecycle events.
+ */
+const SERVER_PORT_SETTING_KEYS = [
+  "SERVER_PORT",
+  "MILADY_API_PORT",
+  "ELIZA_API_PORT",
+] as const;
+
+/** @internal — exported for unit tests in `pty-service-server-port.test.ts`. */
+export function resolveServerPort(runtime: IAgentRuntime): string {
+  for (const key of SERVER_PORT_SETTING_KEYS) {
+    const raw = runtime.getSetting(key);
+    if (typeof raw === "number" && Number.isFinite(raw)) return String(raw);
+    if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  }
   return "2138";
 }
 


### PR DESCRIPTION
## Summary

When a sub-agent (claude / codex / opencode) is spawned, the PTY service injects an HTTP hook URL into the sub-agent's settings so the parent can receive PreToolUse / Stop hook telemetry. The URL is built from `resolveServerPort(runtime)` — which only checks `SERVER_PORT` and otherwise falls back to `2138`.

`2138` is the dev-UI (Vite) port. Modern deployments split UI from API: the API server runs on `MILADY_API_PORT` / `ELIZA_API_PORT` (commonly `47831` or `31337`). Posting to `http://localhost:2138/api/coding-agents/hooks` returns HTTP 404, so PreToolUse / Stop / Write hook callbacks are silently dropped on every sub-agent turn.

Live evidence:

```
[PTYService/Worker] 'Stop hook error: HTTP 404 from http://localhost:2138/api/coding-agents/hooks'
[PTYService/Worker] 'PreToolUse:Write hook error HTTP 404 from http://localhost:2138/api/coding-agents/hooks'
```

The dropped Stop hook is why the parent agent doesn't post a "sub-agent finished" follow-up to chat after generic-task SPAWN_AGENT turns: it never sees the Stop event.

## Fix

Walk an ordered list of setting keys: `SERVER_PORT` first (explicit override), then `MILADY_API_PORT`, then `ELIZA_API_PORT`, fall back to `2138` only when all three are absent.

```ts
const SERVER_PORT_SETTING_KEYS = [
  "SERVER_PORT",
  "MILADY_API_PORT",
  "ELIZA_API_PORT",
] as const;
```

Both `service.env` of typical deployments and the dev orchestrator already populate `MILADY_API_PORT` / `ELIZA_API_PORT`, so this lights up the sub-agent telemetry path with zero config changes.

## Test plan

- [x] Six new unit tests in `plugins/plugin-agent-orchestrator/__tests__/unit/pty-service-server-port.test.ts`:
  - `SERVER_PORT` precedence over deployment env vars
  - Falls back to `MILADY_API_PORT`
  - Falls back to `ELIZA_API_PORT`
  - `2138` only when nothing is configured
  - Accepts numeric port settings
  - Ignores empty/whitespace settings and walks to the next key
- [x] 6/6 pass: `bunx vitest run __tests__/unit/pty-service-server-port.test.ts`
- [x] Verified live: SPAWN_AGENT turn that previously emitted 404s on every tool-use hook now hits the real API endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `resolveServerPort` where the hook URL posted to by spawned sub-agents always defaulted to port `2138` (the Vite dev-UI port) when `SERVER_PORT` was unset, causing HTTP 404s that silently dropped all `PreToolUse`/`Stop` hook telemetry on modern split-port deployments.

- **Core fix**: `resolveServerPort` now walks an ordered list of setting keys — `SERVER_PORT` → `MILADY_API_PORT` → `ELIZA_API_PORT` — before falling back to `2138`; the function is also exported (`@internal`) so the new unit tests can import it directly.
- **Tests**: Six new Vitest unit tests cover precedence ordering, numeric port values, whitespace-skipping, and the final `2138` fallback.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix to a clearly broken code path with no side effects on unrelated functionality.

The diff touches only resolveServerPort, a private helper with a single call site. The new ordered-key walk is straightforward, the fallback to 2138 is preserved for backward compatibility, and all six new unit tests directly verify the priority chain. No existing behavior is removed; deployments that only set SERVER_PORT continue to work identically.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/pty-service.ts | resolveServerPort now walks SERVER_PORT → MILADY_API_PORT → ELIZA_API_PORT before falling back to 2138; function is exported for testability. Logic is correct and well-commented. |
| plugins/plugin-agent-orchestrator/__tests__/unit/pty-service-server-port.test.ts | Six unit tests added covering key resolution, fallback ordering, numeric ports, whitespace skipping, and the default 2138 case. All cases are correct and complete. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant SubAgent as Sub-Agent (Claude/Codex)
    participant PTY as PTYService
    participant RS as resolveServerPort()
    participant RT as IAgentRuntime.getSetting()
    participant API as Parent HTTP API

    PTY->>RS: resolveServerPort(runtime)
    RS->>RT: getSetting("SERVER_PORT")
    RT-->>RS: undefined / empty
    RS->>RT: getSetting("MILADY_API_PORT")
    RT-->>RS: "47831" (or undefined)
    alt MILADY_API_PORT set
        RS-->>PTY: "47831"
    else not set
        RS->>RT: getSetting("ELIZA_API_PORT")
        RT-->>RS: "31337" (or undefined)
        alt ELIZA_API_PORT set
            RS-->>PTY: "31337"
        else nothing set
            RS-->>PTY: "2138" (legacy fallback)
        end
    end
    PTY->>SubAgent: "inject hook URL (http://localhost:{port}/api/coding-agents/hooks)"
    SubAgent->>API: POST /api/coding-agents/hooks (PreToolUse / Stop)
    API-->>SubAgent: 200 OK
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-agent-orchestrator): consult ..."](https://github.com/elizaos/eliza/commit/8fd8154312752ee3b010d64c44cea1000e3b4912) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31575823)</sub>

<!-- /greptile_comment -->