### PR TITLE
fix(app-core): unblock fresh-clone desktop builds + bundle-integrity assertion

### DIFF
--- a/packages/app-core/scripts/assert-required-bundled-packages.test.ts
+++ b/packages/app-core/scripts/assert-required-bundled-packages.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Test for the `assertRequiredBundledPackagesLanded` defense-in-depth check.
+ *
+ * The function fails the desktop build when any package marked
+ * `alwaysBundled` (CORE_PLUGINS / OPTIONAL_CORE_PLUGINS / BASELINE_*) is
+ * missing its `package.json` in `dist/node_modules/` after the copy + prune
+ * phases. Companion safety net to the transitive-walk filter introduced
+ * with the fresh-clone build fixes — if a future refactor accidentally
+ * excludes a required package, the build fails loudly here instead of
+ * shipping a broken bundle.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { assertRequiredBundledPackagesLanded } from "./copy-runtime-node-modules";
+
+let tmpDir: string;
+let nodeModulesDir: string;
+
+function writePackageJson(name: string): void {
+  const dir = name.startsWith("@")
+    ? path.join(nodeModulesDir, ...name.split("/"))
+    : path.join(nodeModulesDir, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "package.json"), JSON.stringify({ name }, null, 2));
+}
+
+describe("assertRequiredBundledPackagesLanded", () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "assert-bundled-"));
+    nodeModulesDir = path.join(tmpDir, "node_modules");
+    mkdirSync(nodeModulesDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("passes when every required package has a package.json", () => {
+    writePackageJson("@elizaos/core");
+    writePackageJson("@elizaos/plugin-sql");
+    writePackageJson("react");
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core", "@elizaos/plugin-sql", "react"]),
+      ),
+    ).not.toThrow();
+  });
+
+  it("passes on an empty alwaysBundled set", () => {
+    expect(() =>
+      assertRequiredBundledPackagesLanded(nodeModulesDir, new Set()),
+    ).not.toThrow();
+  });
+
+  it("throws when a scoped required package is missing", () => {
+    writePackageJson("@elizaos/core"); // present
+    // @elizaos/plugin-sql intentionally not written
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core", "@elizaos/plugin-sql"]),
+      ),
+    ).toThrowError(/@elizaos\/plugin-sql/);
+  });
+
+  it("throws when an unscoped required package is missing", () => {
+    writePackageJson("react"); // present
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["react", "react-dom"]),
+      ),
+    ).toThrowError(/react-dom/);
+  });
+
+  it("lists ALL missing packages, not just the first one", () => {
+    writePackageJson("@elizaos/core");
+    // plugin-sql, plugin-local-embedding, app-companion all missing
+
+    try {
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set([
+          "@elizaos/core",
+          "@elizaos/plugin-sql",
+          "@elizaos/plugin-local-embedding",
+          "@elizaos/app-companion",
+        ]),
+      );
+      throw new Error("expected assertRequiredBundledPackagesLanded to throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain("@elizaos/plugin-sql");
+      expect(message).toContain("@elizaos/plugin-local-embedding");
+      expect(message).toContain("@elizaos/app-companion");
+      // Count of missing should be in the header
+      expect(message).toContain("3 required runtime package");
+    }
+  });
+
+  it("only checks package.json — empty dir for a package still counts as missing", () => {
+    // Create the package dir but NO package.json (could happen if prune
+    // wiped the manifest).
+    mkdirSync(path.join(nodeModulesDir, "@elizaos", "plugin-sql"), { recursive: true });
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/plugin-sql"]),
+      ),
+    ).toThrowError(/@elizaos\/plugin-sql/);
+  });
+
+  it("error message points to the expected on-disk path so ops can investigate", () => {
+    try {
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/plugin-sql"]),
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain(
+        path.join(nodeModulesDir, "@elizaos", "plugin-sql", "package.json"),
+      );
+    }
+  });
+});

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -1565,6 +1565,44 @@ function copyPgliteCompatibilityAssets(targetDist: string): void {
   }
 }
 
