### PR TITLE
fix(core): strip internal task-agent labels and PTY session IDs from messageToUser

### DIFF
--- a/packages/core/src/prompts/evaluator.ts
+++ b/packages/core/src/prompts/evaluator.ts
@@ -17,6 +17,7 @@ rules:
 - if the response would need any unexecuted tool/action side effect to be true, choose CONTINUE; do not imagine the missing result
 - messageToUser is optional progress, diagnosis, question, or final output
 - messageToUser is shown directly to the user; never include internal thoughts, tool names, function syntax, JSON/tool-call attempts, or analysis
+- messageToUser must read like a human teammate, not a meta-orchestrator; never expose internal session ids (e.g. "pty-1778500471501-4cf0e3a6"), auto-generated task-agent labels (e.g. "count-py-files-projects-1", "write-arxiv-grab-py-1"), or enumerate sub-agent names — speak as the agent doing the work, not the dispatcher
 - when decision is FINISH after tool use, include messageToUser with the concise user-facing answer or status grounded in the completed tool results
 - do not paste raw tool transcripts, command banners, or internal logs as messageToUser unless the user explicitly asked for raw output
 - copyToClipboard is optional and must include title and content

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -195,4 +195,110 @@ describe("v5 evaluator skeleton", () => {
 		expect(result.decision).toBe("FINISH");
 		expect(result.success).toBe(true);
 	});
+
+	it("strips internal task-agent session-ids and auto-generated labels from messageToUser", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Both agents spawned.",
+  "messageToUser": "Both agents spawned in parallel (count-py-files-projects-1 and count-ts-files-iqlabs-1). I'll reply with both numbers when they finish."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.messageToUser).not.toContain("count-py-files-projects-1");
+		expect(result.messageToUser).not.toContain("count-ts-files-iqlabs-1");
+		expect(result.messageToUser).toContain("Both agents spawned in parallel.");
+		expect(result.messageToUser).toContain("when they finish");
+	});
+
+	it("strips bare PTY session ids and (session: pty-...) parentheticals", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Spawned.",
+  "messageToUser": "on it — task agent is running (session: pty-1778500471501-4cf0e3a6). it'll write /tmp/x.py and verify."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.messageToUser).not.toMatch(/pty-\d+-[A-Za-z0-9]+/);
+		expect(result.messageToUser).not.toMatch(/\(session/);
+		expect(result.messageToUser).toContain("/tmp/x.py");
+	});
+
+	it("leaves messageToUser unchanged when no mechanics are mentioned", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => `{
+  "success": true,
+  "decision": "FINISH",
+  "thought": "Got it.",
+  "messageToUser": "190G free on / (387G total, 198G used, 52% used)."
+}`,
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.messageToUser).toBe(
+			"190G free on / (387G total, 198G used, 52% used).",
+		);
+	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -105,9 +105,8 @@ export async function runEvaluator(
 		params.provider,
 	);
 	const endedAt = Date.now();
