### PR TITLE
fix(core): failure-reply prompt no longer lets the model hallucinate ungrounded answers

### DIFF
--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { buildFailureReplyPrompt } from "../message";
+
+/**
+ * Pinned hard rules for the transient-failure reply prompt.
+ *
+ * BACKGROUND — live regression on Cerebras gpt-oss-120b (2026-05-12):
+ * a user asked "what is the SHA of the latest commit on develop in
+ * /home/milady/iqlabs/milady/eliza ? short sha only". The planner
+ * trajectory errored (no stages recorded, finalDecision=error) and the
+ * fallback failure-reply path emitted a SHA that appeared in recent
+ * conversation context but did not match the actual current SHA.
+ *
+ * Root cause: the failure prompt contained the line
+ *
+ *   "If the user already gave a clear command and you can plausibly act,
+ *    acknowledge it and offer to take the action directly."
+ *
+ * which the model read as license to invent an answer from context.
+ *
+ * Fix: the prompt now explicitly forbids answering the question on the
+ * merits during a failure reply — even when the answer looks obvious —
+ * because the grounding trajectory never ran. These tests pin the
+ * forbid-list so a future "let's make the failure reply more helpful"
+ * refactor can't silently re-introduce the hallucination vector.
+ */
+describe("buildFailureReplyPrompt", () => {
+	const RECENT =
+		"@e2e: what is the SHA of the latest commit on develop?\n@bot: 7593";
+
+	it("includes the explicit NEVER-answer-on-the-merits rule", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).toContain("NEVER answer the user's question on the merits");
+		expect(prompt).toContain(
+			"The trajectory that would have GROUNDED the answer failed",
+		);
+	});
+
+	it("enumerates the answer-shaped tokens it must refuse to emit", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		// Must list SHA, count, price, date, status, file path, name —
+		// these are the specific identifier-shaped categories the model
+		// was previously tempted to fabricate from context.
+		expect(prompt).toContain("a SHA");
+		expect(prompt).toContain("a count");
+		expect(prompt).toContain("a price");
+		expect(prompt).toContain("a date");
+		expect(prompt).toContain("a status");
+		expect(prompt).toContain("a file path");
+		expect(prompt).toContain("a name");
+	});
+
+	it("does NOT contain the removed 'plausibly act' escape hatch", () => {
+		// Regression guard against the exact wording that caused the
+		// hallucination. If anyone re-introduces this phrasing the bot
+		// can re-hallucinate.
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).not.toContain("plausibly act");
+		expect(prompt).not.toContain("take the action directly");
+	});
+
+	it("requires the reply to invite a retry", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).toContain("Acknowledge that something went wrong");
+		expect(prompt).toContain("suggest a retry");
+	});
+
+	it("forbids paraphrasing the user's question as if about to answer", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).toContain("Do not paraphrase or echo the user's question");
+	});
+
+	it("embeds the recent conversation verbatim for the model to keep voice", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).toContain(RECENT);
+		// The recent-conversation block lives below the rules so the
+		// rules anchor before the context.
+		const ruleIdx = prompt.indexOf("Hard rules:");
+		const recentIdx = prompt.indexOf("Recent Conversation:");
+		expect(ruleIdx).toBeGreaterThanOrEqual(0);
+		expect(recentIdx).toBeGreaterThan(ruleIdx);
+	});
+
+	it("preserves the internal-mechanism vocabulary blocklist", () => {
+		// The bot's character protects against tech-jargon leaks via this
+		// list. Keep it pinned so blanket rewrites of the prompt don't
+		// accidentally drop it.
+		const prompt = buildFailureReplyPrompt(RECENT);
+		for (const term of [
+			"planner",
+			"action_planner",
+			"XML",
+			"JSON",
+			"schema",
+			"prompt",
+			"runtime",
+		]) {
+			expect(prompt).toContain(term);
+		}
+	});
+
+	it("preserves the punctuation rule (no em-dash / en-dash)", () => {
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt).toContain(
+			"Do not use em-dashes or en-dashes. Use a plain hyphen, period, or comma.",
+		);
+	});
+
+	it("does not leak any obvious internal trace into the prompt itself", () => {
+		// Catch accidental newlines / markdown formatting that would
+		// confuse the model. The prompt should be a clean plain-text
+		// instruction block ending with the literal "Reply:" anchor.
+		const prompt = buildFailureReplyPrompt(RECENT);
+		expect(prompt.endsWith("Reply:")).toBe(true);
+		expect(prompt).not.toContain("```");
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2964,11 +2964,7 @@ function normalizeRawParsedForFieldRegistry(
 	}
 	if (normalized.replyText === undefined) {
 		normalized.replyText =
-			raw.replyText ??
-			raw.reply ??
-			fields.replyText ??
-			fields.reply ??
-			"";
+			raw.replyText ?? raw.reply ?? fields.replyText ?? fields.reply ?? "";
 	}
 	if (normalized.contexts === undefined) {
 		normalized.contexts = fields.contexts ?? [];
@@ -2978,14 +2974,17 @@ function normalizeRawParsedForFieldRegistry(
 			raw.candidateActionNames ?? fields.candidateActions ?? [];
 	}
 	const extract =
-		raw.extract && typeof raw.extract === "object" && !Array.isArray(raw.extract)
+		raw.extract &&
+		typeof raw.extract === "object" &&
+		!Array.isArray(raw.extract)
 			? (raw.extract as Record<string, unknown>)
 			: undefined;
 	if (normalized.facts === undefined) {
 		normalized.facts = extract?.facts ?? raw.facts ?? [];
 	}
 	if (normalized.relationships === undefined) {
-		normalized.relationships = extract?.relationships ?? raw.relationships ?? [];
+		normalized.relationships =
+			extract?.relationships ?? raw.relationships ?? [];
 	}
 	if (normalized.addressedTo === undefined) {
 		normalized.addressedTo = extract?.addressedTo ?? raw.addressedTo ?? [];
@@ -3048,7 +3047,8 @@ function messageHandlerFromFieldResult(
 					: "RESPOND";
 	const preemptDirect =
 		preempt?.mode === "ack-and-stop" || preempt?.mode === "direct-reply";
-	const replyText = typeof result.replyText === "string" ? result.replyText : "";
+	const replyText =
+		typeof result.replyText === "string" ? result.replyText : "";
 	const routedContexts = preemptDirect
 		? Array.from(new Set([...contexts, SIMPLE_CONTEXT_ID]))
 		: contexts;
@@ -4687,15 +4687,16 @@ export async function runV5MessageRuntimeStage1(args: {
 		let fieldRunResult: ResponseHandlerFieldRunResult | null = null;
 		let messageHandler: MessageHandlerResult | null = null;
 		if (rawFieldParsed) {
-			fieldRunResult =
-				await args.runtime.responseHandlerFieldRegistry.dispatch({
+			fieldRunResult = await args.runtime.responseHandlerFieldRegistry.dispatch(
+				{
 					rawParsed: normalizeRawParsedForFieldRegistry(rawFieldParsed),
 					runtime: args.runtime,
 					message: args.message,
 					state: args.state,
 					senderRole: senderRole as ResponseHandlerSenderRole,
 					turnSignal: stage1TurnSignal,
-				});
+				},
+			);
 			messageHandler = messageHandlerFromFieldResult(
 				fieldRunResult.parsed,
 				fieldRunResult,
@@ -5398,6 +5399,60 @@ function extractMessageHandlerUsage(raw: GenerateTextResult):
 		out.cacheCreationInputTokens = usage.cacheCreationInputTokens;
 	}
 	return out;
+}
+
+/**
+ * Build the prompt sent to the fallback "failure reply" model when the
+ * planner trajectory errors out (rate limits, transient network failure,
+ * provider 5xx). The prompt forbids the model from emitting any
+ * substantive answer to the user's question — including answers that
+ * appear "obvious" from recent-conversation context — because the
+ * grounding trajectory never ran.
+ *
+ * Why a separate exported function: this prompt is load-bearing for
+ * correctness (a previous version's "if you can plausibly act, do it"
+ * escape hatch caused gpt-oss-120b on Cerebras to hallucinate a git
+ * SHA from prior chat context during a live battle test, even though
+ * no tool was actually called). Pinning the hard rules in tests means
+ * a future "let's make the failure reply more helpful" refactor can't
+ * silently re-introduce the hallucination vector.
+ *
+ * @param recentMessages Plain-text projection of the recent conversation
+ * (whatever the caller has at hand — typically `state.values.recentMessages`).
+ */
+export function buildFailureReplyPrompt(recentMessages: string): string {
+	return [
+		"You hit a transient model error and have to send a short user-facing reply.",
+		"Write a one or two sentence reply in plain language.",
+		"",
+		"Hard rules:",
+		"- Stay in character. Keep your usual voice and tone.",
+		"- NEVER mention internal mechanism words such as: planner, action_planner,",
+		"  XML, JSON, schema, structured output, model, retries, sonnet,",
+		"  opus, claude, anthropic, prompt, parse, parser, xml plan, decision",
+		"  loop, runtime, dispatch, or hand off. The user does not know or care",
+		"  what those are.",
+		"- Do not use em-dashes or en-dashes. Use a plain hyphen, period, or comma.",
+		"- Acknowledge that something went wrong and suggest a retry. Examples:",
+		'  "something flaked, try again in a sec",',
+		'  "weird hiccup, give me another shot in a moment",',
+		'  "got stuck on my end, retry that?"',
+		"- NEVER answer the user's question on the merits in this reply. Even",
+		"  if the answer looks obvious from context (a SHA, a count, a price,",
+		"  a date, a status, a file path, a name, a result), DO NOT emit it.",
+		"  The trajectory that would have GROUNDED the answer failed, so any",
+		"  factual claim you make here is by definition ungrounded — the user",
+		"  will retry, the real run will produce the grounded answer, and",
+		"  meanwhile you must not invent one from recent-conversation context.",
+		"- Do not paraphrase or echo the user's question as if you were about",
+		"  to answer it. Just say something went wrong and invite a retry.",
+		"- Return only the reply text. No labels, no XML, no JSON, no <think>.",
+		"",
+		"Recent Conversation:",
+		recentMessages,
+		"",
+		"Reply:",
+	].join("\n");
 }
 
 /**
@@ -8385,7 +8440,10 @@ export class DefaultMessageService implements IMessageService {
 							]);
 							const scopedStreamingContext: StreamingContext | undefined =
 								streamingContext
-									? { ...streamingContext, ...(abortSignal ? { abortSignal } : {}) }
+									? {
+											...streamingContext,
+											...(abortSignal ? { abortSignal } : {}),
+										}
 									: abortSignal
 										? {
 												onStreamChunk: async () => undefined,
@@ -9854,31 +9912,7 @@ export class DefaultMessageService implements IMessageService {
 			state,
 			message,
 		);
-		const failurePrompt = [
-			"You hit a transient model error and have to send a short user-facing reply.",
-			"Write a one or two sentence reply in plain language.",
-			"",
-			"Hard rules:",
-			"- Stay in character. Keep your usual voice and tone.",
-			"- NEVER mention internal mechanism words such as: planner, action_planner,",
-			"  XML, JSON, schema, structured output, model, retries, sonnet,",
-			"  opus, claude, anthropic, prompt, parse, parser, xml plan, decision",
-			"  loop, runtime, dispatch, or hand off. The user does not know or care",
-			"  what those are.",
-			"- Do not use em-dashes or en-dashes. Use a plain hyphen, period, or comma.",
-			"- Just acknowledge that something went wrong and suggest a retry.",
-			'  Examples: "something flaked, try again in a sec",',
-			'  "weird hiccup, give me another shot in a moment",',
-			'  "got stuck on my end, retry that?"',
-			"- If the user already gave a clear command and you can plausibly act,",
-			"  acknowledge it and offer to take the action directly. Keep it short.",
-			"- Return only the reply text. No labels, no XML, no JSON, no <think>.",
-			"",
-			"Recent Conversation:",
-			recentMessages,
-			"",
-			"Reply:",
-		].join("\n");
+		const failurePrompt = buildFailureReplyPrompt(recentMessages);
 
 		const attempt = await this.generateFailureReplyText(
 			runtime,


### PR DESCRIPTION
## Summary

Live regression on Cerebras gpt-oss-120b during a 2026-05-12 battle test: user asked

> what is the SHA of the latest commit on develop in /home/milady/iqlabs/milady/eliza ? short sha only

The planner trajectory errored out (status=errored, stages=[], finalDecision=error) in 6.3 s — likely a 429 or transient provider failure. The fallback failure-reply path then emitted **\`db8416d\`**, a SHA that appeared in earlier conversation context (from a discussion of PR #7565) but **did not match the actual current SHA** (\`ec0359a\` / \`3600db2\`).

### Root cause

The failure-reply prompt contained:

> "If the user already gave a clear command and you can plausibly act, acknowledge it and offer to take the action directly."

The model read "plausibly act" as license to **fabricate an answer from recent-conversation context** — even though the grounding trajectory that would have actually answered the question had failed.

## Fix (structural, prompt-level)

Replace the "plausibly act" escape hatch with an explicit forbid-list covering the identifier-shaped categories the model was tempted to fabricate (SHA, count, price, date, status, file path, name, result):

> "NEVER answer the user's question on the merits in this reply. Even if the answer looks obvious from context, DO NOT emit it. The trajectory that would have GROUNDED the answer failed, so any factual claim you make here is by definition ungrounded — the user will retry, the real run will produce the grounded answer, and meanwhile you must not invent one from recent-conversation context."

Plus a paraphrase-guard so the failure reply doesn't echo the question as if about to answer.

## Extract + test

Moved the inline prompt-string into an exported \`buildFailureReplyPrompt\` helper so the rules can be pinned by unit tests. **9 new pin tests** in \`__tests__/failure-reply-prompt.test.ts\`:

- the explicit NEVER-answer rule and grounding sentence are present
- all 7 identifier categories (SHA, count, price, date, status, file path, name) are enumerated by the forbid list
- the removed "plausibly act" / "take the action directly" wording is **NOT** present (regression guard against re-introduction)
- retry-invitation language is present
- the paraphrase guard is present
- the recent-conversation block is below the rules (rules anchor)
- the internal-mechanism blocklist (planner/JSON/schema/runtime/etc.) is preserved
- the em-dash / en-dash punctuation rule is preserved
- the prompt ends cleanly with the \`Reply:\` anchor

Full core suite: **811 pass / 3 pre-existing fail.** Lint + format + tsc \`--noEmit\` all clean.

## Why not detect SHA-shape in the reply post-hoc?

A post-hoc filter that strips SHA-shaped strings from failure replies would be the kind of regex-pile we want to avoid: it only catches SHAs (40-hex / 7-hex), not the other identifier shapes (counts, prices, paths, names) the model can equally hallucinate. The prompt-level forbid is the smart fix — it scales to every identifier-shaped answer without per-shape detectors.

## Why not just remove the failure-reply path entirely?

Some kind of user-facing reply IS needed when the planner errors — otherwise the user gets silence and assumes the bot is broken. "Something flaked, retry" is the right shape; the bug was the escape hatch into making up an answer.

## Background

P1.X follow-up from the Cerebras-context debug walkthrough at https://nubilio.org/apps/cerebras-context-debug/. Surfaced during the gpt-oss-120b live battle-test on 2026-05-12 (test #6).

Companion to **#7594** (context budget), **#7597** (provider-switch base-URL guard), **#7598** (per-step result char cap), **#7599** (user-facing tool text isolation).

## Test plan

- [x] \`bun test packages/core/src/services/__tests__/failure-reply-prompt.test.ts\` → **9 pass**
- [x] \`bun test packages/core/\` → **811 pass / 3 pre-existing fail**
- [x] biome lint + format clean
- [x] \`bunx tsc --noEmit -p packages/core/tsconfig.json\` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a live hallucination regression where the failure-reply fallback path was emitting ungrounded answers (e.g., a git SHA) sourced from recent conversation context when the planner trajectory errored. The core change replaces the "plausibly act" escape hatch in the failure prompt with an explicit NEVER-answer rule and a paraphrase guard, then extracts the prompt into an exported `buildFailureReplyPrompt` function backed by 9 new pin tests.

- **`message.ts`**: Inline `failurePrompt` array is extracted to exported `buildFailureReplyPrompt`; the "plausibly act / take the action directly" clause is removed and replaced with an explicit forbid-list covering SHA, count, price, date, status, file path, and name; all other edits are cosmetic line-length reformatting.
- **`failure-reply-prompt.test.ts`**: New pin-test suite with 9 tests that lock in the hard rules, vocabulary blocklist, retry-invitation, paraphrase guard, prompt ordering, and absence of the removed escape-hatch wording.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the prompt change tightens the failure-reply contract and the only notable issue is a cosmetic inconsistency between the prompt's own em-dash usage and the rule it tells the model to follow.

The structural change is well-scoped: the prompt refactoring removes a real regression vector, the exported function is straightforward, and the pin tests are comprehensive. The one inconsistency — an em-dash on line 5444 while the rule on line 5435 forbids em-dashes — is minor, but it's not caught by the existing tests, so it could silently persist or re-appear through future edits.

The em-dash in the buildFailureReplyPrompt body (message.ts line 5444) and the corresponding gap in the punctuation pin test (failure-reply-prompt.test.ts lines 102-107) are the only spots that warrant a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Extracts inline failure-reply prompt into exported `buildFailureReplyPrompt`, replaces "plausibly act" escape hatch with explicit NEVER-answer rules; remaining changes are cosmetic line-wrap reformatting. One em-dash in the new prompt body contradicts the punctuation rule the prompt itself enforces. |
| packages/core/src/services/__tests__/failure-reply-prompt.test.ts | New test file with 9 pin tests that guard the failure-reply prompt's hard rules; tests are thorough but the punctuation test only checks the rule text is present, not that the prompt body itself is dash-free. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): failure-reply prompt no longe..."](https://github.com/elizaos/eliza/commit/fdc3d0c159aae285644658d00800844fedd42bef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31709598)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->