### PR TITLE
fix(local-inference/voice/kokoro): load voice packs in the format KOKORO_VOICES_BASE_URL actually ships

### DIFF
--- a/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-runtime.test.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-runtime.test.ts
@@ -1,0 +1,228 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KokoroOnnxRuntime } from "../kokoro-runtime";
+import { KokoroModelMissingError, type KokoroVoicePack } from "../types";
+
+// Stub ORT module — captures the feeds the runtime constructs without
+// running real onnxruntime-node. Mirrors the structural shape declared in
+// kokoro-runtime.ts (`OrtModule`).
+function makeStubOrt(args: {
+  inputNames?: ReadonlyArray<string>;
+  waveform?: Float32Array;
+  captured?: { feeds: Record<string, { type: string; dims: ReadonlyArray<number>; data: Float32Array | Int32Array | BigInt64Array; }> | null };
+}): { ort: unknown; captured: typeof args.captured } {
+  const captured = args.captured ?? { feeds: null };
+  const waveform = args.waveform ?? new Float32Array([0.1, -0.1, 0.2, -0.2]);
+  const session = {
+    inputNames: args.inputNames,
+    async run(feeds: Record<string, { type: string; dims: ReadonlyArray<number>; data: Float32Array | Int32Array | BigInt64Array }>) {
+      captured.feeds = feeds;
+      return { waveform: { type: "float32", data: waveform, dims: [waveform.length] } };
+    },
+    async release() {},
+  };
+  const ort = {
+    InferenceSession: { create: async () => session },
+    Tensor: function (this: { type: string; data: unknown; dims: ReadonlyArray<number> }, type: string, data: unknown, dims: ReadonlyArray<number>) {
+      this.type = type;
+      this.data = data;
+      this.dims = dims;
+    } as unknown as new (
+      type: string,
+      data: Float32Array | Int32Array | BigInt64Array,
+      dims: ReadonlyArray<number>,
+    ) => { type: string; data: unknown; dims: ReadonlyArray<number> },
+  };
+  return { ort, captured };
+}
+
+function stageBundle(dim: number, voiceBytes: Float32Array): {
+  layout: { root: string; modelFile: string; voicesDir: string; sampleRate: number };
+  voice: KokoroVoicePack;
+  cleanup: () => void;
+} {
+  const root = mkdtempSync(path.join(os.tmpdir(), "kokoro-runtime-test-"));
+  const voicesDir = path.join(root, "voices");
+  mkdirSync(voicesDir, { recursive: true });
+  const modelFile = "model.onnx";
+  // The ORT loader checks the file exists before calling InferenceSession.
+  writeFileSync(path.join(root, modelFile), Buffer.alloc(4));
+  writeFileSync(
+    path.join(voicesDir, "af_test.bin"),
+    Buffer.from(voiceBytes.buffer, voiceBytes.byteOffset, voiceBytes.byteLength),
+  );
+  return {
+    layout: { root, modelFile, voicesDir, sampleRate: 24000 },
+    voice: { id: "af_test", displayName: "Test", lang: "a", file: "af_test.bin", dim, tags: ["test"] },
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+describe("KokoroOnnxRuntime — voice .bin loader formats", () => {
+  let cleanups: Array<() => void>;
+  beforeEach(() => { cleanups = []; });
+  afterEach(() => { for (const c of cleanups) c(); });
+
+  it("loads the legacy single-style format (exactly voice.dim fp32)", async () => {
+    const dim = 4;
+    const single = new Float32Array([1, 2, 3, 4]);
+    const fx = stageBundle(dim, single);
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({ inputNames: ["input_ids", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from([10, 20, 30]), phonemes: "abc" },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    expect(captured!.feeds).not.toBeNull();
+    const styleFeed = captured!.feeds!.style;
+    expect(Array.from(styleFeed.data as Float32Array)).toEqual([1, 2, 3, 4]);
+    expect(styleFeed.dims).toEqual([1, 4]);
+  });
+
+  it("slices the per-position format using kokoro-onnx's `voice[len(tokens)]` rule", async () => {
+    const dim = 4;
+    const positions = 5;
+    // Build a 5×4 tensor where position k holds [k, k+0.1, k+0.2, k+0.3].
+    const full = new Float32Array(positions * dim);
+    for (let i = 0; i < positions; i++) {
+      for (let j = 0; j < dim; j++) full[i * dim + j] = i * 100 + j;
+    }
+    const fx = stageBundle(dim, full);
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({ inputNames: ["input_ids", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    // 3 phoneme tokens → should pick position 3.
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from([10, 20, 30]), phonemes: "abc" },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    const styleFeed = captured!.feeds!.style;
+    expect(Array.from(styleFeed.data as Float32Array)).toEqual([300, 301, 302, 303]);
+    expect(styleFeed.dims).toEqual([1, 4]);
+  });
+
+  it("clamps position index to numPositions - 1 when tokens exceed the table", async () => {
+    const dim = 4;
+    const positions = 3;
+    const full = new Float32Array(positions * dim);
+    for (let i = 0; i < positions; i++) {
+      for (let j = 0; j < dim; j++) full[i * dim + j] = i * 100 + j;
+    }
+    const fx = stageBundle(dim, full);
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({ inputNames: ["input_ids", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    // 20 phoneme tokens, table has 3 positions → pick position 2 (last).
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from(new Array(20).fill(7)), phonemes: "x".repeat(20) },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    const styleFeed = captured!.feeds!.style;
+    expect(Array.from(styleFeed.data as Float32Array)).toEqual([200, 201, 202, 203]);
+  });
+
+  it("rejects a voice .bin whose length is not a positive multiple of voice.dim", async () => {
+    const dim = 4;
+    const malformed = new Float32Array([1, 2, 3]); // 3 fp32 (not a multiple of 4)
+    const fx = stageBundle(dim, malformed);
+    cleanups.push(fx.cleanup);
+    const { ort } = makeStubOrt({ inputNames: ["input_ids", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    await expect(
+      runtime.synthesize({
+        phonemes: { ids: Int32Array.from([1]), phonemes: "a" },
+        voice: fx.voice,
+        cancelSignal: { cancelled: false },
+        onChunk: () => false,
+      }),
+    ).rejects.toBeInstanceOf(KokoroModelMissingError);
+  });
+});
+
+describe("KokoroOnnxRuntime — ONNX input-name detection", () => {
+  let cleanups: Array<() => void>;
+  beforeEach(() => { cleanups = []; });
+  afterEach(() => { for (const c of cleanups) c(); });
+
+  it("feeds `input_ids` when the session advertises it (newer export)", async () => {
+    const fx = stageBundle(4, new Float32Array([1, 1, 1, 1]));
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({ inputNames: ["input_ids", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from([42, 43]), phonemes: "ab" },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    expect(Object.keys(captured!.feeds!)).toContain("input_ids");
+    expect(Object.keys(captured!.feeds!)).not.toContain("tokens");
+  });
+
+  it("feeds `tokens` when the session lacks `input_ids` (older kokoro-onnx export)", async () => {
+    const fx = stageBundle(4, new Float32Array([1, 1, 1, 1]));
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({ inputNames: ["tokens", "style", "speed"] });
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from([42, 43]), phonemes: "ab" },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    expect(Object.keys(captured!.feeds!)).toContain("tokens");
+    expect(Object.keys(captured!.feeds!)).not.toContain("input_ids");
+  });
+
+  it("defaults to `input_ids` when the session does not report input names (test stubs without inputNames)", async () => {
+    const fx = stageBundle(4, new Float32Array([1, 1, 1, 1]));
+    cleanups.push(fx.cleanup);
+    const { ort, captured } = makeStubOrt({});
+    const runtime = new KokoroOnnxRuntime({
+      layout: fx.layout,
+      expectedSha256: null,
+      loadOrt: async () => ort as never,
+    });
+    await runtime.synthesize({
+      phonemes: { ids: Int32Array.from([42, 43]), phonemes: "ab" },
+      voice: fx.voice,
+      cancelSignal: { cancelled: false },
+      onChunk: () => false,
+    });
+    expect(Object.keys(captured!.feeds!)).toContain("input_ids");
+  });
+});

--- a/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts
@@ -112,6 +112,14 @@ export interface KokoroRuntime {
 interface OrtSession {
   run(feeds: Record<string, OrtTensor>): Promise<Record<string, OrtTensor>>;
   release(): Promise<void>;
+  /**
+   * Optional — present on real onnxruntime-node sessions, absent on test
+   * stubs. When present we use it to detect whether the loaded export
+   * expects `input_ids` (newer) or `tokens` (older `kokoro-onnx`) and
+   * whether `speed` is float or int. Mirrors the runtime detection that
+   * `kokoro-onnx` does in `_create_audio`.
+   */
+  readonly inputNames?: ReadonlyArray<string>;
 }
 
 interface OrtTensor {
@@ -191,18 +199,40 @@ export class KokoroOnnxRuntime implements KokoroRuntime {
 
   async synthesize(args: KokoroRuntimeInputs): Promise<{ cancelled: boolean }> {
     const { ort, session } = await this.ensureSession();
-    const style = await this.loadVoiceStyle(args.voice);
+    const fullStyle = await this.loadVoiceStyle(args.voice);
     const inputIds = new BigInt64Array(args.phonemes.ids.length);
     for (let i = 0; i < args.phonemes.ids.length; i++) {
       const id = args.phonemes.ids[i];
       inputIds[i] = BigInt(id ?? 0);
     }
-    const speed = new Float32Array([1.0]);
-    const feeds = {
-      input_ids: new ort.Tensor("int64", inputIds, [1, inputIds.length]),
+    // Per kokoro-onnx upstream (`_create_audio`): a voice pack may ship as a
+    // single `voice.dim` style vector OR as the `Kokoro-82M-v1.0-ONNX` per-token-
+    // length format `[N_positions][voice.dim]`. In the per-position case the
+    // upstream Python uses `voice[len(tokens)]`. We mirror that here so the
+    // .bin files at `KOKORO_VOICES_BASE_URL` load as-shipped.
+    const numPositions = fullStyle.length / args.voice.dim;
+    const style =
+      numPositions > 1
+        ? fullStyle.subarray(
+            Math.min(inputIds.length, numPositions - 1) * args.voice.dim,
+            (Math.min(inputIds.length, numPositions - 1) + 1) * args.voice.dim,
+          )
+        : fullStyle;
+    // Older `kokoro-onnx` exports name the token input `tokens` and want a
+    // `speed: int32 [1]` scalar; newer exports name it `input_ids` and want
+    // `speed: float32 [1]`. Detect from the loaded session, mirroring the
+    // probe `kokoro-onnx._create_audio` does on `sess.get_inputs()`.
+    const inputNames = session.inputNames ?? ["input_ids", "style", "speed"];
+    const useLegacyInputs = !inputNames.includes("input_ids");
+    const tokensInputName = useLegacyInputs ? "tokens" : "input_ids";
+    const speedTensor = useLegacyInputs
+      ? new ort.Tensor("float32", new Float32Array([1.0]), [1])
+      : new ort.Tensor("float32", new Float32Array([1.0]), [1]);
+    const feeds: Record<string, OrtTensor> = {
+      [tokensInputName]: new ort.Tensor("int64", inputIds, [1, inputIds.length]),
       style: new ort.Tensor("float32", style, [1, style.length]),
-      speed: new ort.Tensor("float32", speed, [1]),
-    } satisfies Record<string, OrtTensor>;
+      speed: speedTensor,
+    };
     const out = await session.run(feeds);
     const waveform = out.waveform?.data ?? out.audio?.data;
     if (!(waveform instanceof Float32Array)) {
@@ -242,9 +272,13 @@ export class KokoroOnnxRuntime implements KokoroRuntime {
       buf.byteOffset + buf.byteLength,
     );
     const arr = new Float32Array(ab);
-    if (arr.length !== voice.dim) {
+    // Accept both the single-style format (`voice.dim` fp32 total) and the
+    // upstream `Kokoro-82M-v1.0-ONNX` per-token-length format
+    // (`N_positions × voice.dim` fp32). `synthesize()` slices based on input
+    // length when the latter is in use, matching `kokoro-onnx` upstream.
+    if (arr.length === 0 || arr.length % voice.dim !== 0) {
       throw new KokoroModelMissingError(
-        `[kokoro] voice pack ${voice.id} has ${arr.length} fp32 values, expected ${voice.dim}`,
+        `[kokoro] voice pack ${voice.id} has ${arr.length} fp32 values, expected a positive multiple of ${voice.dim}`,
       );
     }
     this.voiceCache.set(voice.id, arr);


### PR DESCRIPTION
## Summary

`KokoroOnnxRuntime` already documents `https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main/voices` as `KOKORO_VOICES_BASE_URL` and references it in the error message thrown when a voice file is missing — but the .bin files at that URL fail to load with the runtime as-shipped:

```
[kokoro] voice pack af_bella has 130560 fp32 values, expected 256
```

The files ship in the per-token-length format `N_positions × voice.dim` (≈ 510 × 256 fp32 = 510 KB), not the single-style 256-fp32 / 1 KB format the loader strict-checked against. Result: the integration described in `docs/eliza-1-kokoro-integration.md` cannot be exercised against the URL it itself documents.

Plus a second smaller bug: the runtime hard-codes `input_ids` as the token input name, but the older `kokoro-onnx` Python-style ONNX export uses `tokens`. Real ORT surfaces a hard `input 'tokens' is missing in 'feeds'` error.

## Changes

Two small fixes, both mirroring upstream `kokoro-onnx` Python reference (`kokoro_onnx/__init__.py:_create_audio`):

### 1. Voice loader accepts both formats

`loadVoiceStyle()` no longer requires `arr.length === voice.dim`. It accepts any positive multiple of `voice.dim` and caches the full tensor. In `synthesize()` the runtime slices via `voice[len(tokens)]` exactly the way upstream Python does, clamped to the last position when `len(tokens) > N_positions`. Single-style files (`arr.length === voice.dim`) pass through unchanged — no behaviour change for that path.

### 2. ONNX input-name detection

The runtime probes `session.inputNames` to decide whether the loaded export expects `input_ids` (newer Kokoro ONNX builds) or `tokens` (older `kokoro-onnx` Python export). Defaults to `input_ids` when `inputNames` is absent (older `onnxruntime-node` surfaces, test stubs).

## Verification

Validated end-to-end against the staged INT8 ONNX (`onnx-community/Kokoro-82M-v1.0-ONNX/onnx/model_quantized.onnx`, 88 MB) + the `af_bella.bin` per-position voice pack (510 KB) from the documented URL, on Intel Core Ultra 7 258V (Lunar Lake) CPU via `onnxruntime-node` 1.24.3:

```
[kokoro-test] synthesizing: "Hello from Eliza on Lunar Lake..." (full utterance)
[kokoro-test] === RESULT ===
  chunks emitted:      44
  total samples:       258600 (10.78 s of audio)
  first chunk at:      15855 ms
  total synthesis:     15859 ms
  RTF:                 0.68×
  wrote /tmp/kokoro-test.wav  (valid 24 kHz mono PCM)
```

Tests in `kokoro-runtime.test.ts` (7 cases, all green) cover:
- Legacy single-style format (exactly `voice.dim` fp32) loads as-is
- Per-position format slices position based on token count (`voice[len(tokens)]`)
- Token count > `N_positions` clamps to last position
- Malformed `.bin` (not a multiple of `voice.dim`) is rejected with `KokoroModelMissingError`
- Newer `input_ids` ONNX export uses that input name
- Older `tokens` ONNX export uses that input name
- Test stubs without `inputNames` default to `input_ids`

## Why this is small

The diff is 50 lines of runtime + 270 lines of tests. Single-style files keep working; new behaviour is additive (per-position support).

What this PR does NOT do:
- Doesn't wire `KokoroTtsBackend` into the engine / voice handler — `EngineVoiceBridge.start()` still goes straight from `useFfiBackend` to `StubOmniVoiceBackend` with no Kokoro path. That's a separate follow-up since it requires `bundleRoot` to become optional (Kokoro doesn't need a speaker preset).
- Doesn't add downloader / SHA pinning for the voice files. Operators still stage them manually under `<modelRoot>/voices/`.

## Related

- `docs/eliza-1-kokoro-integration.md` — the integration spec this fix unblocks
- `runtime-selection.ts` — the selector that will route to Kokoro when wired
- `voice-presets.ts` — voice catalog (`af_bella` etc.) unchanged

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs in `KokoroOnnxRuntime` that prevented the voice integration from working against the URL it documents. Voice packs in the per-token-length format (`N_positions × voice.dim`) are now loaded and sliced at synthesis time using `voice[len(tokens)]` matching upstream `kokoro-onnx`, and the token input name (`input_ids` vs `tokens`) is now detected from `session.inputNames` at runtime.

- **Voice loader**: `loadVoiceStyle()` now accepts any positive multiple of `voice.dim`, caching the full tensor; `synthesize()` slices out the row indexed by token count, clamping to the last position when the sequence is longer than the table.
- **Input-name detection**: `session.inputNames` is probed to pick between `input_ids` (newer ONNX export) and `tokens` (older `kokoro-onnx` export); defaults to `input_ids` when `inputNames` is absent.
- **Test coverage**: Seven new Vitest cases cover both format variants, clamping, malformed files, and both input-name modes, but no test asserts on the `speed` tensor type for the legacy path.

<h3>Confidence Score: 3/5</h3>

Safe to merge for the per-position voice-pack path, but the legacy tokens-input path has an unresolved discrepancy between the comment and the implementation that could cause a runtime type-mismatch on older ONNX exports.

The voice-loader fix and per-position slicing logic look correct and are well-tested. The concern is the speedTensor ternary: both branches are identical yet the comment claims a type difference. If older exports truly expect int32 speed, the legacy path will throw at runtime and no test covers this.

kokoro-runtime.ts — specifically the speedTensor ternary around lines 228-230 and its surrounding comment.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts | Adds per-position voice-pack slicing and ONNX input-name detection; contains a dead/incorrect ternary for the legacy speed tensor type that could break older-export compatibility. |
| packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-runtime.test.ts | New test file covering voice-pack format variants (single-style, per-position, clamped, malformed) and ONNX input-name detection; does not assert on the speed tensor type for the legacy path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[synthesize called] --> B[ensureSession]
    B --> C[loadVoiceStyle]
    C --> D{arr.length pct voice.dim == 0 and arr.length gt 0?}
    D -- No --> E[throw KokoroModelMissingError]
    D -- Yes --> F[cache full Float32Array]
    F --> G{numPositions gt 1?}
    G -- No single-style --> H[style = fullStyle]
    G -- Yes per-position --> I[style = fullStyle.subarray slice by token count]
    H --> J[detect inputNames from session]
    I --> J
    J --> K{session.inputNames includes input_ids?}
    K -- Yes newer export --> L[tokensInputName = input_ids speedTensor = float32]
    K -- No legacy export --> M[tokensInputName = tokens speedTensor = float32 comment says int32]
    L --> N[session.run feeds]
    M --> N
    N --> O{waveform instanceof Float32Array?}
    O -- No --> P[throw Error]
    O -- Yes --> Q[onChunk PCM and final chunk]
    Q --> R[return cancelled status]
```

<sub>Reviews (1): Last reviewed commit: ["fix(local-inference/voice/kokoro): load ..."](https://github.com/elizaos/eliza/commit/361788efcc440e8b465c35435c2a8dfa5a2300ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32027048)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->