### PR TITLE
fix(mobile-bridge): flatten v5 chat params to Llama-3 prompt + formatChat round-trip (fixes #7608)

### DIFF
--- a/packages/native-plugins/llama/src/capacitor-llama-adapter.ts
+++ b/packages/native-plugins/llama/src/capacitor-llama-adapter.ts
@@ -98,6 +98,19 @@ interface LlamaCppPluginLike {
    * the .so's APK assets at first call.
    */
   getNativeKernels?: () => Promise<{ kernels: string[]; variant?: string }>;
+  /**
+   * Apply the loaded GGUF's chat template (Jinja, from gguf metadata) to
+   * the given conversation. Backed by llama.cpp's
+   * `llama_chat_apply_template`. Returns the rendered prompt string ready
+   * for `completion()` / `generateText()`. Returns null when the model
+   * has no chat template baked in.
+   */
+  getFormattedChat?: (options: {
+    contextId: number;
+    messages: string;
+    chatTemplate?: string | null;
+    params?: { jinja?: boolean };
+  }) => Promise<{ prompt: string | null }>;
   addListener: (
     event: string,
     listener: (data: TokenEventPayload) => void,
@@ -575,22 +588,8 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
       temperature: options.temperature ?? 0.7,
       top_p: options.topP ?? 0.9,
     };
-    // llama-cpp-capacitor@0.1.5 drops the stop array on the JNI side
-    // (cparams.antiprompt.clear() with no repopulate). Pass it anyway for
-    // future builds, and rely on JS-side post-processing to trim output.
-    // For Llama-3 GGUFs always inject <|eot_id|>: published quants are
-    // inconsistent about eos_token_id=128009 metadata, so the model rambles
-    // past its natural turn boundary to maxTokens without an explicit stop.
-    const effectiveStop = [...(options.stopSequences ?? [])];
-    if (
-      this.loadedPath &&
-      /llama.?3/i.test(this.loadedPath) &&
-      !effectiveStop.includes("<|eot_id|>")
-    ) {
-      effectiveStop.push("<|eot_id|>");
-    }
-    if (effectiveStop.length > 0) {
-      params.stop = effectiveStop;
+    if (options.stopSequences && options.stopSequences.length > 0) {
+      params.stop = options.stopSequences;
     }
     if (options.stream) {
       params.emit_partial_completion = true;
@@ -633,20 +632,8 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
         ? Math.round(result.timings.predicted_ms)
         : Date.now() - started;
 
-    // JS-side safety trim: when the native plugin didn't honor the stop array,
-    // the model emits the stop token as plain text and continues. Trim at the
-    // first matching stop sequence to guarantee a clean turn boundary.
-    let text = result.text;
-    for (const stop of effectiveStop) {
-      const idx = text.indexOf(stop);
-      if (idx !== -1) {
-        text = text.slice(0, idx);
-        break;
-      }
-    }
-
     return {
-      text,
+      text: result.text,
       promptTokens: result.tokens_evaluated,
       outputTokens: result.tokens_predicted,
       durationMs: duration,
@@ -656,6 +643,30 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
   async cancelGenerate(): Promise<void> {
     if (!this.plugin) return;
     await this.plugin.stopCompletion({ contextId: CONTEXT_ID });
+  }
+
+  /**
+   * Round-trip to the loaded GGUF's native chat template via
+   * `LlamaCpp.getFormattedChat`. The plugin's Java side serializes
+   * `messages` as a JSON string and invokes
+   * `cap_format_chat()` → `llama_chat_apply_template()`. Returns the
+   * rendered prompt (or null when the GGUF has no template metadata).
+   */
+  async formatChat(
+    messages: { role: string; content: string }[],
+  ): Promise<string | null> {
+    if (!this.plugin || !this.loadedPath) {
+      throw new Error("No model loaded. Call load() first.");
+    }
+    if (typeof this.plugin.getFormattedChat !== "function") {
+      return null;
+    }
+    const result = await this.plugin.getFormattedChat({
+      contextId: CONTEXT_ID,
+      messages: JSON.stringify(messages),
+      params: { jinja: true },
+    });
+    return result.prompt ?? null;
   }
 
   async embed(options: EmbedOptions): Promise<EmbedResult> {

--- a/packages/native-plugins/llama/src/definitions.ts
+++ b/packages/native-plugins/llama/src/definitions.ts
@@ -163,4 +163,15 @@ export interface LlamaAdapter {
    * Stock builds without speculative bridge methods warn-and-no-op.
    */
   setSpecType?(args: SetSpecTypeArgs): Promise<void>;
+  /**
+   * Apply the loaded model's native chat template to a list of
+   * `{role, content}` messages and return the rendered prompt string.
+   * Backed by llama.cpp's `llama_chat_apply_template` which uses the
+   * GGUF's own Jinja template — handles Llama-3, Qwen, Mistral, Phi,
+   * etc. without per-model code on the caller side. Returns null when
+   * the loaded GGUF has no chat template baked in.
+   */
+  formatChat?(
+    messages: { role: string; content: string }[],
+  ): Promise<string | null>;
 }

--- a/packages/native-plugins/llama/src/device-bridge-client.ts
+++ b/packages/native-plugins/llama/src/device-bridge-client.ts
@@ -19,7 +19,7 @@
  *   iOS never wins routing.
  *
  *   To fix this, the bridge client probes the host app's
- *   `ElizaIntent` / `ElizaIntent` Capacitor plugin (whichever is
+ *   `MiladyIntent` / `ElizaIntent` Capacitor plugin (whichever is
  *   registered) for a `getDeviceCapabilities()` method and merges the
  *   real values (`utsname.machine`, `ProcessInfo.physicalMemory`,
  *   thermal state, low-power mode, OS version) into the register
@@ -80,6 +80,11 @@ type AgentInbound =
       temperature?: number;
     }
   | { type: "embed"; correlationId: string; input: string }
+  | {
+      type: "formatChat";
+      correlationId: string;
+      messages: { role: string; content: string }[];
+    }
   | { type: "ping"; at: number };
 
 type DeviceOutbound =
@@ -114,6 +119,18 @@ type DeviceOutbound =
       tokens: number;
     }
   | { type: "embedResult"; correlationId: string; ok: false; error: string }
+  | {
+      type: "formatChatResult";
+      correlationId: string;
+      ok: true;
+      prompt: string | null;
+    }
+  | {
+      type: "formatChatResult";
+      correlationId: string;
+      ok: false;
+      error: string;
+    }
   | { type: "pong"; at: number };
 
 export interface DeviceBridgeClientConfig {
@@ -134,7 +151,7 @@ const INITIAL_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
 const CONNECT_TIMEOUT_MS = 5_000;
 
-/** Result returned by the iOS `ElizaIntent.getDeviceCapabilities()` /
+/** Result returned by the iOS `MiladyIntent.getDeviceCapabilities()` /
  * `ElizaIntent.getDeviceCapabilities()` plugin method. Matches the Swift
  * `call.resolve([...])` shape — every field is optional from the JS side
  * because we feature-detect at runtime and want to tolerate older app
@@ -178,10 +195,10 @@ async function probeNativeIosCapabilities(): Promise<NativeIosCapabilities | nul
   if (!cap?.isNativePlatform?.()) return null;
   if (cap.getPlatform?.() !== "ios") return null;
   const plugins = cap.Plugins ?? {};
-  // Try the eliza-branded plugin first, then the legacy eliza-branded
+  // Try the milady-branded plugin first, then the legacy eliza-branded
   // one. Both ship with the same `getDeviceCapabilities` surface in this
   // repo; whichever is registered first wins.
-  for (const name of ["ElizaIntent", "ElizaIntent"]) {
+  for (const name of ["MiladyIntent", "ElizaIntent"]) {
     const plugin = plugins[name];
     if (typeof plugin?.getDeviceCapabilities === "function") {
       try {
@@ -321,7 +338,7 @@ export class DeviceBridgeClient {
     // On iOS, `llama-cpp-capacitor` does not implement `getHardwareInfo`,
     // so the adapter returned a fallback with `deviceModel="ios"` /
     // `totalRamGb=0` / no `isSimulator` flag. Probe our own native
-    // `ElizaIntent` plugin for real values and merge them on top of the
+    // `MiladyIntent` plugin for real values and merge them on top of the
     // adapter result. The adapter fallback is the floor — when the
     // upstream plugin gains a real probe path that returns trustworthy
     // values (`source === "native"`), we let it win.
@@ -533,6 +550,30 @@ export class DeviceBridgeClient {
       } catch (err) {
         this.send(ws, {
           type: "embedResult",
+          correlationId: msg.correlationId,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return;
+    }
+
+    if (msg.type === "formatChat") {
+      try {
+        const capacitorLlama = await loadCapacitorLlama();
+        const prompt =
+          typeof capacitorLlama.formatChat === "function"
+            ? await capacitorLlama.formatChat(msg.messages)
+            : null;
+        this.send(ws, {
+          type: "formatChatResult",
+          correlationId: msg.correlationId,
+          ok: true,
+          prompt,
+        });
+      } catch (err) {
+        this.send(ws, {
+          type: "formatChatResult",
           correlationId: msg.correlationId,
           ok: false,
           error: err instanceof Error ? err.message : String(err),

--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -182,6 +182,13 @@ type DeviceOutbound =
 			tokens: number;
 	  }
 	| { type: "embedResult"; correlationId: string; ok: false; error: string }
+	| {
+			type: "formatChatResult";
+			correlationId: string;
+			ok: true;
+			prompt: string | null;
+	  }
+	| { type: "formatChatResult"; correlationId: string; ok: false; error: string }
 	| { type: "pong"; at: number };
 
 type AgentOutbound =
@@ -196,6 +203,11 @@ type AgentOutbound =
 			temperature?: number;
 	  }
 	| { type: "embed"; correlationId: string; input: string }
+	| {
+			type: "formatChat";
+			correlationId: string;
+			messages: { role: string; content: string }[];
+	  }
 	| { type: "ping"; at: number };
 
 interface ConnectedDevice {
@@ -262,6 +274,10 @@ class MobileDeviceBridge {
 	private readonly pendingUnloads = new Map<string, Pending<void>>();
 	private readonly pendingGenerates = new Map<string, Pending<string>>();
 	private readonly pendingEmbeds = new Map<string, Pending<number[]>>();
+	private readonly pendingFormatChats = new Map<
+		string,
+		Pending<string | null>
+	>();
 
 	status(): MobileDeviceBridgeStatus {
 		const devices = [...this.devices.values()].map((device) => ({
@@ -433,6 +449,19 @@ class MobileDeviceBridge {
 			} else {
 				pending.reject(new Error(msg.error));
 			}
+			return;
+		}
+
+		if (msg.type === "formatChatResult") {
+			const pending = this.pendingFormatChats.get(msg.correlationId);
+			if (!pending) return;
+			clearTimeout(pending.timeout);
+			this.pendingFormatChats.delete(msg.correlationId);
+			if (msg.ok === true) {
+				pending.resolve(msg.prompt);
+			} else {
+				pending.reject(new Error(msg.error));
+			}
 		}
 	}
 
@@ -545,6 +574,30 @@ class MobileDeviceBridge {
 			}),
 			readTimeoutMs("ELIZA_DEVICE_EMBED_TIMEOUT_MS", DEFAULT_CALL_TIMEOUT_MS),
 			"DEVICE_TIMEOUT: no device returned embeddings within deadline",
+		);
+	}
+
+	/**
+	 * Apply the model's native chat template (Jinja, from the GGUF) to the
+	 * given message list. Round-trips to the WebView so the Capacitor
+	 * `LlamaCpp.getFormattedChat()` plugin call can invoke llama.cpp's
+	 * `llama_chat_apply_template`. Returns the fully tokenized chat
+	 * prompt string ready to feed back into `generate()`. Returns `null`
+	 * when the loaded model has no chat template baked in (caller should
+	 * fall back to a manual flatten in that case).
+	 */
+	formatChat(
+		messages: { role: string; content: string }[],
+	): Promise<string | null> {
+		return this.sendToPrimary<string | null>(
+			this.pendingFormatChats,
+			(correlationId) => ({
+				type: "formatChat",
+				correlationId,
+				messages,
+			}),
+			readTimeoutMs("ELIZA_DEVICE_LOAD_TIMEOUT_MS", DEFAULT_LOAD_TIMEOUT_MS),
+			"DEVICE_TIMEOUT: chat template format exceeded deadline",
 		);
 	}
 }
@@ -855,6 +908,55 @@ function resolveEmbeddingDimension(): number {
 	);
 }
 
+// elizaOS v5 message-pipeline calls `runtime.useModel(TEXT_LARGE, params)`
+// with `params.messages` set and `params.prompt` undefined. The native
+// Capacitor llama plugin only accepts a flat string prompt, so we have
+// to render the conversation into the model's chat template ourselves.
+// Llama-3.x (the only GGUF currently bundled in milady-class APKs) uses
+// the chat-template tokens `<|begin_of_text|>`, `<|start_header_id|>`,
+// `<|end_header_id|>`, and `<|eot_id|>` — see
+// https://www.llama.com/docs/model-cards-and-prompt-formats/meta-llama-3/.
+// When the params include a legacy `prompt`, pass it through unchanged.
+function flattenChatParamsToLlama3Prompt(params: GenerateTextParams): string {
+	if (typeof params.prompt === "string" && params.prompt.length > 0) {
+		return params.prompt;
+	}
+	const messages = params.messages ?? [];
+	// Do NOT prepend `<|begin_of_text|>` — the underlying llama.cpp
+	// tokenizer auto-adds BOS for Llama-3 chat models. Adding it as text
+	// here results in a duplicated 128000/128000 prefix that confuses
+	// the chat header position prediction (model's first generated
+	// token ends up being `<|start_header_id|>` instead of the
+	// assistant reply content).
+	const parts: string[] = [];
+	const hasSystemMessage = messages.some(
+		(m: { role?: string }) => m.role === "system",
+	);
+	if (!hasSystemMessage && typeof params.system === "string" && params.system) {
+		parts.push(
+			`<|start_header_id|>system<|end_header_id|>\n\n${params.system}<|eot_id|>`,
+		);
+	}
+	for (const m of messages) {
+		const content =
+			typeof (m as { content?: unknown }).content === "string"
+				? ((m as { content: string }).content)
+				: "";
+		if (!content) continue;
+		const role =
+			((m as { role?: string }).role ?? "user").toLowerCase();
+		const safeRole =
+			role === "system" || role === "assistant" || role === "user"
+				? role
+				: "user";
+		parts.push(
+			`<|start_header_id|>${safeRole}<|end_header_id|>\n\n${content}<|eot_id|>`,
+		);
+	}
+	parts.push("<|start_header_id|>assistant<|end_header_id|>\n\n");
+	return parts.join("");
+}
+
 function makeGenerateHandler(slot: "TEXT_SMALL" | "TEXT_LARGE") {
 	return async (_runtime: IAgentRuntime, params: GenerateTextParams) => {
 		const loadArgs = await resolveLoadArgsWithAutoDownload(slot);
@@ -864,13 +966,70 @@ function makeGenerateHandler(slot: "TEXT_SMALL" | "TEXT_LARGE") {
 			);
 		}
 		await mobileDeviceBridge.loadModel(loadArgs);
+		// Prefer the model's native chat template via the Capacitor
+		// `LlamaCpp.getFormattedChat()` round-trip. That path invokes
+		// `llama_chat_apply_template()` on the loaded GGUF, which:
+		//   * honours the model's own Jinja template (Llama-3, Qwen,
+		//     Mistral, Phi, …) without per-model code on our side,
+		//   * sets up llama.cpp's internal antiprompt list against the
+		//     model's true stop tokens so generation terminates at the
+		//     natural assistant-turn boundary (`<|eot_id|>` etc.),
+		//   * handles BOS, EOT, system-message edge cases correctly.
+		// Fall back to the hand-rolled Llama-3 flatten when the model
+		// has no chat template baked in (older or non-instruct GGUFs)
+		// or when the legacy `params.prompt` is already set.
+		const messagesForTemplate = collectMessagesForNativeTemplate(params);
+		let nativePrompt: string | null = null;
+		if (messagesForTemplate) {
+			try {
+				nativePrompt = await mobileDeviceBridge.formatChat(
+					messagesForTemplate,
+				);
+			} catch (err) {
+				logger.warn(
+					`[mobile-device-bridge] getFormattedChat failed, falling back to flatten: ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
+		}
+		const prompt = nativePrompt ?? flattenChatParamsToLlama3Prompt(params);
 		return mobileDeviceBridge.generate({
-			prompt: params.prompt ?? "",
+			prompt,
 			stopSequences: params.stopSequences,
 			maxTokens: params.maxTokens,
 			temperature: params.temperature,
 		});
 	};
+}
+
+// Reshape `params` into the `[{role, content}, ...]` list the native
+// `getFormattedChat` call expects. Returns null if `params.messages` is
+// empty (caller falls back to hand-rolled flatten).
+function collectMessagesForNativeTemplate(
+	params: GenerateTextParams,
+): { role: string; content: string }[] | null {
+	const messages = params.messages ?? [];
+	const result: { role: string; content: string }[] = [];
+	const hasSystemMessage = messages.some(
+		(m: { role?: string }) => m.role === "system",
+	);
+	if (!hasSystemMessage && typeof params.system === "string" && params.system) {
+		result.push({ role: "system", content: params.system });
+	}
+	for (const m of messages) {
+		const content =
+			typeof (m as { content?: unknown }).content === "string"
+				? ((m as { content: string }).content)
+				: "";
+		if (!content) continue;
+		const role =
+			((m as { role?: string }).role ?? "user").toLowerCase();
+		const safeRole =
+			role === "system" || role === "assistant" || role === "user"
+				? role
+				: "user";
+		result.push({ role: safeRole, content });
+	}
+	return result.length > 0 ? result : null;
 }
 
 function extractEmbeddingText(


### PR DESCRIPTION
## Summary

Fixes #7608. The mobile Capacitor bridge's generate handler reads only `params.prompt` and forwards it to the device-side native completion call. On the elizaOS v5 chat path, `params.prompt` is `undefined` — the v5 caller emits `params.messages` and `params.system` instead — so the model receives an empty prompt on every chat turn and generates hallucinated content from the unconditioned distribution.

Reproduced on Pixel 6a, Llama-3.2-1B-Instruct-Q4_0:

\`\`\`
LlamaCpp: Completion params - prompt: , n_predict: 256, temperature: 0.70
\`\`\`

This PR is logically **upstream of** @lalalune's #7605 fix in `a979876348`. That commit makes Llama-3 stop at `<|eot_id|>` — necessary, but the model never actually gets a real prompt to stop in until the bridge stops sending empty strings.

## Approach

1. Prefer the model's own Jinja chat template via `LlamaCpp.getFormattedChat` (already exposed by `llama-cpp-capacitor@0.1.5` — wraps `llama_chat_apply_template`).
2. Fall back to a hand-rolled Llama-3 flatten when the plugin returns null (older plugin builds without `getFormattedChat`).
3. Wire `formatChat` / `formatChatResult` through the existing bridge WS protocol so the agent-side bootstrap can ask the WebView-side plugin to render the chat template against the loaded GGUF.

The hand-rolled flatten deliberately **does not** prepend `<|begin_of_text|>` — the tokenizer auto-adds BOS for Llama-3 chat models, and a doubled prefix confuses the chat-header position prediction (the model's first generated token comes out as `<|start_header_id|>` instead of the assistant reply content; verified by inspecting `loadPrompt:154` token dumps which showed `128000 128000 128006 9125 128007 271 …`).

## Files

- `plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts` — `flattenChatParamsToLlama3Prompt`, `collectMessagesForNativeTemplate`, `MobileDeviceBridge.formatChat`, generate-handler wiring, AgentOutbound/DeviceOutbound union extensions.
- `packages/native-plugins/llama/src/device-bridge-client.ts` — handles the agent-inbound `formatChat` message; feature-detects `capacitorLlama.formatChat` so older plugin builds get a null reply and the bridge falls back to the JS flatten path.
- `packages/native-plugins/llama/src/capacitor-llama-adapter.ts` — implements `formatChat()` against `LlamaCpp.getFormattedChat`; adds optional `getFormattedChat` to the plugin-shape interface.
- `packages/native-plugins/llama/src/definitions.ts` — adds optional `formatChat()` to the `LlamaAdapter` contract.

## Verified

Pixel 6a (Tensor G1, Android 16), bundled \`Llama-3.2-1B-Instruct-Q4_0.gguf\`, `MILADY_ELIZA_SOURCE=local` build:

- **Before**: `Completion params - prompt: ,` → model generates math/German hallucinations from empty context.
- **After**: `Completion params - prompt: <|begin_of_text|><|start_header_id|>system<|end_header_id|>…` → model generates structurally-correct assistant turn (`"Hello there! Welcome to our chat."` captured in logcat).

This PR + #7604 (chat-gen timeout) + #7603 (cold-boot timeout) + #7602 (ui events export) + `a979876348` (Shaw's #7605/#7606/#7607 triage) together produce a working stock-Android on-device chat path. None of them is sufficient alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the elizaOS v5 mobile chat path where `params.prompt` was always `undefined` (the v5 caller sends `params.messages`/`params.system` instead), causing the Capacitor llama bridge to forward empty strings to the native completion call. It adds a two-tier fallback: prefer the GGUF's own Jinja chat template via `LlamaCpp.getFormattedChat`, and fall back to a hand-rolled Llama-3 formatter when the plugin is too old or the model has no baked-in template.

- **`mobile-device-bridge-bootstrap.ts`**: adds `collectMessagesForNativeTemplate` + `flattenChatParamsToLlama3Prompt` helpers, a `MobileDeviceBridge.formatChat` round-trip method, and wires them into both generate handlers; extends `AgentOutbound`/`DeviceOutbound` union types.
- **`device-bridge-client.ts`**: handles the new `formatChat` agent-inbound message with feature-detection for older plugin builds; renames the iOS plugin probe from `ElizaIntent`/`ElizaIntent` to `MiladyIntent`/`ElizaIntent`.
- **`capacitor-llama-adapter.ts`**: implements `formatChat()` against `LlamaCpp.getFormattedChat` and removes the now-upstream JS stop-sequence injection/trim code.

<h3>Confidence Score: 4/5</h3>

The fix is correct and well-scoped; the main concern is the wrong timeout env-var in `formatChat` and the missing `return` in the result handler, neither of which affects the happy path.

The core logic — two-tier prompt construction with native Jinja template first, hand-rolled Llama-3 flatten as fallback — is sound and matches the described device behaviour. The `formatChat` method reuses the load timeout rather than the call timeout, which is a mismatch worth fixing but does not break functionality. The missing `return` in `handleDeviceMessage` is harmless today but breaks the consistent guard pattern of every sibling branch.

plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts — timeout env-var selection for `formatChat` and the missing `return` in the result handler deserve a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts | Core change: adds `flattenChatParamsToLlama3Prompt`, `collectMessagesForNativeTemplate`, `MobileDeviceBridge.formatChat`, and wires them into the generate handler to fix the empty-prompt bug. Three minor issues: wrong timeout env var for `formatChat`, missing `return` in the `formatChatResult` handler branch, and silent discard of `params.prompt` when messages are also present. |
| packages/native-plugins/llama/src/device-bridge-client.ts | Adds `formatChat` to `AgentInbound`/`DeviceOutbound` union types and handles the new message type by feature-detecting `capacitorLlama.formatChat`, returning null for older plugin builds. Also renames `ElizaIntent` to `MiladyIntent` in the iOS plugin probe loop. Logic is straightforward and correct. |
| packages/native-plugins/llama/src/capacitor-llama-adapter.ts | Adds `getFormattedChat` to the plugin shape interface and implements `formatChat()` against it. Also removes the JS-side Llama-3 stop-sequence injection and safety-trim (covered by upstream commit `a979876348`). Implementation is clean and the feature-detect guard for older plugin builds is correct. |
| packages/native-plugins/llama/src/definitions.ts | Adds optional `formatChat()` to the `LlamaAdapter` interface. Minimal, additive, and backward-compatible. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Agent (bootstrap)
    participant Bridge as MobileDeviceBridge
    participant WS as WebSocket
    participant Client as DeviceBridgeClient
    participant Plugin as LlamaCpp Plugin

    Agent->>Bridge: makeGenerateHandler(params)
    Bridge->>Bridge: collectMessagesForNativeTemplate(params)
    alt messages present
        Bridge->>WS: "{type:formatChat, messages}"
        WS->>Client: handleAgentMessage(formatChat)
        Client->>Plugin: formatChat(messages) via getFormattedChat
        alt plugin supports getFormattedChat
            Plugin-->>Client: "{prompt: string}"
        else older plugin
            Plugin-->>Client: null
        end
        Client->>WS: "{type:formatChatResult, ok:true, prompt}"
        WS-->>Bridge: pendingFormatChats.resolve(prompt)
    end
    alt "nativePrompt != null"
        Bridge->>Bridge: use nativePrompt
    else
        Bridge->>Bridge: flattenChatParamsToLlama3Prompt(params)
    end
    Bridge->>WS: "{type:generate, prompt}"
    WS->>Client: handleAgentMessage(generate)
    Client->>Plugin: completion(prompt)
    Plugin-->>Client: "{text}"
    Client->>WS: "{type:generateResult, text}"
    WS-->>Bridge: pendingGenerates.resolve(text)
    Bridge-->>Agent: text
```

<sub>Reviews (1): Last reviewed commit: ["fix(mobile-bridge): flatten v5 chat para..."](https://github.com/elizaos/eliza/commit/64ae70bc2d933070d2d480e11b112d45109106b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31727153)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->