### PR TITLE
fix(app-core): restore platform/native-plugin-entrypoints source + expose via exports

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -50,6 +50,16 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./platform/native-plugin-entrypoints": {
+      "import": "./dist/platform/native-plugin-entrypoints.js",
+      "default": "./dist/platform/native-plugin-entrypoints.js",
+      "types": "./dist/platform/native-plugin-entrypoints.d.ts"
+    },
+    "./platform/empty-node-module": {
+      "import": "./dist/platform/empty-node-module.js",
+      "default": "./dist/platform/empty-node-module.js",
+      "types": "./dist/platform/empty-node-module.d.ts"
     }
   },
   "peerDependencies": {

--- a/packages/app-core/src/platform/native-plugin-entrypoints.ts
+++ b/packages/app-core/src/platform/native-plugin-entrypoints.ts
@@ -1,0 +1,24 @@
+// Side-effect barrel that registers every elizaOS Capacitor native plugin so
+// it's available on mobile boot. Each import pulls in the plugin's
+// `web.ts` / `native` registration code under the hood.
+//
+// The published `@elizaos/app-core` npm package contains this file as a
+// publish-time generated entrypoint; the source tree version exists so
+// `MILADY_ELIZA_SOURCE=local` consumers can resolve the same import path
+// against linked workspace packages.
+
+/// <reference path="./capacitor-plugin-modules.d.ts" />
+import "@elizaos/capacitor-camera";
+import "@elizaos/capacitor-canvas";
+import "@elizaos/capacitor-contacts";
+import "@elizaos/capacitor-gateway";
+import "@elizaos/capacitor-location";
+import "@elizaos/capacitor-messages";
+import "@elizaos/capacitor-mobile-signals";
+import "@elizaos/capacitor-appblocker";
+import "@elizaos/capacitor-phone";
+import "@elizaos/capacitor-screencapture";
+import "@elizaos/capacitor-swabble";
+import "@elizaos/capacitor-system";
+import "@elizaos/capacitor-talkmode";
+import "@elizaos/capacitor-websiteblocker";


### PR DESCRIPTION
## Summary

Restores `platform/native-plugin-entrypoints` to source + adds its (plus `platform/empty-node-module`'s) exports entries to `@elizaos/app-core/package.json`.

## What was missing

`packages/app-core/src/platform/native-plugin-entrypoints.ts` is a side-effect barrel that imports every elizaOS Capacitor native plugin so mobile apps register them at WebView boot. Downstream apps statically import it at the top of their renderer entry:

\`\`\`ts
// e.g. milady/apps/app/src/main.tsx
await import("@elizaos/app-core/platform/native-plugin-entrypoints");
\`\`\`

The published \`@elizaos/app-core@2.0.0-alpha.537\` tarball ships this file at \`packages/app-core/src/platform/native-plugin-entrypoints.js\` (with its \`.d.ts\`), generated at publish time — but it does NOT live in the source tree. So workspaces consuming app-core via \`MILADY_ELIZA_SOURCE=local\` fail at vite resolve time with:

> Package subpath './platform/native-plugin-entrypoints' is not defined by "exports"

Same story for \`platform/empty-node-module\`: file ships in dist, but no exports entry.

## Fix

1. Restore \`packages/app-core/src/platform/native-plugin-entrypoints.ts\` to source (content matches the published JS — side-effect imports for the 14 elizaOS Capacitor native plugins).
2. Add \`./platform/native-plugin-entrypoints\` and \`./platform/empty-node-module\` to \`packages/app-core/package.json\` \`exports\` map.

## Verified

Tested against milady \`MILADY_ELIZA_SOURCE=local bun run build:android\`. Before: vite fails at resolve. After: vite + gradle complete and produce a working APK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores `packages/app-core/src/platform/native-plugin-entrypoints.ts` to the source tree and adds `./platform/native-plugin-entrypoints` and `./platform/empty-node-module` to the `exports` map in `package.json`, fixing a Vite resolve failure for `MILADY_ELIZA_SOURCE=local` consumers that import these subpaths from the linked workspace.

- **`package.json` exports**: Two new subpath entries are added, both correctly pointing to `./dist/platform/...` paths. The `empty-node-module` source already existed; only its exports entry was missing.
- **`native-plugin-entrypoints.ts`**: A side-effect barrel that registers 14 elizaOS Capacitor plugins at WebView boot is restored to source; it carries a `/// <reference path>` directive pointing to `./capacitor-plugin-modules.d.ts`, a file that does not exist in `packages/app-core/src/platform/`, which will break `bun run typecheck`. The 14 imported plugin packages are also absent from `package.json` `dependencies` or `optionalDependencies`.

<h3>Confidence Score: 3/5</h3>

The package.json exports change is safe, but native-plugin-entrypoints.ts has a broken triple-slash reference and undeclared plugin dependencies that need resolution before merging.

The new native-plugin-entrypoints.ts references ./capacitor-plugin-modules.d.ts which does not exist in packages/app-core/src/platform/. Running bun run typecheck will fail with a file-not-found error. Additionally, none of the 14 @elizaos/capacitor-* packages imported by this barrel are listed in package.json, leaving the package graph incomplete for non-workspace consumers.

packages/app-core/src/platform/native-plugin-entrypoints.ts — broken reference path and undeclared dependencies warrant a closer look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/platform/native-plugin-entrypoints.ts | New side-effect barrel registering 14 Capacitor plugins; contains a broken triple-slash reference to a non-existent `capacitor-plugin-modules.d.ts` that will break `typecheck`, and the imported packages are absent from the `package.json` dependency graph. |
| packages/app-core/package.json | Adds two new `exports` entries (`./platform/native-plugin-entrypoints` and `./platform/empty-node-module`) pointing to the correct `dist/` paths; change is straightforward and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as Downstream App
    participant Vite
    participant AppCore as @elizaos/app-core exports
    participant Barrel as native-plugin-entrypoints.ts
    participant Plugins as @elizaos/capacitor-* (14 plugins)

    Consumer->>Vite: "import @elizaos/app-core/platform/native-plugin-entrypoints"
    Vite->>AppCore: resolve subpath via exports map
    Note over AppCore: Before PR: subpath missing, resolve fails
    Note over AppCore: After PR: maps to dist/platform/native-plugin-entrypoints.js
    AppCore-->>Vite: ./dist/platform/native-plugin-entrypoints.js
    Vite->>Barrel: load side-effect barrel
    Barrel->>Plugins: side-effect import each plugin
    Plugins-->>Consumer: all native plugins registered at WebView boot
```

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): restore platform/native-p..."](https://github.com/elizaos/eliza/commit/315b7ed40c4dcb3e70548130950a4f981b3cd59d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31614632)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->