### PR TITLE
fix(android): bump chat-gen + device-gen timeouts for stock-Android sideloads

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -782,6 +782,25 @@ public class ElizaAgentService extends Service {
             // device-bridge. The WebView dials it over loopback once the
             // user picks the local runtime mode in onboarding.
             agentEnv.put("ELIZA_DEVICE_BRIDGE_ENABLED", "1");
+            // CPU-only inference on a stock-Android Capacitor APK runs the
+            // same on-device chat path as the AOSP variant — Snapdragon
+            // 4 Gen 1 / Tensor G1 class hardware lands at 3–7 tok/s and a
+            // ~4.5 k-token system prompt + 256-token reply easily blows
+            // past the chat-route 180 s / device-bridge 120 s defaults.
+            // The upstream gate that bumps these (under
+            // `BuildConfig.AOSP_BUILD && isBrandedDevice()` further down)
+            // only fires for branded AOSP builds; stock-Android sideloads
+            // get the defaults and time out on every first turn with
+            // "Chat generation failed with no streamed text
+            // (err=Chat generation timed out after 180000ms)". Set the
+            // same 10 min budget here unconditionally so both build
+            // types finish their cold first turn.
+            if (!env.containsKey("ELIZA_CHAT_GENERATION_TIMEOUT_MS")) {
+                agentEnv.put("ELIZA_CHAT_GENERATION_TIMEOUT_MS", "600000");
+            }
+            if (!env.containsKey("ELIZA_DEVICE_GENERATE_TIMEOUT_MS")) {
+                agentEnv.put("ELIZA_DEVICE_GENERATE_TIMEOUT_MS", "600000");
+            }
             // The mobile bridge ships the bge embedding GGUF disabled
             // by default (`ELIZA_LOCAL_EMBEDDING_ENABLED!="1"`) because
             // mmapping it alongside the chat GGUF would OOM a 4 GB


### PR DESCRIPTION
## Summary

\`ELIZA_CHAT_GENERATION_TIMEOUT_MS\` (chat-routes.ts 180 s default) and \`ELIZA_DEVICE_GENERATE_TIMEOUT_MS\` (plugin-capacitor-bridge 120 s default) are bumped to 10 min in the branded AOSP build path (under \`BuildConfig.AOSP_BUILD && isBrandedDevice()\` further down in \`ElizaAgentService.java\`). Stock-Android Capacitor sideloads — the path Pixel 6a / Moto G Play 2024 users walk when they install a milady-class APK from Play Store / \`adb install\` — don't take that branch and keep the upstream defaults.

The defaults are wrong for any sideload that bundles a chat GGUF and runs the on-device bun agent.

## Reproduction

CPU-only inference on Snapdragon 4 Gen 1 / Tensor G1 lands at 3–7 tok/s. A stage-1 messageHandler prompt sits at ~4.5 k tokens, and the assistant reply is capped at 256 tokens, so end-to-end turn time is consistently 90–180 s and slips past the 180 s chat-route timeout on the first turn.

Deterministic failure mode:
- Renderer surfaces: \`Sorry, I'm having a provider issue\`
- agent.log: \`Chat generation failed with no streamed text (err=Chat generation timed out after 180000ms)\`

## Fix

Set the same 10 min budget unconditionally for the stock-Android path. The AOSP path further down stays at 1 h (cuttlefish numbers are much worse).

## Verified

Milady Pixel 6a APK on a fresh install: chat turns now complete without timeout failures (still hit the EOG-not-honored separate bug, but that's a model/GGUF-metadata issue not a timeout one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a deterministic timeout failure on stock-Android Capacitor sideloads where CPU-only inference (Snapdragon 4 Gen 1 / Tensor G1 at 3–7 tok/s) routinely exceeds the 180 s chat-route and 120 s device-bridge defaults on first turn. The fix inserts two `env.containsKey()` guarded assignments before the existing `BuildConfig.AOSP_BUILD && isBrandedDevice()` block, raising both timeouts to 10 min for any build that hasn't already set them via the parent service environment.

- Both new guards use the same operator-override pattern (`!env.containsKey(...)`) established throughout the file; the AOSP block's subsequent unconditional `agentEnv.put(\"ELIZA_CHAT_GENERATION_TIMEOUT_MS\", \"3600000\")` correctly overwrites the 10-min value to 1 h for AOSP builds.
- `ELIZA_DEVICE_GENERATE_TIMEOUT_MS` has no corresponding AOSP-block override, so AOSP builds now receive 600 000 ms (10 min) for that key instead of the previous 120 s upstream default — an undocumented side effect that is benign because AOSP routes inference through the native llama.so adapter (`ELIZA_LOCAL_LLAMA=1`), not the device bridge.

<h3>Confidence Score: 4/5</h3>

Safe to merge for stock-Android sideloads; the AOSP path gets a minor, likely harmless side effect on one timeout variable.

The fix is narrow and well-motivated: the timeout values were clearly too short for the described hardware, the guard pattern matches the established convention throughout the file, and the AOSP chat timeout is correctly preserved at 3600000 ms by the existing unconditional override. The only wrinkle is that ELIZA_DEVICE_GENERATE_TIMEOUT_MS for AOSP builds changes from the 120 s upstream default to 600 s without a corresponding override or documentation — but since AOSP uses direct llama.so inference and not the device bridge, this variable is dormant on that code path today.

Only ElizaAgentService.java changed; the AOSP block around line 861 is worth a second look to confirm whether ELIZA_DEVICE_GENERATE_TIMEOUT_MS also needs an explicit 3600000 ms override there.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java | Adds env.containsKey() guards before the AOSP block to set ELIZA_CHAT_GENERATION_TIMEOUT_MS and ELIZA_DEVICE_GENERATE_TIMEOUT_MS to 600000 ms for stock-Android sideloads; AOSP chat timeout is correctly overwritten to 3600000 ms further down, but ELIZA_DEVICE_GENERATE_TIMEOUT_MS is not analogously overridden in the AOSP block, silently changing AOSP from the 120 s upstream default to 10 min. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ElizaAgentService: buildAgentEnv] --> B[Set common env vars\nPORT, ELIZA_PLATFORM, AUTH, etc.]
    B --> C{env contains\nELIZA_CHAT_GENERATION_TIMEOUT_MS?}
    C -- No --> D[agentEnv.put 600000ms]
    C -- Yes --> E[Skip — respect operator override]
    D --> F{env contains\nELIZA_DEVICE_GENERATE_TIMEOUT_MS?}
    E --> F
    F -- No --> G[agentEnv.put 600000ms]
    F -- Yes --> H[Skip — respect operator override]
    G --> I{BuildConfig.AOSP_BUILD\n&& isBrandedDevice?}
    H --> I
    I -- Yes AOSP path --> J[agentEnv.put ELIZA_CHAT_GENERATION_TIMEOUT_MS = 3600000\noverrides the 600000 set above]
    J --> K[Set ELIZA_LOCAL_LLAMA=1\nELIZA_LLAMA_N_CTX, THREADS, N_BATCH]
    K --> L[env.putAll agentEnv\nAOSP: chat=3600000ms, device=600000ms]
    I -- No stock-Android path --> M[env.putAll agentEnv\nstock: chat=600000ms, device=600000ms]
```

<sub>Reviews (1): Last reviewed commit: ["fix(android): bump chat-gen + device-gen..."](https://github.com/elizaos/eliza/commit/50e8e2d3b70491ec77dd1cb8d3a22b63f9bb53e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31720290)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->