### PR TITLE
fix(core): resolve {{name}}/{{agentName}} placeholders in buildCanonicalSystemPrompt

### DIFF
--- a/packages/core/src/runtime/__tests__/system-prompt.test.ts
+++ b/packages/core/src/runtime/__tests__/system-prompt.test.ts
@@ -25,6 +25,45 @@ describe("system prompt helpers", () => {
 		);
 	});
 
+	it("substitutes {{name}} / {{agentName}} placeholders in system + bio", () => {
+		// Onboarding presets (packages/shared/dist/onboarding-presets.characters.js)
+		// persist `{{name}}` tokens so character renames propagate. The runtime
+		// must resolve them before the prompt reaches `useModel(...)`.
+		const prompt = buildCanonicalSystemPrompt({
+			character: {
+				name: "Eliza",
+				system: "You are {{name}}. Keep it brief.",
+				bio: [
+					"{{name}} is warm and precise.",
+					"{{agentName}} keeps things calm.",
+				],
+			},
+		});
+
+		expect(prompt).toContain("You are Eliza. Keep it brief.");
+		expect(prompt).toContain("Eliza is warm and precise.");
+		expect(prompt).toContain("Eliza keeps things calm.");
+		expect(prompt).not.toContain("{{name}}");
+		expect(prompt).not.toContain("{{agentName}}");
+	});
+
+	it("substitution is idempotent (no placeholders → unchanged)", () => {
+		const prompt = buildCanonicalSystemPrompt({
+			character: {
+				name: "Eliza",
+				system: "You are Eliza. Keep it brief.",
+				bio: ["Eliza is warm and precise."],
+			},
+		});
+
+		expect(prompt).toBe(
+			[
+				"You are Eliza. Keep it brief.",
+				"# About Eliza\nEliza is warm and precise.",
+			].join("\n\n"),
+		);
+	});
+
 	it("prefers explicit system, then leading message system, then fallback", () => {
 		expect(
 			resolveEffectiveSystemPrompt({

--- a/packages/core/src/runtime/system-prompt.ts
+++ b/packages/core/src/runtime/system-prompt.ts
@@ -7,6 +7,19 @@ type MessageLike = {
 	content?: unknown;
 };
 
+// Mirrors `replaceNameTokens` from @elizaos/shared/src/utils/name-tokens.
+// Inlined here because @elizaos/core does not depend on @elizaos/shared at
+// runtime, and the canonical system prompt must resolve these placeholders
+// before the prompt is passed to `useModel(...)`. Onboarding-preset characters
+// and the character editor (PR #7101) persist `{{name}}` / `{{agentName}}`
+// tokens on save so renames propagate; without this substitution the runtime
+// hands the model literal `{{name}}` text and small instruct models lose
+// coherence (observed on Capacitor mobile with Qwen3-0.6B / Eliza-1).
+function substituteNamePlaceholders(text: string, name: string): string {
+	if (!text || !name) return text;
+	return text.replaceAll("{{name}}", name).replaceAll("{{agentName}}", name);
+}
+
 export function renderSystemPromptBio(value: unknown): string {
 	if (typeof value === "string") {
 		return value.trim();
@@ -32,13 +45,18 @@ export function buildCanonicalSystemPrompt(args: {
 	userRole?: RoleGateRole | string | null;
 }): string {
 	const character = args.character;
-	const system =
-		typeof character?.system === "string" ? character.system.trim() : "";
-	const bio = renderSystemPromptBio(character?.bio);
 	const name =
 		typeof character?.name === "string" && character.name.trim()
 			? character.name.trim()
 			: "the agent";
+	const system = substituteNamePlaceholders(
+		typeof character?.system === "string" ? character.system.trim() : "",
+		name,
+	);
+	const bio = substituteNamePlaceholders(
+		renderSystemPromptBio(character?.bio),
+		name,
+	);
 	const role = normalizeSystemPromptRole(args.userRole);
 	return [
 		system,


### PR DESCRIPTION
## Problem

`buildCanonicalSystemPrompt` in `packages/core/src/runtime/system-prompt.ts` reads `character.system` and `character.bio` verbatim, with no token substitution.

Onboarding-preset characters (`packages/shared/dist/onboarding-presets.characters.js`) ship with `{{name}}` and `{{agentName}}` literals in both `system` and every `bio` line — for example Eliza:

```
"system": "You are {{name}}. Warm, calm, and precise. Keep it brief…",
"bio": [
  "{{name}} is warm, precise, and easy to talk to.",
  "{{name}} values accuracy over speed — she'd rather ask than guess.",
  …12 entries…
]
```

PR #7101 (`fix(character): tokenize name occurrences on save so renames propagate`) deliberately preserves these tokens on save so that renaming the agent in Identity settings continues to propagate through every text field. Its description states *"Runtime prompt composition already resolves `{{name}}` / `{{agentName}}` tokens via @elizaos/prompts, so no backend changes are needed."* — but the canonical system-prompt path goes through `buildCanonicalSystemPrompt`, which does not call any resolver. The result is that `useModel(TEXT_LARGE, { system, messages })` receives a system prompt with literal `{{name}}` text.

## Evidence

Live Capacitor mobile build (Pixel 6a, Eliza-1 0.6B / Qwen3-0.6B base) — captured Capacitor/Console log of the `LlamaCpp.completion` call:

```
"params":{"prompt":"<|start_header_id|>system<|end_header_id|>\n\nYou are {{name}}. Warm, calm, and precise. Keep it brief.…\n\n# About Eliza\n{{name}} is warm, precise, and easy to talk to. {{name}} values accuracy over speed…"}
```

The model (Qwen3-0.6B) sees literal `{{name}}` and produces incoherent output:

```
"content":"\nestudiante = {\n    'nombre': 'Juan',\n    'edad': 18,\n    'matematicas': True,\n    'notas': [90, 75, 80],\n}\n\nprint(estudiante['matematicas']))\n"
"stopped_eos": true
```

(54 tokens, EOG hit cleanly — the unsubstituted system text steered the small instruct model into Python/Spanish hallucination instead of a reply to the user's "hi".)

This affects every call site that goes through `buildCanonicalSystemPrompt`:
- `packages/core/src/runtime.ts:4145`
- `packages/core/src/services/message.ts:2015` (v5 message handler)
- `packages/core/src/runtime/facts-and-relationships.ts:198` (evaluator)
- `packages/core/src/testing/ollama-provider.ts:214,241`

## Fix

Substitute `{{name}}` and `{{agentName}}` against the resolved character name at build time. Mirrors the existing `replaceNameTokens` helper in `@elizaos/shared/src/utils/name-tokens.ts` — inlined here because `@elizaos/core` does not depend on `@elizaos/shared` at runtime.

The PR #7101 load/save round-trip is preserved: persisted templates stay tokenized so renames propagate, and the runtime resolves to the live name on every prompt build.

## Tests

Added two cases in `packages/core/src/runtime/__tests__/system-prompt.test.ts`:

1. **Substitution across system + bio + `{{agentName}}` synonym** — uses an Eliza-shaped character with `{{name}}` and `{{agentName}}` tokens; asserts both forms resolve and no literal tokens remain.
2. **Idempotency** — already-resolved text is unchanged.

```bash
$ bunx vitest run src/runtime/__tests__/system-prompt.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full runtime suite (`bunx vitest run src/runtime/__tests__/`) — 457 passed, 2 skipped, 1 skipped file (unchanged from baseline).

Typecheck (`bun run typecheck` in `packages/core`) — clean.

## Compatibility

- Characters without `{{name}}` placeholders are unaffected (idempotent regex).
- Characters that intentionally use `{{name}}` as literal text are not supported by the existing `replaceNameTokens` helper either; this PR matches its semantics.
- No new runtime dependency; pure inline string substitution.

## Test plan

- [x] `bunx vitest run src/runtime/__tests__/system-prompt.test.ts` — 5/5 pass
- [x] `bunx vitest run src/runtime/__tests__/` — 457/457 pass (2 skipped)
- [x] `bun run typecheck` (packages/core) — clean
- [x] `bun run lint` (packages/core) — no new findings on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `buildCanonicalSystemPrompt` to resolve `{{name}}` and `{{agentName}}` placeholder tokens before the assembled prompt is passed to the model layer. The fix closes the gap left by PR #7101, which deliberately persists these tokens on save for rename propagation while assuming the runtime path would resolve them — an assumption `buildCanonicalSystemPrompt` did not satisfy.

- Introduces a private `substituteNamePlaceholders` helper inlined in `system-prompt.ts` (avoiding a new runtime dependency on `@elizaos/shared`) and applies it to both `character.system` and the rendered `character.bio` string.
- Moves the `name` resolution (`character.name` → `\"the agent\"` fallback) above the `system`/`bio` assignments so the substitution has the resolved name available.
- Adds two targeted tests covering token substitution and idempotency; all five tests in the file pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, self-contained string substitution on an already-assembled text value, with no side-effects on callers.

The fix is narrow: one private helper, two substitution call sites, and the name resolution moved a few lines earlier. All existing callers of buildCanonicalSystemPrompt pass runtime.character which always carries a resolved name, so the 'the agent' fallback is a safe backstop. New tests cover both the substitution and idempotent paths, and the full suite passes unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/system-prompt.ts | Adds `substituteNamePlaceholders` helper and applies it to `system` and `bio` inside `buildCanonicalSystemPrompt`; correctly moves the `name` resolution before those assignments. |
| packages/core/src/runtime/__tests__/system-prompt.test.ts | Adds two new test cases: token substitution across `system` + `bio` (including `{{agentName}}`), and idempotency when no placeholders are present. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(core): resolve {{name}}/{{agentName}..."](https://github.com/elizaos/eliza/commit/035817fa850280aef9f675d6b9815a57e155d85a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31739712)</sub>

<!-- /greptile_comment -->