### PR TITLE
fix(local-inference/voice/kokoro): speed-tensor dtype polarity (kokoro-onnx upstream)

### DIFF
--- a/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts
+++ b/packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts
@@ -218,16 +218,17 @@ export class KokoroOnnxRuntime implements KokoroRuntime {
             (Math.min(inputIds.length, numPositions - 1) + 1) * args.voice.dim,
           )
         : fullStyle;
-    // Older `kokoro-onnx` exports name the token input `tokens` and want a
-    // `speed: int32 [1]` scalar; newer exports name it `input_ids` and want
-    // `speed: float32 [1]`. Detect from the loaded session, mirroring the
-    // probe `kokoro-onnx._create_audio` does on `sess.get_inputs()`.
+    // Speed-tensor dtype mirrors `kokoro-onnx` upstream
+    // (`kokoro_onnx/__init__.py:_create_audio`): the legacy `tokens`
+    // export wants `speed: float32 [1]` and the newer `input_ids` export
+    // wants `speed: int32 [1]`. ORT raises `Unexpected input data type`
+    // when either dtype is swapped, so this polarity is load-bearing.
     const inputNames = session.inputNames ?? ["input_ids", "style", "speed"];
     const useLegacyInputs = !inputNames.includes("input_ids");
     const tokensInputName = useLegacyInputs ? "tokens" : "input_ids";
     const speedTensor = useLegacyInputs
-      ? new ort.Tensor("int32", new Int32Array([1]), [1])
-      : new ort.Tensor("float32", new Float32Array([1.0]), [1]);
+      ? new ort.Tensor("float32", new Float32Array([1.0]), [1])
+      : new ort.Tensor("int32", new Int32Array([1]), [1]);
     const feeds: Record<string, OrtTensor> = {
       [tokensInputName]: new ort.Tensor("int64", inputIds, [
         1,


### PR DESCRIPTION
## Summary

The speed-tensor dtype branches in `KokoroOnnxRuntime.synthesize` are inverted relative to the `kokoro-onnx` upstream Python (`kokoro_onnx/__init__.py:_create_audio`).

Upstream:
- newer `input_ids` export → `speed: int32 [1]`
- legacy `tokens` export   → `speed: float32 [1]`

Current code does the opposite, so every legacy ONNX export (notably the INT8 `model_quantized.onnx` at `onnx-community/Kokoro-82M-v1.0-ONNX`, which uses the `tokens` input name) fails at synthesis with:

```
Unexpected input data type. Actual: (tensor(int32)), expected: (tensor(float))
```

## Fix

Swap the two branches of `useLegacyInputs ? ... : ...` and update the comment to match upstream. Three lines of code, plus the comment refresh. No test change needed — the existing `kokoro-runtime.test.ts` cases already cover the `tokens` and `input_ids` paths with `vi.fn()` stubs that don't care about the dtype, so they continue to pass.

## Verification

`POST /api/tts/local-inference` against the running Milady dev server, with the v1.0 INT8 ONNX (`model_quantized.onnx`) + `af_bella.bin` staged under `~/.eliza/local-inference/models/kokoro/`:

Before (current develop):
```
[HTTP 502, 0.81s] {"error":"Local inference TTS error: Unexpected input data type.
                              Actual: (tensor(int32)), expected: (tensor(float))"}
```

After this patch:
```
[HTTP 200, 3.37s, 183 644 bytes]
file: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz
```

183644 bytes / 2 / 24000 = 3.82 s of audio → **1.13× RTF through Milady's runtime chain on Intel CPU**.

## Provenance

Regression introduced when #7656 was merged. My PR shipped both branches as `float32` (a redundant no-op detection that happened to work for the legacy export this hardware uses), and the merge follow-up correctly noticed the redundancy but flipped the polarity opposite to upstream. The original commit message in #7656 also had the polarity backwards in prose — this PR fixes both the code AND the doc comment to match `kokoro-onnx` actual behavior.

## Related

- #7656 — Kokoro voice loader fixes (where this regression entered)
- #7661 — Kokoro engine wiring (validated end-to-end against this fix)
- `kokoro-onnx/__init__.py:108-115` — upstream reference for the dtype mapping

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inverted dtype polarity for the `speedTensor` in `KokoroOnnxRuntime.synthesize`, introduced as a regression in #7656. The two branches were swapped relative to upstream `kokoro-onnx` (`_create_audio`), causing an ORT `Unexpected input data type` error on every legacy ONNX export (including the widely-used INT8 `model_quantized.onnx`).

- Swaps `useLegacyInputs` branches so the legacy `tokens` path correctly passes `speed: float32 [1]` and the newer `input_ids` path passes `speed: int32 [1]`, matching `kokoro_onnx/__init__.py:108-115`.
- Updates the inline comment to accurately describe the dtype mapping and note that the polarity is load-bearing.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted three-line swap that restores the dtype polarity to match the upstream kokoro-onnx Python reference, with no other logic touched.

The fix is confined to two lines of tensor construction inside a single method, directly traceable to the upstream kokoro_onnx/__init__.py:_create_audio reference cited in the PR. The old code produced a hard ORT type error on the most common ONNX export (INT8 quantized); the new code resolves it. No interface, no data flow, and no other call sites are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/local-inference/voice/kokoro/kokoro-runtime.ts | Swaps the dtype branches for `speedTensor` to match upstream kokoro-onnx: legacy `tokens` export now correctly uses `float32` and newer `input_ids` export uses `int32`; comment updated to match. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(local-inference/voice/kokoro): speed..."](https://github.com/elizaos/eliza/commit/0f8b5f28257f3052beba1199cd8ef3c2e54d7e71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32047284)</sub>

<!-- /greptile_comment -->