### PR TITLE
fix(ui/startup): widen backend-startup timeout to 180s for any Capacitor native build

### DIFF
--- a/packages/ui/src/bridge/electrobun-runtime.test.ts
+++ b/packages/ui/src/bridge/electrobun-runtime.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getBackendStartupTimeoutMs } from "./electrobun-runtime";
+
+// `getBackendStartupTimeoutMs` returns 30s for web/cloud and 180s for any
+// build that hosts the on-device agent (Electrobun desktop, ElizaOS UA,
+// or any Capacitor native platform). The Capacitor probe is lazy: it
+// reads `globalThis.Capacitor` and falls back to 30s when missing.
+
+describe("getBackendStartupTimeoutMs — Capacitor native widening", () => {
+	let originalCapacitor: unknown;
+	let originalNavigator: Navigator | undefined;
+
+	beforeEach(() => {
+		originalCapacitor = (globalThis as { Capacitor?: unknown }).Capacitor;
+		originalNavigator = globalThis.navigator;
+	});
+
+	afterEach(() => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = originalCapacitor;
+		if (originalNavigator) {
+			Object.defineProperty(globalThis, "navigator", {
+				value: originalNavigator,
+				configurable: true,
+			});
+		}
+	});
+
+	function setNavigatorUA(ua: string): void {
+		Object.defineProperty(globalThis, "navigator", {
+			value: { userAgent: ua },
+			configurable: true,
+		});
+	}
+
+	it("returns 30_000ms for plain web (no Capacitor, no ElizaOS UA)", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = undefined;
+		setNavigatorUA("Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0");
+		expect(getBackendStartupTimeoutMs()).toBe(30_000);
+	});
+
+	it("returns 180_000ms when Capacitor.isNativePlatform() is true (Android sideload, iOS test build)", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = {
+			isNativePlatform: () => true,
+			getPlatform: () => "android",
+		};
+		setNavigatorUA("Mozilla/5.0 (Linux; Android 16; Seeker)");
+		expect(getBackendStartupTimeoutMs()).toBe(180_000);
+	});
+
+	it("returns 180_000ms when Capacitor.getPlatform() is 'ios' even if isNativePlatform missing", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = {
+			getPlatform: () => "ios",
+		};
+		setNavigatorUA("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)");
+		expect(getBackendStartupTimeoutMs()).toBe(180_000);
+	});
+
+	it("returns 180_000ms when ElizaOS UA marker is present (legacy path, AOSP build)", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = undefined;
+		setNavigatorUA(
+			"Mozilla/5.0 (Linux; Android 14; Moto G Play 2024) ElizaOS/1.0",
+		);
+		expect(getBackendStartupTimeoutMs()).toBe(180_000);
+	});
+
+	it("returns 30_000ms when Capacitor.getPlatform() is 'web' (Capacitor PWA build, not native)", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = {
+			isNativePlatform: () => false,
+			getPlatform: () => "web",
+		};
+		setNavigatorUA("Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0");
+		expect(getBackendStartupTimeoutMs()).toBe(30_000);
+	});
+
+	it("returns 30_000ms when probing Capacitor throws (defensive fall-through)", () => {
+		(globalThis as { Capacitor?: unknown }).Capacitor = {
+			isNativePlatform: () => {
+				throw new Error("plugin not initialized");
+			},
+		};
+		setNavigatorUA("Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0");
+		expect(getBackendStartupTimeoutMs()).toBe(30_000);
+	});
+});

--- a/packages/ui/src/bridge/electrobun-runtime.ts
+++ b/packages/ui/src/bridge/electrobun-runtime.ts
@@ -46,17 +46,54 @@ export function isElectrobunRuntime(): boolean {
   return hasElectrobunRendererBridge();
 }
 
