### PR TITLE
fix(ui): expose dist/styles/*.css via exports map + ./package.json

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,9 @@
   },
   "exports": {
     ".": "./dist/index.js",
+    "./package.json": "./package.json",
     "./styles": "./dist/styles.js",
+    "./styles/*.css": "./dist/styles/*.css",
     "./api/client-types-cloud": "./dist/api/client-types-cloud.js",
     "./config/app-config": "./dist/config/app-config.js",
     "./onboarding-config": "./dist/onboarding-config.js"


### PR DESCRIPTION
## Summary

Adds `./styles/*.css` and `./package.json` to `@elizaos/ui`'s exports map.

## What was missing

`packages/ui/dist/styles/` ships 7 stylesheets (`base.css`, `brand-gold.css`, `electrobun-mac-window-drag.css`, `onboarding-game.css`, `styles.css`, `theme.css`, `xterm.css`). They're in the published tarball and used by every app shell, but the package.json `exports` field only declares `./styles` (the JS registry) — so consumers cannot do:

\`\`\`ts
import "@elizaos/ui/styles/styles.css";
\`\`\`

Vite/Rollup rejects this with: \`Missing "./styles/styles.css" specifier in "@elizaos/ui" package\`.

Same for \`./package.json\` — common pattern across the rest of the monorepo (\`@elizaos/app-core\` etc.) but missing here.

## Fix

Two-line additions to \`packages/ui/package.json\` \`exports\` map.

## Verified

milady's \`apps/app/src/main.tsx\` imports \`@elizaos/ui/styles/styles.css\` + \`@elizaos/ui/styles/brand-gold.css\`. Before this fix: \`Missing specifier\`. After: vite resolves cleanly + Rollup includes them in the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds two entries to the `@elizaos/ui` package's `exports` map so consumers can import individual CSS stylesheets and access `package.json` directly, resolving the Vite/Rollup `Missing specifier` error that prevented imports like `@elizaos/ui/styles/styles.css`.

- The `\"./styles/*.css\": \"./dist/styles/*.css\"` wildcard export is valid Node.js subpath exports syntax and is handled correctly by `prepare-package-dist.mjs`, which detects `.css` extensions via `isAssetPath()` and strips the `dist/` prefix — resulting in `\"./styles/*.css\"` in the published manifest.
- The `\"./package.json\": \"./package.json\"` entry is technically redundant: `prepare-package-dist.mjs` (lines 80–85) already auto-injects it when absent. Including it explicitly is harmless and makes the source exports field self-documenting.

<h3>Confidence Score: 5/5</h3>

Minimal, targeted change to a single config file with no logic affected — safe to merge.

Both additions to the exports map are correct: the CSS wildcard pattern is valid Node.js subpath exports syntax and integrates cleanly with the prepare-package-dist.mjs build pipeline, while the ./package.json entry matches an established monorepo pattern already applied to other packages.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/package.json | Adds `./styles/*.css` wildcard and `./package.json` to exports map; both entries are valid and transform correctly through the build pipeline |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer import\n@elizaos/ui/styles/styles.css"] --> B{exports map lookup}
    B -- before fix --> C["❌ Missing specifier\nVite/Rollup error"]
    B -- after fix --> D["./styles/*.css matches\n→ ./dist/styles/*.css"]
    D --> E["prepare-package-dist.mjs\nisAssetPath('.css') = true"]
    E --> F["transformAssetPath:\nstrip dist/ prefix"]
    F --> G["Published dist/package.json:\n./styles/*.css → ./styles/*.css"]
    G --> H["✅ Resolves to\ndist/styles/styles.css"]

    I["Consumer import\n@elizaos/ui/package.json"] --> J{exports map lookup}
    J --> K["./package.json entry found\n(explicit or auto-injected)"]
    K --> L["✅ Resolves to\ndist/package.json"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): expose dist/styles/\*.css via ex..."](https://github.com/elizaos/eliza/commit/a106d9767b4ea3510e94f9f6ed219c933c74edc5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31614648)</sub>

<!-- /greptile_comment -->