### PR TITLE
fix(mobile-bridge): model-agnostic plain-text fallback for getFormattedChat (closes #7612)

### DIFF
--- a/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
+++ b/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts
@@ -188,7 +188,12 @@ type DeviceOutbound =
 			ok: true;
 			prompt: string | null;
 	  }
-	| { type: "formatChatResult"; correlationId: string; ok: false; error: string }
+	| {
+			type: "formatChatResult";
+			correlationId: string;
+			ok: false;
+			error: string;
+	  }
 	| { type: "pong"; at: number };
 
 type AgentOutbound =
@@ -911,50 +916,51 @@ function resolveEmbeddingDimension(): number {
 // elizaOS v5 message-pipeline calls `runtime.useModel(TEXT_LARGE, params)`
 // with `params.messages` set and `params.prompt` undefined. The native
 // Capacitor llama plugin only accepts a flat string prompt, so we have
-// to render the conversation into the model's chat template ourselves.
-// Llama-3.x (the only GGUF currently bundled in milady-class APKs) uses
-// the chat-template tokens `<|begin_of_text|>`, `<|start_header_id|>`,
-// `<|end_header_id|>`, and `<|eot_id|>` — see
-// https://www.llama.com/docs/model-cards-and-prompt-formats/meta-llama-3/.
+// to render the conversation into something the model can read when the
+// `LlamaCpp.getFormattedChat()` round-trip is unavailable (older plugin
+// builds, GGUFs without `chat_template` metadata, jinja eval failures).
+//
+// This fallback emits plain role-tagged text — no model-family-specific
+// special tokens. Reasoning: when this code runs we don't know which
+// chat template the loaded GGUF expects. Llama-3's `<|start_header_id|>`
+// fed to Qwen3 / Mistral / Phi tokenizes as subword pieces that the
+// model doesn't interpret as turn boundaries, and the small instruct
+// models then drift into pattern-completion garbage (issue #7612).
+//
+// Plain role-tagged text doesn't beat the model's own template, but it
+// is the only model-agnostic format that won't actively mislead the
+// tokenizer. The decoder still terminates via its own EOG tokens; the
+// caller can tighten the stop signal with `params.stopSequences` if the
+// model rambles past its turn.
+//
 // When the params include a legacy `prompt`, pass it through unchanged.
-function flattenChatParamsToLlama3Prompt(params: GenerateTextParams): string {
+function flattenChatParamsToPlainPrompt(params: GenerateTextParams): string {
 	if (typeof params.prompt === "string" && params.prompt.length > 0) {
 		return params.prompt;
 	}
 	const messages = params.messages ?? [];
-	// Do NOT prepend `<|begin_of_text|>` — the underlying llama.cpp
-	// tokenizer auto-adds BOS for Llama-3 chat models. Adding it as text
-	// here results in a duplicated 128000/128000 prefix that confuses
-	// the chat header position prediction (model's first generated
-	// token ends up being `<|start_header_id|>` instead of the
-	// assistant reply content).
 	const parts: string[] = [];
 	const hasSystemMessage = messages.some(
 		(m: { role?: string }) => m.role === "system",
 	);
 	if (!hasSystemMessage && typeof params.system === "string" && params.system) {
-		parts.push(
-			`<|start_header_id|>system<|end_header_id|>\n\n${params.system}<|eot_id|>`,
-		);
+		parts.push(`system:\n${params.system}`);
 	}
 	for (const m of messages) {
 		const content =
 			typeof (m as { content?: unknown }).content === "string"
-				? ((m as { content: string }).content)
+				? (m as { content: string }).content
 				: "";
 		if (!content) continue;
-		const role =
-			((m as { role?: string }).role ?? "user").toLowerCase();
+		const role = ((m as { role?: string }).role ?? "user").toLowerCase();
 		const safeRole =
 			role === "system" || role === "assistant" || role === "user"
 				? role
 				: "user";
-		parts.push(
-			`<|start_header_id|>${safeRole}<|end_header_id|>\n\n${content}<|eot_id|>`,
-		);
+		parts.push(`${safeRole}:\n${content}`);
 	}
-	parts.push("<|start_header_id|>assistant<|end_header_id|>\n\n");
-	return parts.join("");
+	parts.push("assistant:\n");
+	return parts.join("\n\n");
 }
 
 function makeGenerateHandler(slot: "TEXT_SMALL" | "TEXT_LARGE") {
@@ -982,16 +988,14 @@ function makeGenerateHandler(slot: "TEXT_SMALL" | "TEXT_LARGE") {
 		let nativePrompt: string | null = null;
 		if (messagesForTemplate) {
 			try {
-				nativePrompt = await mobileDeviceBridge.formatChat(
-					messagesForTemplate,
-				);
+				nativePrompt = await mobileDeviceBridge.formatChat(messagesForTemplate);
 			} catch (err) {
 				logger.warn(
 					`[mobile-device-bridge] getFormattedChat failed, falling back to flatten: ${err instanceof Error ? err.message : String(err)}`,
 				);
 			}
 		}
-		const prompt = nativePrompt ?? flattenChatParamsToLlama3Prompt(params);
+		const prompt = nativePrompt ?? flattenChatParamsToPlainPrompt(params);
 		return mobileDeviceBridge.generate({
 			prompt,
 			stopSequences: params.stopSequences,
@@ -1018,11 +1022,10 @@ function collectMessagesForNativeTemplate(
 	for (const m of messages) {
 		const content =
 			typeof (m as { content?: unknown }).content === "string"
-				? ((m as { content: string }).content)
+				? (m as { content: string }).content
 				: "";
 		if (!content) continue;
-		const role =
-			((m as { role?: string }).role ?? "user").toLowerCase();
+		const role = ((m as { role?: string }).role ?? "user").toLowerCase();
 		const safeRole =
 			role === "system" || role === "assistant" || role === "user"
 				? role


### PR DESCRIPTION
## Problem

\`flattenChatParamsToLlama3Prompt\` in \`plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts\` hard-coded Llama-3.x chat template tokens:

\`\`\`ts
parts.push(\`<|start_header_id|>\${safeRole}<|end_header_id|>\n\n\${content}<|eot_id|>\`);
…
parts.push("<|start_header_id|>assistant<|end_header_id|>\n\n");
\`\`\`

The function comment was honest about scope: *"Llama-3.x (the only GGUF currently bundled in milady-class APKs)…"*. That assumption no longer holds — Eliza-1 0.6B / 1.7B (Qwen3 base) is now bundled, and the path also triggers for any third-party GGUF without \`chat_template\` metadata, or when an older \`@elizaos/capacitor-llama\` is missing \`getFormattedChat\`.

When Llama-3 special tokens reach a Qwen3 / Mistral / Phi tokenizer they get broken into subword pieces that the model does not interpret as turn boundaries. Small instruct models then drift into pattern-completion behaviour.

This is issue #7612, with the full reproduction trace.

## Fix

Replace the Llama-3 template with model-agnostic plain role-tagged text:

\`\`\`
system:
{system}

user:
{user}

assistant:
\`\`\`

No special tokens, no model-family assumptions. The decoder still terminates via the loaded GGUF's own EOG tokens (which \`llama.cpp\` recognises from the model's vocab metadata regardless of the input encoding). Callers can tighten the stop signal further via \`params.stopSequences\`.

This doesn't beat the model's native template — \`getFormattedChat\` (now merged via #7610) is still the preferred path. This fallback only fires when the native template round-trip isn't available, and it is the only encoding that won't actively mislead the tokenizer.

Renames \`flattenChatParamsToLlama3Prompt\` → \`flattenChatParamsToPlainPrompt\` so the function name matches its honest scope. Single call site (\`makeGenerateHandler\`) updated.

## Verification

- \`bunx tsc --noEmit -p tsconfig.json\` in \`plugins/plugin-capacitor-bridge\` — clean.
- \`bunx @biomejs/biome check src/mobile-device-bridge-bootstrap.ts\` — clean (after the formatter expanded a few long-line types unrelated to this change).
- On-device verification: in flight; will report tok/s + content of reply when the rebuild lands. Stacks on top of #7611 (\`{{name}}\` substitution).

## Closes

#7612

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the model-agnostic fallback path in the Capacitor mobile bridge by replacing hard-coded Llama-3 chat-template tokens with plain role-tagged text (`system:
…`, `user:
…`, `assistant:
`), and renames `flattenChatParamsToLlama3Prompt` → `flattenChatParamsToPlainPrompt` to match the new honest scope.

- **Core fix**: removes Llama-3-specific `<|start_header_id|>` / `<|eot_id|>` tokens from the fallback path; these were causing subword-piece pollution on Qwen3/Mistral/Phi tokenizers and triggered pattern-completion drift (issue #7612).
- **Rename + comment update**: the function name and its long block comment are updated throughout; one inline comment in `makeGenerateHandler` still refers to \"Llama-3 flatten\" and was missed.

<h3>Confidence Score: 4/5</h3>

The fallback path change is focused and correct; only the plain-text prompt format changes, and the preferred native-template path is untouched.

The rename and token replacement are internally consistent, and the join separator change from empty string to double-newline is correct for the new plain-text format. One inline comment in makeGenerateHandler still says Llama-3 flatten and was not updated with the rename — a minor readability gap that does not affect runtime behaviour.

plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts — the stale Llama-3 flatten comment inside makeGenerateHandler.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts | Renames `flattenChatParamsToLlama3Prompt` to `flattenChatParamsToPlainPrompt` and replaces Llama-3 special tokens with plain role-tagged text; a stale comment inside `makeGenerateHandler` still references "Llama-3 flatten" after the rename. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["makeGenerateHandler called"] --> B["collectMessagesForNativeTemplate(params)"]
    B -->|messages present| C["mobileDeviceBridge.formatChat(messages)"]
    B -->|no messages| E["flattenChatParamsToPlainPrompt(params)"]
    C -->|success| D["nativePrompt = formatted string"]
    C -->|throws| F["logger.warn + fallback"]
    F --> E
    D --> G["mobileDeviceBridge.generate(prompt)"]
    E -->|params.prompt set| H["return params.prompt as-is"]
    E -->|build plain text| I["system:\n{system}\n\nuser:\n{content}\n\nassistant:\n"]
    H --> G
    I --> G
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts`, line 983-987 ([link](https://github.com/elizaos/eliza/blob/1cff929f377924b607e4738a94ea878a4e5e8260/plugins/plugin-capacitor-bridge/src/mobile-device-bridge-bootstrap.ts#L983-L987)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> This comment still says "Llama-3 flatten" after the function was renamed to `flattenChatParamsToPlainPrompt` and the approach changed to model-agnostic plain text. A reader unfamiliar with the PR history will be confused about why a "Llama-3 flatten" is the sensible fallback for Qwen3/Mistral/Phi models.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(mobile-bridge): model-agnostic plain..."](https://github.com/elizaos/eliza/commit/1cff929f377924b607e4738a94ea878a4e5e8260) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31749778)</sub>

<!-- /greptile_comment -->