### PR TITLE
build(dflash): add linux-x64-openvino target + advance submodule to Shaw's milady/main with native OpenVINO + DFlash event schema

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-dflash.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash.mjs
@@ -150,6 +150,31 @@ const SUPPORTED_TARGETS = [
   "linux-x64-cuda",
   "linux-x64-rocm",
   "linux-x64-vulkan",
+  // Intel OpenVINO backend on Linux x64 (ggml-org/llama.cpp PR #15307,
+  // merged into upstream master on 2026-04-08; this fork cherry-picks
+  // the ggml-openvino/ directory). Builds a single llama-server binary
+  // that can target the Intel CPU, Intel iGPU/dGPU (Arc / Xe / Lunar
+  // Lake / Meteor Lake / Panther Lake), OR the Intel NPU (Lunar Lake AI
+  // Boost ~48 TOPS, Meteor Lake NCE, Arrow Lake) — the device is
+  // selected at RUNTIME via `GGML_OPENVINO_DEVICE={CPU,GPU,NPU,GPU.0,
+  // GPU.1}`. NPU coverage is the unique value here: SYCL/Vulkan/CUDA do
+  // not cover the NPU, OpenVINO does, and NPU inference draws ~2-3 W
+  // vs ~15-25 W for the iGPU on the same model. Requires the OpenVINO
+  // Runtime (`apt install openvino-2026.x.x` from
+  // https://apt.repos.intel.com/openvino, or extract the tarball under
+  // /opt/intel/openvino_2026/); `source
+  // /opt/intel/openvino_2026/setupvars.sh` exports `OpenVINO_DIR` and
+  // `LD_LIBRARY_PATH` so CMake's `find_package(OpenVINO)` succeeds and
+  // the runtime can dlopen `libopenvino.so` at execution time. The
+  // W4-B custom kernels (turbo3 / turbo4 / turbo3_tcq / qjl /
+  // polarquant / dflash) do NOT have an OpenVINO backend — those are
+  // CUDA / Vulkan / Metal / CPU only — so this target runs plain ggml
+  // ops translated to OpenVINO compute graphs. The kernel-patches
+  // dispatch in patchAllKernels() correctly no-ops for `backend ===
+  // "openvino"` (the per-backend branches around line 1490 only match
+  // cuda/vulkan/metal). Supported quantizations: FP16, Q8_0, Q4_0,
+  // Q4_1, Q4_K, Q4_K_M (with runtime conversion for Q5_K / Q6_K).
+  "linux-x64-openvino",
   // Linux aarch64. Required for the `server-h200` tier (GH200 = aarch64
   // host + H100/H200 GPU) and for Ampere Altra / AWS Graviton CPU-only
   // deployments. Both targets require a real arm64 Linux host (or a
@@ -880,6 +905,11 @@ function cmakeFlagsForTarget(target, ctx) {
   //     existing `backend === "cpu" && arch === "x64"` / `arm64` blocks
   //     in the `platform === "windows"` section (and a new linux-cpu
   //     block here if a non-native pin is ever needed).
+  //   * OPENVINO-AGENT TODO: extra flags for `linux-x64-openvino` (and
+  //     future `windows-x64-openvino`) go in the `backend ===
+  //     "openvino"` branch below. Eliza-kernel OpenVINO backends, if
+  //     they're ever written, would plug into the same branch alongside
+  //     an entry in patchAllKernels() at the bottom of this file.
   // ──────────────────────────────────────────────────────────────────
   const { platform, arch, backend, isSimulator } = parseTarget(target);
   const flags = ["-DLLAMA_BUILD_TESTS=OFF", "-DLLAMA_BUILD_EXAMPLES=ON"];
@@ -888,7 +918,13 @@ function cmakeFlagsForTarget(target, ctx) {
   flags.push(`-DGGML_NATIVE=${isCross ? "OFF" : "ON"}`);
 
   // Disable backends we don't want by default; flip the chosen one back on.
-  const offByDefault = ["GGML_METAL", "GGML_CUDA", "GGML_HIP", "GGML_VULKAN"];
+  const offByDefault = [
+    "GGML_METAL",
+    "GGML_CUDA",
+    "GGML_HIP",
+    "GGML_VULKAN",
+    "GGML_OPENVINO",
+  ];
   for (const name of offByDefault) flags.push(`-D${name}=OFF`);
 
   if (backend === "metal") {
@@ -935,6 +971,30 @@ function cmakeFlagsForTarget(target, ctx) {
     // narrow/extend with ELIZA_DFLASH_CMAKE_FLAGS; those flags append
     // after this list and win on a CMake conflict.
     flags.push(hipArchListFlag());
+  } else if (backend === "openvino") {
+    // Intel OpenVINO backend. Builds plain ggml-openvino from the
+    // cherry-picked upstream tree (no Eliza kernel patches — those
+    // branches in patch*Kernels() only match cuda/vulkan/metal).
+    // Operator must source the OpenVINO setupvars script (e.g.
+    // `source /opt/intel/openvino_2026/setupvars.sh`) so OpenVINO_DIR
+    // / INTEL_OPENVINO_DIR and LD_LIBRARY_PATH are set before this
+    // script runs. CMake then resolves `find_package(OpenVINO)` from
+    // those env vars.
+    flags[flags.indexOf("-DGGML_OPENVINO=OFF")] = "-DGGML_OPENVINO=ON";
+    // Pass OpenVINO_DIR explicitly when present — find_package() will
+    // honor it. Some OpenVINO tarballs install to non-standard paths
+    // (/opt/intel/openvino_<ver>/runtime/cmake) which CMake's default
+    // search heuristics miss.
+    const openvinoDir =
+      process.env.OpenVINO_DIR || process.env.INTEL_OPENVINO_DIR;
+    if (openvinoDir) {
+      // INTEL_OPENVINO_DIR points at /opt/intel/openvino_<ver>/, but
+      // find_package() wants the runtime/cmake subdirectory. Normalize.
+      const cmakeDir = openvinoDir.endsWith("/cmake")
+        ? openvinoDir
+        : path.join(openvinoDir, "runtime", "cmake");
+      flags.push(`-DOpenVINO_DIR=${cmakeDir}`);
+    }
   } else if (backend === "vulkan") {
     flags[flags.indexOf("-DGGML_VULKAN=OFF")] = "-DGGML_VULKAN=ON";
     if (ctx.glslc) flags.push(`-DVulkan_GLSLC_EXECUTABLE=${ctx.glslc}`);
@@ -1189,6 +1249,16 @@ function targetCompatibility(target, ctx) {
   }
   if (backend === "vulkan" && !ctx.glslc) {
     return { ok: false, reason: "no glslc (Vulkan shader compiler)" };
+  }
+  if (
+    backend === "openvino" &&
+    !(process.env.OpenVINO_DIR || process.env.INTEL_OPENVINO_DIR)
+  ) {
+    return {
+      ok: false,
+      reason:
+        "no OpenVINO_DIR / INTEL_OPENVINO_DIR — source /opt/intel/openvino_<ver>/setupvars.sh first",
+    };
   }
   if (backend === "metal" && process.platform !== "darwin") {
     return { ok: false, reason: "metal requires macOS" };


### PR DESCRIPTION
## Summary

Adds the `linux-x64-openvino` build target to `packages/app-core/scripts/build-llama-cpp-dflash.mjs` AND advances the `packages/inference/llama.cpp` submodule from `a61c93aaa5` (v1.2.0-eliza) to `d629a3768` — Shaw's current `milady/main` HEAD (`milady-v2026.05.09-base-933-gd629a3768`).

Supersedes [#7632](https://github.com/elizaOS/eliza/pull/7632) and [#7630](https://github.com/elizaOS/eliza/pull/7630). The submodule advance pulls in 8 new commits from upstream — most notably **Shaw's own upstream/master merge `79079c25e`** which already imports the same `ggml-src/ggml-openvino/` backend my earlier llama.cpp PR cherry-picked. That PR is now closed.

## Breaking: fork-specific quant IDs renumbered

The upstream/master merge `79079c25e` filled slots 40-41 with `NVFP4 = 40` and `Q1_0 = 41` from upstream, and renumbered milady-fork-specific quant types to sit in the new contiguous 42-48 range:

```
Q1_0_g32   = 42  Q1_0_g128 = 43
TBQ3_0     = 44  TBQ4_0    = 45
QJL1_256   = 46  Q4_POLAR  = 47  TBQ3_TCQ = 48
COUNT      = 49  (was 207 in the pre-merge fork)
```

**Any GGUF file written against the previous submodule pin that uses one of `TBQ3_0`, `TBQ4_0`, `QJL1_256`, `Q4_POLAR`, or `TBQ3_TCQ` will silently parse as the wrong quant type after this advance lands.** There is no version field at the loader layer that catches this — the loader reads an integer ID and dispatches.

If anyone is storing models with the fork-specific custom quants, they need to be re-quantized against the new IDs, or this PR should not land until a migration path exists. As far as I'm aware, no Milady-shipped model registry entry uses these quants today (the registry uses standard Q4_K_M / Q8_0 / Q5_K_M etc., all unchanged). But operators with locally-quantized customs are on the hook.

## What's new in the submodule range (a61c93aaa5..d629a3768)

```
d629a3768 omnivoice: remove Metal DAC codec CPU fallback
04d53bdef feat(inference): wire native DFlash event schema + metrics collector
c58615ed5 omnivoice: wire tools/omnivoice/ into LLAMA_BUILD_OMNIVOICE build
c4bdc0c5d omnivoice: vendor tests/abi-c.c into tools/omnivoice/tests/
80ce2a760 omnivoice: vendor src/, tools/, public header into tools/omnivoice/
f6347f85c build: add LLAMA_BUILD_OMNIVOICE option
79079c25e merge: upstream/master into milady/main (quant-ID remap 42-48, DFlash preserved)
[plus ~600 commits from ggml-org/master, including the OpenVINO backend]
```

## Build script changes (unchanged from #7632)

- `SUPPORTED_TARGETS` gains `"linux-x64-openvino"` with documentation block.
- `cmakeFlagsForTarget` `backend === "openvino"` branch (`-DGGML_OPENVINO=ON`, forwards `OpenVINO_DIR` / `INTEL_OPENVINO_DIR`).
- `GGML_OPENVINO` joins `offByDefault`.
- `targetCompatibility` graceful skip when `OpenVINO_DIR` / `INTEL_OPENVINO_DIR` unset.

## Hardware bench (from the previous PR — still applies to this submodule pointer)

Llama-3.1-8B-Instruct Q4_K_M / Llama-3.2-{3B,1B}-Instruct Q4_K_M, Intel Core Ultra 7 258V (Lunar Lake) + Arc 140V + 48 TOPS NPU, OpenVINO 2026.1.0:

| Path | Model | Tg t/s | Pp t/s | Status |
|---|---|---|---|---|
| OpenVINO CPU | 8B Q4_K_M | 3.89 | 40.7 | coherent |
| OpenVINO NPU | 1B Q4_K_M | 2.07 | 72.2 | coherent |
| OpenVINO NPU | 8B Q4_K_M | crashed | — | exceeds NPU plugin memory budget |
| OpenVINO GPU | 3B Q4_K_M | aborted | — | needs `apt install intel-opencl-icd libigc2 libigdfcl2` on host |
| Vulkan iGPU (W4-B) | 8B Q4_K_M | 5.7 | 172 | coherent |
| Vulkan iGPU (W4-B) | 3B Q4_K_M | 20.0 | 285.9 | coherent (best path) |
| Vulkan spec-decode | 3B+1B | 6.9 | 137 | 31.8% accept (slower than 3B alone) |

Final framing: OpenVINO/NPU is real and reachable, but autoregressive LLM tg is not its strength on Lunar Lake — the killer app for this target is **Whisper-on-NPU + 3B on Vulkan iGPU** for the voice agent. RFC issue [#7633](https://github.com/elizaOS/eliza/issues/7633) proposes the runtime kernel wiring.

## Related

- Supersedes #7630 (submodule bump to v1.2.0-eliza), #7632 (OpenVINO target on stale submodule), and elizaOS/llama.cpp#1 (OpenVINO cherry-pick — Shaw merged upstream/master himself)
- Builds on #7626 (glslc fix)
- Sibling to #7628 (SYCL target)
- RFC: #7633
- Compile-block regressions from this same `79079c25e` merge: tracker [#7636](https://github.com/elizaOS/eliza/issues/7636), fixes at [elizaOS/llama.cpp#4](https://github.com/elizaOS/llama.cpp/pull/4); SWA spec-decode regression and fix at [#7635](https://github.com/elizaOS/eliza/issues/7635) / [elizaOS/llama.cpp#3](https://github.com/elizaOS/llama.cpp/pull/3)
