### PR TITLE
fix(app-core): de-duplicate assertRequiredBundledPackagesLanded (unbreaks desktop build on develop)

### DIFF
--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -1824,34 +1824,6 @@ function main(): void {
  * `nodeModulesDir`. Throws with the full list of missing packages so ops
  * can locate the exact expected path without guessing.
  */
-export function assertRequiredBundledPackagesLanded(
-  nodeModulesDir: string,
-  alwaysBundled: Set<string>,
-): void {
-  const missing: string[] = [];
-
-  for (const pkg of alwaysBundled) {
-    const pkgJsonPath = pkg.startsWith("@")
-      ? path.join(nodeModulesDir, ...pkg.split("/"), "package.json")
-      : path.join(nodeModulesDir, pkg, "package.json");
-
-    if (!fs.existsSync(pkgJsonPath)) {
-      missing.push(
-        `  ${pkg} (expected at ${pkgJsonPath})`,
-      );
-    }
-  }
-
-  if (missing.length > 0) {
-    throw new Error(
-      [
-        `${missing.length} required runtime package(s) are missing from ${nodeModulesDir} after copy+prune:`,
-        ...missing,
-      ].join("\n"),
-    );
-  }
-}
-
 if (
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)


### PR DESCRIPTION
# Risks

Trivial. Pure deletion of a duplicate function body. The surviving declaration is identical in signature and called from \`main()\`; the unit test (\`packages/app-core/scripts/assert-required-bundled-packages.test.ts\`) verifies its behavior — 7/7 green after this PR.

# Background

The squash-merge of #7614 (\"fix(app-core): unblock fresh-clone desktop builds + bundle-integrity assertion\") landed two copies of \`export function assertRequiredBundledPackagesLanded\` in \`packages/app-core/scripts/copy-runtime-node-modules.ts\` — one near the top (the PR's intended body, called from \`main()\` at the seam after \`assertTarSafeRuntimePaths\`), and a second copy appended just before the script entry-point.

Every \`bun run build:desktop\` on develop fails with:

\`\`\`
node:internal/modules/run_main:123
    triggerUncaughtException(
    ^
Error [TransformError]: Transform failed with 2 errors:
.../copy-runtime-node-modules.ts:1827:16: ERROR: Multiple exports with the same name \"assertRequiredBundledPackagesLanded\"
.../copy-runtime-node-modules.ts:1827:16: ERROR: The symbol \"assertRequiredBundledPackagesLanded\" has already been declared
\`\`\`

## Fix

Delete the second declaration (lines 1827-1853, the one appended before the \`if (process.argv[1] === ...) main()\` script entrypoint). Keep the first — that one matches the documented signature \`(string, ReadonlySet<string>)\`, is the one wired into \`main()\`, and is the one the existing unit test covers.

## Verification

1. **Unit tests:** \`bun run --cwd packages/app-core vitest run scripts/assert-required-bundled-packages.test.ts\` — 7/7 pass. The seven cases:
   - all required present → no throw
   - empty alwaysBundled → no throw
   - missing scoped plugin → throws with the plugin name
   - missing unscoped package → throws with the package name
   - lists ALL missing packages, not just the first
   - empty package dir (no package.json) → still flagged as missing
   - error message includes the expected on-disk path

2. **Fresh-clone desktop build:** \`bun run build:desktop\` on milady's clean checkout now succeeds end-to-end. Pre-fix it failed at the esbuild transform of the copy script with the multi-export error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes a duplicate `export function assertRequiredBundledPackagesLanded` declaration that was accidentally introduced in the squash-merge of #7614, causing `bun run build:desktop` to fail on every checkout with an esbuild multi-export error.

- The deleted copy (lines 1827–1853) used `Set<string>`, lacked a platform-compatibility guard, and used inline path construction — the surviving declaration at line 1571 is strictly superior: `ReadonlySet<string>`, calls `isPackageNameCompatibleWithCurrentPlatform`, uses the `packagePath()` helper, and is the one wired into `main()` and covered by the existing 7-test suite.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure deletion of an inferior duplicate export that blocked every desktop build on develop.

The change is a single deletion: the removed function was strictly weaker than the surviving one (mutable Set vs ReadonlySet, missing platform-compatibility guard, no packagePath() helper), was not called from anywhere, and its absence is directly validated by the existing 7-case unit test suite. There is no functional regression risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/copy-runtime-node-modules.ts | Removes the duplicate `assertRequiredBundledPackagesLanded` export that caused an esbuild transform error; the surviving declaration at line 1571 is the correct, test-covered version. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["main()"] --> B["assertTarSafeRuntimePaths()"]
    B --> C["assertRequiredBundledPackagesLanded()\n(line 1571 — kept)"]
    C --> D{missing packages?}
    D -- none --> E[Return — bundle is safe]
    D -- some --> F[Throw Error with sorted list]

    G["❌ Deleted duplicate\n(was appended ~line 1827)\nSet&lt;string&gt;, no platform guard"]:::deleted

    classDef deleted fill:#ffcccc,stroke:#cc0000,color:#000
```

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): de-duplicate assertRequir..."](https://github.com/elizaos/eliza/commit/167c24408a959aa420d31748c7f1a3829e588396) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32027102)</sub>

<!-- /greptile_comment -->