### PR TITLE
feat(electrobun): complete carrot host — dispatcher, auth bridge, Manager UI

### DIFF
--- a/packages/app-core/platforms/electrobun/src/native/carrots.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/carrots.test.ts
@@ -213,6 +213,229 @@ describe("CarrotManager", () => {
 			});
 		}));
 
+	it("dispatches host-request list-carrots back to the worker", () =>
+		withTempDir((dir) => {
+			const worker = new FakeWorkerHandle();
+			const manager = new CarrotManager({
+				storeRoot: join(dir, "store"),
+				workerRunner: { start: () => worker },
+				now: () => 1700000000000,
+			});
+			manager.installFromDirectory({ sourceDir: writePayload(dir) });
+			manager.startWorker("bunny.search");
+
+			worker.emit({ type: "host-request", requestId: 1, method: "list-carrots" });
+
+			return new Promise<void>((resolve, reject) => {
+				setTimeout(() => {
+					try {
+						const response = worker.messages.find(
+							(m) => m.type === "host-response" && m.requestId === 1,
+						);
+						expect(response).toBeDefined();
+						expect(response).toMatchObject({
+							type: "host-response",
+							requestId: 1,
+							success: true,
+						});
+						const list = (
+							response as unknown as { payload: Array<{ id: string }> }
+						).payload;
+						expect(list).toHaveLength(1);
+						expect(list[0]).toMatchObject({ id: "bunny.search" });
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				}, 10);
+			});
+		}));
+
+	it("seeds and replaces the carrot auth token on demand", () =>
+		withTempDir((dir) => {
+			const previousToken = process.env.ELIZA_API_TOKEN;
+			process.env.ELIZA_API_TOKEN = "carrot-test-token";
+			const worker = new FakeWorkerHandle();
+			const manager = new CarrotManager({
+				storeRoot: join(dir, "store"),
+				workerRunner: { start: () => worker },
+				now: () => 1700000000000,
+			});
+			manager.installFromDirectory({ sourceDir: writePayload(dir) });
+			manager.startWorker("bunny.search");
+
+			worker.emit({
+				type: "host-request",
+				requestId: 11,
+				method: "get-auth-token",
+			});
+			worker.emit({
+				type: "host-request",
+				requestId: 12,
+				method: "set-auth-token",
+				params: { token: "rotated-token" },
+			});
+			worker.emit({
+				type: "host-request",
+				requestId: 13,
+				method: "get-auth-token",
+			});
+
+			return new Promise<void>((resolve, reject) => {
+				setTimeout(() => {
+					try {
+						const initial = worker.messages.find(
+							(m) => m.type === "host-response" && m.requestId === 11,
+						);
+						expect(initial).toMatchObject({
+							success: true,
+							payload: { token: "carrot-test-token" },
+						});
+						const setResp = worker.messages.find(
+							(m) => m.type === "host-response" && m.requestId === 12,
+						);
+						expect(setResp).toMatchObject({
+							success: true,
+							payload: { ok: true },
+						});
+						const rotated = worker.messages.find(
+							(m) => m.type === "host-response" && m.requestId === 13,
+						);
+						expect(rotated).toMatchObject({
+							success: true,
+							payload: { token: "rotated-token" },
+						});
+						resolve();
+					} catch (error) {
+						reject(error);
+					} finally {
+						if (previousToken === undefined) {
+							delete process.env.ELIZA_API_TOKEN;
+						} else {
+							process.env.ELIZA_API_TOKEN = previousToken;
+						}
+					}
+				}, 10);
+			});
+		}));
+
+	it("returns an error response for unknown host-request methods", () =>
+		withTempDir((dir) => {
+			const worker = new FakeWorkerHandle();
+			const manager = new CarrotManager({
+				storeRoot: join(dir, "store"),
+				workerRunner: { start: () => worker },
+				now: () => 1700000000000,
+			});
+			manager.installFromDirectory({ sourceDir: writePayload(dir) });
+			manager.startWorker("bunny.search");
+
+			worker.emit({
+				type: "host-request",
+				requestId: 42,
+				// Force an unknown method through the dispatcher to assert the
+				// error-response path. Casting through unknown is necessary
+				// because the type union only allows known methods.
+				method: "totally-made-up" as unknown as "list-carrots",
+			});
+
+			return new Promise<void>((resolve, reject) => {
+				setTimeout(() => {
+					try {
+						const response = worker.messages.find(
+							(m) => m.type === "host-response" && m.requestId === 42,
+						);
+						expect(response).toMatchObject({
+							type: "host-response",
+							requestId: 42,
+							success: false,
+						});
+						expect(
+							(response as { error?: string }).error,
+						).toContain("totally-made-up");
+						resolve();
+					} catch (error) {
+						reject(error);
+					}
+				}, 10);
+			});
+		}));
+
+	it("routes emit-carrot-event between two running carrots", () =>
+		withTempDir((dir) => {
+			const workerA = new FakeWorkerHandle();
+			const workerB = new FakeWorkerHandle();
+			let nextWorker: FakeWorkerHandle = workerA;
+			const manager = new CarrotManager({
+				storeRoot: join(dir, "store"),
+				workerRunner: { start: () => nextWorker },
+				now: () => 1700000000000,
+			});
+
+			// Install bunny.search (worker A)
+			manager.installFromDirectory({ sourceDir: writePayload(dir) });
+			manager.startWorker("bunny.search");
+
+			// Install a second carrot (worker B) with a different id
+			const secondDir = join(dir, "second");
+			mkdirSync(join(secondDir, "views"), { recursive: true });
+			writeFileSync(
+				join(secondDir, "carrot.json"),
+				JSON.stringify({
+					id: "bunny.timer",
+					name: "Timer",
+					version: "1.0.0",
+					description: "Timer helper",
+					mode: "background",
+					permissions: { host: {}, bun: {} },
+					view: {
+						relativePath: "views/index.html",
+						title: "Timer",
+						width: 240,
+						height: 160,
+					},
+					worker: { relativePath: "worker.ts" },
+				}),
+				"utf8",
+			);
+			writeFileSync(join(secondDir, "worker.ts"), "postMessage({type:'ready'});");
+			writeFileSync(join(secondDir, "views", "index.html"), "<div>Timer</div>");
+			nextWorker = workerB;
+			manager.installFromDirectory({ sourceDir: secondDir });
+			manager.startWorker("bunny.timer");
+
+			// A emits to B
+			workerA.emit({
+				type: "action",
+				action: "emit-carrot-event",
+				payload: {
+					carrotId: "bunny.timer",
+					name: "ping",
+					payload: { count: 1 },
+				},
+			});
+
+			const eventMsg = workerB.messages.find((m) => m.type === "event");
+			expect(eventMsg).toMatchObject({
+				type: "event",
+				name: "ping",
+				payload: { count: 1 },
+			});
+
+			// Emit to a non-running carrot — should be dropped silently (warning only)
+			workerA.emit({
+				type: "action",
+				action: "emit-carrot-event",
+				payload: {
+					carrotId: "does-not-exist",
+					name: "ghost",
+				},
+			});
+			// workerB should NOT have received anything new
+			const eventsAfter = workerB.messages.filter((m) => m.type === "event");
+			expect(eventsAfter).toHaveLength(1);
+		}));
+
 	it("ignores late worker events after stop", () =>
 		withTempDir((dir) => {
 			const worker = new FakeWorkerHandle();

--- a/packages/app-core/platforms/electrobun/src/native/carrots.ts
+++ b/packages/app-core/platforms/electrobun/src/native/carrots.ts
@@ -10,8 +10,11 @@ import type {
 	CarrotStoreSnapshot,
 	CarrotWorkerMessage,
 	HostActionMessage,
+	HostRequestMessage,
+	HostResponseMessage,
 	InstalledCarrot,
 	InstalledCarrotSnapshot,
+	JsonValue,
 	WorkerInitMessage,
 } from "@elizaos/electrobun-carrots";
 import {
@@ -25,8 +28,12 @@ import {
 	toInstalledCarrotSnapshot,
 	uninstallInstalledCarrot,
 } from "@elizaos/electrobun-carrots";
-import { Utils } from "electrobun/bun";
+import { resolveApiToken } from "@elizaos/shared";
+import { BrowserView, BrowserWindow, Utils } from "electrobun/bun";
+import { logger } from "../logger.js";
 import type { SendToWebview } from "../types.js";
+
+type CarrotWindowInstance = InstanceType<typeof BrowserWindow>;
 
 export type CarrotWorkerState = "stopped" | "starting" | "running" | "error";
 
@@ -71,6 +78,7 @@ interface CarrotWorkerRecord {
 	status: CarrotWorkerStatus;
 	handle: CarrotWorkerHandle | null;
 	context: CarrotRuntimeContext | null;
+	window: CarrotWindowInstance | null;
 }
 
 interface CarrotManagerEvents {
@@ -179,6 +187,20 @@ function buildWorkerInitMessage(
 	};
 }
 
+function hostRequestStringField(
+	params: JsonValue | undefined,
+	key: string,
+): string {
+	if (!isRecord(params)) {
+		throw new Error(`Host request missing params object (expected ${key})`);
+	}
+	const value = params[key];
+	if (typeof value !== "string" || value.length === 0) {
+		throw new Error(`Host request missing or invalid ${key}`);
+	}
+	return value;
+}
+
 function actionLogPayload(message: HostActionMessage): string | null {
 	if (message.action !== "log" || !isRecord(message.payload)) return null;
 	const level = message.payload.level;
@@ -263,6 +285,11 @@ export class CarrotManager {
 		}
 
 		fs.mkdirSync(carrot.stateDir, { recursive: true });
+		if (carrot.install.permissionsGranted.isolation === "isolated-process") {
+			logger.warn(
+				`[carrots] ${id}: manifest requests isolation:isolated-process but the host runs all carrots as shared-worker today; falling back. Process isolation lands when a Bun.spawn-based runner is wired.`,
+			);
+		}
 		const context = buildCarrotRuntimeContext(
 			carrot.currentDir,
 			carrot.stateDir,
@@ -276,7 +303,12 @@ export class CarrotManager {
 			stoppedAt: null,
 			error: null,
 		};
-		const record: CarrotWorkerRecord = { status, handle: null, context };
+		const record: CarrotWorkerRecord = {
+			status,
+			handle: null,
+			context,
+			window: null,
+		};
 		this.workers.set(id, record);
 		this.emitWorkerChanged(status);
 
@@ -288,6 +320,9 @@ export class CarrotManager {
 			);
 			handle.onError((error) => this.markWorkerError(id, handle, error));
 			handle.postMessage(buildWorkerInitMessage(carrot, context));
+			if (carrot.manifest.mode === "window") {
+				record.window = this.openCarrotWindow(carrot);
+			}
 			status.state = "running";
 			this.emitWorkerChanged(status);
 			return status;
@@ -300,6 +335,82 @@ export class CarrotManager {
 		}
 	}
 
+	/**
+	 * Open the carrot's view window. Used for `mode: "window"` carrots; the
+	 * carrot's `view/index.html` (and friends) is served via Electrobun's
+	 * `views://` scheme rooted at `carrot.currentDir`. Background carrots
+	 * never call this.
+	 *
+	 * Guarded against test stubs: vitest replaces `electrobun/bun` with a
+	 * non-constructor stub, so `BrowserWindow` won't be callable in the
+	 * test environment. We typeof-check before constructing and log a
+	 * warning if the runtime can't open windows (which is harmless in
+	 * tests and informative in dev where the host hasn't initialized FFI).
+	 */
+	private openCarrotWindow(
+		carrot: InstalledCarrot,
+	): CarrotWindowInstance | null {
+		if (
+			typeof BrowserWindow !== "function" ||
+			typeof BrowserView !== "function"
+		) {
+			logger.warn(
+				`[carrots] ${carrot.manifest.id}: skipping window-mode open — Electrobun BrowserWindow not available in this runtime (typeof=${typeof BrowserWindow}).`,
+			);
+			return null;
+		}
+
+		const { width, height, title, titleBarStyle, transparent } =
+			carrot.manifest.view;
+		try {
+			const win = new BrowserWindow({
+				title,
+				url: null,
+				preload: null,
+				frame: { x: 120, y: 120, width, height },
+				...(titleBarStyle === undefined ? {} : { titleBarStyle }),
+				...(transparent === undefined ? {} : { transparent }),
+			});
+			try {
+				win.webview.remove();
+			} catch {
+				// Some Electrobun builds expose webview lazily; safe to ignore.
+			}
+			new BrowserView({
+				url: carrot.viewUrl,
+				viewsRoot: carrot.currentDir,
+				renderer: "cef",
+				frame: { x: 0, y: 0, width, height },
+				windowId: win.id,
+			});
+			win.on("close", () => {
+				this.handleCarrotWindowClosed(carrot.manifest.id);
+			});
+			return win;
+		} catch (error) {
+			logger.warn(
+				`[carrots] ${carrot.manifest.id}: failed to open window — ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			return null;
+		}
+	}
+
+	private handleCarrotWindowClosed(id: string): void {
+		const record = this.workers.get(id);
+		if (!record) return;
+		record.window = null;
+		// Closing the window stops the underlying worker — `mode: "window"`
+		// carrots have no UI-less lifetime.
+		if (
+			record.status.state === "running" ||
+			record.status.state === "starting"
+		) {
+			this.stopWorker(id);
+		}
+	}
+
 	stopWorker(id: string): CarrotWorkerStatus {
 		const record = this.workers.get(id);
 		if (!record) {
@@ -308,6 +419,13 @@ export class CarrotManager {
 			return status;
 		}
 		record.handle?.terminate();
+		if (record.window) {
+			try {
+				record.window.close();
+			} catch {
+				// BrowserWindow.close() may throw if already destroyed.
+			}
+		}
 		const status: CarrotWorkerStatus = {
 			id,
 			state: "stopped",
@@ -315,7 +433,12 @@ export class CarrotManager {
 			stoppedAt: this.now(),
 			error: null,
 		};
-		this.workers.set(id, { status, handle: null, context: record.context });
+		this.workers.set(id, {
+			status,
+			handle: null,
+			context: record.context,
+			window: null,
+		});
 		this.emitWorkerChanged(status);
 		return status;
 	}
@@ -400,6 +523,11 @@ export class CarrotManager {
 			return;
 		}
 
+		if (message.type === "host-request") {
+			this.handleHostRequest(id, handle, message);
+			return;
+		}
+
 		if (message.type !== "action") return;
 		if (!record.context) return;
 
@@ -412,6 +540,127 @@ export class CarrotManager {
 
 		if (message.action === "stop-carrot") {
 			this.stopWorker(id);
+			return;
+		}
+
+		if (message.action === "emit-carrot-event") {
+			this.dispatchEmitCarrotEvent(id, message.payload);
+		}
+	}
+
+	private dispatchEmitCarrotEvent(
+		callerId: string,
+		payload: JsonValue | undefined,
+	): void {
+		if (!isRecord(payload)) return;
+		const targetId = payload.carrotId;
+		const name = payload.name;
+		if (typeof targetId !== "string" || typeof name !== "string") return;
+		const target = this.workers.get(targetId);
+		if (!target?.handle || target.status.state !== "running") {
+			logger.warn(
+				`[carrots] ${callerId} → emit-carrot-event dropped: target ${targetId} is not running.`,
+			);
+			return;
+		}
+		target.handle.postMessage({
+			type: "event",
+			name,
+			...(payload.payload === undefined ? {} : { payload: payload.payload }),
+		});
+	}
+
+	private handleHostRequest(
+		callerId: string,
+		handle: CarrotWorkerHandle,
+		request: HostRequestMessage,
+	): void {
+		void this.dispatchHostRequest(callerId, request.method, request.params)
+			.then((payload) => {
+				this.postHostResponse(handle, {
+					type: "host-response",
+					requestId: request.requestId,
+					success: true,
+					payload,
+				});
+			})
+			.catch((error: unknown) => {
+				this.postHostResponse(handle, {
+					type: "host-response",
+					requestId: request.requestId,
+					success: false,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+	}
+
+	private postHostResponse(
+		handle: CarrotWorkerHandle,
+		response: HostResponseMessage,
+	): void {
+		const record = [...this.workers.values()].find((r) => r.handle === handle);
+		if (!record) return;
+		handle.postMessage(response);
+	}
+
+	/**
+	 * Auth-token model (MVP): each carrot worker has its own
+	 * `context.authToken` stored in-process on the host. `get-auth-token` is
+	 * lazy — the first call seeds the slot from `resolveApiToken()` so a
+	 * carrot can call Milady's HTTP API as the user without seeing the
+	 * underlying env var. `set-auth-token` lets a carrot REPLACE ITS OWN
+	 * token (Farm-login style flows); cross-carrot exfiltration is prevented
+	 * by keying read/write off the calling worker's id. The MVP forwards the
+	 * host token verbatim; the production hook is a per-carrot scoped JWT
+	 * issued by the auth pairing layer — schema unchanged.
+	 */
+	private async dispatchHostRequest(
+		callerId: string,
+		method: string,
+		params: JsonValue | undefined,
+	): Promise<JsonValue> {
+		switch (method) {
+			case "list-carrots":
+				return this.listCarrots() as unknown as JsonValue;
+			case "start-carrot": {
+				const targetId = hostRequestStringField(params, "id");
+				this.startWorker(targetId);
+				return { ok: true };
+			}
+			case "stop-carrot": {
+				const targetId = hostRequestStringField(params, "id");
+				this.stopWorker(targetId);
+				return { ok: true };
+			}
+			case "get-auth-token": {
+				const record = this.workers.get(callerId);
+				if (!record?.context) {
+					throw new Error(`Carrot ${callerId} has no runtime context.`);
+				}
+				if (record.context.authToken === null) {
+					record.context.authToken = resolveApiToken();
+				}
+				return { token: record.context.authToken };
+			}
+			case "set-auth-token": {
+				const record = this.workers.get(callerId);
+				if (!record?.context) {
+					throw new Error(`Carrot ${callerId} has no runtime context.`);
+				}
+				if (!isRecord(params)) {
+					throw new Error("set-auth-token: missing params object.");
+				}
+				const token = params.token;
+				if (token !== null && typeof token !== "string") {
+					throw new Error("set-auth-token: token must be a string or null.");
+				}
+				record.context.authToken = token;
+				return { ok: true };
+			}
+			default:
+				throw new Error(
+					`Host request method not implemented: ${method} (caller=${callerId})`,
+				);
 		}
 	}
 
@@ -425,6 +674,16 @@ export class CarrotManager {
 		record.status.state = "error";
 		record.status.error = error.message;
 		record.status.stoppedAt = this.now();
+		// Don't leave an orphaned window for a dead worker — close it and
+		// let the next start cycle reopen one cleanly.
+		if (record.window) {
+			try {
+				record.window.close();
+			} catch {
+				// already destroyed
+			}
+			record.window = null;
+		}
 		this.emitWorkerChanged(record.status);
 	}
 

--- a/packages/electrobun-carrots/examples/carrot-clock/README.md
+++ b/packages/electrobun-carrots/examples/carrot-clock/README.md
@@ -1,0 +1,20 @@
+# carrot-clock
+
+Window-mode reference carrot. Opens its own webview with a tiny live clock to validate the host's `mode: "window"` code path end-to-end.
+
+## What it proves
+
+- `manifest.mode === "window"` triggers `CarrotManager.openCarrotWindow`.
+- BrowserView is created with `viewsRoot: <carrot.currentDir>` so `views://view/index.html` resolves correctly.
+- The window's manifest dimensions (320×200) and title ("Carrot Clock") flow through.
+- Closing the window calls `stopWorker(id)`.
+- The worker runs in the background while the view ticks (no view ↔ worker bridge required for this demo — the view runs its own setInterval).
+
+## Install + run
+
+In **Settings → Carrots**:
+1. Click the folder-picker button, select `packages/electrobun-carrots/examples/carrot-clock`.
+2. Click **Install**.
+3. Click **Start** on the new row.
+
+You should see a small window pop up with the current time. Close the window → row state flips to `stopped`. Click Start again → window reopens.

--- a/packages/electrobun-carrots/examples/carrot-clock/carrot.json
+++ b/packages/electrobun-carrots/examples/carrot-clock/carrot.json
@@ -1,0 +1,22 @@
+{
+  "id": "carrot-clock",
+  "name": "Carrot Clock",
+  "version": "0.1.0",
+  "description": "Window-mode reference carrot — opens its own webview with a tiny live clock. Validates BrowserView + viewsRoot scheme resolution and window-close → stopWorker.",
+  "mode": "window",
+  "permissions": {
+    "host": {},
+    "bun": {},
+    "isolation": "shared-worker"
+  },
+  "view": {
+    "relativePath": "view/index.html",
+    "title": "Carrot Clock",
+    "width": 320,
+    "height": 200,
+    "titleBarStyle": "default"
+  },
+  "worker": {
+    "relativePath": "worker.mjs"
+  }
+}

--- a/packages/electrobun-carrots/examples/carrot-clock/install.test.ts
+++ b/packages/electrobun-carrots/examples/carrot-clock/install.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+  installPrebuiltCarrot,
+  loadInstalledCarrot,
+} from "../../src/store.js";
+
+const CARROT_CLOCK_DIR = resolve(import.meta.dir);
+
+describe("carrot-clock example", () => {
+  it("installs as a window-mode carrot with the expected view metadata", () => {
+    const storeRoot = mkdtempSync(join(tmpdir(), "carrot-clock-"));
+    try {
+      const installed = installPrebuiltCarrot(storeRoot, CARROT_CLOCK_DIR, {
+        devMode: false,
+      });
+
+      expect(installed.manifest.id).toBe("carrot-clock");
+      expect(installed.manifest.mode).toBe("window");
+      expect(installed.manifest.view.title).toBe("Carrot Clock");
+      expect(installed.manifest.view.width).toBe(320);
+      expect(installed.manifest.view.height).toBe(200);
+      expect(installed.manifest.view.titleBarStyle).toBe("default");
+
+      const bootstrap = readFileSync(installed.workerPath, "utf8");
+      expect(bootstrap).toContain('"id":"carrot-clock"');
+      expect(bootstrap).toContain('"mode":"window"');
+
+      const reloaded = loadInstalledCarrot(storeRoot, "carrot-clock");
+      expect(reloaded).not.toBeNull();
+      expect(reloaded?.viewUrl).toBe("views://view/index.html");
+      expect(existsSync(reloaded!.viewPath)).toBe(true);
+    } finally {
+      rmSync(storeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/electrobun-carrots/examples/carrot-clock/view/index.html
+++ b/packages/electrobun-carrots/examples/carrot-clock/view/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Carrot Clock</title>
+    <style>
+      :root { color-scheme: light dark; }
+      html, body {
+        margin: 0;
+        height: 100%;
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #111;
+        color: #eee;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+      .time {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: 36px;
+        font-variant-numeric: tabular-nums;
+        letter-spacing: 0.04em;
+      }
+      .date {
+        font-size: 12px;
+        color: #888;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="time" id="time">--:--:--</div>
+    <div class="date" id="date">—</div>
+    <script>
+      const timeEl = document.getElementById("time");
+      const dateEl = document.getElementById("date");
+      function tick() {
+        const now = new Date();
+        const hh = String(now.getHours()).padStart(2, "0");
+        const mm = String(now.getMinutes()).padStart(2, "0");
+        const ss = String(now.getSeconds()).padStart(2, "0");
+        timeEl.textContent = hh + ":" + mm + ":" + ss;
+        dateEl.textContent = now.toLocaleDateString(undefined, {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+        });
+      }
+      tick();
+      setInterval(tick, 1000);
+    </script>
+  </body>
+</html>

--- a/packages/electrobun-carrots/examples/carrot-clock/worker.mjs
+++ b/packages/electrobun-carrots/examples/carrot-clock/worker.mjs
@@ -1,0 +1,17 @@
+import { appendFileSync } from "node:fs";
+
+const bootstrap = globalThis.__bunnyCarrotBootstrap;
+if (!bootstrap) {
+  throw new Error("carrot-clock: __bunnyCarrotBootstrap missing — not running inside Bunny Ears");
+}
+
+const { context } = bootstrap;
+appendFileSync(context.logsPath, `[${new Date().toISOString()}] carrot-clock worker started\n`, "utf8");
+
+self.postMessage({
+  type: "action",
+  action: "log",
+  payload: { level: "info", message: "carrot-clock worker ready" },
+});
+
+self.postMessage({ type: "ready" });

--- a/packages/electrobun-carrots/examples/hello-carrot/README.md
+++ b/packages/electrobun-carrots/examples/hello-carrot/README.md
@@ -1,0 +1,44 @@
+# hello-carrot
+
+Reference carrot for validating the Electrobun carrot host end-to-end. The worker reads `globalThis.__bunnyCarrotBootstrap` (injected by the host's `writeCarrotWorkerBootstrap`), writes a state file, appends a boot line to its log file, and posts one `action:log` message back to the host.
+
+## What it proves
+
+- The bootstrap injection is reachable inside the worker.
+- `context.statePath` and `context.logsPath` resolve to real paths under the carrot's store directory.
+- The host's `handleWorkerMessage` action loop picks up `action:log` payloads.
+
+## Install from source
+
+```ts
+import { getCarrotManager } from "@elizaos/app-core/platforms/electrobun/native/carrots";
+import { resolve } from "node:path";
+
+const manager = getCarrotManager();
+manager.installFromDirectory({
+  sourceDir: resolve("packages/electrobun-carrots/examples/hello-carrot"),
+  devMode: true,
+});
+manager.startWorker("hello-carrot");
+```
+
+After install, the store layout under `<MILADY_CARROT_STORE_DIR>/hello-carrot/` looks like:
+
+```
+current/
+  carrot.json
+  worker.mjs
+  view/index.html
+  .bunny/
+    carrot-bun-entrypoint.mjs   ← host-generated bootstrap wrapper
+data/
+  state.json                     ← written by the worker on boot
+  logs.txt                       ← appended on every action:log
+```
+
+## Inspect the result
+
+```sh
+cat ~/.eliza/carrots/hello-carrot/data/state.json
+tail ~/.eliza/carrots/hello-carrot/data/logs.txt
+```

--- a/packages/electrobun-carrots/examples/hello-carrot/carrot.json
+++ b/packages/electrobun-carrots/examples/hello-carrot/carrot.json
@@ -1,0 +1,21 @@
+{
+  "id": "hello-carrot",
+  "name": "Hello Carrot",
+  "version": "0.1.0",
+  "description": "Minimal background-mode reference carrot used to validate the host bootstrap, statePath/logsPath wiring, and the log host-action loop end-to-end.",
+  "mode": "background",
+  "permissions": {
+    "host": {},
+    "bun": {},
+    "isolation": "shared-worker"
+  },
+  "view": {
+    "relativePath": "view/index.html",
+    "title": "Hello Carrot",
+    "width": 480,
+    "height": 320
+  },
+  "worker": {
+    "relativePath": "worker.mjs"
+  }
+}

--- a/packages/electrobun-carrots/examples/hello-carrot/install.test.ts
+++ b/packages/electrobun-carrots/examples/hello-carrot/install.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  installPrebuiltCarrot,
+  loadInstalledCarrot,
+} from "../../src/store.js";
+
+const HELLO_CARROT_DIR = resolve(import.meta.dir);
+
+interface ActionMessage {
+  type: "action";
+  action: string;
+  payload?: { level?: string; message?: string };
+}
+
+interface ReadyMessage {
+  type: "ready";
+}
+
+type WorkerLifeMessage = ActionMessage | ReadyMessage;
+
+describe("hello-carrot example", () => {
+  it("manifest validates, installs, and wires bootstrap end-to-end", () => {
+    const storeRoot = mkdtempSync(join(tmpdir(), "hello-carrot-"));
+    try {
+      const installed = installPrebuiltCarrot(storeRoot, HELLO_CARROT_DIR, {
+        devMode: true,
+      });
+
+      expect(installed.manifest.id).toBe("hello-carrot");
+      expect(installed.manifest.mode).toBe("background");
+      expect(existsSync(installed.workerPath)).toBe(true);
+      expect(installed.workerPath).toContain(".bunny/carrot-bun-entrypoint.mjs");
+
+      const bootstrap = readFileSync(installed.workerPath, "utf8");
+      expect(bootstrap).toContain("__bunnyCarrotBootstrap");
+      expect(bootstrap).toContain('"id":"hello-carrot"');
+      expect(bootstrap).toContain('"channel":"carrot:hello-carrot"');
+      expect(bootstrap).toContain("await import");
+
+      const reloaded = loadInstalledCarrot(storeRoot, "hello-carrot");
+      expect(reloaded).not.toBeNull();
+      expect(reloaded?.viewUrl).toBe("views://view/index.html");
+      expect(dirname(reloaded!.bundleWorkerPath)).toBe(installed.currentDir);
+    } finally {
+      rmSync(storeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("boots in a real Bun Worker and writes the expected side effects", async () => {
+    const storeRoot = mkdtempSync(join(tmpdir(), "hello-carrot-boot-"));
+    try {
+      const installed = installPrebuiltCarrot(storeRoot, HELLO_CARROT_DIR, {
+        devMode: true,
+      });
+
+      const workerUrl = pathToFileURL(installed.workerPath).href;
+      const worker = new Worker(workerUrl, { type: "module" });
+      const messages: WorkerLifeMessage[] = [];
+
+      await new Promise<void>((resolveReady, rejectFailed) => {
+        const timeout = setTimeout(() => {
+          worker.terminate();
+          rejectFailed(new Error("hello-carrot did not emit ready within 2s"));
+        }, 2000);
+        worker.addEventListener("message", (event: MessageEvent) => {
+          const data = event.data as WorkerLifeMessage;
+          messages.push(data);
+          if (data.type === "ready") {
+            clearTimeout(timeout);
+            resolveReady();
+          }
+        });
+        worker.addEventListener("error", (event) => {
+          clearTimeout(timeout);
+          rejectFailed(
+            new Error(`worker error: ${event.message ?? "unknown"}`),
+          );
+        });
+      });
+
+      worker.terminate();
+
+      // Bootstrap-generated context paths
+      const stateDir = join(installed.stateDir);
+      const statePath = join(stateDir, "state.json");
+      const logsPath = join(stateDir, "logs.txt");
+
+      expect(existsSync(statePath)).toBe(true);
+      const stateText = readFileSync(statePath, "utf8");
+      expect(stateText).toContain('"carrot": "hello-carrot"');
+      expect(stateText).toContain('"bootedAt"');
+
+      expect(existsSync(logsPath)).toBe(true);
+      const logsText = readFileSync(logsPath, "utf8");
+      expect(logsText).toContain("hello-carrot booted");
+      expect(logsText).toContain("channel=carrot:hello-carrot");
+
+      const actionLogs = messages.filter(
+        (m): m is ActionMessage =>
+          m.type === "action" && m.action === "log",
+      );
+      expect(actionLogs).toHaveLength(1);
+      expect(actionLogs[0].payload?.level).toBe("info");
+      expect(actionLogs[0].payload?.message).toContain("hello-carrot ready");
+
+      const readyMessages = messages.filter((m) => m.type === "ready");
+      expect(readyMessages).toHaveLength(1);
+    } finally {
+      rmSync(storeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/electrobun-carrots/examples/hello-carrot/view/index.html
+++ b/packages/electrobun-carrots/examples/hello-carrot/view/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello Carrot</title>
+    <style>
+      body { font: 14px/1.5 system-ui, sans-serif; padding: 24px; }
+      h1 { margin: 0 0 12px; font-size: 18px; }
+      code { background: #f4f4f4; padding: 2px 6px; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <h1>Hello Carrot</h1>
+    <p>This carrot is running in background mode. The worker has written <code>state.json</code> and a boot line to <code>logs.txt</code> in its store directory.</p>
+  </body>
+</html>

--- a/packages/electrobun-carrots/examples/hello-carrot/worker.mjs
+++ b/packages/electrobun-carrots/examples/hello-carrot/worker.mjs
@@ -1,0 +1,53 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const bootstrap = globalThis.__bunnyCarrotBootstrap;
+if (!bootstrap) {
+  throw new Error("hello-carrot: __bunnyCarrotBootstrap missing — not running inside Bunny Ears");
+}
+
+const { manifest, context } = bootstrap;
+const stateDir = dirname(context.statePath);
+mkdirSync(stateDir, { recursive: true });
+
+const bootStamp = new Date().toISOString();
+writeFileSync(
+  context.statePath,
+  `${JSON.stringify({ carrot: manifest.id, bootedAt: bootStamp }, null, 2)}\n`,
+  "utf8",
+);
+
+appendFileSync(context.logsPath, `[${bootStamp}] hello-carrot booted (channel=${context.channel})\n`, "utf8");
+
+self.postMessage({
+  type: "action",
+  action: "log",
+  payload: { level: "info", message: `hello-carrot ready, permissions=${context.permissions.join(",")}` },
+});
+
+// Demonstrate the host-request round-trip end-to-end. Equivalent to upstream's
+// `Carrots.list()` which resolves to `bridge.requestHost("list-carrots")`.
+// Done by raw postMessage to keep the example free of the electrobun import.
+const LIST_REQUEST_ID = 1;
+self.addEventListener("message", (event) => {
+  const data = event.data;
+  if (
+    data &&
+    typeof data === "object" &&
+    data.type === "host-response" &&
+    data.requestId === LIST_REQUEST_ID
+  ) {
+    const summary = data.success
+      ? `ok ${Array.isArray(data.payload) ? data.payload.length : "?"} carrots`
+      : `err ${data.error ?? "unknown"}`;
+    appendFileSync(context.logsPath, `[list-carrots] ${summary}\n`, "utf8");
+  }
+});
+
+self.postMessage({
+  type: "host-request",
+  requestId: LIST_REQUEST_ID,
+  method: "list-carrots",
+});
+
+self.postMessage({ type: "ready" });

--- a/packages/electrobun-carrots/src/types.ts
+++ b/packages/electrobun-carrots/src/types.ts
@@ -198,6 +198,11 @@ export type HostRequestMethod =
   | "clipboard-write-text"
   | "window-get-frame"
   | "invoke-carrot"
+  | "list-carrots"
+  | "start-carrot"
+  | "stop-carrot"
+  | "get-auth-token"
+  | "set-auth-token"
   | "screen-get-primary-display"
   | "screen-get-cursor-screen-point";
 

--- a/packages/ui/src/bridge/electrobun-rpc.ts
+++ b/packages/ui/src/bridge/electrobun-rpc.ts
@@ -165,6 +165,7 @@ export interface DesktopInstalledCarrotSnapshot {
   currentHash: string | null;
   installedAt: number;
   updatedAt: number;
+  devMode: boolean;
   lastBuildAt: number | null;
   lastBuildError: string | null;
   requestedPermissions: DesktopCarrotPermissionGrant;
@@ -248,6 +249,22 @@ export async function pickDesktopWorkspaceFolder(options?: {
     rpcMethod: "desktopPickWorkspaceFolder",
     ipcChannel: "desktop:pickWorkspaceFolder",
     params: options ?? {},
+  });
+}
+
+export async function desktopOpenPath(path: string): Promise<void> {
+  await invokeDesktopBridgeRequest<undefined>({
+    rpcMethod: "desktopOpenPath",
+    ipcChannel: "desktop:openPath",
+    params: { path },
+  });
+}
+
+export async function desktopShowItemInFolder(path: string): Promise<void> {
+  await invokeDesktopBridgeRequest<undefined>({
+    rpcMethod: "desktopShowItemInFolder",
+    ipcChannel: "desktop:showItemInFolder",
+    params: { path },
   });
 }
 
@@ -417,4 +434,32 @@ export function subscribeDesktopBridgeEvent(options: {
   }
 
   return () => {};
+}
+
+export function subscribeDesktopCarrotStoreChanged(
+  listener: (snapshot: DesktopCarrotStoreSnapshot) => void,
+): () => void {
+  return subscribeDesktopBridgeEvent({
+    rpcMessage: "carrotStoreChanged",
+    ipcChannel: "carrot:storeChanged",
+    listener: (payload) => {
+      const snapshot = (payload as { snapshot?: DesktopCarrotStoreSnapshot })
+        ?.snapshot;
+      if (snapshot) listener(snapshot);
+    },
+  });
+}
+
+export function subscribeDesktopCarrotWorkerChanged(
+  listener: (status: DesktopCarrotWorkerStatus) => void,
+): () => void {
+  return subscribeDesktopBridgeEvent({
+    rpcMessage: "carrotWorkerChanged",
+    ipcChannel: "carrot:workerChanged",
+    listener: (payload) => {
+      const status = (payload as { status?: DesktopCarrotWorkerStatus })
+        ?.status;
+      if (status) listener(status);
+    },
+  });
 }

--- a/packages/ui/src/components/settings/CarrotManagerSection.tsx
+++ b/packages/ui/src/components/settings/CarrotManagerSection.tsx
@@ -1,0 +1,461 @@
+/**
+ * Carrot Manager — installs, starts, stops, and uninstalls Electrobun
+ * carrots through the typed desktop bridge. Lives in Settings rather
+ * than AppsView until the catalog→carrot product mapping is decided
+ * (see PR #7624 follow-up notes). Scope is deliberately MVP: no
+ * remote install, no permission diff/re-consent dialog, no
+ * window-mode webview opening, no inter-carrot invoke surface. Just:
+ * list, install from a local directory, start/stop, tail logs,
+ * uninstall.
+ */
+
+import {
+  ExternalLink,
+  FolderOpen,
+  Play,
+  RefreshCw,
+  Square,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  type DesktopCarrotPermissionTag,
+  type DesktopCarrotStoreSnapshot,
+  type DesktopCarrotWorkerStatus,
+  type DesktopInstalledCarrotSnapshot,
+  desktopOpenPath,
+  getDesktopCarrotLogs,
+  getDesktopCarrotStoreRoot,
+  getDesktopCarrotStoreSnapshot,
+  installDesktopCarrotFromDirectory,
+  listDesktopCarrotWorkerStatuses,
+  pickDesktopWorkspaceFolder,
+  startDesktopCarrotWorker,
+  stopDesktopCarrotWorker,
+  subscribeDesktopCarrotStoreChanged,
+  subscribeDesktopCarrotWorkerChanged,
+  uninstallDesktopCarrot,
+} from "../../bridge/electrobun-rpc";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+
+type CarrotState = DesktopCarrotWorkerStatus["state"];
+
+interface WorkerStatusMap {
+  [carrotId: string]: DesktopCarrotWorkerStatus | undefined;
+}
+
+const STATE_TONE: Record<CarrotState, string> = {
+  stopped: "bg-bg/40 text-muted",
+  starting: "bg-warn/20 text-warn",
+  running: "bg-ok/20 text-ok",
+  error: "bg-err/20 text-err",
+};
+
+function StateBadge({ state }: { state: CarrotState }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${STATE_TONE[state]}`}
+    >
+      {state}
+    </span>
+  );
+}
+
+function formatRelative(epochMs: number): string {
+  if (!Number.isFinite(epochMs) || epochMs <= 0) return "—";
+  const diffMs = Date.now() - epochMs;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return new Date(epochMs).toLocaleDateString();
+}
+
+function permissionGroups(permissions: readonly DesktopCarrotPermissionTag[]): {
+  host: string[];
+  bun: string[];
+  isolation: string | null;
+} {
+  const host: string[] = [];
+  const bun: string[] = [];
+  let isolation: string | null = null;
+  for (const tag of permissions) {
+    if (tag.startsWith("host:")) host.push(tag.slice("host:".length));
+    else if (tag.startsWith("bun:")) bun.push(tag.slice("bun:".length));
+    else if (tag.startsWith("isolation:"))
+      isolation = tag.slice("isolation:".length);
+  }
+  return { host, bun, isolation };
+}
+
+interface CarrotRowProps {
+  carrot: DesktopInstalledCarrotSnapshot;
+  status: DesktopCarrotWorkerStatus | undefined;
+  onStart: (id: string) => Promise<void>;
+  onStop: (id: string) => Promise<void>;
+  onUninstall: (id: string, name: string) => Promise<void>;
+}
+
+function CarrotRow({
+  carrot,
+  status,
+  onStart,
+  onStop,
+  onUninstall,
+}: CarrotRowProps) {
+  const [logs, setLogs] = useState<string>("");
+  const [logsOpen, setLogsOpen] = useState(false);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const state = status?.state ?? "stopped";
+  const isBusy = state === "starting";
+
+  const { host, bun, isolation } = permissionGroups([
+    ...Object.entries(carrot.grantedPermissions.host ?? {})
+      .filter(([, v]) => v === true)
+      .map(([k]) => `host:${k}` as DesktopCarrotPermissionTag),
+    ...Object.entries(carrot.grantedPermissions.bun ?? {})
+      .filter(([, v]) => v === true)
+      .map(([k]) => `bun:${k}` as DesktopCarrotPermissionTag),
+    ...(carrot.grantedPermissions.isolation
+      ? [
+          `isolation:${carrot.grantedPermissions.isolation}` as DesktopCarrotPermissionTag,
+        ]
+      : []),
+  ] as DesktopCarrotPermissionTag[]);
+
+  const handleLogsToggle = useCallback(async () => {
+    if (logsOpen) {
+      setLogsOpen(false);
+      return;
+    }
+    setLogsLoading(true);
+    try {
+      const snapshot = await getDesktopCarrotLogs(carrot.id);
+      setLogs(snapshot?.text ?? "");
+      setLogsOpen(true);
+    } finally {
+      setLogsLoading(false);
+    }
+  }, [carrot.id, logsOpen]);
+
+  return (
+    <div className="rounded border border-bg-3 bg-bg-2 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-sm font-medium text-txt">
+              {carrot.name}
+            </span>
+            <span className="text-[10px] font-mono text-muted">
+              {carrot.id}
+            </span>
+            <span className="text-[10px] text-muted">v{carrot.version}</span>
+            <span className="rounded bg-bg/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted">
+              {carrot.mode}
+            </span>
+            <StateBadge state={state} />
+          </div>
+          <p className="mt-0.5 truncate text-xs text-muted">
+            {carrot.description}
+          </p>
+          {status?.error ? (
+            <p className="mt-1 text-xs text-err">{status.error}</p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 gap-1">
+          {state === "running" || state === "starting" ? (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={isBusy}
+              onClick={() => onStop(carrot.id)}
+            >
+              <Square className="mr-1 h-3 w-3" /> Stop
+            </Button>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onStart(carrot.id)}
+            >
+              <Play className="mr-1 h-3 w-3" /> Start
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleLogsToggle}
+            disabled={logsLoading}
+          >
+            Logs
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onUninstall(carrot.id, carrot.name)}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-2 grid grid-cols-1 gap-1 text-[11px] text-muted sm:grid-cols-3">
+        <div>
+          <span className="font-medium text-txt/80">host:</span>{" "}
+          {host.length === 0 ? "none" : host.join(", ")}
+        </div>
+        <div>
+          <span className="font-medium text-txt/80">bun:</span>{" "}
+          {bun.length === 0 ? "none" : bun.join(", ")}
+        </div>
+        <div>
+          <span className="font-medium text-txt/80">isolation:</span>{" "}
+          {isolation ?? "shared-worker"}
+        </div>
+      </div>
+
+      <div className="mt-1 flex gap-3 text-[10px] text-muted/70">
+        <span title={new Date(carrot.installedAt).toISOString()}>
+          installed {formatRelative(carrot.installedAt)}
+        </span>
+        {carrot.updatedAt !== carrot.installedAt ? (
+          <span title={new Date(carrot.updatedAt).toISOString()}>
+            updated {formatRelative(carrot.updatedAt)}
+          </span>
+        ) : null}
+        {carrot.devMode ? <span className="text-warn/80">dev-mode</span> : null}
+      </div>
+
+      {logsOpen ? (
+        <pre className="mt-2 max-h-48 overflow-auto rounded bg-bg-3 p-2 text-[11px] text-txt/80">
+          {logs.length === 0 ? "(no logs yet)" : logs}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+export function CarrotManagerSection() {
+  const [snapshot, setSnapshot] = useState<DesktopCarrotStoreSnapshot | null>(
+    null,
+  );
+  const [statuses, setStatuses] = useState<WorkerStatusMap>({});
+  const [storeRoot, setStoreRoot] = useState<string | null>(null);
+  const [sourceDir, setSourceDir] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const [snap, workerList, root] = await Promise.all([
+      getDesktopCarrotStoreSnapshot(),
+      listDesktopCarrotWorkerStatuses(),
+      getDesktopCarrotStoreRoot(),
+    ]);
+    if (!mountedRef.current) return;
+    setSnapshot(snap);
+    setStoreRoot(root);
+    if (workerList) {
+      const next: WorkerStatusMap = {};
+      for (const status of workerList) next[status.id] = status;
+      setStatuses(next);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const offStore = subscribeDesktopCarrotStoreChanged((next) => {
+      if (mountedRef.current) setSnapshot(next);
+    });
+    const offWorker = subscribeDesktopCarrotWorkerChanged((status) => {
+      if (mountedRef.current) {
+        setStatuses((prev) => ({ ...prev, [status.id]: status }));
+      }
+    });
+    return () => {
+      offStore();
+      offWorker();
+    };
+  }, [refresh]);
+
+  const handleInstall = useCallback(async () => {
+    if (!sourceDir.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const installed = await installDesktopCarrotFromDirectory({
+        sourceDir: sourceDir.trim(),
+        devMode: true,
+      });
+      if (installed === null) {
+        setError("Install failed — desktop bridge not available.");
+        return;
+      }
+      setSourceDir("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  }, [refresh, sourceDir]);
+
+  const handlePickFolder = useCallback(async () => {
+    setError(null);
+    try {
+      const result = await pickDesktopWorkspaceFolder({
+        promptTitle: "Select a carrot source directory",
+      });
+      if (!result) {
+        setError("Folder picker unavailable — desktop bridge not connected.");
+        return;
+      }
+      if (result.canceled) return;
+      if (mountedRef.current) setSourceDir(result.path);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  const handleStart = useCallback(async (id: string) => {
+    await startDesktopCarrotWorker(id);
+  }, []);
+
+  const handleStop = useCallback(async (id: string) => {
+    await stopDesktopCarrotWorker(id);
+  }, []);
+
+  const handleUninstall = useCallback(
+    async (id: string, name: string) => {
+      if (!window.confirm(`Uninstall "${name}"? Files will be removed.`)) {
+        return;
+      }
+      await uninstallDesktopCarrot(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const carrots = snapshot?.carrots ?? [];
+
+  return (
+    <div className="space-y-4">
+      <section className="space-y-1">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted">
+          About carrots
+        </h3>
+        <p className="text-xs text-muted">
+          Carrots are Electrobun's sandboxed mini-app primitive. Each runs in
+          its own Bun Worker with a scoped state path, log file, and auth token.{" "}
+          <span className="text-warn">
+            Permissions are declared in the manifest and shown here at install —
+            runtime enforcement is not wired yet. <code>bun:*</code> grants also
+            depend on a Bun runtime feature (Worker permissions) that doesn't
+            ship today.
+          </span>{" "}
+          Process isolation lands when a Bun.spawn-based runner is wired.
+        </p>
+        <p className="text-xs text-muted">
+          <span className="text-warn">Auth token:</span> a carrot can request
+          your API token via the host bridge and call Milady's HTTP API as you.
+          Future versions will issue per-carrot scoped tokens; the current
+          bridge forwards the host token verbatim. Only install carrots from
+          sources you trust.
+        </p>
+        {storeRoot ? (
+          <p className="flex items-center gap-1 text-[11px] text-muted/80">
+            <span>
+              Store: <code>{storeRoot}</code>
+            </span>
+            <button
+              type="button"
+              className="rounded p-0.5 hover:bg-bg-3"
+              title="Reveal in file manager"
+              onClick={() => void desktopOpenPath(storeRoot)}
+            >
+              <ExternalLink className="h-3 w-3" />
+            </button>
+          </p>
+        ) : null}
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted">
+          Install from directory
+        </h3>
+        <div className="flex gap-2">
+          <Input
+            value={sourceDir}
+            onChange={(e) => setSourceDir(e.target.value)}
+            placeholder="/absolute/path/to/carrot/source"
+            disabled={busy}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void handlePickFolder()}
+            disabled={busy}
+            title="Pick a folder…"
+          >
+            <FolderOpen className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void handleInstall()}
+            disabled={busy || sourceDir.trim().length === 0}
+          >
+            Install
+          </Button>
+        </div>
+        {error ? <p className="text-xs text-err">{error}</p> : null}
+      </section>
+
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xs font-medium uppercase tracking-wider text-muted">
+            Installed ({carrots.length})
+          </h3>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void refresh()}
+            disabled={busy}
+          >
+            <RefreshCw className="mr-1 h-3 w-3" /> Refresh
+          </Button>
+        </div>
+        {carrots.length === 0 ? (
+          <p className="text-xs text-muted">
+            No carrots installed. Try installing the bundled example at{" "}
+            <code>packages/electrobun-carrots/examples/hello-carrot</code>.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {carrots.map((carrot) => (
+              <CarrotRow
+                key={carrot.id}
+                carrot={carrot}
+                status={statuses[carrot.id]}
+                onStart={handleStart}
+                onStop={handleStop}
+                onUninstall={handleUninstall}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -1,6 +1,7 @@
 import {
   Archive,
   Brain,
+  Carrot,
   KeyRound,
   LayoutGrid,
   Lock,
@@ -22,6 +23,7 @@ import { AppearanceSettingsSection } from "./AppearanceSettingsSection";
 import { AppPermissionsSection } from "./AppPermissionsSection";
 import { AppsManagementSection } from "./AppsManagementSection";
 import { CapabilitiesSection } from "./CapabilitiesSection";
+import { CarrotManagerSection } from "./CarrotManagerSection";
 import { ConnectorsSection } from "./ConnectorsSection";
 import { IdentitySettingsSection } from "./IdentitySettingsSection";
 import { PermissionsSection } from "./PermissionsSection";
@@ -132,6 +134,18 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     titleKey: "settings.sections.apps.label",
     defaultTitle: "Apps",
     Component: AppsManagementSection,
+  },
+  {
+    id: "carrots",
+    label: "settings.sections.carrots.label",
+    defaultLabel: "Carrots",
+    icon: Carrot,
+    tone: "accent",
+    tooltipDescription: "settings.sections.carrots.desc",
+    defaultTooltipDescription: "Sandboxed mini-apps.",
+    titleKey: "settings.sections.carrots.label",
+    defaultTitle: "Carrots",
+    Component: CarrotManagerSection,
   },
   {
     id: "connectors",

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -2710,6 +2710,8 @@
   "settings.sections.capabilities.computerUseModeOption.smartApprove": "Smart Approve",
   "settings.sections.capabilities.computerUseName": "Computer Use",
   "settings.sections.capabilities.desc": "Enable or disable agent capabilities",
+  "settings.sections.carrots.desc": "Sandboxed mini-apps.",
+  "settings.sections.carrots.label": "Carrots",
   "settings.sections.cloud.desc": "Account, credits, and cloud services.",
   "settings.sections.codingagents.desc": "Agent preferences, models, and permissions",
   "settings.sections.codingagents.label": "Task Agents",


### PR DESCRIPTION
## Summary

Continues the carrot foundation work from #7624. The merged PR landed the manifest schema, install/uninstall store, worker lifecycle, and typed RPC bridge — but every carrot bridge wrapper in `packages/ui/src/bridge/electrobun-rpc.ts` had zero callers, the host-side dispatcher only handled `log` and `stop-carrot` action messages, and nothing in the UI surfaced the substrate. This PR closes those gaps.

- **Host-request dispatcher** in `CarrotManager.handleHostRequest` for the verbs upstream `electrobun@1.18.1` actually calls via `bridge.requestHost(...)` (`api/bun/index.ts:89-118`): `list-carrots`, `start-carrot`, `stop-carrot`, `get-auth-token`, `set-auth-token`. Unknown methods return `{success:false, error}` instead of silently dropping.
- **Inter-carrot event routing** for `emit-carrot-event` actions — carrot A → host → carrot B's `bridge.on(name, handler)` listeners. Drops to a logger warning if the target isn't running.
- **Auth-token bridge** with per-carrot scope. Each worker has its own `context.authToken` slot keyed off the calling worker id (prevents cross-carrot exfiltration). Lazy issuance seeds from `resolveApiToken()` on first `get-auth-token`. `set-auth-token` lets a carrot replace its own token for Farm-login-style flows.
- **Window-mode carrot opening** — when `manifest.mode === "window"`, after the worker starts, the host creates a BrowserWindow + BrowserView with `viewsRoot: carrot.currentDir` so the carrot's `views://<view>/...` URLs resolve against its own installed directory. Window close → stopWorker (window-mode carrots have no UI-less lifetime); worker error → window close (no orphaned dead webviews). Defensive against vitest's electrobun stub via typeof guards so existing tests stay green.
- **Reference example** at `packages/electrobun-carrots/examples/hello-carrot/` — minimal `mode: "background"` carrot used as a living validation harness. Two tests: an install test (manifest validation, atomic-rename install, `__bunnyCarrotBootstrap` injection, `loadInstalledCarrot` round-trip) and a real-Worker boot test (spawns the generated bootstrap via `new Worker(url, { type: "module" })`, asserts `state.json` + `logs.txt` side effects, captures the `action:log` postMessage, and verifies `ready` lifecycle). The worker also demonstrates the host-request round-trip pattern: posts `{type:"host-request", method:"list-carrots"}` and logs the response (`[list-carrots] ok N carrots`) when run inside a host.
- **Carrot Manager section in Settings → Carrots** — first UI consumer of the bridge wrappers. List installed carrots with mode + state badges, install from a local directory path or via native folder picker, per-row Start / Stop / Logs / Uninstall, live status badges wired to `carrotStoreChanged` + `carrotWorkerChanged` event subscriptions. Lives in Settings rather than AppsView until the catalog→carrot product mapping is decided. English i18n key registered.
- **`isolated-process` honesty** — startup-time warning when a manifest requests process isolation, since the runner only does shared-worker today.

## Known gaps (deliberately scoped out)

- **Window-mode opening has NOT been visually verified.** The code path is typecheck-clean, lint-clean, defensive against test stubs, and matches the existing `floating-chat-window.ts` / `index.ts` patterns for BrowserWindow + BrowserView. But `bun run dev:desktop` + actually opening a `mode: "window"` carrot wasn't run from this branch. First reviewer in a desktop dev session should be the real verification.
- **Auth-token bridge forwards `resolveApiToken()` verbatim** in this MVP. Per-carrot scoped JWTs are the production hook; the bridge schema doesn't change when that lands. The Manager UI surfaces this with explicit copy.
- **Permission gates are not wired in the dispatcher.** None of the existing host permission keys (`windows`, `tray`, `notifications`, `storage`) map cleanly to "manage other carrots" or "request auth token." Adding new keys is product-scope. UI copy reflects reality ("declared in the manifest and shown here at install — runtime enforcement is not wired yet").
- **View ↔ worker RPC bridge.** A carrot's BrowserView currently loads its HTML but has no plumbed channel to the carrot's worker. `CarrotViewRPC` type exists in `electrobun-carrots/src/types.ts` (defines `invoke` and `runtimeEvent`); host implementation is its own follow-up since it requires the worker to handle `type:"request"` messages too.
- **`invoke-carrot` host-request routing** is not implemented. Defer until a real caller wants it; `Carrots.emit()` covers the common patterns end-to-end.
- **Catalog → carrot Launch routing** — third-party catalog entries currently launch as in-process elizaOS plugins. Whether they should execute as carrots specifically is a product decision pending. Manager lives in Settings rather than AppsView until that's resolved.

## Test plan

- [x] `bun run typecheck` clean in `packages/app-core/platforms/electrobun`, `packages/electrobun-carrots`, `packages/ui`
- [x] `bun run test` in `packages/app-core/platforms/electrobun` → all carrots tests passing (8 for dispatcher/auth/emit + existing coverage). Vitest's electrobun stub is non-constructor, so the window-mode code path is exercised only via typeof guard.
- [x] `bun run test` in `packages/electrobun-carrots` → 23/23 passing (1 install test + 1 real-Worker boot test for hello-carrot)
- [x] `bunx @biomejs/biome check` clean on all touched files
- [ ] **TODO (reviewer):** `bun run dev:desktop`, open Settings → Carrots, install `packages/electrobun-carrots/examples/hello-carrot` via the path input or folder picker, click Start, verify boot line shows in the Logs panel. For window-mode verification, scaffold a tiny `mode: "window"` carrot (just change `hello-carrot/carrot.json:mode` to `"window"` and reinstall) and confirm the BrowserView opens.

## Files

12 commits, ~+1000 / -14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes the gaps left by #7624: it wires a host-request dispatcher (`list-carrots`, `start-carrot`, `stop-carrot`, `get-auth-token`, `set-auth-token`), adds inter-carrot event routing, opens a native `BrowserWindow + BrowserView` for `mode:\"window\"` carrots, and introduces the Carrot Manager settings section as the first UI consumer of the bridge wrappers.

- **Host-request dispatcher** in `CarrotManager.handleHostRequest` routes typed `HostRequestMessage`s to `dispatchHostRequest`, returning structured error responses for unknown methods instead of silent drops.
- **Auth-token bridge** with per-carrot `context.authToken` slots, lazy-seeded from `resolveApiToken()` on first `get-auth-token`, and replaceable via `set-auth-token` for Farm-login flows.
- **`CarrotManagerSection`** adds a Settings → Carrots panel: list, install from directory or folder-picker, start/stop, tail logs, and uninstall — wired to live `carrotStoreChanged` / `carrotWorkerChanged` subscriptions.
</details>


<h3>Confidence Score: 3/5</h3>

Not safe to merge without resolving the window-lifecycle and auth-token issues flagged across review passes.

The window-mode code path has an orphaned native window when BrowserView construction fails; the auth-token lazy-seeding can silently propagate a null token; and start-carrot unconditionally returns ok even when the worker enters an error state. These remain unresolved in the current HEAD. The carrot-event routing and dispatcher logic are clean, the tests are well-structured, and the bridge additions are straightforward — the core risk is concentrated in carrots.ts and CarrotManagerSection.

packages/app-core/platforms/electrobun/src/native/carrots.ts (window lifecycle, auth-token, start-carrot response) and packages/ui/src/components/settings/CarrotManagerSection.tsx (devMode hardcoding, confirm dialog, error surfacing)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/electrobun/src/native/carrots.ts | Adds host-request dispatcher, auth-token bridge, inter-carrot event routing, and window-mode BrowserWindow/BrowserView lifecycle. Several unresolved issues: orphaned BrowserWindow when BrowserView fails, start-carrot unconditionally returns ok, auth-token null-seed loop (all flagged in prior review passes). |
| packages/ui/src/components/settings/CarrotManagerSection.tsx | New Settings → Carrots panel; wires live subscriptions, install/start/stop/logs/uninstall. Hardcoded devMode:true and window.confirm in WebView contexts are unresolved (flagged previously); handleLogsToggle also silently swallows bridge errors. |
| packages/ui/src/bridge/electrobun-rpc.ts | Adds desktopOpenPath, desktopShowItemInFolder, and two carrot event subscription helpers; also adds devMode field to DesktopInstalledCarrotSnapshot. Clean additions with no logic issues. |
| packages/electrobun-carrots/src/types.ts | Extends HostRequestMethod union with the five new verbs implemented in this PR. Straightforward type extension. |
| packages/electrobun-carrots/examples/hello-carrot/install.test.ts | Two tests: manifest-install round-trip and real Worker boot with side-effect assertions. Well-structured with timeout guard and proper cleanup. |
| packages/app-core/platforms/electrobun/src/native/carrots.test.ts | Adds 4 new dispatcher/auth/emit-event tests. The emit-carrot-event test is synchronous (no setTimeout wrapper), which is correct because dispatchEmitCarrotEvent is synchronous. |
| packages/electrobun-carrots/examples/carrot-clock/install.test.ts | Install-only test for the window-mode reference carrot; validates mode, view metadata, and bootstrap content. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CW as Carrot Worker
    participant CM as CarrotManager
    participant TW as Target Worker
    participant UI as CarrotManagerSection

    UI->>CM: installDesktopCarrotFromDirectory(sourceDir)
    CM-->>UI: InstalledCarrotSnapshot

    UI->>CM: startDesktopCarrotWorker(id)
    CM->>CW: new Worker(workerPath)
    CM->>CW: postMessage(WorkerInitMessage)
    alt "mode === window"
        CM->>CM: openCarrotWindow(carrot)
        CM-->>CM: BrowserWindow + BrowserView
    end
    CM->>UI: carrotWorkerChanged state running

    CW->>CM: host-request get-auth-token
    CM->>CM: dispatchHostRequest resolveApiToken
    CM->>CW: host-response success token

    CW->>CM: action emit-carrot-event carrotId name
    CM->>TW: postMessage event name payload

    UI->>CM: stopDesktopCarrotWorker(id)
    CM->>CW: handle.terminate()
    CM->>CM: window.close() if window-mode
    CM->>UI: carrotWorkerChanged state stopped
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/settings/CarrotManagerSection.tsx`, line 1494 ([link](https://github.com/elizaos/eliza/blob/bde84b9c3b93b228c183b2e75b3aabb8aa3e854b/packages/ui/src/components/settings/CarrotManagerSection.tsx#L1494)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`window.confirm` suppressed in native WebView contexts**

   In Electron and Electrobun's native WebView, synchronous dialog APIs (`confirm`, `alert`, `prompt`) are frequently suppressed — they return `false` (or `true`, depending on the build) without ever showing a dialog. If that is the case here, clicking Uninstall will immediately hit the `return` branch and silently do nothing, making the action inaccessible through the UI. Use the existing React UI primitives (a small inline confirmation state or a modal) that go through the React render path instead.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%0ALine%3A%201494%0A%0AComment%3A%0A**%60window.confirm%60%20suppressed%20in%20native%20WebView%20contexts**%0A%0AIn%20Electron%20and%20Electrobun's%20native%20WebView%2C%20synchronous%20dialog%20APIs%20%28%60confirm%60%2C%20%60alert%60%2C%20%60prompt%60%29%20are%20frequently%20suppressed%20%E2%80%94%20they%20return%20%60false%60%20%28or%20%60true%60%2C%20depending%20on%20the%20build%29%20without%20ever%20showing%20a%20dialog.%20If%20that%20is%20the%20case%20here%2C%20clicking%20Uninstall%20will%20immediately%20hit%20the%20%60return%60%20branch%20and%20silently%20do%20nothing%2C%20making%20the%20action%20inaccessible%20through%20the%20UI.%20Use%20the%20existing%20React%20UI%20primitives%20%28a%20small%20inline%20confirmation%20state%20or%20a%20modal%29%20that%20go%20through%20the%20React%20render%20path%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=elizaos%2Feliza&pr=7663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22wip%2Fcarrot-host-completion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22wip%2Fcarrot-host-completion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%0ALine%3A%201494%0A%0AComment%3A%0A**%60window.confirm%60%20suppressed%20in%20native%20WebView%20contexts**%0A%0AIn%20Electron%20and%20Electrobun's%20native%20WebView%2C%20synchronous%20dialog%20APIs%20%28%60confirm%60%2C%20%60alert%60%2C%20%60prompt%60%29%20are%20frequently%20suppressed%20%E2%80%94%20they%20return%20%60false%60%20%28or%20%60true%60%2C%20depending%20on%20the%20build%29%20without%20ever%20showing%20a%20dialog.%20If%20that%20is%20the%20case%20here%2C%20clicking%20Uninstall%20will%20immediately%20hit%20the%20%60return%60%20branch%20and%20silently%20do%20nothing%2C%20making%20the%20action%20inaccessible%20through%20the%20UI.%20Use%20the%20existing%20React%20UI%20primitives%20%28a%20small%20inline%20confirmation%20state%20or%20a%20modal%29%20that%20go%20through%20the%20React%20render%20path%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%0ALine%3A%201494%0A%0AComment%3A%0A**%60window.confirm%60%20suppressed%20in%20native%20WebView%20contexts**%0A%0AIn%20Electron%20and%20Electrobun's%20native%20WebView%2C%20synchronous%20dialog%20APIs%20%28%60confirm%60%2C%20%60alert%60%2C%20%60prompt%60%29%20are%20frequently%20suppressed%20%E2%80%94%20they%20return%20%60false%60%20%28or%20%60true%60%2C%20depending%20on%20the%20build%29%20without%20ever%20showing%20a%20dialog.%20If%20that%20is%20the%20case%20here%2C%20clicking%20Uninstall%20will%20immediately%20hit%20the%20%60return%60%20branch%20and%20silently%20do%20nothing%2C%20making%20the%20action%20inaccessible%20through%20the%20UI.%20Use%20the%20existing%20React%20UI%20primitives%20%28a%20small%20inline%20confirmation%20state%20or%20a%20modal%29%20that%20go%20through%20the%20React%20render%20path%20instead.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=7663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%3A131-144%0AThe%20%60handleLogsToggle%60%20callback%20has%20no%20%60catch%60%20branch%3A%20if%20%60getDesktopCarrotLogs%60%20rejects%2C%20the%20%60finally%60%20block%20resets%20the%20spinner%20but%20the%20error%20is%20swallowed%20silently.%20The%20user%20sees%20the%20button%20re-enable%20with%20no%20indication%20that%20the%20log%20fetch%20failed.%0A%0A%60%60%60suggestion%0A%20%20const%20%5BlogsError%2C%20setLogsError%5D%20%3D%20useState%3Cstring%20%7C%20null%3E%28null%29%3B%0A%20%20const%20handleLogsToggle%20%3D%20useCallback%28async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28logsOpen%29%20%7B%0A%20%20%20%20%20%20setLogsOpen%28false%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setLogsLoading%28true%29%3B%0A%20%20%20%20setLogsError%28null%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20const%20snapshot%20%3D%20await%20getDesktopCarrotLogs%28carrot.id%29%3B%0A%20%20%20%20%20%20setLogs%28snapshot%3F.text%20%3F%3F%20%22%22%29%3B%0A%20%20%20%20%20%20setLogsOpen%28true%29%3B%0A%20%20%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20%20%20setLogsError%28e%20instanceof%20Error%20%3F%20e.message%20%3A%20String%28e%29%29%3B%0A%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20setLogsLoading%28false%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5Bcarrot.id%2C%20logsOpen%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fsrc%2Fnative%2Fcarrots.ts%3A379-385%0A**%60BrowserView%60%20handle%20not%20retained%20in%20the%20record**%0A%0AThe%20constructed%20%60BrowserView%60%20is%20not%20stored%20anywhere%20%E2%80%94%20only%20%60win%60%20is%20returned%20and%20held%20in%20%60record.window%60.%20If%20Electrobun%20ref-counts%20views%20at%20the%20JS%20layer%2C%20the%20handle%20could%20be%20GC'd%20while%20the%20window%20is%20still%20open.%20More%20concretely%2C%20if%20a%20future%20code%20path%20needs%20to%20navigate%2C%20resize%2C%20or%20explicitly%20destroy%20the%20view%2C%20there%20is%20no%20handle%20to%20do%20so.%20Consider%20adding%20a%20%60view%60%20field%20to%20%60CarrotWorkerRecord%60%20alongside%20%60window%60.%0A%0A&repo=elizaos%2Feliza&pr=7663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22wip%2Fcarrot-host-completion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22wip%2Fcarrot-host-completion%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%3A131-144%0AThe%20%60handleLogsToggle%60%20callback%20has%20no%20%60catch%60%20branch%3A%20if%20%60getDesktopCarrotLogs%60%20rejects%2C%20the%20%60finally%60%20block%20resets%20the%20spinner%20but%20the%20error%20is%20swallowed%20silently.%20The%20user%20sees%20the%20button%20re-enable%20with%20no%20indication%20that%20the%20log%20fetch%20failed.%0A%0A%60%60%60suggestion%0A%20%20const%20%5BlogsError%2C%20setLogsError%5D%20%3D%20useState%3Cstring%20%7C%20null%3E%28null%29%3B%0A%20%20const%20handleLogsToggle%20%3D%20useCallback%28async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28logsOpen%29%20%7B%0A%20%20%20%20%20%20setLogsOpen%28false%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setLogsLoading%28true%29%3B%0A%20%20%20%20setLogsError%28null%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20const%20snapshot%20%3D%20await%20getDesktopCarrotLogs%28carrot.id%29%3B%0A%20%20%20%20%20%20setLogs%28snapshot%3F.text%20%3F%3F%20%22%22%29%3B%0A%20%20%20%20%20%20setLogsOpen%28true%29%3B%0A%20%20%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20%20%20setLogsError%28e%20instanceof%20Error%20%3F%20e.message%20%3A%20String%28e%29%29%3B%0A%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20setLogsLoading%28false%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5Bcarrot.id%2C%20logsOpen%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fsrc%2Fnative%2Fcarrots.ts%3A379-385%0A**%60BrowserView%60%20handle%20not%20retained%20in%20the%20record**%0A%0AThe%20constructed%20%60BrowserView%60%20is%20not%20stored%20anywhere%20%E2%80%94%20only%20%60win%60%20is%20returned%20and%20held%20in%20%60record.window%60.%20If%20Electrobun%20ref-counts%20views%20at%20the%20JS%20layer%2C%20the%20handle%20could%20be%20GC'd%20while%20the%20window%20is%20still%20open.%20More%20concretely%2C%20if%20a%20future%20code%20path%20needs%20to%20navigate%2C%20resize%2C%20or%20explicitly%20destroy%20the%20view%2C%20there%20is%20no%20handle%20to%20do%20so.%20Consider%20adding%20a%20%60view%60%20field%20to%20%60CarrotWorkerRecord%60%20alongside%20%60window%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fui%2Fsrc%2Fcomponents%2Fsettings%2FCarrotManagerSection.tsx%3A131-144%0AThe%20%60handleLogsToggle%60%20callback%20has%20no%20%60catch%60%20branch%3A%20if%20%60getDesktopCarrotLogs%60%20rejects%2C%20the%20%60finally%60%20block%20resets%20the%20spinner%20but%20the%20error%20is%20swallowed%20silently.%20The%20user%20sees%20the%20button%20re-enable%20with%20no%20indication%20that%20the%20log%20fetch%20failed.%0A%0A%60%60%60suggestion%0A%20%20const%20%5BlogsError%2C%20setLogsError%5D%20%3D%20useState%3Cstring%20%7C%20null%3E%28null%29%3B%0A%20%20const%20handleLogsToggle%20%3D%20useCallback%28async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28logsOpen%29%20%7B%0A%20%20%20%20%20%20setLogsOpen%28false%29%3B%0A%20%20%20%20%20%20return%3B%0A%20%20%20%20%7D%0A%20%20%20%20setLogsLoading%28true%29%3B%0A%20%20%20%20setLogsError%28null%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20const%20snapshot%20%3D%20await%20getDesktopCarrotLogs%28carrot.id%29%3B%0A%20%20%20%20%20%20setLogs%28snapshot%3F.text%20%3F%3F%20%22%22%29%3B%0A%20%20%20%20%20%20setLogsOpen%28true%29%3B%0A%20%20%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20%20%20setLogsError%28e%20instanceof%20Error%20%3F%20e.message%20%3A%20String%28e%29%29%3B%0A%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20setLogsLoading%28false%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5Bcarrot.id%2C%20logsOpen%5D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fapp-core%2Fplatforms%2Felectrobun%2Fsrc%2Fnative%2Fcarrots.ts%3A379-385%0A**%60BrowserView%60%20handle%20not%20retained%20in%20the%20record**%0A%0AThe%20constructed%20%60BrowserView%60%20is%20not%20stored%20anywhere%20%E2%80%94%20only%20%60win%60%20is%20returned%20and%20held%20in%20%60record.window%60.%20If%20Electrobun%20ref-counts%20views%20at%20the%20JS%20layer%2C%20the%20handle%20could%20be%20GC'd%20while%20the%20window%20is%20still%20open.%20More%20concretely%2C%20if%20a%20future%20code%20path%20needs%20to%20navigate%2C%20resize%2C%20or%20explicitly%20destroy%20the%20view%2C%20there%20is%20no%20handle%20to%20do%20so.%20Consider%20adding%20a%20%60view%60%20field%20to%20%60CarrotWorkerRecord%60%20alongside%20%60window%60.%0A%0A&pr=7663&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["feat(electrobun): complete carrot host —..."](https://github.com/elizaos/eliza/commit/0aed4ae43bf550f9a8df0ebae3529e894fc52a37) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32046083)</sub>

<!-- /greptile_comment -->