+function isCapacitorNativePlatform(): boolean {
+  try {
+    // Lazy import keeps @capacitor/core out of the desktop / web bundle
+    // graph. @elizaos/ui declares @capacitor/core as a devDependency, so
+    // the import only resolves when a Capacitor app (mobile native) is
+    // the consumer; everywhere else this throws and we fall through.
+    const cap = (
+      globalThis as unknown as {
+        Capacitor?: {
+          isNativePlatform?: () => boolean;
+          getPlatform?: () => string;
+        };
+      }
+    ).Capacitor;
+    if (!cap) return false;
+    if (typeof cap.isNativePlatform === "function" && cap.isNativePlatform()) {
+      return true;
+    }
+    if (typeof cap.getPlatform === "function") {
+      const p = cap.getPlatform();
+      return p === "ios" || p === "android";
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export function getBackendStartupTimeoutMs(): number {
   if (isElectrobunRuntime()) return 180_000;
-  // ElizaOS runs the on-device agent in the same APK; cold-boot is
-  // ~30s PGlite migration + ~30s agent registration before the API is
-  // reachable, vs. <5s for cloud/remote backends. Use the same 3-minute
-  // budget as the desktop path so the splash poll loop catches it
-  // instead of dead-ending on a "Backend Timeout" card.
+  // Any build that hosts the on-device agent in the same process gets
+  // the 3-minute budget. Three paths qualify:
+  //  - Electrobun desktop (handled above)
+  //  - AOSP / branded ElizaOS Capacitor builds — UA carries `ElizaOS/<tag>`
+  //  - Stock Capacitor sideloads (Pixel 6a, Solana Seeker, Moto G,
+  //    iOS test installs) — UA has no ElizaOS marker but still runs
+  //    the bundled agent on 127.0.0.1:31337. Cold-boot is ~30s PGlite
+  //    migration + ~30s agent registration before /api/auth/status
+  //    binds, vs. <5s for cloud/remote backends.
+  // Web / hosted-cloud builds keep the snappy 30s budget so a real
+  // backend outage surfaces fast instead of staring at the splash.
   if (
     typeof navigator !== "undefined" &&
     /\bElizaOS\//.test(navigator.userAgent ?? "")
   ) {
+    return 180_000;
+  }
+  if (isCapacitorNativePlatform()) {
     return 180_000;
   }
   return 30_000;


### PR DESCRIPTION
## Problem

\`getBackendStartupTimeoutMs()\` in \`packages/ui/src/bridge/electrobun-runtime.ts\` gates the inner \`optDeadline\` of the polling-backend phase (\`startup-phase-poll.ts:265\`). It was correctly bumped to 180s for Electrobun desktop and for any WebView whose UA carries \`ElizaOS/<tag>\`. Everything else got the 30s cloud budget — **including stock Capacitor sideloads of on-device-agent builds**.

Reproduced today on:
- **Solana Seeker** (Dimensity 7300, Android 16)
- **Pixel 6a** (Tensor G1)
- **Moto G Play 2024** (Snapdragon 4 Gen 1)

All three sideload the milady debug APK (no \`ElizaOS/\` UA marker) and host the bundled agent on \`127.0.0.1:31337\`. Cold-boot is ~30s PGlite migration + ~30s plugin/registration before the API binds. With the 30s budget, the inner loop dead-ends and the React shell renders **"AGENT TIMEOUT — Startup failed"** roughly 60-90s after launch. Tapping "Retry Startup" reconnects immediately because the agent IS up by then; the watchdog just gave up too early.

## Why #7603 didn't fix it

#7603 raised \`createMobilePolicy.{backendTimeoutMs, agentReadyTimeoutMs}\` to 180s/300s. But:

1. **Stock Android routes through \`createAndroidPolicy\`**, not \`createMobilePolicy\` (\`useStartupCoordinator.ts:89-98\`: \`if (isAndroid) return createAndroidPolicy();\`).
2. **\`getBackendStartupTimeoutMs()\` and \`getAgentReadyTimeoutMs()\` are UA-sniffing globals** — they don't take \`PlatformPolicy\` as input. The policy fields are vestigial for these gates.

So #7603 was effectively a no-op on Seeker / Pixel / Moto G.

## Fix

Add a lazy Capacitor native-platform probe to \`getBackendStartupTimeoutMs()\`. Any build whose Capacitor reports \`isNativePlatform()\` (or \`getPlatform() === 'ios'/'android'\`) gets the 3-minute budget. The probe reads \`globalThis.Capacitor\` so it stays out of the desktop/web bundle graph and falls back to 30s when the global is absent.

\`\`\`ts
function isCapacitorNativePlatform(): boolean {
  try {
    const cap = (globalThis as { Capacitor?: { isNativePlatform?: () => boolean; getPlatform?: () => string } }).Capacitor;
    if (!cap) return false;
    if (typeof cap.isNativePlatform === "function" && cap.isNativePlatform()) return true;
    if (typeof cap.getPlatform === "function") {
      const p = cap.getPlatform();
      return p === "ios" || p === "android";
    }
    return false;
  } catch {
    return false;
  }
}
\`\`\`

Same defensive pattern as \`storage-bridge.ts:isNativePlatform()\` which the rest of \`packages/ui/src/bridge/\` already uses.

## Compat

- **Web / hosted cloud**: unchanged at 30s — \`globalThis.Capacitor\` is undefined, probe returns false.
- **Capacitor PWA (\`getPlatform() === 'web'\`)**: stays at 30s — \`isNativePlatform()\` returns false.
- **Electrobun desktop**: unchanged at 180s — handled by the existing early return.
- **AOSP / branded ElizaOS Capacitor builds**: unchanged at 180s — UA marker still matches.
- **Stock Capacitor sideloads (Seeker / Pixel / Moto G / iOS test installs)**: **now 180s** (was 30s). Fixes the AGENT TIMEOUT card.

## Tests

Adds \`packages/ui/src/bridge/electrobun-runtime.test.ts\` with 6 cases. \`bunx vitest run src/bridge/electrobun-runtime.test.ts\` → 6/6 pass.

\`\`\`
Test Files  1 passed (1)
     Tests  6 passed (6)
\`\`\`

## Follow-up (not in this PR)

The runtime/poll phase reading from UA-sniffing helpers instead of \`PlatformPolicy.{backendTimeoutMs, agentReadyTimeoutMs}\` is the root architectural issue — that's why #7603 was a no-op. Worth filing as a separate "wire PlatformPolicy through getBackendStartupTimeoutMs + getAgentReadyTimeoutMs" tracking issue so the next PR doesn't waste a round-trip. Will file if you want.

## Test plan

- [x] \`bunx vitest run src/bridge/electrobun-runtime.test.ts\` — 6/6 pass
- [x] \`bunx tsc --noEmit\` on packages/ui — no new errors (the 3 pre-existing \`@capacitor/app\` errors are unrelated)
- [x] \`bunx @biomejs/biome check\` on changed files — clean
- [ ] On-device verify on Solana Seeker (the original repro) — pending APK rebuild + reinstall, will comment once landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a spurious "AGENT TIMEOUT" splash card on stock Capacitor sideloads (Android/iOS) where the backend startup watchdog was expiring at 30 s before the bundled agent had finished its ~60 s cold-boot sequence. The fix adds a lazy `globalThis.Capacitor` probe that grants the same 180 s budget already given to Electrobun desktop and ElizaOS-branded UA builds.

- **`electrobun-runtime.ts`**: new `isCapacitorNativePlatform()` reads `globalThis.Capacitor.isNativePlatform()` / `getPlatform()` with a defensive try/catch; `getBackendStartupTimeoutMs()` returns 180 s when the probe is truthy.
- **`electrobun-runtime.test.ts`**: 6 Vitest cases cover the web (30 s), Android sideload, iOS platform-string, ElizaOS UA, Capacitor PWA (30 s), and throwing-plugin paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is an additive timeout widening guarded by a well-isolated, defensive probe with no side effects on web or desktop paths.

The new `isCapacitorNativePlatform()` helper reads a single global property, falls through to false on any error, and only affects builds where globalThis.Capacitor is present. All existing paths (Electrobun, ElizaOS UA, plain web) are untouched and the 6 new tests cover the meaningful branches.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/bridge/electrobun-runtime.ts | Adds `isCapacitorNativePlatform()` to probe `globalThis.Capacitor` and widen `getBackendStartupTimeoutMs()` to 180s for native iOS/Android builds; logic is correct and defensive, but the block comment inside the helper inaccurately describes a dynamic import that doesn't exist. |
| packages/ui/src/bridge/electrobun-runtime.test.ts | New test file covering 6 timeout scenarios for the Capacitor native probe; good coverage of happy-path, fallback-platform, ElizaOS-UA, Capacitor-PWA, and throwing cases. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getBackendStartupTimeoutMs] --> B{isElectrobunRuntime?}
    B -- yes --> C[return 180_000ms]
    B -- no --> D{navigator.userAgent contains ElizaOS/?}
    D -- yes --> C
    D -- no --> E{isCapacitorNativePlatform?}
    E --> F[read globalThis.Capacitor]
    F --> G{cap exists?}
    G -- no --> H[return false]
    G -- yes --> I{isNativePlatform === function?}
    I -- yes returns true --> J[return true]
    I -- no or false --> K{getPlatform === function?}
    K -- returns ios or android --> J
    K -- returns web or absent --> H
    F -- throws --> H
    E -- true --> C
    E -- false --> L[return 30_000ms]
```

<sub>Reviews (3): Last reviewed commit: ["fix(ui/startup): widen backend-startup t..."](https://github.com/elizaos/eliza/commit/787fc660521a1d657a0f0aa6ced5315322296fcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31757597)</sub>

<!-- /greptile_comment -->