### PR TITLE
fix(agent): provider-switch stops stamping openai default models when OPENAI_BASE_URL is third-party

### DIFF
--- a/packages/agent/src/api/provider-switch-config.test.ts
+++ b/packages/agent/src/api/provider-switch-config.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ElizaConfig } from "../config/types.eliza";
 import {
   applySubscriptionProviderConfig,
   clearSubscriptionProviderConfig,
+  openAiBaseUrlIsThirdParty,
 } from "./provider-switch-config";
 
 describe("applySubscriptionProviderConfig", () => {
@@ -46,5 +47,90 @@ describe("applySubscriptionProviderConfig", () => {
 
     expect(config.agents?.defaults?.subscriptionProvider).toBeUndefined();
     expect(process.env.OPENAI_API_KEY).toBe("sk-direct-openai-key");
+  });
+});
+
+describe("openAiBaseUrlIsThirdParty", () => {
+  // Tests are sequential so they can mutate `process.env.OPENAI_BASE_URL`
+  // without cross-test contamination — vitest serializes tests within a
+  // single `describe` block.
+  const originalBaseUrl = process.env.OPENAI_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (typeof originalBaseUrl === "string") {
+      process.env.OPENAI_BASE_URL = originalBaseUrl;
+    } else {
+      delete process.env.OPENAI_BASE_URL;
+    }
+  });
+
+  it("returns false when OPENAI_BASE_URL is unset", () => {
+    expect(openAiBaseUrlIsThirdParty()).toBe(false);
+  });
+
+  it("returns false when OPENAI_BASE_URL is whitespace-only", () => {
+    process.env.OPENAI_BASE_URL = "   ";
+    expect(openAiBaseUrlIsThirdParty()).toBe(false);
+  });
+
+  it("returns false when OPENAI_BASE_URL points at api.openai.com (canonical)", () => {
+    process.env.OPENAI_BASE_URL = "https://api.openai.com/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(false);
+  });
+
+  it("returns false for api.openai.com with a trailing path / query", () => {
+    process.env.OPENAI_BASE_URL = "https://api.openai.com/v1/?tracing=1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(false);
+  });
+
+  it("returns true for the Cerebras host (the case that motivated this guard)", () => {
+    process.env.OPENAI_BASE_URL = "https://api.cerebras.ai/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for Groq", () => {
+    process.env.OPENAI_BASE_URL = "https://api.groq.com/openai/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for OpenRouter", () => {
+    process.env.OPENAI_BASE_URL = "https://openrouter.ai/api/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for Together AI", () => {
+    process.env.OPENAI_BASE_URL = "https://api.together.xyz/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for localhost (vLLM / LM Studio / Ollama gateway)", () => {
+    process.env.OPENAI_BASE_URL = "http://localhost:11434/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for an arbitrary in-house gateway", () => {
+    process.env.OPENAI_BASE_URL = "https://gateway.acme.internal/openai";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("treats unparseable URLs as third-party (fail-safe)", () => {
+    process.env.OPENAI_BASE_URL = "not://a real:url";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("returns true for openai.com subdomains other than api.openai.com", () => {
+    // Future-proof: this protects against someone pointing at
+    // `platform.openai.com` or `dashboard.openai.com` by mistake.
+    process.env.OPENAI_BASE_URL = "https://platform.openai.com/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(true);
+  });
+
+  it("is case-insensitive on the hostname", () => {
+    process.env.OPENAI_BASE_URL = "https://API.OpenAI.COM/v1";
+    expect(openAiBaseUrlIsThirdParty()).toBe(false);
   });
 });

--- a/packages/agent/src/api/provider-switch-config.ts
+++ b/packages/agent/src/api/provider-switch-config.ts
@@ -437,13 +437,64 @@ const PROVIDER_DEFAULT_MODELS: Record<
   },
 };
 
+/**
+ * True when the active `OPENAI_BASE_URL` points at a non-openai.com host
+ * (Cerebras, Groq, OpenRouter, Together, vLLM, LM Studio, an in-house
+ * gateway, etc.). The "openai" provider id then represents an OpenAI-API
+ * shape served by a *different* upstream — `gpt-5.5` and `gpt-5-mini`
+ * are not portable to those upstreams, so stamping them as the default
+ * model ids actively breaks the runtime.
+ *
+ * Returns false when:
+ *  - `OPENAI_BASE_URL` is unset (the caller is using openai.com directly,
+ *    so the default model ids are correct), OR
+ *  - the base URL parses to an `api.openai.com` host (still openai.com).
+ *
+ * Returns true when the URL is set to any other host — including
+ * subdomains of openai.com that aren't `api.openai.com`. We err on the
+ * conservative side here: an operator pointing at a custom OpenAI
+ * endpoint can pass explicit model ids; the failure mode of NOT stamping
+ * is "user has to type their model name", which is strictly better than
+ * stamping a model the upstream rejects with 404.
+ */
+/** @internal Exported for testing only. */
+export function openAiBaseUrlIsThirdParty(): boolean {
+  const raw = process.env.OPENAI_BASE_URL?.trim();
+  if (!raw) return false;
+  try {
+    const hostname = new URL(raw).hostname.trim().toLowerCase();
+    if (!hostname) return false;
+    return hostname !== "api.openai.com";
+  } catch {
+    // Unparseable URL: assume third-party. Stamping defaults under a
+    // broken base URL is never the right move.
+    return true;
+  }
+}
+
 function applyDefaultModelNames(
   config: MutableElizaConfig,
   provider: string,
 ): void {
   const defaults = PROVIDER_DEFAULT_MODELS[provider];
   if (!defaults) return;
-  // Only set if not already configured — don't clobber user overrides
+
+  // Guard: when the active `OPENAI_BASE_URL` points at a non-openai.com
+  // upstream (Cerebras, Groq, OpenRouter, vLLM, an in-house gateway, …),
+  // skip stamping the `OPENAI_*_MODEL` defaults — those gpt-5.5 /
+  // gpt-5-mini ids are openai.com inventory and will 404 on every other
+  // upstream. The caller can still pin specific models via the
+  // `primaryModel` field on the connection object; that path is unaffected.
+  //
+  // We only guard the `openai` provider id because (a) it's the only
+  // provider with this base-URL-override pattern in practice and (b) the
+  // `anthropic` / `google` / `groq` / `mlx` provider ids each point at
+  // their own SDK + endpoint, with no equivalent "base URL swap" footgun.
+  if (provider === "openai" && openAiBaseUrlIsThirdParty()) {
+    return;
+  }
+
+  // Only set if not already configured — don't clobber user overrides.
   if (!process.env[defaults.smallKey]) {
     setEnvValue(config, defaults.smallKey, defaults.smallVal);
   }


### PR DESCRIPTION
## Summary

When \`POST /api/provider/switch\` is called with \`provider: \"openai\"\`, the persisted config has historically been written with \`OPENAI_LARGE_MODEL = gpt-5.5\` and \`OPENAI_SMALL_MODEL = gpt-5-mini\` — values that are valid openai.com inventory but **404 on every other upstream** that speaks the OpenAI API shape (Cerebras, Groq, OpenRouter, Together, vLLM, in-house gateways).

This is a real footgun. The \`openai\` provider id represents an OpenAI-API *shape*, not specifically openai.com; operators routinely point \`OPENAI_BASE_URL\` at a different host. The persisted defaults then override the user's already-configured model names at next runtime hydration, silently breaking inference.

## Fix

When \`OPENAI_BASE_URL\` is set to anything other than \`api.openai.com\`, skip stamping the \`OPENAI_*_MODEL\` defaults. The user can still pin specific models via the \`primaryModel\` field on the connection object — that path is unaffected.

**Guard scope is intentionally narrow:**
- Only the \`openai\` provider id is guarded — \`anthropic\` / \`google\` / \`groq\` / \`mlx\` each point at their own SDK + endpoint with no equivalent footgun.
- Unparseable URLs treated as third-party (fail-safe — stamping defaults under a broken URL is never the right move).
- openai.com subdomains that aren't \`api.openai.com\` (e.g. \`platform.openai.com\`) treated as third-party too.
- Hostname matching is case-insensitive.

## Tests

13 new unit tests covering canonical third-party hosts (Cerebras, Groq, OpenRouter, Together, localhost, in-house gateway), the canonical openai.com positive cases, openai.com subdomains, unparseable URLs, whitespace, unset env, and case-insensitivity.

\`openAiBaseUrlIsThirdParty\` is exported with an \`@internal\` marker strictly for the test suite — production callers continue through \`applyOnboardingConnectionConfig\` and pick up the guard as a side effect.

\`bun test packages/agent/src/api/provider-switch-config.test.ts\` → **17 pass** · biome lint + format + tsc \`--noEmit\` all clean.

## Background

This bug is documented in §7.2 of the Cerebras-context debug walkthrough at https://nubilio.org/apps/cerebras-context-debug/ — it took ~90 minutes to track down during the original Cerebras switchover because \`process.env\` showed the user-supplied model name correctly, while the runtime had already mutated it from milady.json. This change prevents the mutation at write time.

Companion to **#7594** (per-model context window + cumulative-token guard), addressing P1.5 from the same debug report.

## Test plan

- [x] \`bun test packages/agent/src/api/provider-switch-config.test.ts\` → 17 pass
- [x] \`bunx @biomejs/biome lint\` on changed files → clean
- [x] \`bunx @biomejs/biome format\` on changed files → clean
- [x] \`bunx tsc --noEmit -p packages/agent/tsconfig.json\` → clean
- [ ] Live verification: deferred to CI on develop (local bot env has an unrelated \`@elizaos/plugin-zai\` 404 blocking \`bun install\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a guard in `applyDefaultModelNames` that skips writing `OPENAI_SMALL_MODEL` / `OPENAI_LARGE_MODEL` defaults when `OPENAI_BASE_URL` is set to a non-openai.com host, preventing silent 404s on third-party OpenAI-compatible upstreams (Cerebras, Groq, OpenRouter, etc.).

- New `openAiBaseUrlIsThirdParty()` helper parses `OPENAI_BASE_URL` from `process.env`, uses hostname comparison (case-insensitive, exact match on `api.openai.com`), and defaults to `true` (third-party) for empty hostnames or unparseable URLs — the conservative fail-safe direction.
- Guard is scoped only to `provider === "openai"` since the other provider IDs (`anthropic`, `google`, `groq`, `mlx`) each own their own SDK endpoint and don't share this base-URL-override pattern.
- 13 new unit tests cover the full decision surface; env isolation via `beforeEach`/`afterEach` is correct.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped to the write path for OpenAI default model names and does not alter any read path, credential handling, or routing logic.

The guard logic is correct and the test coverage is thorough. The only issue is a double-JSDoc comment that leaves the detailed function description orphaned from the declaration.

No files require special attention; both changed files are self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/api/provider-switch-config.ts | Adds `openAiBaseUrlIsThirdParty()` guard that skips stamping `OPENAI_*_MODEL` defaults when `OPENAI_BASE_URL` points at a non-openai.com host. Logic and guard placement are correct; minor JSDoc duplication leaves the long description orphaned. |
| packages/agent/src/api/provider-switch-config.test.ts | Adds 13 new unit tests for `openAiBaseUrlIsThirdParty` covering canonical third-party hosts, openai.com positive cases, subdomains, unparseable URLs, case-insensitivity, and whitespace. Test isolation via `beforeEach`/`afterEach` is correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["applyDefaultModelNames(config, provider)"] --> B{provider has defaults?}
    B -- No --> Z[return]
    B -- Yes --> C{provider === 'openai'?}
    C -- No --> E[stamp small + large model defaults]
    C -- Yes --> D["openAiBaseUrlIsThirdParty()"]
    D --> F{OPENAI_BASE_URL set and non-empty?}
    F -- No --> G[return false - not third-party]
    F -- Yes --> H{Parseable URL?}
    H -- No --> I[return true - treated as third-party]
    H -- Yes --> J{hostname === 'api.openai.com'?}
    J -- Yes --> G
    J -- No --> I
    G --> E
    I --> K[skip stamping model defaults]
    E --> L[setEnvValue OPENAI_SMALL_MODEL if unset]
    E --> M[setEnvValue OPENAI_LARGE_MODEL if unset]
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent): provider-switch route stops ..."](https://github.com/elizaos/eliza/commit/20a58bb24e2163caadb813331db59800abfe6ac6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31697935)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->