-	const output = repairMissingEvaluatorSuccess(
-		parseEvaluatorOutput(raw),
-		params.trajectory,
+	const output = sanitizeOutputMessage(
+		repairMissingEvaluatorSuccess(parseEvaluatorOutput(raw), params.trajectory),
 	);
 	const streamingContext = getStreamingContext();
 	await emitStreamingHook(streamingContext, "onEvaluation", {
@@ -317,6 +316,77 @@ export function parseEvaluatorOutput(
 				: undefined,
 		raw: parsed as Record<string, unknown>,
 	};
+}
+
+/**
+ * Patterns that match internal orchestration mechanics the LLM
+ * sometimes echoes into `messageToUser` after a TASKS / sub-agent
+ * spawn. They expose implementation details (auto-generated agent
+ * labels, raw PTY session IDs, multi-agent enumeration verbiage) and
+ * read as robotic to the human on the other end of the chat.
+ *
+ * Each pattern is conservative: it targets a parenthetical / inline
+ * annotation that the LLM appends as metadata, not the surrounding
+ * natural language. The replacement either drops the parenthetical
+ * entirely or substitutes a neutral phrase, then collapses any
+ * doubled whitespace.
+ */
+const INTERNAL_MECHANIC_PATTERNS: ReadonlyArray<{
+	pattern: RegExp;
+	replacement: string;
+}> = [
+	// "(session: pty-1778500471501-4cf0e3a6)", "(session pty-...)"
+	{
+		pattern: /\s*\((?:session(?:[- _]?id)?\s*[:=]?\s*)?pty-\d+-[A-Za-z0-9]+\)/g,
+		replacement: "",
+	},
+	// Bare session IDs "pty-1778500471501-4cf0e3a6" anywhere in the message
+	{ pattern: /\s+pty-\d+-[A-Za-z0-9]+/g, replacement: "" },
+	// "(session write-arxiv-grab-py-1)" / "(write-arxiv-grab-py-1)" /
+	// "(count-py-files-projects-1 and count-ts-files-iqlabs-1)" —
+	// auto-generated labels in parens.
+	{
+		pattern:
+			/\s*\((?:session\s*[:=]?\s*|sessions?\s+)?(?:[a-z][a-z0-9]*-)+\d+(?:\s+and\s+(?:[a-z][a-z0-9]*-)+\d+)*\)/g,
+		replacement: "",
+	},
+	// "session write-arxiv-grab-py-1" inline (no parens).
+	{
+		pattern: /\s+session\s+(?:[a-z][a-z0-9]*-)+\d+/g,
+		replacement: "",
+	},
+	// "task-agent / task_agent / subagent" mechanic phrases that
+	// surface as "task-agent count-py-files-projects-1" right before
+	// a label. Drop the prefix; keep "agent" in the natural-language
+	// sense by mapping to "agent" only when the label follows.
+	{
+		pattern: /\b(?:task[-_]agent|subagent)\s+(?:[a-z][a-z0-9]*-)+\d+/g,
+		replacement: "agent",
+	},
+];
+
+function sanitizeMessageToUser(text: string): string {
+	let cleaned = text;
+	for (const { pattern, replacement } of INTERNAL_MECHANIC_PATTERNS) {
+		cleaned = cleaned.replace(pattern, replacement);
+	}
+	// Collapse multiple spaces introduced by the substitutions and
+	// trim trailing space before punctuation (", ." -> ".").
+	cleaned = cleaned.replace(/[ \t]{2,}/g, " ");
+	cleaned = cleaned.replace(/\s+([.,!?:;])/g, "$1");
+	return cleaned.trim();
+}
+
+function sanitizeOutputMessage(output: EvaluatorOutput): EvaluatorOutput {
+	if (typeof output.messageToUser !== "string") return output;
+	const sanitized = sanitizeMessageToUser(output.messageToUser);
+	if (sanitized === output.messageToUser) return output;
+	if (sanitized.length === 0) {
+		// If sanitization removed everything, drop messageToUser so the
+		// runtime doesn't post an empty Discord message.
+		return { ...output, messageToUser: undefined };
+	}
+	return { ...output, messageToUser: sanitized };
 }
 
 function repairMissingEvaluatorSuccess(


### PR DESCRIPTION
## Summary

The bot reads robotic / exposes implementation plumbing whenever a TASKS / SPAWN_AGENT turn produces a user-facing reply:

```
on it — task agent is running (session write-arxiv-grab-py-1)...
Both agents spawned in parallel (count-py-files-projects-1 and count-ts-files-iqlabs-1). I'll reply with both numbers when they finish.
```

Auto-generated agent labels and raw PTY session IDs are orchestration plumbing — useful in logs / trajectory data, NOT in chat. The bot should sound like a human teammate, not a dispatcher.

## Fix

Two layers:

### 1. Prompt rule (evaluator template)

Added one bullet to the evaluator's `messageToUser` rules:

> messageToUser must read like a human teammate, not a meta-orchestrator; never expose internal session ids (e.g. "pty-1778500471501-4cf0e3a6"), auto-generated task-agent labels (e.g. "count-py-files-projects-1", "write-arxiv-grab-py-1"), or enumerate sub-agent names — speak as the agent doing the work, not the dispatcher

### 2. Server-side sanitizer (`sanitizeMessageToUser`)

Even with the prompt rule, the LLM still echoes labels when the TASKS action data exposes them. Belt-and-suspenders: run a sanitizer at the same chokepoint as the existing FINISH/CONTINUE repairs, before `applyEvaluatorEffects` posts to chat.

Conservative pattern list — only strips parentheticals / inline metadata that match the actual auto-generated formats:

- `(session: pty-NNNN-XXXX)` and `(session pty-...)` parentheticals
- bare `pty-NNNN-XXXX` session-id mentions anywhere in the message
- `(count-X-files-Y-N and count-X-files-Y-M)` style auto-label parentheticals
- inline `session <auto-label>` mentions
- `task-agent <auto-label>` / `subagent <auto-label>` prefixes → "agent"

If sanitization empties the message entirely, drop `messageToUser` so the runtime doesn't post a blank Discord reply.

## Test plan

- [x] Three new tests in `packages/core/src/runtime/__tests__/evaluator.test.ts`:
  - parenthetical label list strip
  - bare PTY session-id + `(session: pty-...)` strip
  - clean message passthrough (no false-positive scrubbing of e.g. `190G total, 198G used`)
- [x] 8/8 evaluator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a two-layer defence against the bot exposing orchestration internals (PTY session IDs, auto-generated task-agent labels) in user-facing chat: a new prompt rule in the evaluator template, and a server-side `sanitizeMessageToUser` function that applies five conservative regex patterns to `messageToUser` before it reaches chat.

- **`packages/core/src/runtime/evaluator.ts`**: `sanitizeOutputMessage` wraps the existing `repairMissingEvaluatorSuccess` \u2192 `parseEvaluatorOutput` pipeline; five `INTERNAL_MECHANIC_PATTERNS` strip PTY parentheticals, bare session IDs, auto-label lists, inline session references, and `task-agent`/`subagent` prefixes, with empty-result guarding.
- **`packages/core/src/prompts/evaluator.ts`**: One bullet added to the `messageToUser` rules asking the LLM to speak as a human teammate rather than exposing sub-agent names or session IDs.
- **`packages/core/src/runtime/__tests__/evaluator.test.ts`**: Three tests cover the label-list strip, PTY-session strip, and a passthrough guard; Patterns 4 and 5 remain untested.

<h3>Confidence Score: 5/5</h3>

The change is a narrow, additive sanitization pass on a single string field and cannot affect decision, success, or any other evaluator output.

The sanitizer only mutates messageToUser after the existing repair pipeline; the empty-result guard prevents blank chat posts. The passthrough test confirms no false-positive scrubbing on real-looking disk-usage strings.

The five regex patterns in packages/core/src/runtime/evaluator.ts deserve a second look for breadth — particularly Pattern 3, which was flagged for matching overly simple word-N forms.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/evaluator.ts | Adds sanitizeOutputMessage/sanitizeMessageToUser pipeline applied to every evaluator output; five regex patterns strip PTY session IDs, auto-generated agent labels, and related orchestration phrases from messageToUser before it reaches chat. |
| packages/core/src/prompts/evaluator.ts | Adds one prompt rule instructing the LLM not to expose internal session IDs or auto-generated task-agent labels in messageToUser. Minimal and well-targeted change. |
| packages/core/src/runtime/__tests__/evaluator.test.ts | Three new tests cover Pattern 1 (session: pty-...), Pattern 3 (parenthetical label list), and the no-false-positive passthrough case. Patterns 4 and 5 are not exercised by any test. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LLM raw output] --> B[parseEvaluatorOutput]
    B --> C[repairMissingEvaluatorSuccess]
    C --> D[sanitizeOutputMessage]
    D --> E{messageToUser is a string?}
    E -- No --> F[Return output unchanged]
    E -- Yes --> G[sanitizeMessageToUser]
    G --> H[Pattern 1: strip pty- parentheticals]
    H --> I[Pattern 2: strip bare pty- IDs]
    I --> J[Pattern 3: strip auto-label parentheticals]
    J --> K[Pattern 4: strip inline session labels]
    K --> L[Pattern 5: task-agent/subagent label to agent]
    L --> M[Collapse whitespace and trim]
    M --> N{sanitized == original?}
    N -- Yes --> O[Return output unchanged]
    N -- No --> P{sanitized is empty?}
    P -- Yes --> Q[Drop messageToUser]
    P -- No --> R[Return with sanitized messageToUser]
    R --> S[applyEvaluatorEffects to chat]
    Q --> S
    O --> S
    F --> S
```

<sub>Reviews (2): Last reviewed commit: ["fix(core): strip internal task-agent lab..."](https://github.com/elizaos/eliza/commit/53b48d1a5527ce35041b212cd9728583e611d08b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31582340)</sub>

<!-- /greptile_comment -->