### PR TITLE
fix(core): stop leaking tool-diagnostic text (shell wrapper, exit codes) into user replies

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TrajectoryRecorder } from "../trajectory-recorder";
+import { runPlannerLoop } from "../planner-loop";
+
+/**
+ * Regression coverage for the structural fix that stops tool-diagnostic
+ * `text` (shell prompts, `[exit 0]`, `--- stdout ---` wrappers, cwd
+ * markers, byte counts) from being shown to users verbatim.
+ *
+ * Before this PR, `latestToolResultText` returned `step.result.text` —
+ * the tool's log-shaped projection. Tools like BASH emit:
+ *
+ *   $ find /home/milady/.milady/trajectories -type f
+ *   [exit 0] (cwd=/home/milady/iqlabs/milady/eliza, took=37ms)
+ *   --- stdout ---
+ *   443
+ *
+ * That entire wrapper string was leaking into Discord replies because
+ * the planner-loop's terminal-FINISH fallback chain used it when the
+ * evaluator didn't supply a `messageToUser`.
+ *
+ * The fix is structural: `PlannerToolResult` now carries an explicit
+ * `userFacingText` field. The framework only uses that for direct user
+ * display. Tools that emit logs leave it undefined → the framework
+ * falls through to a synthesized response message instead of leaking
+ * the wrapper. This avoids regex-based wrapper detection and gives
+ * every tool a clear contract.
+ */
+
+describe("planner-loop — user-facing tool text isolation", () => {
+	it("does not leak tool-diagnostic text into the user reply when userFacingText is unset", async () => {
+		// Mimic the BASH wrapper that was leaking. A tool that emits a
+		// shell log and *no* userFacingText must NOT have its log become
+		// the user-facing reply.
+		const bashWrapper =
+			"$ find /tmp -type f\n[exit 0] (cwd=/home/milady, took=12ms)\n--- stdout ---\n443";
+		const runtime = {
+			useModel: vi
+				.fn()
+				// First call: planner — emits one tool call, no messageToUser.
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [{ id: "call-1", name: "BASH", arguments: {} }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				})
+				// Second call: evaluator — decides FINISH, no messageToUser.
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Tool finished cleanly.",
+						// No messageToUser — this is the failure mode that used to
+						// trigger the leak.
+					}),
+					usage: { promptTokens: 50, completionTokens: 20, totalTokens: 70 },
+				}),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			// Tool's diagnostic log goes into `text` — must NEVER reach user.
+			text: bashWrapper,
+			// `userFacingText` deliberately omitted — BASH is a log-only tool.
+		}));
+		const recorder: TrajectoryRecorder = {
+			startTrajectory: vi.fn(() => "trj-1"),
+			recordStage: vi.fn(async () => undefined),
+			endTrajectory: vi.fn(async () => undefined),
+			load: vi.fn(async () => null),
+			list: vi.fn(async () => []),
+		};
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "Done.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+			recorder,
+			trajectoryId: "trj-1",
+		});
+
+		expect(result.status).toBe("finished");
+		// The final message must not contain any portion of the shell
+		// wrapper. Specifically: no `$ `, no `[exit `, no `--- stdout ---`,
+		// no `cwd=`. (These are properties of the wrapper, not regex used
+		// to fix it — the fix itself is the userFacingText opt-in. These
+		// assertions just prove the leak is gone.)
+		const finalMessage = result.finalMessage ?? "";
+		expect(finalMessage).not.toContain("$ find");
+		expect(finalMessage).not.toContain("[exit");
+		expect(finalMessage).not.toContain("--- stdout ---");
+		expect(finalMessage).not.toContain("cwd=");
+	});
+
+	it("uses userFacingText as the reply when a tool sets it", async () => {
+		const userFriendly = "Here are your 3 most recent PRs: #7593, #7592, #7588.";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [{ id: "call-1", name: "Q_AND_A", arguments: {} }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				})
+				// Evaluator: FINISH with no messageToUser → framework falls
+				// through to latestToolResultText, which now returns
+				// userFacingText.
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Tool answered.",
+					}),
+					usage: { promptTokens: 50, completionTokens: 20, totalTokens: 70 },
+				}),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: `Q_AND_A result\n[exit 0]\n--- stdout ---\n${userFriendly}`,
+			userFacingText: userFriendly,
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			thought: "Done.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.finalMessage).toBe(userFriendly);
+		// Diagnostic wrapper still must not leak.
+		expect(result.finalMessage ?? "").not.toContain("[exit 0]");
+	});
+
+	it("does not regress evaluator's explicit messageToUser path", async () => {
+		// When evaluator provides a clean messageToUser, the tool's
+		// userFacingText is not even consulted — the evaluator wins.
+		const evaluatorMessage = "All three counters reset to zero.";
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [{ id: "call-1", name: "ANY", arguments: {} }],
+					usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+				})
+				.mockResolvedValueOnce({
+					text: JSON.stringify({
+						success: true,
+						decision: "FINISH",
+						thought: "Tool finished.",
+						messageToUser: evaluatorMessage,
+					}),
+					usage: { promptTokens: 50, completionTokens: 20, totalTokens: 70 },
+				}),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "internal log",
+			userFacingText: "tool would also have something to say",
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			messageToUser: evaluatorMessage,
+			thought: "Done.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.finalMessage).toBe(evaluatorMessage);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2045,11 +2045,30 @@ function terminalMessageFromToolCalls(
 	);
 }
 