+/**
+ * Defense-in-depth check: every package marked `alwaysBundled` must land in
+ * `dist/node_modules/<name>/package.json` once the copy + prune phases are
+ * done. The existing `missingAlwaysBundled` tracker already throws when a
+ * package fails to *resolve*, but it can't catch:
+ *
+ *  - a future filter refactor that silently skips a CORE plugin in the
+ *    transitive walk (the same class of bug as elizaOS/eliza#7617's
+ *    transitive-filter change — companion safety net),
+ *  - `pruneCopiedPackageDir` removing a load-bearing file like
+ *    `package.json` because a new rule pattern grew too aggressive.
+ *
+ * Re-walking the dist and asserting presence is O(N) over the bundled set,
+ * runs once per build, and fails the build loudly so the regression never
+ * ships.
+ */
+export function assertRequiredBundledPackagesLanded(
+  targetNodeModules: string,
+  alwaysBundled: ReadonlySet<string>,
+): void {
+  const missing: string[] = [];
+  for (const name of alwaysBundled) {
+    if (!isPackageNameCompatibleWithCurrentPlatform(name)) continue;
+    const pkgJsonPath = path.join(packagePath(name, targetNodeModules), "package.json");
+    if (!fs.existsSync(pkgJsonPath)) {
+      missing.push(name);
+    }
+  }
+  if (missing.length === 0) return;
+  throw new Error(
+    [
+      `[runtime-copy] ${missing.length} required runtime package(s) failed to land in the bundle after copy + prune:`,
+      ...missing.sort().map((n) => `  ${n}  (missing ${path.join(packagePath(n, targetNodeModules), "package.json")})`),
+      "This usually means a filter in the transitive-walk or a rule in pruneCopiedPackageDir accidentally excluded a required package. Bundle is unsafe to ship.",
+    ].join("\n"),
+  );
+}
+
 function assertTarSafeRuntimePaths(targetDist: string): void {
   const unsafe: string[] = [];
 
@@ -1762,6 +1800,7 @@ function main(): void {
 
   copyPgliteCompatibilityAssets(targetDist);
   assertTarSafeRuntimePaths(targetDist);
+  assertRequiredBundledPackagesLanded(targetNodeModules, alwaysBundled);
 
   console.log(
     `[runtime-copy] bundled ${copiedNames.size} package(s) into ${targetNodeModules}`,

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -1736,6 +1736,21 @@ function main(): void {
         continue;
       }
 
+      // Same filter we apply at initial discovery: runtime plugins that
+      // aren't in `alwaysBundled` (CORE_PLUGINS / OPTIONAL_CORE_PLUGINS /
+      // BASELINE_*) are post-release-installable and must not be physically
+      // bundled into the desktop runtime. Without this guard, an
+      // alwaysBundled package's non-optional peerDependency or dependency
+      // on a post-release plugin (e.g. @elizaos/app-wallet → peerDep on
+      // @elizaos/plugin-wallet) drags the entire transitive tree in,
+      // including @orca-so/whirlpools → @solana-program/* → @solana/kit
+      // with three coexisting major versions of @solana/codecs* nested
+      // 8 levels deep, which then trips `assertTarSafeRuntimePaths`.
+      if (!shouldBundleDiscoveredPackage(dep.name, alwaysBundled)) {
+        filteredOptionalPlugins.add(dep.name);
+        continue;
+      }
+
       queue.push({
         name: dep.name,
         spec: dep.spec,

--- a/packages/app-core/src/browser.ts
+++ b/packages/app-core/src/browser.ts
@@ -34,21 +34,25 @@ export function sharedVault(): never {
   throw new Error("sharedVault is server-only");
 }
 
-// ELIZA local-mode renderer reach-through: pull in the full app-core
-// dist surface so eliza's `main.tsx` can resolve symbols like
-// `DesktopOnboardingRuntime`, `AppProvider`, `client`, etc. that the
-// minimal browser entry omits. Server-only re-exports inside dist
-// (account-pool, onboarding-routes, etc.) are kept renderer-safe by
-// stubbing `@elizaos/agent` and `@elizaos/plugin-elizacloud` to
-// browser stubs (see apps/app/vite.config.ts native-module-stub plugin).
-export * from "../dist/index.js";
+// Reach-through to the full app-core surface so eliza's `main.tsx` can
+// resolve symbols like `DesktopOnboardingRuntime`, `AppProvider`,
+// `client`, etc. that the minimal browser entry omits. We import from
+// `./index.ts` (the source barrel) — tsconfig.build.json has
+// `rewriteRelativeImportExtensions: true`, so this becomes `./index.js`
+// in the published dist. Same file at runtime; no pre-built `dist/`
+// required for local-source consumers (vite in milady's source mode).
+// Server-only re-exports inside the barrel (account-pool,
+// onboarding-routes, etc.) are kept renderer-safe by stubbing
+// `@elizaos/agent` and `@elizaos/plugin-elizacloud` to browser stubs
+// (see apps/app/vite.config.ts native-module-stub plugin).
+export * from "./index.ts";
 
 // `ConfigField` and `getPlugins` exist in both `@elizaos/ui` (UI component +
-// runtime helper) and the dist barrel (registry type + bridge function).
-// Pin the dist side explicitly so eliza's main.tsx gets the registry
-// `ConfigField` type it expects; UI consumers can still import the
-// component directly from `@elizaos/ui`.
-export { type ConfigField, getPlugins } from "../dist/index.js";
+// runtime helper) and the app-core registry barrel. Pin the registry side
+// explicitly so eliza's main.tsx gets the registry `ConfigField` type it
+// expects; UI consumers can still import the component directly from
+// `@elizaos/ui`.
+export { type ConfigField, getPlugins } from "./index.ts";
 
 // ELIZA local-mode stubs for symbols removed during the P1A refactor.
 // The mobile/web renderer doesn't actually mount these (the desktop

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -687,7 +687,26 @@ async function ensureTelegramBotPolling(runtime: AgentRuntime): Promise<void> {
  * so we do not re-download multi‑GB models. Opt out:
  * `ELIZA_EMBEDDING_WARMUP_NO_REUSE=1`.
  */
+// In-flight promise cache so concurrent callers (bootElizaRuntime +
+// startEliza both run on agent boot) share a single download. Without this,
+// two `fs.createWriteStream(dest)` open the same GGUF target concurrently,
+// and the first to fail calls `safeUnlink(dest)` — which deletes the file
+// out from under the second's pending write. Downstream `llama.loadModel`
+// then opens the now-missing file and throws ENOENT, which surfaces as an
+// uncaughtException and kills the agent.
+let warmupInFlight: Promise<void> | null = null;
+
 async function warmupEmbeddingModel(
+  onProgress?: EmbeddingProgressCallback,
+): Promise<void> {
+  if (warmupInFlight) return warmupInFlight;
+  warmupInFlight = warmupEmbeddingModelImpl(onProgress).finally(() => {
+    warmupInFlight = null;
+  });
+  return warmupInFlight;
+}
+
+async function warmupEmbeddingModelImpl(
   onProgress?: EmbeddingProgressCallback,
 ): Promise<void> {
   // Mobile bundle does not ship `node-llama-cpp` (no Android prebuild) and

--- a/packages/app-core/src/runtime/embedding-manager-support.ts
+++ b/packages/app-core/src/runtime/embedding-manager-support.ts
@@ -458,7 +458,13 @@ export async function ensureModel(
   }
 
   const log = getLogger();
-  fs.mkdirSync(path.resolve(modelsDir), { recursive: true });
+  // Bundled embedding filenames are namespaced under `text/`, `tts/`, etc.
+  // (e.g. `text/eliza-1-lite-0_6b-32k.gguf`), and the download target is
+  // `<modelsDir>/<filename>`. We need to create the *file's* parent dir
+  // (`<modelsDir>/text`), not just `modelsDir`. Without this, downloadFile's
+  // `fs.createWriteStream(dest)` emits an ENOENT that escapes the warmup
+  // catch as an uncaughtException, kills the agent at boot.
+  fs.mkdirSync(path.dirname(path.resolve(modelPath)), { recursive: true });
 
   const url = `https://huggingface.co/${safeRepo}/resolve/main/${safeFilename}`;
   log.info(


### PR DESCRIPTION
# Relates to

Downstream issue: a fresh clone of a downstream consumer (Milady) running `bun install && bun run eliza:local && bun run build:desktop` fails in four places, all root-caused to issues in this repo. With these fixes a fresh clone builds end-to-end and the packaged Electrobun app boots the agent on :31337 with 24/24 plugins loaded — no env-var bypasses, no manual sub-builds.

Rebased on latest `develop` (no conflicts).

# Risks

Low. All four changes are surgical:

- **browser.ts** path change relies on `tsconfig.build.json` already having `rewriteRelativeImportExtensions: true` (verified). Published dist output is byte-identical: `from "./index.ts"` → `from "./index.js"`. No behavior change in packages-mode.
- **warmup** change wraps an existing function in an in-flight promise cache. Single-caller paths (CLI, server-only) see no behavior change; only concurrent callers are deduplicated.
- **copy-runtime-node-modules** change applies an existing filter (`shouldBundleDiscoveredPackage`) uniformly. Enforces the same post-release-plugin policy at transitive walks that's already enforced at initial discovery. No new policy.
- **ensureModel** mkdir change uses `path.dirname(modelPath)` instead of `modelsDir`. For flat-namespaced filenames the result is identical (`path.dirname("<dir>/file.gguf")` = `<dir>`). For namespaced filenames (`text/file.gguf`) it correctly creates the `text/` subdir.

# Background

## 1. `packages/app-core/src/browser.ts`: import from source, not pre-built dist

`browser.ts` (the renderer-side barrel for `@elizaos/app-core`) re-exported the full app-core surface via:

```ts
export * from "../dist/index.js";
export { type ConfigField, getPlugins } from "../dist/index.js";
```

In the **published npm package**, this works fine: `browser.ts` is compiled to `dist/browser.js`, and `../dist/index.js` from there resolves to the sibling `dist/index.js`.

In **local-source mode** (a downstream repo aliasing `@elizaos/app-core` to `eliza/packages/app-core/src/` directly — what Milady does for live elizaOS development), the same `../dist/index.js` from `src/browser.ts` resolves to `packages/app-core/dist/index.js` — which doesn't exist on a fresh clone until someone runs `bun run build` inside `packages/app-core/`. Renderer build fails with `getPlugins is not exported`.

**Fix:** import from the source barrel `./index.ts`. `tsconfig.build.json` already has `rewriteRelativeImportExtensions: true`, so the published `dist/browser.js` ends up with `from "./index.js"` — same dist, semantically identical. Local-source consumers now resolve directly to source; no separate dist build needed.

## 2. `packages/app-core/src/runtime/eliza.ts`: `warmupEmbeddingModel` in-flight promise cache

`warmupEmbeddingModel` is called from both `bootElizaRuntime` (line ~785) and `startEliza` (line ~1081). When the agent boot path invokes both, two concurrent calls hit `ensureModel` → `downloadFile` for the same `dest` path:

```ts
const file = fs.createWriteStream(dest);  // both calls open this concurrently
```

If either errors (network blip, HF rate limit, ECONNRESET, etc.), its error handler calls `safeUnlink(dest)` — which deletes the file out from under the other concurrent call's in-progress write. Downstream `node-llama-cpp`'s `llama.loadModel({ modelPath: dest })` then opens the now-missing file and throws ENOENT.

Because the throw happens asynchronously inside the binding (after the warmup's try/catch already returned), it surfaces on the agent process's `uncaughtException` handler → `process.exit(1)` → agent dies → desktop renderer shows "Failed to fetch" forever.

**Fix:** wrap `warmupEmbeddingModel` so concurrent callers share a single in-flight promise. Cache is cleared on completion via `.finally()` so re-init flows (boot → kill → re-boot) still work correctly. No behavior change for single-caller paths (CLI, server-only).

## 3. `packages/app-core/scripts/copy-runtime-node-modules.ts`: filter post-release plugins at transitive walks

`shouldBundleDiscoveredPackage` already enforces eliza's existing policy: post-release `@elizaos/plugin-*` packages (those NOT in `CORE_PLUGINS` / `OPTIONAL_CORE_PLUGINS` / `BASELINE_*`) are installed via the plugin registry on demand, not physically bundled in the desktop runtime.

That filter was only applied at the initial seed-discovery pass. Transitive walks (`queue.push` after `getRuntimeDependencyEntries`) didn't re-apply it, so a bundled package's non-optional `peerDependencies` / `dependencies` on a post-release plugin smuggled the plugin in through the back door — dragging the entire transitive tree with it.

Concrete failure observed on a fresh clone: `@elizaos/app-companion` (CORE_PLUGIN) → `@elizaos/app-wallet` → peerDep `@elizaos/plugin-wallet` (not bundled) → `@orca-so/whirlpools*` → `@solana-program/*` → `@solana/kit@5.5.1` + 3 coexisting major versions of `@solana/codecs*` (2.0.0-rc.1, 2.3.0, 5.5.1) — nested 8 levels deep in `dist/node_modules/`, producing paths up to 267 chars and tripping `assertTarSafeRuntimePaths` (default cap 202).

**Fix:** apply the same `shouldBundleDiscoveredPackage` filter at transitive walks. Net effect: 928 packages bundled (down from prior failure mode), plugin-wallet + @orca-so + @solana-program + the deep @solana/codecs variants all correctly classified as `filteredOptionalPlugins`. The plugin registry already knows how to fetch them post-install.

## 4. `packages/app-core/src/runtime/embedding-manager-support.ts`: `ensureModel` mkdirs the file's actual parent

`ensureModel` resolves the model path via `resolveModelPath(modelsDir, safeFilename)` — for bundled embedding configs, `safeFilename` is namespaced (`text/eliza-1-lite-0_6b-32k.gguf`), so the final dest is `<modelsDir>/text/<file>`. The code then did:

```ts
fs.mkdirSync(path.resolve(modelsDir), { recursive: true });
```

That creates `<modelsDir>`, not `<modelsDir>/text/`. Downstream, `downloadFile`'s `fs.createWriteStream(dest)` opens the dest path, which synchronously throws ENOENT because `text/` doesn't exist. The throw escapes the warmup's awaited try/catch as an `uncaughtException` on the agent process, which `run-main.ts`'s handler reacts to with `process.exit(1)`. Agent dies at boot, renderer never sees a backend, desktop GUI gets stuck on "Failed to fetch" forever.

**Fix:**

```ts
fs.mkdirSync(path.dirname(path.resolve(modelPath)), { recursive: true });
```

mkdir the file's own parent directory. Same `{ recursive: true }`, so no behavior change for flat-namespaced filenames.

## What kind of change is this?

Bug fixes (non-breaking). No API changes, no behavior change for non-affected callers.

# Testing

End-to-end verified on Linux desktop (`bun 1.3.13`, Node `24.15.0`):

1. Fresh clone of downstream Milady repo (no models pre-downloaded, no env vars set).
2. `bun install && bun run eliza:local` — succeeds.
3. `bun run build:desktop` — succeeds without `ELIZA_RUNTIME_TAR_SAFE_RELATIVE_PATH_MAX` bypass, without manual `bun run build` inside `packages/app-core/`, without `ELIZA_DISABLE_LOCAL_EMBEDDINGS`. 928 packages bundled, no tar-unsafe paths, deepest path 207 chars (well under POSIX-ustar 255).
4. Launch packaged Electrobun app → agent boots clean on `:31337` after ~30s embedding-model download.
5. `curl /api/health` → `{"ready":true,"plugins":{"loaded":24,"failed":0},...}`. 3+ min uptime stable.
6. `curl -X POST /api/cloud/login` → returns valid OAuth session: `{"ok":true,"sessionId":"...","browserUrl":"https://www.elizacloud.ai/auth/cli-login?session=..."}`.
7. Renderer console logs (positive): `Keychain scan found 2 provider(s): ["anthropic-subscription","ollama"]`.

Packages-mode regression check: `browser.ts` compiles to a byte-identical `dist/browser.js` thanks to tsc's existing extension-rewrite. Other three changes only affect specific failure modes (concurrent warmup, post-release-plugin smuggling, namespaced model filenames) that don't fire on the packages-mode happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four distinct fresh-clone desktop build failures in `packages/app-core`: a `browser.ts` import resolving against a non-existent `dist/` on first clone, concurrent `warmupEmbeddingModel` calls racing on the same file write, a transitive-walk filter gap that let post-release plugins smuggle large dependency trees into the bundle, and `ensureModel` creating the wrong parent directory for namespaced model filenames.

- **`browser.ts`**: Redirects re-exports from `../dist/index.js` to `./index.ts`; `tsconfig.build.json`'s `rewriteRelativeImportExtensions` ensures the published dist is byte-identical.
- **`eliza.ts`**: Adds a module-level `warmupInFlight` promise cache so concurrent `bootElizaRuntime` + `startEliza` calls share one download, preventing a `safeUnlink` race that caused ENOENT on `llama.loadModel`.
- **`copy-runtime-node-modules.ts`**: Applies `shouldBundleDiscoveredPackage` at transitive-walk steps (not just initial discovery) to exclude post-release `@elizaos/plugin-*` packages that were dragging in multi-version Solana codec trees and tripping `assertTarSafeRuntimePaths`; also adds a new `assertRequiredBundledPackagesLanded` defense-in-depth check with a matching test suite.

<h3>Confidence Score: 5/5</h3>

All four fixes are narrowly scoped to the described failure modes and do not alter behavior for the existing packages-mode happy path.

The browser.ts import change is byte-identical in the published dist thanks to tsconfig.build.json's extension rewriting. The warmup dedup correctly clears the in-flight promise via .finally() so re-boot cycles are unaffected. The transitive-walk filter applies shouldBundleDiscoveredPackage — verified to pass through all non-plugin npm packages and only exclude post-release @elizaos/plugin-* packages not in alwaysBundled, matching the existing seed-discovery policy. The ensureModel mkdir fix correctly uses path.dirname(path.resolve(modelPath)) for namespaced filenames. No new correctness or security issues were found.

copy-runtime-node-modules.ts warrants a second look: assertRequiredBundledPackagesLanded now runs before the existing missingAlwaysBundled guard, meaning an uninstalled-package failure surfaces with a 'copy + prune' error message rather than the more specific 'missing installed runtime package(s)' message — purely a diagnostic clarity issue, not a correctness gap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/browser.ts | Changes re-exports from ../dist/index.js to ./index.ts; safe because tsconfig.build.json rewrites the extension to .js in published dist. |
| packages/app-core/src/runtime/eliza.ts | Adds warmupInFlight promise cache to deduplicate concurrent model downloads; first caller's onProgress is used, subsequent concurrent callers get the same result but no progress events (acknowledged in prior review thread). |
| packages/app-core/src/runtime/embedding-manager-support.ts | Fixes mkdirSync to use path.dirname(path.resolve(modelPath)) instead of modelsDir, correctly creating namespaced subdirectories like text/ before download. |
| packages/app-core/scripts/copy-runtime-node-modules.ts | Applies shouldBundleDiscoveredPackage filter at transitive walk (mirrors initial discovery), and adds assertRequiredBundledPackagesLanded defense-in-depth check; the new assertion runs before the existing missingAlwaysBundled guard, which can shadow the more specific 'failed to resolve' error message in uninstalled-package scenarios. |
| packages/app-core/scripts/assert-required-bundled-packages.test.ts | New test file with thorough coverage of assertRequiredBundledPackagesLanded — scoped/unscoped packages, all-missing aggregation, empty dir, and path reporting in error messages. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bootElizaRuntime / startEliza] --> B{warmupInFlight set?}
    B -- Yes --> C[Return existing promise\nconcurrent caller joins]
    B -- No --> D[Set warmupInFlight\nwarmupEmbeddingModelImpl]
    D --> E{Mobile platform?}
    E -- Yes --> F[Skip warmup]
    E -- No --> G{Model file present?}
    G -- Yes --> H[Return modelPath]
    G -- No --> I[ensureModel]
    I --> J[path.dirname path.resolve modelPath\nmkdirSync recursive]
    J --> K[downloadFile to modelPath]
    K --> L[llama.loadModel]
    L --> M[warmupInFlight cleared via .finally]

    subgraph build[Desktop Build: copy-runtime-node-modules]
        N[Initial discovery:\nshouldBundleDiscoveredPackage filter]
        N --> O[BFS queue walk]
        O --> P{shouldBundleDiscoveredPackage\nfor each transitive dep?}
        P -- No --> Q[filteredOptionalPlugins\nskip post-release plugin]
        P -- Yes --> R[Copy to dist/node_modules]
        R --> O
        R --> S[assertTarSafeRuntimePaths]
        S --> T[assertRequiredBundledPackagesLanded\ncheck package.json present]
        T --> U[missingAlwaysBundled guard]
    end
```

<sub>Reviews (4): Last reviewed commit: ["test(app-core): defense-in-depth check t..."](https://github.com/elizaos/eliza/commit/5bef700e760e5369b0a4f6d871144e59e88665e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31753642)</sub>

<!-- /greptile_comment -->