### PR TITLE
fix(ui): expose ./events subpath in exports map

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,6 +43,7 @@
     "./styles/*.css": "./dist/styles/*.css",
     "./api/client-types-cloud": "./dist/api/client-types-cloud.js",
     "./config/app-config": "./dist/config/app-config.js",
+    "./events": "./dist/events/index.js",
     "./onboarding-config": "./dist/onboarding-config.js",
     "./dist/styles/*.css": "./dist/styles/*.css",
     "./*.css": "./dist/*.css",


### PR DESCRIPTION
## Summary

\`@elizaos/ui/src/events/index.ts\` ships compiled to \`dist/events/index.js\` and exports \`dispatchFocusConnector\` plus the canonical event-name constants (\`COMMAND_PALETTE_EVENT\`, \`AGENT_READY_EVENT\`, etc.) — but \`./events\` isn't in the package.json \`exports\` map, so any consumer that imports the subpath fails to resolve.

## Reproduction

\`\`\`
$ grep -rl 'from "@elizaos/ui/events"' packages plugins
plugins/app-lifeops/src/hooks/useGoogleLifeOpsConnector.ts
plugins/app-lifeops/src/components/MessagingConnectorCards.tsx
plugins/app-lifeops/src/components/LifeOpsOperationalPanels.tsx
plugins/app-lifeops/src/components/LifeOpsSetupGate.tsx
\`\`\`

Building a downstream workspace that consumes \`@elizaos/ui\` as in-tree source (e.g. milady with \`MILADY_ELIZA_SOURCE=local\`) hits:

> [vite]: Rollup failed to resolve import \"@elizaos/ui/events\" from \"plugins/app-lifeops/src/hooks/useGoogleLifeOpsConnector.ts\".

## Fix

One-line addition to \`packages/ui/package.json\` exports map. The wildcard \`./*\` fallback doesn't route directories through \`/index.js\` automatically, so the directory needs its own explicit entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a missing subpath export by adding `"./events": "./dist/events/index.js"` to the `exports` map in `packages/ui/package.json`, resolving the Vite/Rollup resolution error downstream consumers hit when importing `@elizaos/ui/events`.

- The one-line addition follows the same pattern as other existing specific subpath entries (`./api/client-types-cloud`, `./config/app-config`, `./onboarding-config`) — a bare JS path string with no `types` condition.
- The source file `packages/ui/src/events/index.ts` exists and exports the expected constants and helpers; the `tsc` build will produce `dist/events/index.js` alongside a `dist/events/index.d.ts`, which TypeScript can pick up automatically for most `moduleResolution` settings.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a one-line addition to the exports map with no runtime logic changes.

The change adds a single, explicit subpath export that directly mirrors the compiled output of an existing source file. It follows the exact same pattern as three other specific subpath entries already in the map, the source file and its exports are well-established, and there is no risk of breaking existing consumers since the entry is purely additive.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/package.json | Adds `"./events": "./dist/events/index.js"` to the exports map so downstream consumers can resolve `@elizaos/ui/events`. Change is minimal and follows the same pattern as other specific subpath entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer: import from '@elizaos/ui/events'"] --> B{Resolve via exports map}
    B -- "Before PR: no exact match" --> C["Wildcard ./* fallback"]
    C --> D["Tries dist/events.js ❌\n(file doesn't exist)"]
    D --> E["Rollup resolution error"]
    B -- "After PR: exact match './events'" --> F["dist/events/index.js ✅"]
    F --> G["dispatchFocusConnector, COMMAND_PALETTE_EVENT, etc."]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): expose ./events subpath in expo..."](https://github.com/elizaos/eliza/commit/cfc51fec60569af9e98dba69628e1ffd5da3f1cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31720266)</sub>

<!-- /greptile_comment -->