+/**
+ * Latest user-safe projection of a tool's result, walking the trajectory
+ * back-to-front. Returns ONLY the tool's `userFacingText` field — never
+ * the diagnostic `text` field, because `text` is log-shaped (shell
+ * prompts, exit codes, cwd, byte counts) and leaks the tool's wrapper
+ * format into the user channel.
+ *
+ * Tools that produce real user-facing answers (Q&A, content generation,
+ * REPLY) must opt in by setting `userFacingText`. Tools that emit logs
+ * (BASH, SHELL, fetchers, file readers) leave it unset; this function
+ * then returns undefined and the caller falls through to the evaluator's
+ * synthesized reply instead of dumping the log into the channel.
+ *
+ * Pre-PR, this function returned `step.result.text` directly — that's
+ * how `$ find … [exit 0] (cwd=…) --- stdout --- 443` ever ended up as
+ * a literal Discord reply. The fix is structural: tools tell the
+ * framework what's safe, the framework doesn't guess by parsing
+ * wrapper text.
+ */
 function latestToolResultText(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	for (const step of [...trajectory.steps].reverse()) {
-		const text = step.result?.text?.trim();
+		const text = step.result?.userFacingText?.trim();
 		if (text) {
 			return text;
 		}

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -76,7 +76,31 @@ export interface PlannerRuntime {
 
 export interface PlannerToolResult {
 	success: boolean;
+	/**
+	 * Diagnostic / log-shaped projection of the tool's output. Goes into
+	 * the trajectory and the planner's tool-result message. Used by the
+	 * model to reason about success/failure and to decide the next step.
+	 *
+	 * **Never** rendered directly to the user — this often contains
+	 * wrapper formatting (shell prompts, exit codes, cwd, byte counts,
+	 * stderr-vs-stdout separators). Tools that want their output to be
+	 * shown to the user verbatim must set `userFacingText` separately.
+	 */
 	text?: string;
+	/**
+	 * Optional user-facing projection of the tool's output. When set,
+	 * the planner-loop's terminal-FINISH fallback may use this as the
+	 * `finalMessage` shown to the user — instead of leaking the tool's
+	 * diagnostic `text` wrapper.
+	 *
+	 * Tools that produce a true user-facing answer (Q&A tools, REPLY
+	 * actions, content generators) should set this. Tools that emit
+	 * logs (BASH, SHELL, fetchers, file readers) should leave it
+	 * undefined; in that case the framework falls through to the
+	 * evaluator's synthesized reply rather than dumping shell-wrapper
+	 * text into the user channel.
+	 */
+	userFacingText?: string;
 	data?: Record<string, unknown>;
 	error?: unknown;
 	continueChain?: boolean;


### PR DESCRIPTION
## Summary

When the planner-loop reaches terminal FINISH without an explicit \`messageToUser\`, the fallback chain has been:

\`\`\`
evaluator.messageToUser ?? latestToolResultText(trajectory) ?? evaluator.thought
\`\`\`

\`latestToolResultText\` returned \`step.result.text\` directly. For log-emitting tools like BASH, that's the diagnostic wrapper:

\`\`\`
$ <command>
[exit 0] (cwd=…, took=…ms)
--- stdout ---
<stdout>
\`\`\`

That whole wrapper has been ending up as the user-visible reply. **Observed live during the Cerebras gpt-oss-120b battle test on 2026-05-12** — user asked "how many .json files in trajectories?", bot answered with a full shell-tool transcript instead of just \`443\`.

## Fix — structural, not regex

Add \`userFacingText?: string\` to \`PlannerToolResult\`. Tools that produce a true user-facing answer (Q&A, content generators, REPLY actions) opt in by setting it. Tools that emit logs (BASH, SHELL, fetchers, file readers) leave it undefined.

\`latestToolResultText\` now reads ONLY \`userFacingText\` — never the diagnostic \`text\`. Unset → returns undefined → fallback chain falls through to the evaluator's reply (then to the generic "I handled the available step." sentinel). Never the wrapper.

**This is the smart fix:** tools tell the framework what's safe to display; the framework doesn't try to detect-wrapper-text-by-regex. It scales to every log-emitting tool — BASH's \`[exit 0]\`, file-readers' \`bytes=\`, fetchers' \`HTTP 200 …\`, future tools we haven't written yet — without piling up more regex patterns.

### Why not extend \`isUnsafeUserVisibleText\` with a wrapper regex?

That sibling function detects a few function-call-leak patterns (\`to=functions.X\`, \`"action":"functions.X"\`), but extending it to "sniff shell-wrapper text" by \`^\\\$ /\` or \`\\[exit \\d+\\]\` would be fragile — it only catches BASH, not the wrappers other log tools emit. The structural opt-in scales to all of them with zero per-tool regex.

## Backward compatibility

Pure addition. Optional field. Every existing tool keeps exactly the same observable behavior in the trajectory's tool-result message (still gets \`step.result.text\`). The only change: the terminal-FINISH fallback no longer reaches for \`text\` — and in every pre-PR case where the fallback was reaching for log-shaped text, that was the bug.

## Tests

3 new cases in \`__tests__/planner-loop-user-facing-text.test.ts\`:

- **BASH-style log-only tool:** wrapper text never reaches the final message (no \`$ \`, no \`[exit \`, no \`--- stdout ---\`, no \`cwd=\` in the user reply).
- **Q&A-style tool with \`userFacingText\` set:** that clean text is what the user sees — and the diagnostic \`text\` is NOT leaked alongside.
- **Evaluator-provides-messageToUser path:** unaffected — the explicit evaluator reply wins regardless of what tools set.

\`bun test packages/core/\` → **805 pass / 3 pre-existing fail.** Lint + format + tsc \`--noEmit\` all clean.

## Background

P1.X follow-up surfaced during the gpt-oss-120b Cerebras battle-test session documented at https://nubilio.org/apps/cerebras-context-debug/.

Companion to:
- **#7594** — per-model context window + cumulative-token guard
- **#7597** — provider-switch base-URL guard
- **#7598** — per-step result char cap

## Test plan

- [x] \`bun test packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts\` → 3 pass
- [x] \`bun test packages/core/src/runtime/__tests__/planner-loop.test.ts\` → 22 pass (no regression)
- [x] \`bun test packages/core/\` → 805 pass / 3 pre-existing fail
- [x] biome lint + format clean
- [x] \`bunx tsc --noEmit -p packages/core/tsconfig.json\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a live production bug where the planner-loop's terminal-FINISH fallback was leaking BASH tool diagnostic wrappers (`$ <cmd>`, `[exit 0]`, `--- stdout ---`, `cwd=`) directly into user replies when the evaluator omitted `messageToUser`. The fix introduces `userFacingText?: string` on `PlannerToolResult` and changes `latestToolResultText` to read only that field — tools that emit logs leave it unset and the fallback falls through to the evaluator's synthesised reply.

- **`planner-types.ts`**: adds the new optional `userFacingText` field with clear JSDoc distinguishing it from the existing `text` field.
- **`planner-loop.ts`**: single-line change in `latestToolResultText` (`text` → `userFacingText`); well-documented. Note that `actionResultToPlannerToolResult` does not propagate `userFacingText`, so standard `Action` handlers have no path to opt into the mechanism today.
- **`planner-loop-user-facing-text.test.ts`**: three targeted regression cases covering the leak, the opt-in path, and the evaluator-wins path.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a minimal one-field swap that eliminates a confirmed live leak; all existing action handlers use callbacks so they are unaffected by the opt-in gap.

The core fix is correct and the three new tests directly cover the failure mode. The only gap is that `actionResultToPlannerToolResult` does not set `userFacingText`, meaning no standard `Action` handler can opt into the mechanism without a follow-up change to `ActionResult`. This does not break existing behavior (all current handlers use callbacks) but creates a silent footgun for future action authors.

packages/core/src/runtime/planner-loop.ts — specifically the `actionResultToPlannerToolResult` function, which is not part of the diff but is the only path through which standard Action handlers produce `PlannerToolResult` objects.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-types.ts | Adds `userFacingText?: string` to `PlannerToolResult` with clear documentation distinguishing it from the diagnostic `text` field; additive-only, no breaking changes. |
| packages/core/src/runtime/planner-loop.ts | Replaces `step.result?.text` with `step.result?.userFacingText` in `latestToolResultText`, eliminating the shell-wrapper leak. However, `actionResultToPlannerToolResult` (line 2243–2249) does not set `userFacingText`, leaving standard Action handlers with no way to opt in to the new mechanism. |
| packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts | New test file with three focused regression cases — BASH wrapper leak, `userFacingText` opt-in path, and evaluator-wins path — all well-documented and targeting the correct behavior. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Planner loop reaches terminal FINISH] --> B{evaluator.messageToUser set?}
    B -- Yes --> C[userSafeFinalMessage with evaluator.messageToUser]
    B -- No --> D{plannerOutput.messageToUser set?}
    D -- Yes --> C
    D -- No --> E[latestToolResultText: read step.result.userFacingText]
    E -- userFacingText set --> F[userSafeFinalMessage with userFacingText]
    E -- undefined --> G{evaluator.thought set?}
    G -- Yes --> H[userSafeFinalMessage with evaluator.thought]
    G -- No --> I[finalMessage = undefined]
    C --> J{isUnsafeUserVisibleText?}
    F --> J
    H --> J
    J -- Safe --> K[Return candidate as finalMessage]
    J -- Unsafe --> L[Call latestToolResultText again as fallback]
    L -- found safe text --> K
    L -- nothing --> M[Return 'I handled the available step.']
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/runtime/planner-loop.ts`, line 2233-2249 ([link](https://github.com/elizaos/eliza/blob/390f2b7c1d398d3565148b29073e4b85fe960749/packages/core/src/runtime/planner-loop.ts#L2233-L2249)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`ActionResult` handlers have no path to opt into `userFacingText`**

   `actionResultToPlannerToolResult` maps `ActionResult.text` → `PlannerToolResult.text`, but never sets `userFacingText`. This means every standard `Action` handler (draftReplyAction, plugin-manager handlers, etc.) will produce a `PlannerToolResult` with `userFacingText: undefined`, so `latestToolResultText` always returns `undefined` for them. The terminal-FINISH fallback then falls through to `evaluator.thought` or the `"I handled the available step."` sentinel — even for actions that set `result.text` to clean, user-facing copy.

   All existing handlers use the `callback` path so this isn't a current regression, but any future action that sets `result.text` expecting it to surface as `finalMessage` (without using a callback) will be silently broken with no error or warning. Adding `userFacingText?: string` to `ActionResult` and propagating it here would close the gap.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(core): stop leaking tool-diagnostic ..."](https://github.com/elizaos/eliza/commit/390f2b7c1d398d3565148b29073e4b85fe960749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31708433)</sub>

<!-- /greptile_comment -->