### PR TITLE
build(dflash): add linux-x64-sycl target for Intel oneAPI / iGPUs

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-dflash.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash.mjs
@@ -150,6 +150,22 @@ const SUPPORTED_TARGETS = [
   "linux-x64-cuda",
   "linux-x64-rocm",
   "linux-x64-vulkan",
+  // Intel oneAPI / SYCL on Linux x64. Targets Intel discrete and
+  // integrated GPUs (Arc, Xe, Lunar Lake / Meteor Lake / Panther Lake
+  // iGPUs) through upstream ggml-sycl. Requires Intel oneAPI Base
+  // Toolkit (icx/icpx + oneMKL) on the build host; `source
+  // /opt/intel/oneapi/setvars.sh` before invoking this script. Optional
+  // `ELIZA_DFLASH_SYCL_TARGET=NVIDIA` / `AMD` overrides the default
+  // `INTEL` cross-architecture target (DPC++ can compile SYCL → PTX or
+  // ROCm via the same toolchain — useful for benchmarking against
+  // CUDA/HIP backends). Custom W4-B kernels (turbo3 / turbo4 /
+  // turbo3_tcq / qjl / polarquant / dflash) do NOT have a SYCL backend
+  // in this fork today (CUDA / Vulkan / Metal / CPU only), so the SYCL
+  // target falls back to upstream-equivalent perf. The kernel-patches
+  // dispatch in this script's `patch*Kernels` hooks correctly no-ops
+  // for `backend === "sycl"` (the per-backend branches around line
+  // 1490 only match cuda/vulkan/metal).
+  "linux-x64-sycl",
   // Linux aarch64. Required for the `server-h200` tier (GH200 = aarch64
   // host + H100/H200 GPU) and for Ampere Altra / AWS Graviton CPU-only
   // deployments. Both targets require a real arm64 Linux host (or a
@@ -880,6 +896,11 @@ function cmakeFlagsForTarget(target, ctx) {
   //     existing `backend === "cpu" && arch === "x64"` / `arm64` blocks
   //     in the `platform === "windows"` section (and a new linux-cpu
   //     block here if a non-native pin is ever needed).
+  //   * SYCL-AGENT TODO: extra flags for `linux-x64-sycl` go in the
+  //     `backend === "sycl"` branch below. Future Eliza-kernel SYCL
+  //     backends (turbo3 / qjl / polarquant) will plug into the same
+  //     branch alongside an entry in patchAllKernels() at the bottom
+  //     of this file.
   // ──────────────────────────────────────────────────────────────────
   const { platform, arch, backend, isSimulator } = parseTarget(target);
   const flags = ["-DLLAMA_BUILD_TESTS=OFF", "-DLLAMA_BUILD_EXAMPLES=ON"];
@@ -888,7 +909,13 @@ function cmakeFlagsForTarget(target, ctx) {
   flags.push(`-DGGML_NATIVE=${isCross ? "OFF" : "ON"}`);
 
   // Disable backends we don't want by default; flip the chosen one back on.
-  const offByDefault = ["GGML_METAL", "GGML_CUDA", "GGML_HIP", "GGML_VULKAN"];
+  const offByDefault = [
+    "GGML_METAL",
+    "GGML_CUDA",
+    "GGML_HIP",
+    "GGML_VULKAN",
+    "GGML_SYCL",
+  ];
   for (const name of offByDefault) flags.push(`-D${name}=OFF`);
 
   if (backend === "metal") {
@@ -935,6 +962,33 @@ function cmakeFlagsForTarget(target, ctx) {
     // narrow/extend with ELIZA_DFLASH_CMAKE_FLAGS; those flags append
     // after this list and win on a CMake conflict.
     flags.push(hipArchListFlag());
+  } else if (backend === "sycl") {
+    // Intel oneAPI / SYCL backend. Builds plain ggml-sycl from the
+    // upstream tree (no Eliza kernel patches — those branches in
+    // patch*Kernels() only match cuda/vulkan/metal). Operator must
+    // `source /opt/intel/oneapi/setvars.sh` so icx/icpx + MKLROOT are
+    // on PATH before this script runs.
+    flags[flags.indexOf("-DGGML_SYCL=OFF")] = "-DGGML_SYCL=ON";
+    // Use Intel's DPC++ compiler. CMake honors CC/CXX, but setting the
+    // compiler vars explicitly catches the common case where setvars.sh
+    // was not sourced (CMake would silently fall back to gcc, which
+    // can't compile SYCL TUs and emits a confusing pragma error 100+
+    // lines deep into a translation unit).
+    flags.push("-DCMAKE_C_COMPILER=icx", "-DCMAKE_CXX_COMPILER=icpx");
+    // FP16 path: Intel iGPUs (Xe2 in Lunar Lake, Xe-LPG in Meteor Lake,
+    // Battlemage discrete) all support FP16 via XMX matrix engines.
+    // Discrete Arc A-series and prior also benefit. Disable only if a
+    // host reports a SYCL_VALIDATION_ERROR on FP16 ops.
+    flags.push("-DGGML_SYCL_F16=ON");
+    // SYCL target architecture. DPC++ can compile SYCL → Intel GPU
+    // (default), → NVIDIA PTX (codeplay/oneAPI-for-CUDA plugin), or
+    // → AMD HIP (codeplay/oneAPI-for-HIP plugin). The vast majority
+    // of users hitting this target want INTEL; expose the override
+    // env knob in case someone benchmarks against the same source tree.
+    const syclTarget = (
+      process.env.ELIZA_DFLASH_SYCL_TARGET || "INTEL"
+    ).toUpperCase();
+    flags.push(`-DGGML_SYCL_TARGET=${syclTarget}`);
   } else if (backend === "vulkan") {
     flags[flags.indexOf("-DGGML_VULKAN=OFF")] = "-DGGML_VULKAN=ON";
     if (ctx.glslc) flags.push(`-DVulkan_GLSLC_EXECUTABLE=${ctx.glslc}`);
@@ -1189,6 +1243,13 @@ function targetCompatibility(target, ctx) {
   }
   if (backend === "vulkan" && !ctx.glslc) {
     return { ok: false, reason: "no glslc (Vulkan shader compiler)" };
+  }
+  if (backend === "sycl" && !(has("icpx") && has("icx"))) {
+    return {
+      ok: false,
+      reason:
+        "no icx/icpx (Intel oneAPI Base Toolkit) — source /opt/intel/oneapi/setvars.sh first",
+    };
   }
   if (backend === "metal" && process.platform !== "darwin") {
     return { ok: false, reason: "metal requires macOS" };


### PR DESCRIPTION
## Summary

Adds a Linux x64 SYCL build target to `packages/app-core/scripts/build-llama-cpp-dflash.mjs`. Lets Intel Arc / Xe / Lunar Lake / Meteor Lake iGPU users build llama.cpp through ggml-sycl + oneMKL without going around the dflash build script.

This is purely additive — the W4-B custom kernels (`turbo3`, `turbo4`, `turbo3_tcq`, `qjl`, `polarquant`, `dflash`) have CUDA / Vulkan / Metal / CPU backends today but no SYCL backend, so the SYCL target builds plain upstream ggml-sycl. The per-backend dispatch in `patchAllKernels()` correctly no-ops for `backend === "sycl"`.

## Changes

- `SUPPORTED_TARGETS` gains `"linux-x64-sycl"` with a comment block spelling out what hardware it targets and why kernel patches do not apply yet.
- `cmakeFlagsForTarget` grows a `backend === "sycl"` branch that:
  - sets `-DGGML_SYCL=ON`
  - pins `-DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx` (CMake silently falls back to gcc if you forget `setvars.sh`; the SYCL TUs then explode 100+ lines deep into a `#pragma` error)
  - enables `GGML_SYCL_F16` for XMX matrix engines on Xe2 / Xe-LPG iGPUs
  - exposes `ELIZA_DFLASH_SYCL_TARGET=INTEL|NVIDIA|AMD` (DPC++ can compile SYCL → PTX or HIP with the codeplay plugins — useful for same-source-tree benchmarking against CUDA/HIP backends)
- `GGML_SYCL` joins the `offByDefault` list so non-SYCL targets explicitly disable it (parity with METAL / CUDA / HIP / VULKAN).
- `targetCompatibility` returns a graceful `no icx/icpx` skip when oneAPI is not installed, instead of crashing inside CMake with a deep template error.
- The `TODO ANCHORS` comment in `cmakeFlagsForTarget` grows a `SYCL-AGENT TODO` line for future kernel work.

## Verification

On a Debian box with no oneAPI installed, the dispatch path skips cleanly:

```
$ node packages/app-core/scripts/build-llama-cpp-dflash.mjs --target linux-x64-sycl --jobs 1
[dflash-build] target linux-x64-sycl is not buildable: no icx/icpx (Intel oneAPI Base Toolkit) — source /opt/intel/oneapi/setvars.sh first
```

Build verification on an actual Intel iGPU host (Lunar Lake Arc 140V, oneAPI 2025.x) is **pending** — I don't currently have a box with oneAPI installed. Happy to retest on whatever the maintainers prefer; the dispatch is intentionally minimal so the scaffolding lands now and the real build path can be exercised when an Intel-host CI runner exists.

## Test plan

- [x] `node --check` on the modified file
- [x] Dry-run on a host without oneAPI → graceful skip with the expected reason string
- [ ] Build on a real Intel iGPU + oneAPI host (need a maintainer with Arc / Lunar Lake hardware to verify)

## Out of scope

- A real SYCL backend for the W4-B kernels (turbo3 / qjl / polarquant). The TODO-ANCHOR comment block calls out the right insertion point in `patchAllKernels()` once those land.
- `omnivoice-fuse` support for SYCL (the fused variants in `FUSED_TARGETS` are currently CUDA/Vulkan/Metal/CPU only).

## Related

- Companion OpenVINO target / submodule advance: #7634
- RFC for wiring all this into `LocalRuntimeKernel`: #7633
- Build script reuses the glslc-path fix from #7626
