### PR TITLE
ci(cloud-cf-deploy): fail loud when CF secrets are missing on push/dispatch

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -105,12 +105,21 @@ jobs:
         env:
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$HAS_TOKEN" = "true" ] && [ "$HAS_ACCOUNT" = "true" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured — skipping Worker deploy. Add them at https://github.com/elizaOS/eliza/settings/secrets/actions to enable." >> "$GITHUB_STEP_SUMMARY"
+            MSG="CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured. Add them at https://github.com/elizaOS/eliza/settings/secrets/actions."
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              # PRs from forks legitimately lack access to repo secrets.
+              echo "::warning::$MSG Skipping Worker deploy (PR event)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error::$MSG Refusing to silently skip Worker deploy on $EVENT_NAME event." >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::$MSG Refusing to silently skip Worker deploy on $EVENT_NAME event."
+              exit 1
+            fi
           fi
 
       - name: Deploy to Cloudflare Workers
@@ -179,12 +188,21 @@ jobs:
         env:
           HAS_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
           HAS_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID != '' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$HAS_TOKEN" = "true" ] && [ "$HAS_ACCOUNT" = "true" ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
           else
             echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured — skipping Pages deploy. Add them at https://github.com/elizaOS/eliza/settings/secrets/actions to enable." >> "$GITHUB_STEP_SUMMARY"
+            MSG="CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured. Add them at https://github.com/elizaOS/eliza/settings/secrets/actions."
+            if [ "$EVENT_NAME" = "pull_request" ]; then
+              # PRs from forks legitimately lack access to repo secrets.
+              echo "::warning::$MSG Skipping Pages deploy (PR event)." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "::error::$MSG Refusing to silently skip Pages deploy on $EVENT_NAME event." >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::$MSG Refusing to silently skip Pages deploy on $EVENT_NAME event."
+              exit 1
+            fi
           fi
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary

When `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` aren't set in repo secrets, the cloud-cf-deploy workflow currently skips the Worker / Pages deploy with only a step-summary warning. The job still reports **success**, so a green CI light on a push to `main` / `develop` looks like a successful deploy even when nothing was deployed.

This is what caused the production `/api/*` 405 outage: secrets were missing from `elizaOS/eliza`, every push silently skipped the deploy, and out-of-band manual `wrangler pages deploy` runs missed the sibling `functions/` directory — so the same-origin proxy never shipped.

## Change

- `push` and `workflow_dispatch` events with missing secrets → step now fails with `::error::` (surfaces on the run page, blocks merge-status, sets `Deploy ...` job to ❌).
- `pull_request` events keep the soft-skip path with a `::warning::` — PRs from forks legitimately have no access to repo secrets, and we don't want fork contributors to see a red CI for something they can't fix.

Same logic applied symmetrically to both `deploy-api` and `deploy-frontend` jobs.

## Test plan

- [ ] Open this PR (event = `pull_request`, secrets absent in elizaOS/eliza right now) → \"Check Cloudflare credentials\" step should print the `::warning::` summary and the job should continue but skip the deploy. Verify both `deploy-api` and `deploy-frontend` go ✅ with the warning visible.
- [ ] After secrets are added + PR is merged, push to `develop` → \"Check Cloudflare credentials\" should resolve `HAS_TOKEN: true, HAS_ACCOUNT: true` and the deploy step should run successfully, producing a Pages deployment that includes the `functions/` bundle (verify with `curl -i -X POST https://staging.elizacloud.ai/api/auth/steward-session -d '{}'` returning `400 JSON {\"error\":\"Token required\"}` rather than `405`).
- [ ] If secrets are removed in the future, the next push to `main`/`develop` should now fail loudly with `::error::CLOUDFLARE_API_TOKEN/CLOUDFLARE_ACCOUNT_ID not configured ...` instead of silently green-lighting.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `cloud-cf-deploy` workflow so that a missing `CLOUDFLARE_API_TOKEN` or `CLOUDFLARE_ACCOUNT_ID` on a `push`/`workflow_dispatch` event now fails the job with `::error::` and `exit 1`, instead of silently succeeding. PR events keep the soft-skip path to accommodate fork contributors who cannot access repo secrets.

- **`deploy-api`**: Adds `EVENT_NAME` env var and branches on `pull_request` vs other events; the PR branch is actually unreachable because the job already has `if: github.event_name != 'pull_request'` at the job level.
- **`deploy-frontend`**: Same credential-check logic applied correctly — this job runs for all events including `pull_request`, so both branches are reachable.
- **Error surfacing**: The `::error::` annotation is emitted both to `$GITHUB_STEP_SUMMARY` (as literal text) and to stdout (as an active workflow command annotation), followed by `exit 1` to fail the step.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change correctly hardens both deploy jobs against missing secrets on production-bound pushes.

The fix achieves its stated goal. The only oddity is dead code in `deploy-api`'s credential check: the `pull_request` soft-skip branch can never execute because the job is gated at the job level to skip PR events entirely. This doesn't cause incorrect behavior but makes the logic less symmetric than the PR description implies.

`deploy-api`'s `Check Cloudflare credentials` step — the `pull_request` branch inside the shell script is unreachable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/cloud-cf-deploy.yml | Adds per-event-type credential check logic to both deploy jobs — fails loudly on push/dispatch and soft-skips on PR. deploy-api's pull_request branch is unreachable dead code due to the job-level `if: github.event_name != 'pull_request'` guard. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered] --> B{Event type?}
    B -- push / workflow_dispatch --> C[deploy-api runs\ndeploy-frontend runs]
    B -- pull_request --> D[deploy-api SKIPPED\nby job-level guard]
    D --> E[deploy-frontend runs]

    C --> F{Secrets present?}
    E --> G{Secrets present?}

    F -- yes --> H[configured=true\nDeploy runs]
    F -- no --> I["::error:: + exit 1\nJob failed"]

    G -- yes --> J[configured=true\nDeploy runs]
    G -- no --> K{Event = pull_request?}
    K -- yes --> L["::warning:: to summary\nDeploy skipped, job passes"]
    K -- no --> M["::error:: + exit 1\nJob failed"]
```

<sub>Reviews (1): Last reviewed commit: ["ci(cloud-cf-deploy): fail loud when CF s..."](https://github.com/elizaos/eliza/commit/678608d8b4a67689f131f423d9582005b194bf39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31576766)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->