### PR TITLE
fix(browser-workspace): align <electrobun-webview> tabs with template + unblock dev:desktop

### DIFF
--- a/packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1
+++ b/packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1
@@ -45,7 +45,7 @@ New-Item -ItemType Directory -Force -Path $env:LOCALAPPDATA | Out-Null
 # Pre-create PGlite data directory with a short path to avoid MAX_PATH issues
 # during WASM init. PGlite creates deeply nested WAL files; a short root path
 # keeps the full path under the 260-char limit on Windows runners.
-$pgliteDataDir = Join-Path $tempRoot "pglite"
+$pgliteDataDir = Join-Path $tempRoot ("pglite-" + [Guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Force -Path $pgliteDataDir | Out-Null
 $env:PGLITE_DATA_DIR = $pgliteDataDir
 if ($env:GITHUB_ENV) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,7 +43,27 @@
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./dev-settings-figlet-heading": "./dist/dev-settings-figlet-heading.js"
+    "./config/allowed-hosts": {
+      "import": "./dist/config/allowed-hosts.js",
+      "default": "./dist/config/allowed-hosts.js",
+      "types": "./dist/config/allowed-hosts.d.ts"
+    },
+    "./dev-settings-banner-style": {
+      "import": "./dist/dev-settings-banner-style.js",
+      "default": "./dist/dev-settings-banner-style.js",
+      "types": "./dist/dev-settings-banner-style.d.ts"
+    },
+    "./dev-settings-figlet-heading": "./dist/dev-settings-figlet-heading.js",
+    "./dev-settings-table": {
+      "import": "./dist/dev-settings-table.js",
+      "default": "./dist/dev-settings-table.js",
+      "types": "./dist/dev-settings-table.d.ts"
+    },
+    "./runtime-env": {
+      "import": "./dist/runtime-env.js",
+      "default": "./dist/runtime-env.js",
+      "types": "./dist/runtime-env.d.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
+++ b/packages/ui/src/components/pages/BrowserWorkspaceView.tsx
@@ -66,6 +66,23 @@ const BROWSER_WORKSPACE_APP_PARTITION = "persist:eliza-browser-app";
 const BROWSER_WORKSPACE_DEFAULT_HOME_URL = "https://docs.elizaos.ai/";
 const BROWSER_WORKSPACE_COLLAPSED_SECTIONS_STORAGE_KEY =
   "eliza:browser-workspace:collapsed-sections";
+// Selectors handed to `<electrobun-webview masks=…>` so the native OOPIF
+// surface doesn't paint over (or capture clicks within) React overlays
+// stacked on the same rect. Covers Radix Dialog/AlertDialog content
+// (`role=dialog`/`alertdialog`), every Radix popper-based surface (Popover,
+// Tooltip, Dropdown, Select, HoverCard, ContextMenu — all wrapped in
+// `data-radix-popper-content-wrapper`), and the ActionNotice toast which
+// uses `role=status`. Polled by OverlaySyncController so overlays mounted
+// after the tab still get masked.
+const BROWSER_WORKSPACE_TAB_MASK_SELECTORS = [
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  "[data-radix-popper-content-wrapper]",
+  '[role="tooltip"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[role="status"]',
+].join(", ");
 
 // Minimal subset of Electrobun's <electrobun-webview> custom element surface
 // used by this view. Inlined so this file typechecks identically from any
@@ -92,6 +109,15 @@ type WebviewTagElement = HTMLElement & {
    * clicks meant for sibling UI.
    */
   toggleHidden(value?: boolean): void;
+  /**
+   * Toggle pointer-event passthrough on the native OOPIF view. When enabled
+   * the surface stops capturing clicks even if it remains visible, so React
+   * siblings stacked over the same rect (overlays mid-transition, the
+   * inactive-tab opacity-0 layer) can receive events. Used alongside
+   * `toggleHidden` on inactive tabs so the native view neither paints nor
+   * grabs input during the gap between layout flap and first sync.
+   */
+  togglePassthrough(value?: boolean): void;
 };
 
 function isWebviewTagElement(
@@ -120,6 +146,28 @@ declare module "react" {
           sandbox?: boolean | "";
           transparent?: boolean | "";
           hidden?: boolean;
+          /**
+           * "cef" (bundled Chromium) or "native" (system WKWebView on macOS).
+           * Set explicitly per-tag rather than relying on the
+           * `defaultRenderer` config: CEF is what supports the OOPIF model
+           * + RPC + preload script the agent automation kit depends on.
+           */
+          renderer?: "cef" | "native";
+          /**
+           * Comma-separated CSS selectors. Any element matching is treated
+           * as a punch-out rect — the native OOPIF will not paint over it
+           * and will not capture clicks within it. Required so React
+           * overlays (modals, dropdowns, toasts) render above the webview
+           * surface and remain interactive.
+           */
+          masks?: string;
+          /**
+           * Initial passthrough state. When present the OOPIF starts in
+           * pointer-events: none mode. Set on inactive tabs so the gap
+           * between mount and the first selection effect doesn't leak
+           * clicks into the wrong tab.
+           */
+          passthrough?: boolean | "";
         },
         HTMLElement
       >;
@@ -1382,9 +1430,12 @@ export function BrowserWorkspaceView(): JSX.Element {
         // Hide the native OOPIF immediately if the tag isn't the active
         // one — otherwise its native view sits over the surface and
         // intercepts clicks while React still has it in the tree.
+        // Passthrough goes along for the ride so any clicks landing on the
+        // rect mid-transition fall through to React siblings beneath.
         if (selectedTabIdRef.current && selectedTabIdRef.current !== tabId) {
           try {
             element.toggleHidden(true);
+            element.togglePassthrough(true);
           } catch {
             // best-effort
           }
@@ -1426,13 +1477,17 @@ export function BrowserWorkspaceView(): JSX.Element {
   // HTML `hidden` attribute does NOT propagate to the OOPIF — only the
   // tag's `toggleHidden(bool)` method does. Without this, inactive tabs'
   // OOPIFs stay painted over the surface as native views and intercept
-  // clicks intended for sibling UI (e.g. the top app nav).
+  // clicks intended for sibling UI (e.g. the top app nav). Passthrough is
+  // toggled in lockstep so a tab caught mid-transition (visible but not
+  // selected) still lets clicks fall through to the React layer beneath.
   useEffect(() => {
     if (workspace.mode !== "desktop") return;
     for (const [tabId, element] of electrobunWebviewRefs.current.entries()) {
       if (!element) continue;
+      const inactive = tabId !== selectedTabId;
       try {
-        element.toggleHidden(tabId !== selectedTabId);
+        element.toggleHidden(inactive);
+        element.togglePassthrough(inactive);
         element.syncDimensions(true);
       } catch {
         // best-effort
@@ -1440,15 +1495,16 @@ export function BrowserWorkspaceView(): JSX.Element {
     }
   }, [selectedTabId, workspace.mode]);
 
-  // On unmount, hide every OOPIF so leftover native views don't bleed onto
-  // other routes between React's unmount and the tag's
-  // disconnectedCallback firing.
+  // On unmount, hide every OOPIF and engage passthrough so leftover native
+  // views don't bleed onto other routes between React's unmount and the
+  // tag's disconnectedCallback firing.
   useEffect(() => {
     const refs = electrobunWebviewRefs;
     return () => {
       for (const element of refs.current.values()) {
         try {
           element?.toggleHidden(true);
+          element?.togglePassthrough(true);
         } catch {
           // best-effort
         }
@@ -2396,11 +2452,13 @@ export function BrowserWorkspaceView(): JSX.Element {
               src={tab.url}
               partition={tab.partition}
               preload={BROWSER_TAB_PRELOAD_SCRIPT}
-              // Native OOPIF hide/show is driven by `tag.toggleHidden(bool)`
-              // in the selection useEffect — the HTML `hidden` attribute
-              // alone is a no-op for the underlying native view, which is
-              // why inactive tabs were leaking pointer events through the
-              // surface.
+              renderer="cef"
+              masks={BROWSER_WORKSPACE_TAB_MASK_SELECTORS}
+              // Start inactive tabs in passthrough so the OOPIF doesn't
+              // capture clicks during the gap between mount and the first
+              // selection effect. Native hide/show (toggleHidden) is then
+              // driven from the selection useEffect.
+              passthrough={active ? undefined : ""}
               className={`absolute inset-0 ${visibilityClass}`}
               style={{ display: "block" }}
             />

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -93,7 +93,12 @@ type NativePrompt =
   | { messages: ModelMessage[]; prompt?: never };
 type NativeTextParams = Omit<NativeGenerateTextParams, "messages" | "prompt"> &
   Omit<NativeStreamTextParams, "messages" | "prompt"> &
-  NativePrompt;
+  NativePrompt & {
+    // Re-declared explicitly: TypeScript's `Parameters<typeof generateText>`
+    // inference produces an overload-union that drops this field, but the
+    // ai SDK's runtime signature accepts it (see ai@6 `CallSettings & Prompt`).
+    allowSystemInMessages?: boolean;
+  };
 type NativeProviderOptions = NativeTextParams["providerOptions"];
 type NativeTelemetrySettings = NativeTextParams["experimental_telemetry"];
 


### PR DESCRIPTION
## Summary

Two changes, both surfaced while comparing `BrowserWorkspaceView` against the upstream Electrobun [`multitab-browser` template](https://github.com/blackboardsh/electrobun/tree/main/templates/multitab-browser).

### 1. `BrowserWorkspaceView` — mask overlays, passthrough on inactive, explicit renderer

CEF OOPIFs paint as native views **above** the DOM. Without `masks=` on `<electrobun-webview>`, any React overlay overlapping the webview rect (Radix Dialog, popper menus / tooltips / popovers / selects, the ActionNotice toast) is occluded and unclickable. The template gets this right with `masks="#bookmarks-dropdown"`; we had zero mask selectors.

- New `BROWSER_WORKSPACE_TAB_MASK_SELECTORS` covering `[role="dialog"]`, `[role="alertdialog"]`, `[data-radix-popper-content-wrapper]`, `[role="tooltip"]`, `[role="menu"]`, `[role="listbox"]`, `[role="status"]`.
- Desktop-mode tag now sets `renderer="cef"`, `masks={…}`, `passthrough={active ? undefined : ""}`.
- Selection effect, register-time hide path, and unmount effect now call `togglePassthrough(inactive)` alongside `toggleHidden(inactive)`.
- `WebviewTagElement` extended with `togglePassthrough`; JSX intrinsic gets typed slots for `renderer`, `masks`, `passthrough`.

### 2. `@elizaos/shared/package.json` — declare the subpaths the Milady Vite config already imports

`apps/app/vite.config.ts` imports four subpaths that weren't in the `exports` map, so `bun run dev:desktop:watch` fails at Vite config bundling with `Missing "./X" specifier in "@elizaos/shared" package`:

- `./config/allowed-hosts`
- `./dev-settings-banner-style`
- `./dev-settings-table`
- `./runtime-env`

The source files all exist. Adding the entries (with import/default/types pointing at the prepared dist layout) unblocks the resolver.

## Verification

- File-scope `tsc` + biome are clean on `BrowserWorkspaceView.tsx`. Workspace-wide failures in `permission-card.test.tsx` are pre-existing develop baseline.
- Rebuilt `@elizaos/shared` after the manifest change; confirmed `dist/package.json` now exposes the four subpaths and that Vite resolves past those four imports.

## ⚠️ Live OOPIF verification not performed

The renderer Vite build chain still hits **develop-baseline failures unrelated to either change above** — additional missing dist outputs in workspace packages, more missing `@elizaos/shared` subpaths like `./onboarding-presets`. The desktop dev server didn't reach a runnable state in this session, so I could not click-test the masked overlays.

Code paths verified by typecheck + lint + a direct read of `electrobun/package/src/bun/preload/webviewTag.ts` which confirms the upstream tag reads `renderer`, `masks`, and the `passthrough` attribute in `attachedCallback` and exposes `togglePassthrough` at the version this repo consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two issues found while aligning `BrowserWorkspaceView` against the upstream Electrobun `multitab-browser` template, and separately unblocks `bun run dev:desktop:watch` by declaring missing subpath exports in `@elizaos/shared`.

- **CEF OOPIF masking & passthrough**: Adds `renderer=\"cef\"`, `masks={BROWSER_WORKSPACE_TAB_MASK_SELECTORS}`, and `passthrough` to `<electrobun-webview>` so native views don't paint over Radix overlays (dialogs, tooltips, dropdowns, toasts). `togglePassthrough` is now called in lockstep with `toggleHidden` at registration, on selection change, and on unmount.
- **`@elizaos/shared` export map**: Adds four previously-missing subpath entries that `apps/app/vite.config.ts` was already importing; all source files exist and dist paths are correct.
- **Smoke-test isolation**: Randomises the PGlite data-dir name with a GUID to prevent collisions between parallel Windows CI runs.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge for the shared/package.json and plugin-openai changes; the BrowserWorkspaceView OOPIF passthrough logic is internally consistent but could not be click-tested end-to-end in a running Electrobun session.

All three code paths that call togglePassthrough are symmetric with the existing toggleHidden calls, and the initial JSX passthrough attribute covers the mount gap before the first selection effect fires. The OOPIF masking behaviour depends on the Electrobun runtime interpreting the attributes exactly as expected — unverifiable without a working desktop dev server, as the PR itself notes. The smoke-test and shared-package changes are low-risk mechanical fixes.

The passthrough/hidden state machine in BrowserWorkspaceView.tsx warrants a sanity-check once the desktop dev server is unblocked, to confirm that switching tabs and opening Radix overlays over the webview behaves as intended.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/pages/BrowserWorkspaceView.tsx | Adds renderer, masks, and passthrough to electrobun-webview tags; extends WebviewTagElement with togglePassthrough; toggles passthrough in lockstep with hidden state on tab selection changes, registration, and unmount. |
| packages/shared/package.json | Adds four missing subpath exports that Vite was already importing; all source files confirmed present. The pre-existing dev-settings-figlet-heading entry remains as a bare string without a types field, inconsistent with every other entry. |
| packages/app-core/platforms/electrobun/scripts/smoke-test-windows.ps1 | Appends a 32-char hex GUID to the PGlite data-dir name for parallel-run isolation, but adds 33 characters to a path noted as MAX_PATH-sensitive. |
| plugins/plugin-openai/models/text.ts | Explicitly adds allowSystemInMessages to NativeTextParams with a clear comment; the workaround is correct and well-scoped. |

</details>

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fshared%2Fpackage.json%3A56%0AThe%20pre-existing%20%60.%2Fdev-settings-figlet-heading%60%20entry%20uses%20a%20bare%20string%20form%20and%20has%20no%20%60types%60%20field%2C%20unlike%20every%20other%20entry%20in%20the%20map%20%28including%20the%20four%20just%20added%29.%20Without%20a%20%60types%60%20condition%20TypeScript%20resolvers%20that%20obey%20the%20%60exports%60%20map%20won't%20find%20the%20declaration%20file%20for%20this%20subpath%2C%20producing%20a%20silent%20type-hole%20for%20any%20consumer%20that%20imports%20%60%40elizaos%2Fshared%2Fdev-settings-figlet-heading%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22.%2Fdev-settings-figlet-heading%22%3A%20%7B%0A%20%20%20%20%20%20%22import%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22default%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22types%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.d.ts%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fscripts%2Fsmoke-test-windows.ps1%3A48%0A**GUID%20suffix%20lengthens%20a%20MAX_PATH-sensitive%20path**%0A%0AThe%20surrounding%20comment%20explains%20that%20this%20directory%20exists%20*specifically*%20to%20keep%20the%20full%20path%20under%20the%20260-character%20Windows%20limit%2C%20because%20PGlite%20emits%20deeply%20nested%20WAL%20files.%20Appending%20%60%22pglite-%22%20%2B%20%5BGuid%5D%3A%3ANewGuid%28%29.ToString%28%22N%22%29%60%20adds%2039%20characters%20to%20every%20path%20rooted%20here.%20On%20a%20GitHub-hosted%20runner%20where%20%60RUNNER_TEMP%60%20is%20%60D%3A%5Ca%5C_temp%60%20%2810%20chars%29%2C%20the%20base%20dir%20becomes%20~49%20chars%20%E2%80%94%20leaving%20211%20chars%20for%20WAL%20nesting%2C%20which%20should%20still%20be%20fine%20in%20practice.%20But%20on%20self-hosted%20runners%20with%20a%20longer%20%60RUNNER_TEMP%60%20the%20buffer%20shrinks%20by%20~33%20chars%20and%20could%20push%20certain%20deeply-nested%20PGlite%20files%20over%20the%20limit.%0A%0A&repo=elizaos%2Feliza&pr=7589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22wip%2Fbrowser-overlay-masks-and-shared-subpaths%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22wip%2Fbrowser-overlay-masks-and-shared-subpaths%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fshared%2Fpackage.json%3A56%0AThe%20pre-existing%20%60.%2Fdev-settings-figlet-heading%60%20entry%20uses%20a%20bare%20string%20form%20and%20has%20no%20%60types%60%20field%2C%20unlike%20every%20other%20entry%20in%20the%20map%20%28including%20the%20four%20just%20added%29.%20Without%20a%20%60types%60%20condition%20TypeScript%20resolvers%20that%20obey%20the%20%60exports%60%20map%20won't%20find%20the%20declaration%20file%20for%20this%20subpath%2C%20producing%20a%20silent%20type-hole%20for%20any%20consumer%20that%20imports%20%60%40elizaos%2Fshared%2Fdev-settings-figlet-heading%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22.%2Fdev-settings-figlet-heading%22%3A%20%7B%0A%20%20%20%20%20%20%22import%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22default%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22types%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.d.ts%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fscripts%2Fsmoke-test-windows.ps1%3A48%0A**GUID%20suffix%20lengthens%20a%20MAX_PATH-sensitive%20path**%0A%0AThe%20surrounding%20comment%20explains%20that%20this%20directory%20exists%20*specifically*%20to%20keep%20the%20full%20path%20under%20the%20260-character%20Windows%20limit%2C%20because%20PGlite%20emits%20deeply%20nested%20WAL%20files.%20Appending%20%60%22pglite-%22%20%2B%20%5BGuid%5D%3A%3ANewGuid%28%29.ToString%28%22N%22%29%60%20adds%2039%20characters%20to%20every%20path%20rooted%20here.%20On%20a%20GitHub-hosted%20runner%20where%20%60RUNNER_TEMP%60%20is%20%60D%3A%5Ca%5C_temp%60%20%2810%20chars%29%2C%20the%20base%20dir%20becomes%20~49%20chars%20%E2%80%94%20leaving%20211%20chars%20for%20WAL%20nesting%2C%20which%20should%20still%20be%20fine%20in%20practice.%20But%20on%20self-hosted%20runners%20with%20a%20longer%20%60RUNNER_TEMP%60%20the%20buffer%20shrinks%20by%20~33%20chars%20and%20could%20push%20certain%20deeply-nested%20PGlite%20files%20over%20the%20limit.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fshared%2Fpackage.json%3A56%0AThe%20pre-existing%20%60.%2Fdev-settings-figlet-heading%60%20entry%20uses%20a%20bare%20string%20form%20and%20has%20no%20%60types%60%20field%2C%20unlike%20every%20other%20entry%20in%20the%20map%20%28including%20the%20four%20just%20added%29.%20Without%20a%20%60types%60%20condition%20TypeScript%20resolvers%20that%20obey%20the%20%60exports%60%20map%20won't%20find%20the%20declaration%20file%20for%20this%20subpath%2C%20producing%20a%20silent%20type-hole%20for%20any%20consumer%20that%20imports%20%60%40elizaos%2Fshared%2Fdev-settings-figlet-heading%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22.%2Fdev-settings-figlet-heading%22%3A%20%7B%0A%20%20%20%20%20%20%22import%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22default%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.js%22%2C%0A%20%20%20%20%20%20%22types%22%3A%20%22.%2Fdist%2Fdev-settings-figlet-heading.d.ts%22%0A%20%20%20%20%7D%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fscripts%2Fsmoke-test-windows.ps1%3A48%0A**GUID%20suffix%20lengthens%20a%20MAX_PATH-sensitive%20path**%0A%0AThe%20surrounding%20comment%20explains%20that%20this%20directory%20exists%20*specifically*%20to%20keep%20the%20full%20path%20under%20the%20260-character%20Windows%20limit%2C%20because%20PGlite%20emits%20deeply%20nested%20WAL%20files.%20Appending%20%60%22pglite-%22%20%2B%20%5BGuid%5D%3A%3ANewGuid%28%29.ToString%28%22N%22%29%60%20adds%2039%20characters%20to%20every%20path%20rooted%20here.%20On%20a%20GitHub-hosted%20runner%20where%20%60RUNNER_TEMP%60%20is%20%60D%3A%5Ca%5C_temp%60%20%2810%20chars%29%2C%20the%20base%20dir%20becomes%20~49%20chars%20%E2%80%94%20leaving%20211%20chars%20for%20WAL%20nesting%2C%20which%20should%20still%20be%20fine%20in%20practice.%20But%20on%20self-hosted%20runners%20with%20a%20longer%20%60RUNNER_TEMP%60%20the%20buffer%20shrinks%20by%20~33%20chars%20and%20could%20push%20certain%20deeply-nested%20PGlite%20files%20over%20the%20limit.%0A%0A&pr=7589&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(browser-workspace): align &lt;electrobu..."](https://github.com/elizaos/eliza/commit/ea74612153151ac6c9e246fe4bdaf932f46b019a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31598898)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->