### PR TITLE
feat(local-inference/voice): Kokoro-only voice bridge for hosts without an Eliza-1 bundle

### DIFF
--- a/packages/app-core/src/services/local-inference/engine.ts
+++ b/packages/app-core/src/services/local-inference/engine.ts
@@ -70,6 +70,7 @@ import {
   type EngineVoiceBridgeOptions,
   VoiceStartupError,
 } from "./voice/engine-bridge";
+import { resolveKokoroEngineConfig } from "./voice/kokoro/kokoro-engine-discovery";
 import type { VoicePipelineEvents } from "./voice/pipeline";
 import {
   type DflashTextRunner,
@@ -1317,6 +1318,17 @@ export class LocalInferenceEngine {
   }
 
   /**
+   * True when a voice session is currently active on the engine. Callers
+   * use this to decide whether to lazy-start one (e.g. the TTS model
+   * handler in `ensure-local-inference-handler.ts`, which auto-starts a
+   * Kokoro-only bridge on the first TEXT_TO_SPEECH invocation when the
+   * Kokoro artifacts are on disk and no Eliza-1 bundle has activated).
+   */
+  hasActiveVoiceBridge(): boolean {
+    return this.voiceBridge !== null;
+  }
+
+  /**
    * Arm the voice lifecycle on the active bridge — lazily loads the TTS
    * mmap region, optional ASR region when present, voice caches, and
    * voice scheduler nodes via the shared resource registry. Throws
@@ -1350,16 +1362,28 @@ export class LocalInferenceEngine {
     let bridge = this.voiceBridge;
     if (!bridge) {
       const bundle = this.activeEliza1Bundle;
-      if (!bundle) {
-        throw new VoiceStartupError(
-          "missing-bundle-root",
-          "[voice] Cannot start local voice: no active Eliza-1 bundle is loaded.",
-        );
+      if (bundle) {
+        bridge = this.startVoice({
+          bundleRoot: bundle.root,
+          useFfiBackend: true,
+        });
+      } else {
+        // No Eliza-1 bundle. Fall back to the Kokoro-only path when its
+        // artifacts are staged. No silent degrade: when both are absent
+        // the error names both staging options.
+        const kokoro = resolveKokoroEngineConfig();
+        if (!kokoro) {
+          throw new VoiceStartupError(
+            "missing-bundle-root",
+            "[voice] Cannot start local voice: no active Eliza-1 bundle is loaded and no Kokoro artifacts are staged under ~/.eliza/local-inference/models/kokoro/. Install an Eliza-1 bundle, or stage the Kokoro ONNX + at least one voice .bin to enable local TTS.",
+          );
+        }
+        bridge = this.startVoice({
+          bundleRoot: "",
+          useFfiBackend: false,
+          kokoroOnly: kokoro,
+        });
       }
-      bridge = this.startVoice({
-        bundleRoot: bundle.root,
-        useFfiBackend: true,
-      });
     }
     await bridge.arm();
     return bridge;

--- a/packages/app-core/src/services/local-inference/voice/engine-bridge.ts
+++ b/packages/app-core/src/services/local-inference/voice/engine-bridge.ts
@@ -31,6 +31,9 @@ import os from "node:os";
 import path from "node:path";
 import { localInferenceRoot } from "../paths";
 import { VoiceStartupError } from "./errors";
+import { KokoroTtsBackend } from "./kokoro/kokoro-backend";
+import type { KokoroEngineDiscoveryResult } from "./kokoro/kokoro-engine-discovery";
+import { KokoroOnnxRuntime } from "./kokoro/kokoro-runtime";
 import type {
   ElizaInferenceContextHandle,
   ElizaInferenceFfi,
@@ -538,6 +541,16 @@ export interface EngineVoiceBridgeOptions {
   lifecycleLoaders?: VoiceLifecycleLoaders;
   /** Optional whisper.cpp interim ASR configuration. */
   whisper?: WhisperCppOptions;
+  /**
+   * Construct a `KokoroTtsBackend` directly and skip the bundle-root +
+   * speaker-preset + FFI checks the fused omnivoice path requires.
+   * Kokoro voices are picked by id (`KOKORO_VOICE_PACKS`), so the bundle's
+   * per-user speaker preset is not used. Mutually exclusive with
+   * `useFfiBackend: true` and `backendOverride`. Lifecycle loaders
+   * default to no-op handles (ORT owns the model memory; nothing to
+   * mmap-evict).
+   */
+  kokoroOnly?: KokoroEngineDiscoveryResult;
 }
 
 /**
@@ -614,6 +627,15 @@ export class EngineVoiceBridge {
    * the call throws.
    */
   static start(opts: EngineVoiceBridgeOptions): EngineVoiceBridge {
+    if (opts.kokoroOnly) {
+      if (opts.useFfiBackend || opts.backendOverride) {
+        throw new VoiceStartupError(
+          "missing-fused-build",
+          "[voice] kokoroOnly cannot be combined with useFfiBackend or backendOverride. Caller must pick exactly one backend path.",
+        );
+      }
+      return EngineVoiceBridge.startKokoroOnly(opts);
+    }
     if (!opts.bundleRoot || !existsSync(opts.bundleRoot)) {
       throw new VoiceStartupError(
         "missing-bundle-root",
@@ -745,6 +767,94 @@ export class EngineVoiceBridge {
       ffiHandle,
       ffiContextRef,
       asrAvailable,
+      phraseCache,
+      opts.whisper,
+    );
+  }
+
+  /**
+   * Kokoro-only path. Skips bundle-root / speaker-preset / FFI checks
+   * (Kokoro picks voices by id against `KOKORO_VOICE_PACKS`) and
+   * synthesizes a minimal `SpeakerPreset` keyed to the discovered voice
+   * id. Defaults lifecycle loaders to no-op handles since ORT owns the
+   * model memory. `asrAvailable` is `false`: callers needing ASR
+   * construct `createStreamingTranscriber` directly.
+   */
+  private static startKokoroOnly(opts: EngineVoiceBridgeOptions): EngineVoiceBridge {
+    if (!opts.kokoroOnly) {
+      throw new VoiceStartupError(
+        "missing-bundle-root",
+        "[voice] startKokoroOnly called without `kokoroOnly` config — this is an internal error.",
+      );
+    }
+    const kokoro = opts.kokoroOnly;
+    const sampleRate = opts.sampleRate ?? kokoro.layout.sampleRate;
+    const workDir =
+      opts.bundleRoot && existsSync(opts.bundleRoot)
+        ? opts.bundleRoot
+        : localInferenceRoot();
+
+    // Synthesize a minimal preset. Kokoro's `resolveVoice(preset)` looks
+    // up `preset.voiceId` against `KOKORO_VOICE_PACKS`; the embedding +
+    // bytes fields are ignored on this path (voice cloning is OmniVoice-only).
+    const preset: SpeakerPreset = {
+      voiceId: kokoro.defaultVoiceId,
+      embedding: new Float32Array(0),
+      bytes: new Uint8Array(0),
+    };
+
+    const runtime = new KokoroOnnxRuntime({
+      layout: kokoro.layout,
+      expectedSha256: null,
+    });
+    const backend = new KokoroTtsBackend({
+      layout: kokoro.layout,
+      runtime,
+      defaultVoiceId: kokoro.defaultVoiceId,
+    });
+
+    const phraseCache = new PhraseCache();
+    for (const entry of opts.prewarmedPhrases ?? []) {
+      phraseCache.put(entry);
+    }
+
+    const config: SchedulerConfig = {
+      chunkerConfig: {
+        maxTokensPerPhrase:
+          opts.maxTokensPerPhrase ??
+          readPositiveIntEnv("ELIZA_VOICE_MAX_TOKENS_PER_PHRASE") ??
+          PHRASE_MAX_TOKENS_DEFAULT,
+      },
+      preset,
+      ringBufferCapacity:
+        opts.ringBufferCapacity ?? RING_BUFFER_CAPACITY_DEFAULT,
+      sampleRate,
+      maxInFlightPhrases:
+        opts.maxInFlightPhrases ??
+        readPositiveIntEnv("ELIZA_VOICE_MAX_IN_FLIGHT_PHRASES"),
+    };
+
+    const sinkOverride = opts.sink;
+    const scheduler = new VoiceScheduler(
+      config,
+      sinkOverride
+        ? { backend, sink: sinkOverride, phraseCache }
+        : { backend, phraseCache },
+      opts.events ?? {},
+    );
+
+    const registry = opts.sharedResources ?? new SharedResourceRegistry();
+    const loaders = opts.lifecycleLoaders ?? kokoroOnlyLifecycleLoaders();
+    const lifecycle = new VoiceLifecycle({ registry, loaders });
+
+    return new EngineVoiceBridge(
+      scheduler,
+      backend,
+      workDir,
+      lifecycle,
+      null, // no FFI handle on Kokoro-only
+      null, // no FFI context on Kokoro-only
+      false, // ASR is not served from this path
       phraseCache,
       opts.whisper,
     );
@@ -1258,6 +1368,39 @@ function ensureContext(
   if (ref === null) return null;
   if (typeof ref === "object" && "ensure" in ref) return ref.ensure();
   return ref;
+}
+
+/**
+ * No-op lifecycle loaders for the Kokoro-only bridge. ORT owns the
+ * model memory; nothing to mmap-acquire or evict. ASR is not served
+ * from this path — callers that need ASR construct
+ * `createStreamingTranscriber` directly (the chain in `transcriber.ts`
+ * supports `openvino-whisper` and `whisper.cpp` without a bundle).
+ */
+function kokoroOnlyLifecycleLoaders(): VoiceLifecycleLoaders {
+  const noopMmap = (id: string): MmapRegionHandle => ({
+    id,
+    path: "",
+    sizeBytes: 0,
+    async evictPages() {
+      // Nothing to evict — ORT owns the model bytes.
+    },
+    async release() {
+      // No mmap region to release.
+    },
+  });
+  return {
+    loadTtsRegion: async () => noopMmap("kokoro:tts"),
+    loadAsrRegion: async () => noopMmap("kokoro:asr"),
+    loadVoiceCaches: async () => ({
+      id: "kokoro:voice-caches",
+      async release() {},
+    }),
+    loadVoiceSchedulerNodes: async () => ({
+      id: "kokoro:voice-scheduler-nodes",
+      async release() {},
+    }),
+  };
 }
 
 function defaultLifecycleLoaders(

--- a/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-bridge.test.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-bridge.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration tests for `EngineVoiceBridge.startKokoroOnly` — the entry
+ * point that constructs a Kokoro-backed bridge without an Eliza-1 bundle.
+ *
+ * No `vi.mock` here: `KokoroOnnxRuntime`'s constructor does not touch
+ * disk (the model file is only opened lazily inside `ensureSession()`,
+ * which we never call in these tests), and `KokoroTtsBackend` works the
+ * same way. So the tests exercise the real classes against a fake layout
+ * pointing at a never-read path.
+ *
+ * The standalone integration script at `scripts/test-kokoro-tts.mjs`
+ * covers the real-ORT path against staged artifacts on disk.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { EngineVoiceBridge, VoiceStartupError } from "../../engine-bridge";
+import { KokoroTtsBackend } from "../kokoro-backend";
+import type { KokoroEngineDiscoveryResult } from "../kokoro-engine-discovery";
+import type { VoiceLifecycleLoaders } from "../../lifecycle";
+import type { MmapRegionHandle, RefCountedResource } from "../../shared-resources";
+
+function makeKokoroConfig(rootOverride?: string): KokoroEngineDiscoveryResult {
+  return {
+    layout: {
+      root: rootOverride ?? "/tmp/fake-kokoro",
+      modelFile: "kokoro-v1.0.onnx",
+      voicesDir: path.join(rootOverride ?? "/tmp/fake-kokoro", "voices"),
+      sampleRate: 24_000,
+    },
+    defaultVoiceId: "af_bella",
+  };
+}
+
+function lifecycleLoadersOk(): VoiceLifecycleLoaders {
+  const region: MmapRegionHandle = {
+    id: "test-region",
+    path: "/tmp/test",
+    sizeBytes: 0,
+    async evictPages() {},
+    async release() {},
+  };
+  const refc: RefCountedResource = { id: "refc", async release() {} };
+  return {
+    loadTtsRegion: async () => region,
+    loadAsrRegion: async () => region,
+    loadVoiceCaches: async () => refc,
+    loadVoiceSchedulerNodes: async () => refc,
+  };
+}
+
+describe("EngineVoiceBridge — kokoroOnly mode", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "kokoro-bridge-test-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("constructs a KokoroTtsBackend when kokoroOnly is set, even without a real bundle", () => {
+    const bridge = EngineVoiceBridge.start({
+      bundleRoot: "", // intentionally empty — kokoroOnly skips the existsSync check
+      useFfiBackend: false,
+      kokoroOnly: makeKokoroConfig(),
+      lifecycleLoaders: lifecycleLoadersOk(),
+    });
+    expect(bridge.backend).toBeInstanceOf(KokoroTtsBackend);
+    expect(bridge.asrAvailable).toBe(false); // ASR is not served from this path
+    expect(bridge.ffi).toBeNull();
+    bridge.dispose();
+  });
+
+  it("uses provided bundleRoot as working dir when it exists", () => {
+    const bridge = EngineVoiceBridge.start({
+      bundleRoot: tmp, // a real tmp dir; should be honored as work-dir hint
+      useFfiBackend: false,
+      kokoroOnly: makeKokoroConfig(),
+      lifecycleLoaders: lifecycleLoadersOk(),
+    });
+    expect(bridge.backend).toBeInstanceOf(KokoroTtsBackend);
+    bridge.dispose();
+  });
+
+  it("throws when kokoroOnly is combined with useFfiBackend:true", () => {
+    expect(() =>
+      EngineVoiceBridge.start({
+        bundleRoot: "",
+        useFfiBackend: true,
+        kokoroOnly: makeKokoroConfig(),
+      }),
+    ).toThrow(VoiceStartupError);
+  });
+
+  it("throws when kokoroOnly is combined with backendOverride", () => {
+    expect(() =>
+      EngineVoiceBridge.start({
+        bundleRoot: "",
+        useFfiBackend: false,
+        kokoroOnly: makeKokoroConfig(),
+        backendOverride: { async synthesize() { return { phraseId: 0, fromIndex: 0, toIndex: 0, pcm: new Float32Array(0), sampleRate: 24000 }; } } as never,
+      }),
+    ).toThrow(VoiceStartupError);
+  });
+
+  it("uses no-op lifecycle loaders by default (no real mmap regions)", async () => {
+    const bridge = EngineVoiceBridge.start({
+      bundleRoot: "",
+      useFfiBackend: false,
+      kokoroOnly: makeKokoroConfig(),
+    });
+    // Default loaders should arm without hitting real disk.
+    await expect(bridge.arm()).resolves.toBeUndefined();
+    bridge.dispose();
+  });
+
+  it("preserves the requested sample rate from the kokoroOnly layout", () => {
+    const bridge = EngineVoiceBridge.start({
+      bundleRoot: "",
+      useFfiBackend: false,
+      kokoroOnly: {
+        ...makeKokoroConfig(),
+        layout: {
+          ...makeKokoroConfig().layout,
+          sampleRate: 16_000,
+        },
+      },
+      lifecycleLoaders: lifecycleLoadersOk(),
+    });
+    expect(bridge.backend.sampleRate).toBe(16_000);
+    bridge.dispose();
+  });
+});

--- a/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-discovery.test.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-discovery.test.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  kokoroEngineModelDir,
+  resolveKokoroEngineConfig,
+} from "../kokoro-engine-discovery";
+
+function makeStaged(opts: {
+  modelFile?: string;
+  voices?: string[];
+}): { root: string; cleanup: () => void } {
+  const root = mkdtempSync(path.join(os.tmpdir(), "kokoro-engine-test-"));
+  if (opts.modelFile) {
+    writeFileSync(path.join(root, opts.modelFile), Buffer.alloc(4));
+  }
+  if (opts.voices && opts.voices.length > 0) {
+    mkdirSync(path.join(root, "voices"), { recursive: true });
+    for (const v of opts.voices) {
+      writeFileSync(path.join(root, "voices", v), Buffer.alloc(1024));
+    }
+  }
+  return { root, cleanup: () => rmSync(root, { recursive: true, force: true }) };
+}
+
+describe("resolveKokoroEngineConfig", () => {
+  let cleanups: Array<() => void>;
+  let origEnv: Record<string, string | undefined>;
+  beforeEach(() => {
+    cleanups = [];
+    origEnv = {
+      ELIZA_KOKORO_MODEL_DIR: process.env.ELIZA_KOKORO_MODEL_DIR,
+      ELIZA_KOKORO_MODEL_FILE: process.env.ELIZA_KOKORO_MODEL_FILE,
+      ELIZA_KOKORO_DEFAULT_VOICE_ID: process.env.ELIZA_KOKORO_DEFAULT_VOICE_ID,
+    };
+    delete process.env.ELIZA_KOKORO_MODEL_DIR;
+    delete process.env.ELIZA_KOKORO_MODEL_FILE;
+    delete process.env.ELIZA_KOKORO_DEFAULT_VOICE_ID;
+  });
+  afterEach(() => {
+    for (const c of cleanups) c();
+    for (const [k, v] of Object.entries(origEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("returns null when the model dir does not exist", () => {
+    process.env.ELIZA_KOKORO_MODEL_DIR = path.join(
+      os.tmpdir(),
+      `definitely-not-here-${Date.now()}`,
+    );
+    expect(resolveKokoroEngineConfig()).toBeNull();
+  });
+
+  it("returns null when the model dir exists but no ONNX is staged", () => {
+    const fx = makeStaged({ voices: ["af_bella.bin"] });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    expect(resolveKokoroEngineConfig()).toBeNull();
+  });
+
+  it("returns null when no voice .bin is staged", () => {
+    const fx = makeStaged({ modelFile: "kokoro-v1.0.onnx" });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    expect(resolveKokoroEngineConfig()).toBeNull();
+  });
+
+  it("returns the default voice when af_bella.bin is staged", () => {
+    const fx = makeStaged({
+      modelFile: "kokoro-v1.0.onnx",
+      voices: ["af_bella.bin"],
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    const cfg = resolveKokoroEngineConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.defaultVoiceId).toBe("af_bella");
+    expect(cfg!.layout.modelFile).toBe("kokoro-v1.0.onnx");
+    expect(cfg!.layout.sampleRate).toBe(24_000);
+    expect(cfg!.layout.root).toBe(fx.root);
+    expect(cfg!.layout.voicesDir).toBe(path.join(fx.root, "voices"));
+  });
+
+  it("auto-prefers the INT8 ONNX when it is the only one staged", () => {
+    const fx = makeStaged({
+      modelFile: "kokoro-v1.0.int8.onnx",
+      voices: ["af_bella.bin"],
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    const cfg = resolveKokoroEngineConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.layout.modelFile).toBe("kokoro-v1.0.int8.onnx");
+  });
+
+  it("picks any staged voice when the catalog default is missing", () => {
+    const fx = makeStaged({
+      modelFile: "model.onnx",
+      voices: ["af_sarah.bin"], // not the default `af_bella`
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    const cfg = resolveKokoroEngineConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.defaultVoiceId).toBe("af_sarah");
+  });
+
+  it("honours ELIZA_KOKORO_DEFAULT_VOICE_ID when set + staged", () => {
+    const fx = makeStaged({
+      modelFile: "model.onnx",
+      voices: ["af_bella.bin", "af_nicole.bin"],
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    process.env.ELIZA_KOKORO_DEFAULT_VOICE_ID = "af_nicole";
+    const cfg = resolveKokoroEngineConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.defaultVoiceId).toBe("af_nicole");
+  });
+
+  it("returns null when ELIZA_KOKORO_DEFAULT_VOICE_ID is set but the .bin is missing", () => {
+    const fx = makeStaged({
+      modelFile: "model.onnx",
+      voices: ["af_bella.bin"],
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    process.env.ELIZA_KOKORO_DEFAULT_VOICE_ID = "af_nicole";
+    expect(resolveKokoroEngineConfig()).toBeNull();
+  });
+
+  it("honours ELIZA_KOKORO_MODEL_FILE override when present", () => {
+    const fx = makeStaged({
+      modelFile: "custom-export.onnx",
+      voices: ["af_bella.bin"],
+    });
+    cleanups.push(fx.cleanup);
+    process.env.ELIZA_KOKORO_MODEL_DIR = fx.root;
+    process.env.ELIZA_KOKORO_MODEL_FILE = "custom-export.onnx";
+    const cfg = resolveKokoroEngineConfig();
+    expect(cfg).not.toBeNull();
+    expect(cfg!.layout.modelFile).toBe("custom-export.onnx");
+  });
+});
+
+describe("kokoroEngineModelDir", () => {
+  let origDir: string | undefined;
+  beforeEach(() => {
+    origDir = process.env.ELIZA_KOKORO_MODEL_DIR;
+  });
+  afterEach(() => {
+    if (origDir === undefined) delete process.env.ELIZA_KOKORO_MODEL_DIR;
+    else process.env.ELIZA_KOKORO_MODEL_DIR = origDir;
+  });
+
+  it("returns the env override when set", () => {
+    process.env.ELIZA_KOKORO_MODEL_DIR = "/tmp/custom-kokoro";
+    expect(kokoroEngineModelDir()).toBe("/tmp/custom-kokoro");
+  });
+
+  it("returns the canonical home path when env is unset", () => {
+    delete process.env.ELIZA_KOKORO_MODEL_DIR;
+    expect(kokoroEngineModelDir()).toBe(
+      path.join(os.homedir(), ".eliza", "local-inference", "models", "kokoro"),
+    );
+  });
+});

--- a/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-engine-discovery.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-engine-discovery.ts
@@ -1,0 +1,125 @@
+/**
+ * On-disk discovery for the Kokoro-only voice mode. Probes
+ * `~/.eliza/local-inference/models/kokoro/` (or `$ELIZA_KOKORO_MODEL_DIR`)
+ * for an ONNX file + at least one voice `.bin` under `voices/`. Returns
+ * null when anything is missing — no auto-download (AGENTS.md §3).
+ *
+ * Env overrides:
+ *   ELIZA_KOKORO_MODEL_DIR        — directory root
+ *   ELIZA_KOKORO_MODEL_FILE       — ONNX filename inside the root
+ *   ELIZA_KOKORO_DEFAULT_VOICE_ID — default voice id (e.g. `af_bella`)
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { KOKORO_DEFAULT_VOICE_ID, KOKORO_VOICE_PACKS } from "./voice-presets";
+import type { KokoroModelLayout, KokoroVoicePack } from "./types";
+
+/** Canonical Kokoro v1.0 output sample rate. */
+export const KOKORO_DEFAULT_SAMPLE_RATE = 24_000;
+
+/** Filenames the loader will accept if `ELIZA_KOKORO_MODEL_FILE` is unset. */
+const CANDIDATE_MODEL_FILES: ReadonlyArray<string> = [
+  "kokoro-v1.0.onnx",
+  "kokoro-v1.0.int8.onnx",
+  "model.onnx",
+  "model_quantized.onnx",
+];
+
+export interface KokoroEngineDiscoveryResult {
+  layout: KokoroModelLayout;
+  /**
+   * Resolved default voice id. Falls back to `KOKORO_DEFAULT_VOICE_ID`
+   * when the env override is unset and `af_bella.bin` is on disk; otherwise
+   * picks the first voice pack whose `.bin` is actually staged.
+   */
+  defaultVoiceId: string;
+}
+
+/** Returns the on-disk directory the discovery probes. */
+export function kokoroEngineModelDir(): string {
+  const env = process.env.ELIZA_KOKORO_MODEL_DIR?.trim();
+  if (env) return env;
+  return path.join(
+    os.homedir(),
+    ".eliza",
+    "local-inference",
+    "models",
+    "kokoro",
+  );
+}
+
+/**
+ * Probe disk for a usable Kokoro layout. Returns null when any required
+ * piece is missing — the engine then falls back to its existing behaviour
+ * (fused omnivoice or `StubOmniVoiceBackend`).
+ */
+export function resolveKokoroEngineConfig(): KokoroEngineDiscoveryResult | null {
+  const root = kokoroEngineModelDir();
+  if (!existsSync(root)) return null;
+
+  const modelFile = resolveModelFile(root);
+  if (!modelFile) return null;
+
+  const voicesDir = path.join(root, "voices");
+  if (!existsSync(voicesDir)) return null;
+
+  const defaultVoiceId = resolveDefaultVoiceId(voicesDir);
+  if (!defaultVoiceId) return null;
+
+  return {
+    layout: {
+      root,
+      modelFile,
+      voicesDir,
+      sampleRate: KOKORO_DEFAULT_SAMPLE_RATE,
+    },
+    defaultVoiceId,
+  };
+}
+
+function resolveModelFile(root: string): string | null {
+  const env = process.env.ELIZA_KOKORO_MODEL_FILE?.trim();
+  if (env) {
+    return existsSync(path.join(root, env)) ? env : null;
+  }
+  for (const candidate of CANDIDATE_MODEL_FILES) {
+    if (existsSync(path.join(root, candidate))) return candidate;
+  }
+  return null;
+}
+
+function resolveDefaultVoiceId(voicesDir: string): string | null {
+  const env = process.env.ELIZA_KOKORO_DEFAULT_VOICE_ID?.trim();
+  if (env) {
+    const pack = findVoicePack(env);
+    if (pack && existsSync(path.join(voicesDir, pack.file))) return pack.id;
+    return null;
+  }
+  // Prefer the catalog default when its file is staged.
+  const defaultPack = findVoicePack(KOKORO_DEFAULT_VOICE_ID);
+  if (defaultPack && existsSync(path.join(voicesDir, defaultPack.file))) {
+    return defaultPack.id;
+  }
+  // Otherwise pick the first catalog voice whose file is on disk. This
+  // lets operators stage a single voice (any voice) and have it just work.
+  const staged = listStagedVoiceIds(voicesDir);
+  return staged[0] ?? null;
+}
+
+function findVoicePack(id: string): KokoroVoicePack | null {
+  return KOKORO_VOICE_PACKS.find((v) => v.id === id) ?? null;
+}
+
+function listStagedVoiceIds(voicesDir: string): string[] {
+  try {
+    const present = new Set(readdirSync(voicesDir));
+    return KOKORO_VOICE_PACKS.filter((v) => present.has(v.file)).map(
+      (v) => v.id,
+    );
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Wires `KokoroTtsBackend` into `EngineVoiceBridge.start()` as a first-class backend path. Today `engine.ensureActiveBundleVoiceReady()` throws "no active Eliza-1 bundle" whenever the fused omnivoice library and an Eliza-1 bundle are both absent — that's every Linux host right now, since the fused build isn't shipping yet. This closes the gap by lazy-arming a Kokoro bridge when the Kokoro artifacts are staged.

The integration spec for Kokoro lived at `docs/eliza-1-kokoro-integration.md` and the runtime classes (`KokoroTtsBackend`, `KokoroOnnxRuntime`) were already in tree — they just weren't being constructed from the engine layer.

## Changes

- **`kokoro-engine-discovery.ts`** (new). Probes `~/.eliza/local-inference/models/kokoro/` for an ONNX file + at least one voice `.bin`. Returns `null` when anything is missing — no auto-download (AGENTS.md §3). Env overrides: `ELIZA_KOKORO_MODEL_DIR`, `ELIZA_KOKORO_MODEL_FILE`, `ELIZA_KOKORO_DEFAULT_VOICE_ID`. Auto-prefers `af_bella` (catalog default) when its `.bin` is staged; otherwise picks any staged catalog voice so operators can install one voice and have it just work.

- **`EngineVoiceBridge.start({ kokoroOnly })`** — new option. Branches to `startKokoroOnly()` which skips bundle-root / speaker-preset / FFI validation, synthesizes a minimal `SpeakerPreset` keyed to the discovered voice id (Kokoro picks voices by id, not embedding), constructs `KokoroOnnxRuntime` + `KokoroTtsBackend`, and uses no-op lifecycle loaders (ORT owns the model memory; nothing to mmap-evict). `asrAvailable: false` — ASR callers construct `createStreamingTranscriber` directly. Mutually exclusive with `useFfiBackend: true` and `backendOverride`.

- **`LocalInferenceEngine.ensureActiveBundleVoiceReady()`** — prefers an active bundle; falls back to Kokoro-only when one is on disk. When both are absent the error is updated to name both staging options. No silent degrade.

- **`LocalInferenceEngine.hasActiveVoiceBridge()`** — new helper.

## Tests

```
packages/app-core/src/services/local-inference/voice/kokoro/__tests__/
  kokoro-engine-discovery.test.ts   11 cases (env / layout combinations, home-path default)
  kokoro-engine-bridge.test.ts       6 cases (backend type, mutually-exclusive options,
                                                no-op lifecycle loaders, sample-rate
                                                plumb-through)
```

17 new cases, all green. The full `voice/` suite stays at **478 passed | 3 skipped** (the 3 skips are pre-existing `embedding-server.test.ts` skips unrelated to this PR).

## Verification on real hardware

`scripts/test-kokoro-tts.mjs` (already in tree from #7656) drives `KokoroTtsBackend` end-to-end against staged INT8 ONNX + `af_bella.bin`. Synthesized 10.78s of valid 24 kHz mono WAV.

With this PR + the same artifacts staged, the running dev server now serves `POST /api/tts/local-inference` instead of returning `503 [voice] Cannot start local voice: no active Eliza-1 bundle is loaded`.

## Out of scope

- Voice cloning (`ref_audio_24k` / `ref_audio_tokens` in the omnivoice ABI) — omnivoice-only by design; Kokoro v1.0 has no per-user cloning.
- Full `runtime-selection.ts` heuristic wiring (currently "fused first, else Kokoro"; switching to the documented `auto`/`kokoro`/`omnivoice` selector is a clean follow-up).
- Auto-download of artifacts. Operators stage them once from `https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX`.

## Related

- `docs/eliza-1-kokoro-integration.md` — the integration spec this PR completes
- #7656 — Kokoro voice loader fixes (merged today)
- #7658 — OpenVINO Whisper ASR adapter (merged today, complements this PR on the ASR side)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `KokoroTtsBackend` into `EngineVoiceBridge.start()` as a first-class backend, closing the gap for Linux hosts where the fused omnivoice library and an Eliza-1 bundle are both absent. `ensureActiveBundleVoiceReady()` now prefers an active Eliza-1 bundle and falls back to Kokoro-only when its ONNX + voice `.bin` artifacts are staged on disk.

- **`kokoro-engine-discovery.ts`** (new): probes `~/.eliza/local-inference/models/kokoro/` for a usable ONNX model and at least one catalog voice `.bin`; respects `ELIZA_KOKORO_MODEL_DIR`, `ELIZA_KOKORO_MODEL_FILE`, and `ELIZA_KOKORO_DEFAULT_VOICE_ID` env overrides; returns `null` with no auto-download.
- **`EngineVoiceBridge.startKokoroOnly()`** (new): bypasses bundle-root / FFI / speaker-preset checks, synthesizes a minimal `SpeakerPreset` keyed to the discovered voice id, constructs `KokoroOnnxRuntime` + `KokoroTtsBackend`, and installs no-op lifecycle loaders since ORT owns the model memory.
- **17 new test cases** covering env/layout combinations, mutual-exclusion guards, no-op lifecycle loaders, and sample-rate plumbing.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the Kokoro-only path is well-isolated from the existing FFI/bundle path and the no-op lifecycle loaders are a deliberate, correct design for ORT-owned memory.

The new code paths are additive, the mutual-exclusion guards are tested, and the only finding is a stale error code string that does not affect runtime behaviour.

No files require special attention; the engine.ts error code renaming suggestion is minor.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/local-inference/voice/kokoro/kokoro-engine-discovery.ts | New discovery module that probes disk for Kokoro ONNX + voice .bin files; clean logic, but previous-thread comments note that null returns from env-override misconfigurations are silent. |
| packages/app-core/src/services/local-inference/voice/engine-bridge.ts | Adds kokoroOnly branch to EngineVoiceBridge.start() and the full startKokoroOnly() implementation; functionally correct but reuses two semantically mismatched error codes (covered in previous threads). |
| packages/app-core/src/services/local-inference/engine.ts | ensureActiveBundleVoiceReady() gains Kokoro fallback path and new hasActiveVoiceBridge() helper; the "both absent" error throws code "missing-bundle-root" which no longer accurately describes the expanded two-option fix. |
| packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-bridge.test.ts | New integration tests for the kokoroOnly bridge path; covers backend type, mutual-exclusion guards, no-op lifecycle loaders, and sample-rate plumbing. |
| packages/app-core/src/services/local-inference/voice/kokoro/__tests__/kokoro-engine-discovery.test.ts | New tests for resolveKokoroEngineConfig; covers env/layout combinations, home-path default, af_bella preference, and graceful null for missing artifacts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ensureActiveBundleVoiceReady] --> B{voiceBridge != null?}
    B -- yes --> G[bridge.arm]
    B -- no --> C{activeEliza1Bundle?}
    C -- yes --> D[startVoice\nbundleRoot=bundle.root\nuseFfiBackend=true]
    C -- no --> E[resolveKokoroEngineConfig]
    E -- null --> F[throw VoiceStartupError\nmissing-bundle-root]
    E -- KokoroEngineDiscoveryResult --> H[startVoice\nbundleRoot=''\nkokoroOnly=kokoro]
    D --> I[EngineVoiceBridge.start\nnormal FFI path]
    H --> J[EngineVoiceBridge.start\nkokoroOnly branch]
    J --> K[startKokoroOnly\nKokoroOnnxRuntime\nKokoroTtsBackend\nno-op lifecycle loaders]
    I --> G
    K --> G
    G --> L[return bridge]
```

<sub>Reviews (2): Last reviewed commit: ["feat(local-inference/voice): Kokoro-only..."](https://github.com/elizaos/eliza/commit/83b8e7207c44ba0d9ce24f69b8ca6a22c8f7075d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32044441)</sub>

<!-- /greptile_comment -->