### PR TITLE
fix(core): compaction can now cap per-tool-result chars to bound oversized kept steps

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-rendering.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-rendering.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../../types/model";
+import type { PlannerStep } from "../planner-types";
+import {
+	trajectoryStepsToMessages,
+	truncateToolResultText,
+} from "../planner-rendering";
+
+/**
+ * Build a single completed planner step whose tool-result text is the
+ * provided string. Test-only helper — the actual planner emits a richer
+ * structure, but for the truncation render-path only the result text
+ * matters.
+ */
+function stepWithResult(
+	iteration: number,
+	toolName: string,
+	resultText: string,
+): PlannerStep {
+	return {
+		iteration,
+		thought: "test",
+		toolCall: {
+			id: `call-${iteration}`,
+			name: toolName,
+			params: {},
+		},
+		result: {
+			success: true,
+			text: resultText,
+		},
+	};
+}
+
+function getRenderedResultValue(messages: ChatMessage[]): string {
+	const toolMsg = messages.find((m) => m.role === "tool");
+	if (!toolMsg) throw new Error("expected a tool message");
+	const content = toolMsg.content;
+	if (!Array.isArray(content)) throw new Error("tool content must be array");
+	const part = content[0];
+	if (
+		!part ||
+		typeof part !== "object" ||
+		!("output" in part) ||
+		typeof part.output !== "object" ||
+		!part.output ||
+		!("value" in part.output) ||
+		typeof part.output.value !== "string"
+	) {
+		throw new Error("expected text-output tool-result");
+	}
+	return part.output.value;
+}
+
+describe("truncateToolResultText (pure)", () => {
+	it("returns input unchanged when maxChars is undefined", () => {
+		const input = "x".repeat(20_000);
+		expect(truncateToolResultText(input, undefined)).toBe(input);
+	});
+
+	it("returns input unchanged when maxChars is 0 or negative", () => {
+		const input = "x".repeat(20_000);
+		expect(truncateToolResultText(input, 0)).toBe(input);
+		expect(truncateToolResultText(input, -5)).toBe(input);
+	});
+
+	it("returns input unchanged when maxChars is non-finite", () => {
+		const input = "x".repeat(20_000);
+		expect(truncateToolResultText(input, Number.NaN)).toBe(input);
+		expect(truncateToolResultText(input, Number.POSITIVE_INFINITY)).toBe(input);
+	});
+
+	it("returns input unchanged when it already fits", () => {
+		const input = "short text";
+		expect(truncateToolResultText(input, 1_000)).toBe(input);
+	});
+
+	it("truncates with a head + marker + tail when input exceeds maxChars", () => {
+		const input = `${"H".repeat(2_000)}${"M".repeat(20_000)}${"T".repeat(2_000)}`;
+		const out = truncateToolResultText(input, 1_000);
+		expect(out.length).toBeLessThan(input.length);
+		expect(out).toMatch(/chars truncated/);
+		// Head must start with H, tail must end with T — proves we kept
+		// both ends rather than slicing only from one side.
+		expect(out.startsWith("H")).toBe(true);
+		expect(out.endsWith("T")).toBe(true);
+		// The marker carries the count of dropped characters.
+		const match = out.match(/\[(\d+) chars truncated\]/);
+		expect(match).not.toBeNull();
+		const dropped = Number.parseInt(match?.[1] ?? "0", 10);
+		expect(dropped).toBeGreaterThan(0);
+		expect(dropped).toBeLessThan(input.length);
+	});
+
+	it("preserves the byte count: head + truncated + tail = original length", () => {
+		const input = `${"A".repeat(5_000)}${"B".repeat(50_000)}${"C".repeat(5_000)}`;
+		const out = truncateToolResultText(input, 2_000);
+		const match = out.match(/\[(\d+) chars truncated\]/);
+		expect(match).not.toBeNull();
+		const dropped = Number.parseInt(match?.[1] ?? "0", 10);
+		// Strip the marker (and the surrounding `" [N chars truncated] "`)
+		// to count the preserved bytes.
+		const preserved = out.replace(/\s\[\d+ chars truncated\]\s/, "").length;
+		expect(preserved + dropped).toBe(input.length);
+	});
+
+	it("emits a deterministic 60/40 head/tail split for large inputs", () => {
+		const input = `${"H".repeat(60_000)}${"T".repeat(40_000)}`;
+		const out = truncateToolResultText(input, 1_000);
+		const match = out.match(/^(H+)\s+\[\d+ chars truncated\]\s+(T+)$/);
+		expect(match).not.toBeNull();
+		const headLen = match?.[1]?.length ?? 0;
+		const tailLen = match?.[2]?.length ?? 0;
+		// 60/40 split of the usable budget — head should be roughly 1.5x tail.
+		expect(headLen).toBeGreaterThan(tailLen);
+		expect(headLen / tailLen).toBeGreaterThanOrEqual(1.4);
+		expect(headLen / tailLen).toBeLessThanOrEqual(1.6);
+	});
+
+	it("bails out to the original when the input is too small for the head/tail floor to be useful", () => {
+		// The head/tail floor is 10 chars each; with a 15-char input we
+		// have nothing meaningful to drop, so the helper returns the input
+		// unchanged. Better to emit a short raw string than crop below the
+		// readability floor.
+		const input = "x".repeat(15);
+		const out = truncateToolResultText(input, 10);
+		expect(out).toBe(input);
+	});
+});
+
+describe("trajectoryStepsToMessages — maxToolResultChars option", () => {
+	// `toolMessageContent` (called inside `trajectoryStepsToMessages`)
+	// wraps the raw `result.text` as `text: <body>`, so the assertions
+	// compare against that wire shape.
+	const RESULT_PREFIX = "text: ";
+
+	it("renders full result text when maxToolResultChars is unset (back-compat)", () => {
+		const longResult = "y".repeat(50_000);
+		const steps = [stepWithResult(1, "BASH", longResult)];
+		const messages = trajectoryStepsToMessages(steps);
+		expect(getRenderedResultValue(messages)).toBe(
+			`${RESULT_PREFIX}${longResult}`,
+		);
+	});
+
+	it("renders full result text when maxToolResultChars is undefined (explicit)", () => {
+		const longResult = "y".repeat(50_000);
+		const steps = [stepWithResult(1, "BASH", longResult)];
+		const messages = trajectoryStepsToMessages(steps, {
+			maxToolResultChars: undefined,
+		});
+		expect(getRenderedResultValue(messages)).toBe(
+			`${RESULT_PREFIX}${longResult}`,
+		);
+	});
+
+	it("truncates oversized results when maxToolResultChars is set", () => {
+		const longResult = `${"A".repeat(20_000)}${"B".repeat(20_000)}`;
+		const steps = [stepWithResult(1, "BASH", longResult)];
+		const messages = trajectoryStepsToMessages(steps, {
+			maxToolResultChars: 1_000,
+		});
+		const rendered = getRenderedResultValue(messages);
+		expect(rendered.length).toBeLessThan(longResult.length);
+		expect(rendered).toMatch(/chars truncated/);
+	});
+
+	it("does not truncate already-small results when maxToolResultChars is set", () => {
+		const smallResult = "ok";
+		const steps = [stepWithResult(1, "BASH", smallResult)];
+		const messages = trajectoryStepsToMessages(steps, {
+			maxToolResultChars: 1_000,
+		});
+		expect(getRenderedResultValue(messages)).toBe(
+			`${RESULT_PREFIX}${smallResult}`,
+		);
+	});
+
+	it("truncates each oversized step independently (per-step cap, not global)", () => {
+		const longResult = "Z".repeat(10_000);
+		const steps = [
+			stepWithResult(1, "BASH", longResult),
+			stepWithResult(2, "BASH", longResult),
+			stepWithResult(3, "BASH", longResult),
+		];
+		const messages = trajectoryStepsToMessages(steps, {
+			maxToolResultChars: 500,
+		});
+		const toolMessages = messages.filter((m) => m.role === "tool");
+		expect(toolMessages.length).toBe(3);
+		// Every tool result message should carry the truncation marker.
+		for (const m of toolMessages) {
+			const content = m.content;
+			if (!Array.isArray(content)) throw new Error("expected array content");
+			const part = content[0];
+			if (
+				!part ||
+				typeof part !== "object" ||
+				!("output" in part) ||
+				typeof part.output !== "object" ||
+				!part.output ||
+				!("value" in part.output) ||
+				typeof part.output.value !== "string"
+			) {
+				throw new Error("expected text-output tool-result");
+			}
+			expect(part.output.value).toMatch(/chars truncated/);
+			expect(part.output.value.length).toBeLessThan(longResult.length);
+		}
+	});
+
+	it("does not mutate the underlying PlannerStep.result.text", () => {
+		const original = "X".repeat(20_000);
+		const steps: PlannerStep[] = [stepWithResult(1, "BASH", original)];
+		trajectoryStepsToMessages(steps, { maxToolResultChars: 200 });
+		// Trajectory must remain pristine — only the rendered message is truncated.
+		expect(steps[0]?.result?.text).toBe(original);
+	});
+});

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -15,6 +15,26 @@ export interface ChainingLoopConfig {
 	compactionEnabled: boolean;
 	/** Number of newest completed tool steps kept verbatim after compaction. */
 	compactionKeepSteps: number;
+	/**
+	 * When set, caps each tool-result string rendered into the planner
+	 * input to this many characters (head + `[N chars truncated]` marker
+	 * + tail). The trajectory itself is unchanged — only the wire-shape
+	 * messages are truncated.
+	 *
+	 * Why this exists: the compactor keeps the four newest steps
+	 * verbatim by default (`compactionKeepSteps: 4`). A single
+	 * pathologically-large tool result inside the kept window — a 30 KB
+	 * shell dump, a multi-thousand-line file read, a full grep — can
+	 * blow the model's per-call context budget single-handedly, even
+	 * after compaction has done its job. This cap protects against that
+	 * single-step pathology without touching the trajectory's
+	 * archival/replay fidelity.
+	 *
+	 * Default: undefined (no cap — exact pre-PR behavior). Recommended
+	 * for tight-context models: ~8000 (one tool result still gets
+	 * roughly two pages of head + a half page of tail context).
+	 */
+	compactionMaxKeptStepChars?: number;
 }
 
 export const DEFAULT_CHAINING_LOOP_CONFIG: ChainingLoopConfig = {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -472,6 +472,13 @@ function renderPlannerModelInput(params: {
 	trajectory: PlannerTrajectory;
 	template?: string;
 	runtime?: PlannerRuntime;
+	/**
+	 * Optional per-tool-result character cap. Forwarded directly to
+	 * `trajectoryStepsToMessages` — caps the rendered tool-result
+	 * string for each kept-verbatim step without mutating the
+	 * trajectory itself.
+	 */
+	maxToolResultChars?: number;
 }): {
 	messages: ChatMessage[];
 	promptSegments: PromptSegment[];
@@ -481,7 +488,9 @@ function renderPlannerModelInput(params: {
 	const instructions = (
 		template.split("context_object:")[0] ?? template
 	).trim();
-	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps);
+	const stepMessages = trajectoryStepsToMessages(params.trajectory.steps, {
+		maxToolResultChars: params.maxToolResultChars,
+	});
 	const liveActionsBlock = renderAvailableActionsBlock(params.context);
 	const availableActionsBlock = params.runtime
 		? resolveOptimizedActionDescriptions(params.runtime, liveActionsBlock)
@@ -970,6 +979,7 @@ async function callPlanner(params: {
 		trajectory: params.trajectory,
 		template: resolveOptimizedPlannerTemplate(params.runtime),
 		runtime: params.runtime,
+		maxToolResultChars: params.config.compactionMaxKeptStepChars,
 	});
 	let modelInputBudget = buildModelInputBudget({
 		messages: renderedInput.messages,
@@ -995,6 +1005,7 @@ async function callPlanner(params: {
 				trajectory: params.trajectory,
 				template: resolveOptimizedPlannerTemplate(params.runtime),
 				runtime: params.runtime,
+				maxToolResultChars: params.config.compactionMaxKeptStepChars,
 			});
 			modelInputBudget = buildModelInputBudget({
 				messages: renderedInput.messages,
@@ -1203,6 +1214,7 @@ async function maybeCompactBeforeNextModelCall(args: {
 	const renderedInput = renderPlannerModelInput({
 		context: args.trajectory.context,
 		trajectory: args.trajectory,
+		maxToolResultChars: args.config.compactionMaxKeptStepChars,
 	});
 	const budget = buildModelInputBudget({
 		messages: renderedInput.messages,

--- a/packages/core/src/runtime/planner-rendering.ts
+++ b/packages/core/src/runtime/planner-rendering.ts
@@ -28,7 +28,77 @@ import {
  * planner-loop then iterates until `TrajectoryLimitExceeded` on every
  * shell-tool turn.
  */
-export function trajectoryStepsToMessages(steps: PlannerStep[]): ChatMessage[] {
+/**
+ * Options for {@link trajectoryStepsToMessages}.
+ */
+export interface TrajectoryStepsToMessagesOptions {
+	/**
+	 * When set, caps each rendered tool-result string to this many characters.
+	 *
+	 * A single pathologically-large tool result (a 30 KB shell output, a
+	 * full file read, a multi-thousand-line grep) can blow the planner's
+	 * compaction budget single-handedly when it lives inside the
+	 * kept-verbatim window after compaction. This cap renders such results
+	 * as `<head> ... [N chars truncated] ... <tail>` so the planner still
+	 * sees the beginning and end of the result (which is where structure
+	 * lives) without paying for the middle.
+	 *
+	 * **The trajectory itself is unchanged** — the raw `PlannerStep.result`
+	 * still carries the full content for archival, recorder, replay, and
+	 * any downstream consumer that wants the unredacted output. Only the
+	 * wire-shape message that goes to the next planner call is truncated.
+	 *
+	 * Default: undefined (no cap — exact pre-PR behavior).
+	 */
+	maxToolResultChars?: number;
+}
+
+/**
+ * Truncate a tool-result string to fit within `maxChars` by keeping a head
+ * + tail and stitching in a deterministic marker. Pure function — exported
+ * so the evaluator/recorder can mirror the exact rendering rule.
+ *
+ * Returns the input unchanged when it already fits OR when `maxChars` is
+ * unset / non-positive / not finite.
+ */
+export function truncateToolResultText(
+	text: string,
+	maxChars: number | undefined,
+): string {
+	if (
+		typeof maxChars !== "number" ||
+		!Number.isFinite(maxChars) ||
+		maxChars <= 0
+	) {
+		return text;
+	}
+	if (text.length <= maxChars) {
+		return text;
+	}
+	// 60/40 head/tail split — the head usually carries the most signal
+	// (action confirmation, primary output) while the tail catches summary
+	// lines, exit codes, and trailing error context. The marker accounts
+	// for ~50 chars of overhead so we shave from the actual content limit.
+	const markerSuffixSample = " [0 chars truncated] ";
+	const overhead = markerSuffixSample.length;
+	const usable = Math.max(20, maxChars - overhead);
+	const headChars = Math.max(10, Math.floor(usable * 0.6));
+	const tailChars = Math.max(10, usable - headChars);
+	const truncatedCount = text.length - headChars - tailChars;
+	if (truncatedCount <= 0) {
+		// Numeric edge case: marker overhead pushed the budget below the
+		// raw length. Just return the raw text.
+		return text;
+	}
+	const head = text.slice(0, headChars);
+	const tail = text.slice(text.length - tailChars);
+	return `${head} [${truncatedCount} chars truncated] ${tail}`;
+}
+
+export function trajectoryStepsToMessages(
+	steps: PlannerStep[],
+	options: TrajectoryStepsToMessagesOptions = {},
+): ChatMessage[] {
 	const messages: ChatMessage[] = [];
 	for (const step of steps) {
 		if (!step.toolCall || !step.result) {
@@ -52,6 +122,11 @@ export function trajectoryStepsToMessages(steps: PlannerStep[]): ChatMessage[] {
 			content: assistantContent,
 		});
 
+		const rawResultText = toolMessageContent(step.result);
+		const renderedResultText = truncateToolResultText(
+			rawResultText,
+			options.maxToolResultChars,
+		);
 		messages.push({
 			role: "tool",
 			content: [
@@ -59,7 +134,7 @@ export function trajectoryStepsToMessages(steps: PlannerStep[]): ChatMessage[] {
 					type: "tool-result",
 					toolCallId,
 					toolName: step.toolCall.name,
-					output: { type: "text", value: toolMessageContent(step.result) },
+					output: { type: "text", value: renderedResultText },
 				},
 			],
 		});


### PR DESCRIPTION
## Summary

The compactor's default \`compactionKeepSteps: 4\` keeps the four newest trajectory steps verbatim after compaction. **A single pathologically-large tool result inside that kept window** — a 30 KB shell dump, a multi-thousand-line file read, a full grep dump — can blow the model's per-call context budget single-handedly, even after compaction has already done its job on the older steps.

This PR introduces an opt-in per-step character cap that's applied at the wire-rendering layer.

## Changes

- **New \`ChainingLoopConfig.compactionMaxKeptStepChars?: number\`.** Default \`undefined\` (no cap — exact pre-PR behavior).
- **New exported \`truncateToolResultText(text, maxChars)\` helper** in \`runtime/planner-rendering.ts\`. Returns input unchanged when \`maxChars\` is unset / non-positive / non-finite / already-fitting. Otherwise emits \`<head> [N chars truncated] <tail>\` with a 60/40 head/tail split, a 10-char floor on each side, and a numeric edge-case bail-out when the budget is too tight for meaningful truncation.
- **\`trajectoryStepsToMessages\` accepts an optional \`{ maxToolResultChars }\`** options object and forwards it to the truncation helper. Both call sites in \`planner-loop.ts\` (\`renderPlannerModelInput\` for the planner stage and \`maybeCompactBeforeNextModelCall\` for the post-compaction re-render) pull the cap from \`config.compactionMaxKeptStepChars\`.
- **The trajectory itself is unchanged** — the raw \`PlannerStep.result.text\` still carries the full content for archival, recorder, replay, and any downstream consumer that wants the unredacted output. Only the wire-shape message that goes to the next planner call is truncated. A regression test pins this invariant.

## Tests

**14 new unit tests** in \`__tests__/planner-rendering.test.ts\`:

**Pure-helper coverage:**
- unset / 0 / negative / non-finite \`maxChars\` return input unchanged
- head/tail floors (10 chars each) enforced
- 60/40 split verified
- byte-count preservation (head + truncated + tail = original length)
- numeric bail-out for too-tight budgets

**Render-path coverage:**
- back-compat path (no options object) — unchanged
- back-compat path (explicit \`undefined\`) — unchanged
- oversized result is truncated
- small result is left alone
- per-step independence (each oversized step in a multi-step trajectory gets its own truncation)
- the invariant that \`PlannerStep.result.text\` is **not** mutated

Full core suite: **816 pass / 3 pre-existing failures** unrelated to this PR (action-structure-audit, turn-controller isolation, facts keyword weighting — none touch planner-rendering or planner-loop). Lint + format + typecheck clean.

## Background

P1.4 follow-up from the Cerebras-context debug walkthrough at https://nubilio.org/apps/cerebras-context-debug/. The previous PR #7594 fixed the **window-level** budget; this PR fixes the **per-step** budget so a single big tool output can't single-handedly overflow the kept-verbatim window inside the budget.

Companion to **#7594** (per-model context window + cumulative-token guard) and **#7597** (provider-switch base-URL guard).

## Test plan

- [x] \`bun test packages/core/src/runtime/__tests__/planner-rendering.test.ts\` → 14 pass
- [x] \`bun test packages/core/\` → 816 pass / 3 pre-existing failures
- [x] \`bunx @biomejs/biome lint\` on changed files → clean
- [x] \`bunx @biomejs/biome format\` on changed files → clean
- [x] \`bunx tsc --noEmit -p packages/core/tsconfig.json\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an opt-in per-step character cap (`compactionMaxKeptStepChars`) that truncates oversized tool-result strings at the wire-rendering layer, protecting the planner's kept-verbatim window from single pathologically-large outputs without mutating the underlying trajectory.

- **`truncateToolResultText`** — new pure helper that applies a 60/40 head/tail split with a `[N chars truncated]` marker; the original `PlannerStep.result.text` is never modified.
- **`trajectoryStepsToMessages`** — accepts an optional `{ maxToolResultChars }` options object and applies truncation at render time; all three call sites in `planner-loop.ts` thread the new config field through.
- **14 new unit tests** cover edge cases (non-positive/non-finite cap, floor enforcement, per-step independence, mutation invariant).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the cap is opt-in and defaults to undefined, so no existing behaviour changes unless the caller sets the new config field.

The core logic is correct and well-tested. The only findings are a misplaced JSDoc (the original comment for trajectoryStepsToMessages now sits above the new TrajectoryStepsToMessagesOptions interface instead of the function) and a minor comment/constant discrepancy where the overhead comment and sample value disagree, meaning the rendered output can overshoot maxChars by a few characters for realistic inputs. Neither affects runtime correctness for the intended use case.

packages/core/src/runtime/planner-rendering.ts — the orphaned JSDoc and the overhead constant comment should be tidied up before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-rendering.ts | Adds truncateToolResultText helper and wires it into trajectoryStepsToMessages via an options object; original JSDoc for the function is now orphaned above the new interface |
| packages/core/src/runtime/limits.ts | Adds optional compactionMaxKeptStepChars field to ChainingLoopConfig; cleanly typed and documented, no issues |
| packages/core/src/runtime/planner-loop.ts | Adds maxToolResultChars parameter to renderPlannerModelInput and threads config.compactionMaxKeptStepChars to all three call sites; wiring looks correct |
| packages/core/src/runtime/__tests__/planner-rendering.test.ts | 14 new unit tests covering the pure helper and the render-path; includes back-compat, per-step independence, and mutation-invariant checks |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/runtime/planner-rendering.ts`, line 12-34 ([link](https://github.com/elizaos/eliza/blob/7132ee6be8a459d52f06c0f595b5640694a332c4/packages/core/src/runtime/planner-rendering.ts#L12-L34)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The original JSDoc for `trajectoryStepsToMessages` was left above the new `TrajectoryStepsToMessagesOptions` interface, so TypeScript/IDE tooling now attaches it to the interface rather than to the function. The function itself ends up with no JSDoc. The long comment should live immediately above `trajectoryStepsToMessages`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(core): compaction can now cap per-to..."](https://github.com/elizaos/eliza/commit/7132ee6be8a459d52f06c0f595b5640694a332c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31699562)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->