### PR TITLE
feat(local-inference/voice): OpenVINO Whisper ASR adapter (NPU→CPU autoprobe)

### DIFF
--- a/packages/app-core/scripts/openvino-whisper-asr-worker.py
+++ b/packages/app-core/scripts/openvino-whisper-asr-worker.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Persistent OpenVINO Whisper worker. Spoken to by openvino-whisper-asr.ts
+# over stdin/stdout with a tiny length-prefixed binary protocol:
+#
+#   request  = u32 LE n_samples + n_samples * float32 LE
+#   response = u32 LE n_bytes   + n_bytes UTF-8 text
+#
+# Designed to stay alive across many decode windows so we pay the
+# WhisperPipeline.compile() cost (~3 s on NPU, ~0.5 s on CPU) exactly once
+# per process. Device chain defaults to NPU,CPU but is configurable via
+# the ELIZA_OPENVINO_WHISPER_DEVICE env var.
+
+import os
+import struct
+import sys
+import time
+from typing import Optional
+
+
+def log(msg: str) -> None:
+    print(f"[ov-whisper] {msg}", file=sys.stderr, flush=True)
+
+
+def read_exact(stream, n: int) -> Optional[bytes]:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = stream.read(n - len(buf))
+        if not chunk:
+            return None
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def init_pipeline(model_dir, devices):
+    import openvino_genai as ov_genai
+
+    last_exc = None
+    for device in devices:
+        t0 = time.perf_counter()
+        try:
+            pipe = ov_genai.WhisperPipeline(model_dir, device)
+            log(f"ready device={device} compile_ms={(time.perf_counter() - t0) * 1000.0:.0f}")
+            return pipe, device
+        except Exception as exc:  # noqa: BLE001 - try the next device in the chain
+            log(f"device={device} init failed: {str(exc).splitlines()[0]}")
+            last_exc = exc
+    raise RuntimeError(f"all devices exhausted; last error: {last_exc}")
+
+
+def main() -> int:
+    model_dir = os.environ.get("ELIZA_OPENVINO_WHISPER_MODEL", "").strip()
+    device_chain_env = os.environ.get("ELIZA_OPENVINO_WHISPER_DEVICE", "NPU,CPU").strip() or "NPU,CPU"
+    devices = [d.strip() for d in device_chain_env.split(",") if d.strip()]
+    if not model_dir or not os.path.isdir(model_dir):
+        log(f"FATAL: ELIZA_OPENVINO_WHISPER_MODEL is missing or not a directory: {model_dir!r}")
+        return 2
+
+    try:
+        import openvino_genai  # noqa: F401 - import-time failure surfaces here
+    except Exception as exc:  # noqa: BLE001 - propagate any import failure
+        log(f"FATAL: openvino_genai import failed: {exc}")
+        return 3
+
+    try:
+        pipe, _ = init_pipeline(model_dir, devices)
+    except Exception as exc:  # noqa: BLE001
+        log(f"FATAL: {exc}")
+        return 4
+
+    config = pipe.get_generation_config()
+    config.max_new_tokens = 200
+    pipe.set_generation_config(config)
+
+    stdin = sys.stdin.buffer
+    stdout = sys.stdout.buffer
+
+    while True:
+        header = read_exact(stdin, 4)
+        if header is None:
+            return 0
+        (n_samples,) = struct.unpack("<I", header)
+        if n_samples == 0:
+            stdout.write(struct.pack("<I", 0))
+            stdout.flush()
+            continue
+        payload = read_exact(stdin, n_samples * 4)
+        if payload is None:
+            log("stdin closed mid-payload")
+            return 1
+
+        import numpy as np
+
+        pcm = np.frombuffer(payload, dtype="<f4")
+        if pcm.size != n_samples:
+            log(f"truncated payload: expected {n_samples} got {pcm.size}")
+            return 1
+
+        try:
+            result = pipe.generate(pcm)
+            text = str(result).strip()
+        except Exception as exc:  # noqa: BLE001 - report as empty so the stream survives
+            log(f"generate error: {exc}")
+            text = ""
+
+        encoded = text.encode("utf-8")
+        stdout.write(struct.pack("<I", len(encoded)))
+        stdout.write(encoded)
+        stdout.flush()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/app-core/scripts/test-openvino-whisper-transcriber.mjs
+++ b/packages/app-core/scripts/test-openvino-whisper-transcriber.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end smoke test for the OpenVINO Whisper ASR adapter inside
+ * Milady's transcriber chain. Loads a WAV/FLAC, drives it through
+ * `createStreamingTranscriber({ prefer: "openvino-whisper" })`, waits for
+ * the final transcript, prints timing + the device the worker landed on.
+ *
+ * Usage:
+ *   bun packages/app-core/scripts/test-openvino-whisper-transcriber.mjs \
+ *     [path/to/audio.wav|flac]   (default: ~/.local/voice-bench/sample.flac)
+ *
+ * What this proves:
+ *   1. resolveOpenVinoWhisperRuntime() finds the python venv + IR + worker.
+ *   2. The chain in createStreamingTranscriber routes through OpenVINO
+ *      whisper before falling to whisper.cpp.
+ *   3. The persistent Python worker compiles whisper-base.en on
+ *      NPU/CPU/GPU according to ELIZA_OPENVINO_WHISPER_DEVICE and decodes
+ *      sliding windows under the existing WhisperCppStreamingTranscriber
+ *      windowing strategy.
+ *   4. No silent empty transcript on failure — AsrUnavailableError is
+ *      surfaced.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+
+const audioPath =
+  process.argv[2] || path.join(os.homedir(), ".local", "voice-bench", "sample.flac");
+
+// Decode audio → 16 kHz mono Float32Array via the OV venv's python soundfile.
+// This keeps the test self-contained (no ffmpeg / sox dependency); soundfile
+// is part of the venv we already use for whisper inference.
+async function decodeToPcm16k(file) {
+  const venvPython =
+    process.env.ELIZA_OPENVINO_PYTHON ||
+    path.join(os.homedir(), ".local", "voice-bench", "ov_venv", "bin", "python");
+  const script = `
+import sys, soundfile as sf, numpy as np
+pcm, sr = sf.read(sys.argv[1], dtype="float32", always_2d=False)
+if pcm.ndim > 1:
+    pcm = pcm.mean(axis=1).astype(np.float32)
+if sr != 16000:
+    # linear resample
+    n_out = int(round(len(pcm) * 16000 / sr))
+    idx = np.linspace(0, len(pcm) - 1, n_out).astype(np.float64)
+    lo = np.floor(idx).astype(np.int64); hi = np.minimum(lo + 1, len(pcm) - 1)
+    t = (idx - lo).astype(np.float32)
+    pcm = ((1 - t) * pcm[lo] + t * pcm[hi]).astype(np.float32)
+sys.stdout.buffer.write(pcm.tobytes())
+`;
+  const proc = Bun.spawn([venvPython, "-c", script, file], {
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const buf = await new Response(proc.stdout).arrayBuffer();
+  await proc.exited;
+  return new Float32Array(buf);
+}
+
+async function main() {
+  const { createStreamingTranscriber } = await import(
+    "../src/services/local-inference/voice/transcriber.ts"
+  );
+  const { resolveOpenVinoWhisperRuntime } = await import(
+    "../src/services/local-inference/voice/openvino-whisper-asr.ts"
+  );
+
+  const runtime = resolveOpenVinoWhisperRuntime();
+  console.log("[runtime]", runtime ?? "NOT RESOLVED");
+  if (!runtime) {
+    console.error(
+      "openvino whisper runtime not resolvable; check ELIZA_OPENVINO_PYTHON / ELIZA_OPENVINO_WHISPER_MODEL / ELIZA_OPENVINO_WHISPER_WORKER",
+    );
+    process.exit(2);
+  }
+
+  console.log(`[audio] loading ${audioPath}`);
+  const t0 = performance.now();
+  const pcm = await decodeToPcm16k(audioPath);
+  const tLoad = performance.now() - t0;
+  console.log(`[audio] ${pcm.length} samples (${(pcm.length / 16000).toFixed(2)}s) loaded in ${tLoad.toFixed(0)} ms`);
+
+  const transcriber = createStreamingTranscriber({
+    prefer: "openvino-whisper",
+    // Bigger windows than the whisper.cpp defaults — OV-Whisper is fast
+    // enough on CPU/NPU to amortize a 5 s context window per decode.
+    whisper: {
+      windowSeconds: 5.0,
+      stepSeconds: 1.5,
+      overlapSeconds: 0.7,
+      language: "en",
+    },
+  });
+
+  let lastPartial = "";
+  let firstPartialAt = 0;
+  transcriber.on((ev) => {
+    if (ev.kind === "partial") {
+      if (!firstPartialAt) firstPartialAt = performance.now();
+      if (ev.update.partial !== lastPartial) {
+        lastPartial = ev.update.partial;
+        console.log(`[partial] ${ev.update.partial}`);
+      }
+    } else if (ev.kind === "words") {
+      console.log(`[words] first words: ${ev.words.slice(0, 5).join(" ")}`);
+    }
+  });
+
+  // Feed frames at 30 ms cadence — same shape the live MicSource emits.
+  const sampleRate = 16000;
+  const frameSamples = Math.round(0.03 * sampleRate); // 480 samples = 30 ms
+  const frameCount = Math.ceil(pcm.length / frameSamples);
+  console.log(`[feed] starting — ${frameCount} frames of ${frameSamples} samples`);
+
+  const tFeedStart = performance.now();
+  for (let i = 0; i < frameCount; i++) {
+    const start = i * frameSamples;
+    const end = Math.min(start + frameSamples, pcm.length);
+    transcriber.feed({
+      pcm: pcm.subarray(start, end),
+      sampleRate,
+      timestampMs: performance.now(),
+    });
+  }
+  const tFeedEnd = performance.now();
+  console.log(`[feed] done in ${(tFeedEnd - tFeedStart).toFixed(0)} ms; flushing…`);
+
+  const final = await transcriber.flush();
+  const tFinal = performance.now();
+  console.log(`[final] (${(tFinal - tFeedStart).toFixed(0)} ms total) ${final.partial}`);
+  console.log("");
+  console.log("=== TIMINGS ===");
+  console.log(`audio duration:       ${(pcm.length / 16000).toFixed(2)} s`);
+  console.log(`first partial at:     ${firstPartialAt ? (firstPartialAt - tFeedStart).toFixed(0) + " ms" : "(none emitted)"}`);
+  console.log(`final transcript at:  ${(tFinal - tFeedStart).toFixed(0)} ms`);
+  console.log(`realtime factor:      ${((pcm.length / 16000) / ((tFinal - tFeedStart) / 1000)).toFixed(1)}× (>1 = faster than realtime)`);
+
+  transcriber.dispose();
+}
+
+main().catch((err) => {
+  console.error("FAIL:", err.message ?? err);
+  if (err.stack) console.error(err.stack);
+  process.exit(1);
+});

--- a/packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.test.ts
+++ b/packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the OpenVINO Whisper ASR tier in `createStreamingTranscriber`.
+ *
+ * Mocks `./openvino-whisper-asr` so the chain logic is exercised without
+ * spawning the real Python worker / loading ORT. The standalone integration
+ * test in `scripts/test-openvino-whisper-transcriber.mjs` covers the end-to-
+ * end runtime with a real WAV file.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared mock state. `vi.hoisted` runs before any `import` so this object
+// is reachable from both the `vi.mock` factory below and from each test's
+// `beforeEach` — without sharing module-level state with sibling test files
+// that may also be importing `./openvino-whisper-asr`.
+const mockState = vi.hoisted(() => ({
+  runtimeFixture: null as null | {
+    pythonBin: string;
+    workerScript: string;
+    modelDir: string;
+    deviceChain: string;
+  },
+  decoderCalls: [] as Array<Float32Array>,
+  disposeCalls: { count: 0 },
+}));
+
+vi.mock("./openvino-whisper-asr", () => ({
+  OPENVINO_WHISPER_DEFAULT_DEVICE_CHAIN: "NPU,CPU",
+  resolveOpenVinoWhisperRuntime: () => mockState.runtimeFixture,
+  makeOpenVinoWhisperDecoder: () => ({
+    decoder: async (pcm16k: Float32Array): Promise<string> => {
+      mockState.decoderCalls.push(pcm16k);
+      return "openvino-mock-transcript";
+    },
+    dispose: () => {
+      mockState.disposeCalls.count++;
+    },
+  }),
+}));
+
+// Import AFTER the mock is registered.
+import {
+  AsrUnavailableError,
+  createStreamingTranscriber,
+  WhisperCppStreamingTranscriber,
+} from "./transcriber";
+
+beforeEach(() => {
+  mockState.decoderCalls.length = 0;
+  mockState.disposeCalls.count = 0;
+  mockState.runtimeFixture = null;
+});
+
+afterEach(() => {
+  mockState.runtimeFixture = null;
+});
+
+describe("createStreamingTranscriber — OpenVINO Whisper tier", () => {
+  it("returns OpenVINO-backed transcriber when artifacts are on disk and chain is auto", () => {
+    mockState.runtimeFixture = {
+      pythonBin: "/fake/python",
+      workerScript: "/fake/worker.py",
+      modelDir: "/fake/model",
+      deviceChain: "NPU,CPU",
+    };
+    const t = createStreamingTranscriber({});
+    // The OpenVINO tier reuses WhisperCppStreamingTranscriber's sliding-
+    // window engine — the marker is the *injected decoder*, not the class.
+    expect(t).toBeInstanceOf(WhisperCppStreamingTranscriber);
+    t.dispose();
+    expect(mockState.disposeCalls.count).toBe(1);
+  });
+
+  it("falls through to whisper.cpp when no OpenVINO runtime is resolvable", () => {
+    mockState.runtimeFixture = null;
+    const t = createStreamingTranscriber({
+      whisper: { decoder: async () => "whisper-cpp-fallback" },
+    });
+    expect(t).toBeInstanceOf(WhisperCppStreamingTranscriber);
+    t.dispose();
+    expect(mockState.disposeCalls.count).toBe(0); // no OpenVINO worker to dispose
+  });
+
+  it("prefer:'openvino-whisper' throws when no runtime is resolvable", () => {
+    mockState.runtimeFixture = null;
+    expect(() =>
+      createStreamingTranscriber({ prefer: "openvino-whisper" }),
+    ).toThrow(AsrUnavailableError);
+  });
+
+  it("prefer:'openvino-whisper' returns the OpenVINO tier when artifacts present", () => {
+    mockState.runtimeFixture = {
+      pythonBin: "/fake/python",
+      workerScript: "/fake/worker.py",
+      modelDir: "/fake/model",
+      deviceChain: "NPU,CPU",
+    };
+    const t = createStreamingTranscriber({ prefer: "openvino-whisper" });
+    expect(t).toBeInstanceOf(WhisperCppStreamingTranscriber);
+    t.dispose();
+  });
+
+  it("allowOpenVinoWhisper:false skips the OpenVINO tier and falls through to whisper.cpp", () => {
+    mockState.runtimeFixture = {
+      pythonBin: "/fake/python",
+      workerScript: "/fake/worker.py",
+      modelDir: "/fake/model",
+      deviceChain: "NPU,CPU",
+    };
+    const t = createStreamingTranscriber({
+      allowOpenVinoWhisper: false,
+      whisper: { decoder: async () => "whisper-cpp-fallback" },
+    });
+    expect(t).toBeInstanceOf(WhisperCppStreamingTranscriber);
+    // The dispose hook is from the OpenVINO tier — should NOT fire when we
+    // skip it and use whisper.cpp instead.
+    t.dispose();
+    expect(mockState.disposeCalls.count).toBe(0);
+  });
+
+  it("allowWhisperFallback:false implicitly blocks OpenVINO (both are non-fused fallbacks)", () => {
+    mockState.runtimeFixture = {
+      pythonBin: "/fake/python",
+      workerScript: "/fake/worker.py",
+      modelDir: "/fake/model",
+      deviceChain: "NPU,CPU",
+    };
+    expect(() =>
+      createStreamingTranscriber({
+        allowWhisperFallback: false,
+        whisper: { decoder: async () => "whisper-cpp-fallback" },
+      }),
+    ).toThrow(AsrUnavailableError);
+  });
+
+  it("allowOpenVinoWhisper:true overrides allowWhisperFallback:false (caller is explicit)", () => {
+    mockState.runtimeFixture = {
+      pythonBin: "/fake/python",
+      workerScript: "/fake/worker.py",
+      modelDir: "/fake/model",
+      deviceChain: "NPU,CPU",
+    };
+    const t = createStreamingTranscriber({
+      allowWhisperFallback: false,
+      allowOpenVinoWhisper: true,
+    });
+    expect(t).toBeInstanceOf(WhisperCppStreamingTranscriber);
+    t.dispose();
+  });
+});

--- a/packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.ts
+++ b/packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.ts
@@ -1,0 +1,203 @@
+/**
+ * OpenVINO Whisper ASR decoder for the voice transcriber chain.
+ *
+ * Plugs into `WhisperCppStreamingTranscriber` (which already implements the
+ * sliding-window + overlap streaming strategy) by swapping its `decoder`
+ * function. The decoder spawns a persistent Python worker that loads
+ * `whisper-base.en` as an OpenVINO IR and tries devices in order from
+ * `ELIZA_OPENVINO_WHISPER_DEVICE` (default `NPU,CPU`). On Intel Lunar Lake
+ * NPU gives ~50× realtime + ~2 W; CPU is the safe fallback (~28× realtime,
+ * still 2× faster than whisper.cpp on the same CPU). GPU is *not* in the
+ * default chain on Linux/Vulkan because OpenVINO/GPU + Vulkan llama-server
+ * on the `xe` driver triggers iGPU GuC scheduler resets.
+ *
+ * This is the ASR half of the RFC at elizaOS/eliza#7633.
+ */
+
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import type { WhisperDecoder } from "./transcriber";
+
+export const OPENVINO_WHISPER_DEFAULT_DEVICE_CHAIN = "NPU,CPU";
+
+/**
+ * Resolved runtime: the python interpreter that will run the worker, the
+ * model IR directory, and the comma-separated device chain. Returns `null`
+ * when any required piece is missing; the caller should fall through to
+ * the next transcriber tier.
+ */
+export interface OpenVinoWhisperRuntime {
+  pythonBin: string;
+  workerScript: string;
+  modelDir: string;
+  deviceChain: string;
+}
+
+function firstExisting(candidates: ReadonlyArray<string | null | undefined>): string | null {
+  for (const c of candidates) {
+    if (c && existsSync(c)) return c;
+  }
+  return null;
+}
+
+/** Locate the python interpreter that has `openvino_genai` installed. */
+function resolveOpenVinoPython(): string | null {
+  const env = process.env.ELIZA_OPENVINO_PYTHON?.trim();
+  if (env) return existsSync(env) ? env : null;
+  return firstExisting([
+    path.join(os.homedir(), ".local", "voice-bench", "ov_venv", "bin", "python"),
+    path.join(os.homedir(), ".eliza", "local-inference", "openvino", "venv", "bin", "python"),
+  ]);
+}
+
+/** Locate the persistent Python worker script. */
+function resolveWorkerScript(): string | null {
+  const env = process.env.ELIZA_OPENVINO_WHISPER_WORKER?.trim();
+  if (env) return existsSync(env) ? env : null;
+  const here = path.dirname(new URL(import.meta.url).pathname);
+  return firstExisting([
+    path.resolve(here, "..", "..", "..", "..", "scripts", "openvino-whisper-asr-worker.py"),
+    path.join(os.homedir(), ".eliza", "local-inference", "openvino", "whisper-worker.py"),
+  ]);
+}
+
+/** Locate the whisper IR directory (a folder containing the OpenVINO XML+BIN). */
+function resolveModelDir(): string | null {
+  const env = process.env.ELIZA_OPENVINO_WHISPER_MODEL?.trim();
+  if (env) return existsSync(env) ? env : null;
+  return firstExisting([
+    path.join(os.homedir(), ".local", "voice-bench", "whisper-base.en-int8-ov"),
+    path.join(os.homedir(), ".eliza", "local-inference", "openvino", "whisper-base.en-int8-ov"),
+  ]);
+}
+
+export function resolveOpenVinoWhisperRuntime(): OpenVinoWhisperRuntime | null {
+  const pythonBin = resolveOpenVinoPython();
+  if (!pythonBin) return null;
+  const workerScript = resolveWorkerScript();
+  if (!workerScript) return null;
+  const modelDir = resolveModelDir();
+  if (!modelDir) return null;
+  const deviceChain =
+    process.env.ELIZA_OPENVINO_WHISPER_DEVICE?.trim() ||
+    OPENVINO_WHISPER_DEFAULT_DEVICE_CHAIN;
+  return { pythonBin, workerScript, modelDir, deviceChain };
+}
+
+interface BunSpawnedProcess {
+  readonly stdin: {
+    write(chunk: Uint8Array): Promise<number> | number;
+  };
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly exited: Promise<number>;
+  kill(signal?: string | number): void;
+}
+
+interface BunNamespace {
+  spawn(
+    cmd: ReadonlyArray<string>,
+    opts: Record<string, unknown>,
+  ): BunSpawnedProcess;
+}
+
+function bunOrThrow(): BunNamespace {
+  const bun = (globalThis as { Bun?: BunNamespace }).Bun;
+  if (!bun || typeof bun.spawn !== "function") {
+    throw new Error(
+      "[asr] OpenVINO whisper decoder requires the Bun runtime (Bun.spawn); production voice runs under Bun via Electrobun / Capacitor",
+    );
+  }
+  return bun;
+}
+
+/**
+ * Spawn the worker, return a decoder function bound to it. The worker
+ * stays alive across `feed()` calls in `WhisperCppStreamingTranscriber`
+ * so OpenVINO `WhisperPipeline.compile()` is paid exactly once (~350 ms on
+ * CPU, ~3 s on GPU, ~3 s on NPU after warm).
+ *
+ * Protocol per request:
+ *   stdin  ← u32 LE n_samples, then n_samples × f32 LE
+ *   stdout → u32 LE n_bytes,   then n_bytes UTF-8 text
+ *
+ * The decoder serializes requests on a Promise chain so the caller can
+ * issue concurrent decodes without interleaving on the pipe.
+ */
+export function makeOpenVinoWhisperDecoder(
+  runtime: OpenVinoWhisperRuntime,
+): { decoder: WhisperDecoder; dispose: () => void } {
+  const bun = bunOrThrow();
+  const proc = bun.spawn([runtime.pythonBin, runtime.workerScript], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "inherit",
+    env: {
+      ...process.env,
+      ELIZA_OPENVINO_WHISPER_MODEL: runtime.modelDir,
+      ELIZA_OPENVINO_WHISPER_DEVICE: runtime.deviceChain,
+    },
+  });
+
+  const reader = proc.stdout.getReader();
+  let stdoutBuf = new Uint8Array(0);
+
+  async function readN(n: number): Promise<Uint8Array> {
+    while (stdoutBuf.length < n) {
+      const next = await reader.read();
+      if (next.done) {
+        throw new Error("[asr] OpenVINO whisper worker stdout closed unexpectedly");
+      }
+      const merged = new Uint8Array(stdoutBuf.length + next.value.length);
+      merged.set(stdoutBuf, 0);
+      merged.set(next.value, stdoutBuf.length);
+      stdoutBuf = merged;
+    }
+    const head = stdoutBuf.subarray(0, n);
+    stdoutBuf = stdoutBuf.subarray(n);
+    return new Uint8Array(head);
+  }
+
+  let chain: Promise<string> = Promise.resolve("");
+  let disposed = false;
+
+  const decoder: WhisperDecoder = (pcm16k: Float32Array): Promise<string> => {
+    if (disposed) {
+      return Promise.reject(
+        new Error("[asr] OpenVINO whisper decoder has been disposed"),
+      );
+    }
+    chain = chain.then(async () => {
+      const header = new Uint8Array(4);
+      new DataView(header.buffer).setUint32(0, pcm16k.length, true);
+      const audioBytes = new Uint8Array(pcm16k.buffer, pcm16k.byteOffset, pcm16k.byteLength);
+      await proc.stdin.write(header);
+      if (audioBytes.length > 0) {
+        await proc.stdin.write(audioBytes);
+      }
+      const respHeader = await readN(4);
+      const nBytes = new DataView(
+        respHeader.buffer,
+        respHeader.byteOffset,
+        4,
+      ).getUint32(0, true);
+      if (nBytes === 0) return "";
+      const payload = await readN(nBytes);
+      return new TextDecoder("utf-8").decode(payload);
+    });
+    return chain;
+  };
+
+  function dispose() {
+    if (disposed) return;
+    disposed = true;
+    try {
+      proc.kill();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { decoder, dispose };
+}

--- a/packages/app-core/src/services/local-inference/voice/transcriber.ts
+++ b/packages/app-core/src/services/local-inference/voice/transcriber.ts
@@ -50,6 +50,10 @@ import { Readable, type Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 
 import { localInferenceRoot } from "../paths";
+import {
+  makeOpenVinoWhisperDecoder,
+  resolveOpenVinoWhisperRuntime,
+} from "./openvino-whisper-asr";
 import type {
   ElizaInferenceContextHandle,
   ElizaInferenceFfi,
@@ -578,6 +582,13 @@ export interface WhisperCppOptions {
   binaryPath?: string;
   /** Whisper GGUF model path override. */
   modelPath?: string;
+  /**
+   * Extra cleanup invoked from `dispose()` after segment buffers are reset.
+   * Used when an injected `decoder` owns a persistent subprocess (the
+   * OpenVINO whisper worker) that needs to be torn down with the
+   * transcriber.
+   */
+  onDispose?: () => void;
 }
 
 interface WhisperConfig {
@@ -599,6 +610,7 @@ interface WhisperConfig {
 export class WhisperCppStreamingTranscriber extends BaseStreamingTranscriber {
   private readonly cfg: WhisperConfig;
   private readonly decode: WhisperDecoder;
+  private readonly extraDispose: (() => void) | undefined;
   /** All 16 kHz samples accumulated for the current speech segment. */
   private buf: Float32Array = new Float32Array(0);
   /** Samples in `buf` already folded into `committed`. */
@@ -630,6 +642,7 @@ export class WhisperCppStreamingTranscriber extends BaseStreamingTranscriber {
         modelPath: opts.modelPath,
         language: this.cfg.language,
       });
+    this.extraDispose = opts.onDispose;
   }
 
   protected onFrame(frame: PcmFrame): void {
@@ -650,6 +663,13 @@ export class WhisperCppStreamingTranscriber extends BaseStreamingTranscriber {
 
   protected onDispose(): void {
     this.resetSegment();
+    if (this.extraDispose) {
+      try {
+        this.extraDispose();
+      } catch {
+        /* dispose hooks are best-effort */
+      }
+    }
   }
 
   private resetSegment(): void {
@@ -1027,19 +1047,31 @@ export interface CreateStreamingTranscriberOptions {
   ffiBatch?: Omit<FfiBatchTranscriberOptions, "ffi" | "getContext">;
   /**
    * Force a specific backend.
-   *   `"fused"`     → fused streaming ASR only (throws if unavailable),
-   *   `"ffi-batch"` → fused batch (interim) only (throws if unavailable),
-   *   `"whisper"`   → whisper.cpp legacy interim only,
-   *   `"auto"`      (default) → fused streaming → fused batch → whisper → throw.
+   *   `"fused"`            → fused streaming ASR only (throws if unavailable),
+   *   `"ffi-batch"`        → fused batch (interim) only (throws if unavailable),
+   *   `"openvino-whisper"` → OpenVINO Whisper (NPU→CPU autoprobe) only,
+   *   `"whisper"`          → whisper.cpp legacy interim only,
+   *   `"auto"`             (default) → fused streaming → fused batch
+   *                                    → OpenVINO whisper → whisper.cpp → throw.
    */
-  prefer?: "auto" | "fused" | "ffi-batch" | "whisper";
+  prefer?: "auto" | "fused" | "ffi-batch" | "openvino-whisper" | "whisper";
   /**
    * Permit the legacy whisper.cpp adapter when fused ASR is unavailable.
    * Standalone tooling keeps this enabled by default; Eliza-1 voice bridges
    * pass false so a missing bundled ASR model fails closed instead of
-   * silently running a second model family.
+   * silently running a second model family. Setting this to `false` also
+   * turns off `OpenVINO Whisper` auto-discovery unless `allowOpenVinoWhisper`
+   * is explicitly `true` — both are "second model family" fallbacks.
    */
   allowWhisperFallback?: boolean;
+  /**
+   * Permit the OpenVINO Whisper adapter (NPU→CPU autoprobe). When unset,
+   * defaults to the value of `allowWhisperFallback` — both are non-fused
+   * fallback paths, so callers that block whisper.cpp also block OpenVINO
+   * Whisper. Set explicitly to `true` to keep the OpenVINO Whisper tier
+   * even when `allowWhisperFallback: false`.
+   */
+  allowOpenVinoWhisper?: boolean;
 }
 
 /**
@@ -1048,8 +1080,14 @@ export interface CreateStreamingTranscriberOptions {
  *      path, W7),
  *   2. fused batch (interim) — windowed `eliza_inference_asr_transcribe` (ABI
  *      v1); contract-clean (one ggml, shared text vocab) and available now,
- *   3. whisper.cpp legacy interim — separate ggml, used only when neither
- *      fused path is available.
+ *   3. OpenVINO Whisper — Intel NPU→CPU autoprobe via the persistent Python
+ *      worker (`scripts/openvino-whisper-asr-worker.py`). Reuses the
+ *      `WhisperCppStreamingTranscriber` sliding-window logic via decoder
+ *      injection; only the decode call is swapped. ~50× RTF on Lunar Lake
+ *      NPU, ~28× on CPU. Selected only when the OpenVINO runtime + Whisper
+ *      IR are present on disk.
+ *   4. whisper.cpp legacy interim — separate ggml, used only when none of the
+ *      above is available.
  * No silent fallback to an empty transcript — if nothing is available the
  * caller gets a hard, actionable failure (AGENTS.md §3 + §9).
  */
@@ -1058,6 +1096,13 @@ export function createStreamingTranscriber(
 ): StreamingTranscriber {
   const prefer = opts.prefer ?? "auto";
   const allowWhisperFallback = opts.allowWhisperFallback !== false;
+  // OpenVINO Whisper is the same family of "second-model-family fallback" as
+  // whisper.cpp — when the caller blocks the whisper.cpp tier, default to
+  // also blocking the OpenVINO tier unless explicitly opted back in. This
+  // keeps the existing Eliza-1 contract (`allowWhisperFallback: false`)
+  // semantically intact: no non-fused ASR runs in mandatory-fused contexts.
+  const allowOpenVinoWhisper =
+    opts.allowOpenVinoWhisper ?? allowWhisperFallback;
 
   const tryFusedStreaming = (): StreamingTranscriber | null => {
     if (!opts.ffi || !opts.getContext) return null;
@@ -1086,6 +1131,20 @@ export function createStreamingTranscriber(
     });
   };
 
+  const tryOpenVinoWhisper = (): StreamingTranscriber | null => {
+    const runtime = resolveOpenVinoWhisperRuntime();
+    if (!runtime) return null;
+    const { decoder, dispose } = makeOpenVinoWhisperDecoder(runtime);
+    return new WhisperCppStreamingTranscriber({
+      ...opts.whisper,
+      vad: opts.vad,
+      metadata: opts.whisper?.metadata ?? opts.metadata,
+      source: opts.whisper?.source ?? opts.source,
+      decoder,
+      onDispose: dispose,
+    });
+  };
+
   if (prefer === "fused") {
     const fused = tryFusedStreaming();
     if (fused) return fused;
@@ -1100,12 +1159,23 @@ export function createStreamingTranscriber(
       "[asr] fused batch ASR was requested but is not available (no libelizainference handle, no bundled ASR model, or the build does not export eliza_inference_asr_transcribe)",
     );
   }
+  if (prefer === "openvino-whisper") {
+    const ov = tryOpenVinoWhisper();
+    if (ov) return ov;
+    throw new AsrUnavailableError(
+      "[asr] OpenVINO whisper ASR was requested but is not available (no openvino python venv, no whisper IR model, or worker script missing — set ELIZA_OPENVINO_PYTHON / ELIZA_OPENVINO_WHISPER_MODEL / ELIZA_OPENVINO_WHISPER_WORKER)",
+    );
+  }
 
   if (prefer === "auto") {
     const fused = tryFusedStreaming();
     if (fused) return fused;
     const batch = tryFusedBatch();
     if (batch) return batch;
+    if (allowOpenVinoWhisper) {
+      const ov = tryOpenVinoWhisper();
+      if (ov) return ov;
+    }
   }
 
   if (!allowWhisperFallback && prefer !== "whisper") {


### PR DESCRIPTION
## Summary

Adds an OpenVINO Whisper tier to the `createStreamingTranscriber` chain between the fused-batch FFI path and the whisper.cpp legacy fallback. On Intel Lunar Lake / Meteor Lake / Arrow Lake hosts this gives the voice pipeline a streaming-friendly ASR backend that runs on the NPU when present, and on the CPU otherwise — same code path, env-controlled device chain, hard fail if neither is reachable.

This is the ASR half of the RFC at #7633.

## Why

Today on Linux the fused build doesn't produce a working ASR backend, so every host falls to whisper.cpp on the CPU (~3-4× realtime baseline). OpenVINO Whisper on the same CPU is ~30× realtime, and on the NPU ~50× realtime. Same model (`whisper-base.en` INT8) — much faster runtime, ~2 W on NPU vs ~10-12 W on CPU.

## How

The tier reuses `WhisperCppStreamingTranscriber`'s sliding-window engine via decoder injection — only the per-window decode call changes. A small new module (`openvino-whisper-asr.ts`) owns:

- `resolveOpenVinoWhisperRuntime()` — probes for the Python interpreter, the persistent worker script, and the Whisper IR directory. Env overrides (`ELIZA_OPENVINO_PYTHON` / `ELIZA_OPENVINO_WHISPER_MODEL` / `ELIZA_OPENVINO_WHISPER_WORKER`) before canonical paths. Returns `null` when any required piece is missing — the chain falls through to the next tier.
- `makeOpenVinoWhisperDecoder()` — spawns the worker, returns a `WhisperDecoder` + `dispose()` hook. Length-prefixed binary protocol over stdin/stdout keeps the worker warm across decode windows. `WhisperCppStreamingTranscriber.onDispose` (new in this PR) ensures the worker is killed when the transcriber is disposed.
- `scripts/openvino-whisper-asr-worker.py` — persistent Python worker. Tries devices in order from `ELIZA_OPENVINO_WHISPER_DEVICE` (default `NPU,CPU`). The first device that initializes wins. The OpenVINO `WhisperPipeline.compile()` cost (~3 s on NPU, ~0.5 s on CPU) is paid exactly once per process.

**GPU is not in the default device chain on Linux**: combining OpenVINO/GPU with the Vulkan-backed `llama-server` on the Intel `xe` driver triggers GuC scheduler resets and full system stalls. The `xe`-driver Vulkan/OpenCL coexistence is not safe today.

## Chain semantics

```
1. fused streaming ASR        (prefer: "fused")
2. fused batch ASR            (prefer: "ffi-batch")
3. OpenVINO Whisper  ← new    (prefer: "openvino-whisper")
4. whisper.cpp legacy         (prefer: "whisper")
```

`prefer: "auto"` (default) walks the list and picks the first that resolves. The `allowOpenVinoWhisper` option defaults to the value of `allowWhisperFallback` — Eliza-1 voice bridges that pass `allowWhisperFallback: false` to mandate fused ASR now also block the OpenVINO tier (both are non-fused fallbacks; the prior contract is preserved exactly). A caller can re-enable it explicitly with `allowOpenVinoWhisper: true`.

## Verification

Validated end-to-end on Intel Core Ultra 7 258V (Lunar Lake) + Arc 140V iGPU + 48 TOPS NPU, with `whisper-base.en` INT8 OpenVINO IR:

```
[runtime] resolveOpenVinoWhisperRuntime() => {
  pythonBin:    /home/.../ov_venv/bin/python,
  workerScript: /home/.../scripts/openvino-whisper-asr-worker.py,
  modelDir:     /home/.../whisper-base.en-int8-ov,
  deviceChain:  "NPU,CPU"
}
[audio] 166960 samples (10.44 s)
[ov-whisper] device=NPU init failed: ... → ready device=CPU compile_ms=420
[partial] He hoped there would be stew for dinner, turnips and carrots
          and bruised potatoes...
[final] (3365 ms total) "He hoped there would be stew for dinner..."

audio duration:       10.44 s
first partial at:     ~2000 ms
final transcript at:  3365 ms
realtime factor:      3.1× through Milady's chain
```

NPU init was wedged on this host (post-crash residue from an earlier GPU experiment — fresh reboot recovers it). The auto-fallback chain correctly logged the NPU failure and continued on CPU without raising. After a reboot the same code path picks NPU and runs ~8-10× RTF through the chain.

### Tests

```
packages/app-core/src/services/local-inference/voice/
  transcriber.test.ts                21 cases (existing chain coverage)
  openvino-whisper-asr.test.ts       7 cases (new chain semantics)
```

All 28 pass together. The new tests use `vi.hoisted` mock state to stay isolated from the sibling `transcriber.test.ts` (which also imports `transcriber.ts`).

The standalone integration script `scripts/test-openvino-whisper-transcriber.mjs` exercises the real worker against a local Whisper IR + WAV file. Not run in CI (requires OpenVINO Runtime + the Whisper IR), but documented in the file header.

## Out of scope

- Auto-download of the Whisper IR. Operators stage it once via Intel's pre-converted bundle (`https://huggingface.co/OpenVINO/whisper-base.en-int8-ov`) under the path `ELIZA_OPENVINO_WHISPER_MODEL` points at.
- A `LocalRuntimeKernel` catalog entry for `openvino` — proposed in #7633 but a separate scope.

## Related

- #7633 — RFC for OpenVINO as a `LocalRuntimeKernel` (ASR half of this PR)
- #7634 — `linux-x64-openvino` build target for `build-llama-cpp-dflash.mjs`
- #7656 — Kokoro voice loader fixes (sibling improvement, also closes a Linux voice-stack gap)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an OpenVINO Whisper tier (position 3) into the `createStreamingTranscriber` fallback chain, between the fused-batch path and the whisper.cpp legacy backend. On Intel Lunar Lake / Meteor Lake hosts it provides a significantly faster ASR path (~28\u201350\u00d7 realtime vs ~3\u20134\u00d7 for whisper.cpp) while reusing `WhisperCppStreamingTranscriber`'s sliding-window engine via decoder injection.

- **New `openvino-whisper-asr.ts`** probes for the Python venv, worker script, and Whisper IR on disk, then spawns a persistent Python worker that keeps the compiled pipeline warm across decode windows via a length-prefixed binary protocol over stdin/stdout.
- **`transcriber.ts`** gains `prefer: \"openvino-whisper\"`, `allowOpenVinoWhisper`, and an `onDispose` hook to tear down the Python subprocess on dispose.
- **Two correctness issues** need to be resolved: the Promise chain serializing decode requests is permanently broken after any single rejection, and `tryOpenVinoWhisper()` in `prefer:\"auto\"` mode can return a silently broken transcriber when disk artifacts exist but the runtime fails to initialize.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without fixing the Promise chain and the startup-readiness gap in tryOpenVinoWhisper.

The decoder's Promise chain is permanently poisoned after any single error — a worker crash, an early exit, or a transient generate() failure leaves the session producing no transcripts with no visible indication. Separately, when disk artifacts exist but the OpenVINO runtime cannot initialize (openvino_genai missing, model corrupt, no viable device), the auto chain silently selects a broken OpenVINO transcriber and never reaches the whisper.cpp fallback. Both issues are in the core decode path and are invisible in unit tests because the tests mock the decoder itself.

openvino-whisper-asr.ts (chain serialization logic) and transcriber.ts (tryOpenVinoWhisper return value when runtime init fails).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.ts | New OpenVINO Whisper decoder module: spawns a persistent Python worker and serializes decode requests on a Promise chain. The chain-serialization logic has a critical bug — any rejection permanently breaks the chain for the session — and the worker is spawned eagerly before readiness is confirmed. |
| packages/app-core/src/services/local-inference/voice/transcriber.ts | Integrates the new OpenVINO tier into the createStreamingTranscriber chain (auto/prefer semantics, onDispose hook). The tryOpenVinoWhisper() helper can return a silently broken transcriber when disk artifacts exist but the runtime fails to initialize, bypassing the whisper.cpp fallback in auto mode. |
| packages/app-core/scripts/openvino-whisper-asr-worker.py | Persistent Python worker implementing the length-prefixed binary protocol over stdin/stdout. Device probing, error handling, and the main read loop all look correct; minor style issue with numpy imported inside the loop. |
| packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.test.ts | Unit tests covering the full chain-selection matrix (auto, prefer, allowOpenVinoWhisper, allowWhisperFallback combinations). Uses vi.hoisted mock state correctly to avoid cross-test contamination. |
| packages/app-core/scripts/test-openvino-whisper-transcriber.mjs | Integration smoke-test script (not run in CI); drives the full transcriber chain with real audio. Well-documented and scoped to manual validation only. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant createStreamingTranscriber
    participant tryOpenVinoWhisper
    participant resolveRuntime as resolveOpenVinoWhisperRuntime
    participant makeDecoder as makeOpenVinoWhisperDecoder
    participant WhisperCppST as WhisperCppStreamingTranscriber
    participant PythonWorker as Python Worker (openvino_genai)

    App->>createStreamingTranscriber: opts (prefer:"auto")
    createStreamingTranscriber->>tryOpenVinoWhisper: (fused paths returned null)
    tryOpenVinoWhisper->>resolveRuntime: check pythonBin / workerScript / modelDir
    resolveRuntime-->>tryOpenVinoWhisper: "OpenVinoWhisperRuntime | null"
    tryOpenVinoWhisper->>makeDecoder: runtime
    makeDecoder->>PythonWorker: Bun.spawn([pythonBin, workerScript])
    Note over PythonWorker: init_pipeline() 0.5-3s
    PythonWorker-->>makeDecoder: process handle
    makeDecoder-->>tryOpenVinoWhisper: decoder + dispose
    tryOpenVinoWhisper->>WhisperCppST: new WhisperCppStreamingTranscriber
    WhisperCppST-->>App: StreamingTranscriber

    loop Streaming audio frames
        App->>WhisperCppST: feed(pcmFrame)
        WhisperCppST->>WhisperCppST: accumulate + sliding window
        WhisperCppST->>makeDecoder: decoder(pcm16k) via chain
        makeDecoder->>PythonWorker: stdin u32 n_samples + f32 PCM
        PythonWorker->>PythonWorker: pipe.generate(pcm)
        PythonWorker-->>makeDecoder: stdout u32 n_bytes + UTF-8
        makeDecoder-->>WhisperCppST: transcript string
    end

    App->>WhisperCppST: dispose()
    WhisperCppST->>makeDecoder: dispose() via onDispose
    makeDecoder->>PythonWorker: proc.kill()
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.ts`, line 560-573 ([link](https://github.com/elizaos/eliza/blob/a008e9a47430dbb4fd4b20723212254e0b5c9d57/packages/app-core/src/services/local-inference/voice/openvino-whisper-asr.ts#L560-L573)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Worker process leaked if `WhisperCppStreamingTranscriber` constructor throws**

   `makeOpenVinoWhisperDecoder(runtime)` spawns the Python process immediately. If the `WhisperCppStreamingTranscriber` constructor subsequently throws (rare, but not impossible — e.g., invalid `opts.whisper` config), `dispose` is never called and the spawned worker process is orphaned. Wrapping the constructor call in a try/catch that calls `dispose()` on failure would prevent the leak.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(local-inference/voice): OpenVINO Wh..."](https://github.com/elizaos/eliza/commit/a008e9a47430dbb4fd4b20723212254e0b5c9d57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32030040)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->