### PR TITLE
fix(cloud-provisioning): unblock V2 image build and e2e sandbox launch

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -10,7 +10,9 @@ on:
   push:
     branches: [develop, main]
     paths:
-      - "packages/app-core/deploy/Dockerfile.cloud"
+      - "packages/app-core/deploy/Dockerfile.ci"
+      - "plugins/plugin-sql/**"
+      - "plugins/plugin-elizacloud/**"
       - "packages/agent/**"
       - "packages/server/**"
       - "packages/core/**"
@@ -42,6 +44,13 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo docker image prune -a -f || true
+
+      - name: Install jq
+        # Required by packages/app-core/scripts/docker-ci-smoke.sh per-plugin
+        # build loop: it gates each `bun run build` on `jq -e '.scripts.build'`.
+        # Without jq, the gate silently fails and the plugin dist/ is never
+        # produced, which ships a broken image (plugin-sql index.node.js missing).
+        run: sudo apt-get install -y --no-install-recommends jq
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -81,10 +90,49 @@ jobs:
           fi
           rm -f "$install_log"
 
+      - name: Build workspace plugins
+        # Dockerfile.ci copies the repo and relies on pre-built dist/ in each
+        # workspace plugin. The docker-ci-smoke script (used by the smoke
+        # workflow) is the canonical place this lives; reuse the same loop so
+        # plugin-sql, plugin-elizacloud, etc. land in the image with their
+        # built artifacts.
+        env:
+          NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
+        run: |
+          for plugin in plugin-sql plugin-video plugin-agent-skills plugin-pdf \
+            plugin-browser plugin-capacitor-bridge plugin-coding-tools \
+            plugin-computeruse plugin-discord plugin-elizacloud plugin-imessage \
+            plugin-local-inference plugin-mcp plugin-signal plugin-streaming \
+            plugin-telegram plugin-whatsapp plugin-workflow plugin-x402; do
+            plugin_dir="plugins/$plugin"
+            if [[ -f "$plugin_dir/package.json" ]] && jq -e '.scripts.build' "$plugin_dir/package.json" >/dev/null; then
+              echo "::group::Building @elizaos/$plugin"
+              (cd "$plugin_dir" && bun run build)
+              echo "::endgroup::"
+            fi
+          done
+
       - name: Build UI
         env:
           NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
         run: bun run build:client
+
+      - name: Build agent workspace
+        env:
+          NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
+        run: |
+          pushd packages/agent >/dev/null
+          bun run build:docker-dist
+          popd >/dev/null
+
+      - name: Build app UI
+        env:
+          NODE_ENV: production
+          NODE_LLAMA_CPP_SKIP_DOWNLOAD: "true"
+        run: |
+          pushd packages/app >/dev/null
+          bun run build:web
+          popd >/dev/null
 
       - uses: docker/login-action@v4
         with:
@@ -117,7 +165,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: packages/app-core/deploy/Dockerfile.cloud
+          file: packages/app-core/deploy/Dockerfile.ci
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -75,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: packages/app-core/deploy/Dockerfile.cloud
+          file: packages/app-core/deploy/Dockerfile.ci
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -517,7 +517,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     try {
       // Ensure volume directory exists
       await ssh.exec(
-        `mkdir -p ${shellQuote(volumePath)} ${shellQuote(`${volumePath}/eliza`)} ${shellQuote(`${volumePath}/eliza`)}`,
+        `mkdir -p ${shellQuote(volumePath)} ${shellQuote(`${volumePath}/eliza`)}`,
         DOCKER_CMD_TIMEOUT_MS,
       );
 
@@ -607,7 +607,6 @@ export class DockerSandboxProvider implements SandboxProvider {
           ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"]
           : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
-        `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 3000).
         // Publish both externally allocated host ports to that live listener so

--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -44,7 +44,11 @@ import {
   WEBUI_PORT_MIN,
 } from "./docker-sandbox-utils";
 import { headscaleIntegration } from "./headscale-integration";
-import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
+import type {
+  SandboxCreateConfig,
+  SandboxHandle,
+  SandboxProvider,
+} from "./sandbox-provider-types";
 
 // ---------------------------------------------------------------------------
 // Exported metadata type for strongly-typed provider metadata
@@ -88,7 +92,6 @@ const DOCKER_IMAGE_OVERRIDE = containersEnv.defaultAgentImageOverride();
 const DOCKER_NETWORK = containersEnv.dockerNetwork();
 let hasWarnedMissingStewardTenantApiKey = false;
 
-const DEFAULT_LEGACY_PORT = containersEnv.legacyContainerPort();
 const DEFAULT_AGENT_PORT = containersEnv.agentPort();
 const DEFAULT_BRIDGE_PORT = containersEnv.agentBridgePort();
 
@@ -104,7 +107,10 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
+  return resolveStewardContainerUrl(
+    resolveStewardHostUrl(),
+    env.STEWARD_CONTAINER_URL,
+  );
 }
 
 /**
@@ -113,7 +119,9 @@ function resolveStewardContainerEnvUrl(): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildStewardProxyEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -144,7 +152,9 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
+    throw new Error(
+      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
+    );
   }
   // /api/health returns 200 or 401 (auth required) — both mean the server is up.
   // Use curl with -o /dev/null and check status code to accept either.
@@ -154,7 +164,9 @@ function getDockerHealthCmd(port: string): string {
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
+    throw new Error(
+      "[docker-sandbox] Steward token endpoint returned an empty response",
+    );
   }
 
   try {
@@ -235,7 +247,7 @@ agent_name = ${JSON.stringify(agentName)}
 
 
 def post(path, payload):
-    headers = {"Content-Type": "application/json"}
+    headers = {"Content-Type": "application/json", "User-Agent": "eliza-cloud-provisioner/1.0"}
     if tenant_id:
         headers["X-Steward-Tenant"] = tenant_id
     if api_key:
@@ -338,7 +350,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
+    throw (
+      lastError ??
+      new Error("[docker-sandbox] create exhausted all retry attempts")
+    );
   }
 
   /**
@@ -349,14 +364,18 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
+  private async _createOnce(
+    config: SandboxCreateConfig,
+  ): Promise<SandboxHandle> {
     const { agentId, agentName, environmentVars, organizationId } = config;
 
     // Resolve Docker image: operator env override > per-agent DB override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
     // overrides are not accidentally shadowed by the generic Eliza default.
     const resolvedImage =
-      DOCKER_IMAGE_OVERRIDE || config.dockerImage || "ghcr.io/elizaos/eliza:latest";
+      DOCKER_IMAGE_OVERRIDE ||
+      config.dockerImage ||
+      "ghcr.io/elizaos/eliza:latest";
     const imagePlatform = containersEnv.defaultAgentImagePlatform();
     const platformFlags = dockerPlatformFlag(imagePlatform);
 
@@ -368,7 +387,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     // getAvailableNode + incrementAllocated + getUsedDockerHostPorts are three sequential
     // DB round-trips without a transaction boundary; the UNIQUE port index and
     // retry logic provide safety against concurrent capacity changes.
-    let dbNode = await dockerNodeManager.getAvailableNode({ requiredPlatform: imagePlatform });
+    let dbNode = await dockerNodeManager.getAvailableNode({
+      requiredPlatform: imagePlatform,
+    });
     if (!dbNode) {
       dbNode = await this.provisionAutoscaledNodeForAgent({
         image: resolvedImage,
@@ -416,7 +437,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
+    const bridgePort = allocatePort(
+      BRIDGE_PORT_MIN,
+      BRIDGE_PORT_MAX,
+      usedPorts,
+    );
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -443,7 +468,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     let vpnEnvVars: Record<string, string> = {};
     if (headscaleEnabled) {
       try {
-        const vpnSetup = await headscaleIntegration.prepareContainerVPN(agentId);
+        const vpnSetup =
+          await headscaleIntegration.prepareContainerVPN(agentId);
         vpnEnvVars = vpnSetup.envVars;
         logger.info(`[docker-sandbox] Headscale VPN enabled for ${agentId}`);
       } catch (err) {
@@ -465,10 +491,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       ELIZA_CLOUD_PROVISIONED: "1",
       STEWARD_API_URL: stewardContainerUrl,
       STEWARD_AGENT_ID: agentId,
-      // The current cloud agent image listens on PORT (default 3000).
-      // Keep ELIZA_PORT for compatibility, but publish/probe the external
-      // host ports against PORT so new containers don't expose a dead 2138.
-      ELIZA_PORT: DEFAULT_LEGACY_PORT,
+      // V2 image binds the eliza-api server to ELIZA_PORT, not PORT. Keep both
+      // aligned to DEFAULT_AGENT_PORT so the daemon's HTTP probe (which hits
+      // the host port mapped to container PORT) reaches the actual listener.
+      ELIZA_PORT: DEFAULT_AGENT_PORT,
       PORT: DEFAULT_AGENT_PORT,
       BRIDGE_PORT: DEFAULT_BRIDGE_PORT,
       // Eliza server requires JWT_SECRET in production mode.
@@ -481,7 +507,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
+    const ssh = DockerSSHClient.getClient(
+      hostname,
+      sshPort,
+      hostKeyFingerprint,
+      sshUser,
+    );
 
     try {
       // Ensure volume directory exists
@@ -491,10 +522,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
 
       // Pull image (may take a while on first run)
-      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
+      logger.info(
+        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
+      );
       try {
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
+            " ",
+          ),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -533,6 +568,12 @@ export class DockerSandboxProvider implements SandboxProvider {
         // provisioned containers (no token + cloud flag = 401).
         AGENT_DISABLE_AUTO_API_TOKEN: "1",
         ELIZA_DISABLE_AUTO_API_TOKEN: "1",
+        // V2 image refuses to boot on headless Linux without a passphrase
+        // (no D-Bus keychain). Generate one per container — the vault state
+        // lives only in the per-container PGlite, so a unique per-launch key
+        // is fine.
+        ELIZA_VAULT_PASSPHRASE:
+          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
       };
 
       // Validate env keys/values before they are interpolated into remote shell commands.
@@ -553,7 +594,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--name ${shellQuote(containerName)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) ||
+        Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || DEFAULT_AGENT_PORT))}`,
@@ -561,7 +603,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-timeout 5s",
         "--health-start-period 15s",
         "--health-retries 6",
-        ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
+        ...(headscaleEnabled
+          ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"]
+          : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
@@ -577,7 +621,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
       );
-      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker start ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
@@ -592,18 +639,24 @@ export class DockerSandboxProvider implements SandboxProvider {
           cloud: {
             enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
             apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "https://www.elizacloud.ai/api/v1",
+            baseUrl:
+              allEnv.ELIZAOS_CLOUD_BASE_URL ||
+              "https://www.elizacloud.ai/api/v1",
           },
         });
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
+          "base64",
+        );
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
+        logger.info(
+          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
+        );
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
@@ -617,7 +670,9 @@ export class DockerSandboxProvider implements SandboxProvider {
           `curl -s -X DELETE -H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)} ${stewardTenant.apiKey ? `-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}` : ""} ${shellQuote(`${resolveStewardHostUrl()}/agents/${agentId}`)} || true`,
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
+        logger.info(
+          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
+        );
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -625,7 +680,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       await ssh
-        .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
+        .exec(
+          `docker rm -f ${shellQuote(containerName)}`,
+          DOCKER_CMD_TIMEOUT_MS,
+        )
         .catch(() => {});
 
       // Rollback allocated_count on failure
@@ -634,11 +692,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {
-        await headscaleIntegration.cleanupContainerVPN(agentId).catch((cleanupErr) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
-          );
-        });
+        await headscaleIntegration
+          .cleanupContainerVPN(agentId)
+          .catch((cleanupErr) => {
+            logger.warn(
+              `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+            );
+          });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -648,7 +708,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
       try {
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(agentId, 60_000);
+        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
+          agentId,
+          60_000,
+        );
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -714,18 +777,24 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
-        hasHcloudToken: Boolean(hcloudToken),
-        hasPublicKey: Boolean(publicKey),
-      });
+      logger.warn(
+        "[docker-sandbox] No Docker capacity and autoscale is not configured",
+        {
+          hasHcloudToken: Boolean(hcloudToken),
+          hasPublicKey: Boolean(publicKey),
+        },
+      );
       return null;
     }
 
     try {
-      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
-        image,
-        platform,
-      });
+      logger.info(
+        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
+        {
+          image,
+          platform,
+        },
+      );
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -740,7 +809,9 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
+        const node = await dockerNodesRepository.findByNodeId(
+          provisioned.nodeId,
+        );
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -753,18 +824,26 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
+        );
       }
 
-      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
-        nodeId: provisioned.nodeId,
-        hostname: provisioned.hostname,
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
+        {
+          nodeId: provisioned.nodeId,
+          hostname: provisioned.hostname,
+        },
+      );
       return null;
     } catch (error) {
-      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node provisioning failed",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -789,7 +868,10 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (stopErr) {
       logger.warn(
@@ -798,7 +880,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (rmErr) {
       logger.error(
@@ -815,11 +900,13 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Clean up Headscale VPN registration if enabled
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
-      await headscaleIntegration.cleanupContainerVPN(meta.agentId).catch((err) => {
-        logger.warn(
-          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      await headscaleIntegration
+        .cleanupContainerVPN(meta.agentId)
+        .catch((err) => {
+          logger.warn(
+            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
     }
 
     // Remove from in-memory registry
@@ -890,10 +977,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
+        );
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(remaining, 1000)),
+        );
       } else {
         break;
       }
@@ -920,11 +1011,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
-        containerName: meta.containerName,
-        error:
-          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
-      });
+      logger.warn(
+        "[docker-sandbox] Failed to collect health timeout diagnostics",
+        {
+          containerName: meta.containerName,
+          error:
+            diagnosticsError instanceof Error
+              ? diagnosticsError.message
+              : String(diagnosticsError),
+        },
+      );
     }
     return false;
   }
@@ -933,12 +1029,19 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
+  async runCommand(
+    sandboxId: string,
+    cmd: string,
+    args?: string[],
+  ): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
+    const escapedArgs =
+      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs
+      ? `${shellQuote(cmd)} ${escapedArgs}`
+      : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -985,7 +1088,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         let sshUser = DEFAULT_SSH_USERNAME;
         let hostKeyFingerprint: string | undefined;
 
-        const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
+        const dbNode = await dockerNodesRepository.findByNodeId(
+          sandbox.node_id,
+        );
         if (dbNode) {
           hostname = dbNode.hostname;
           sshPort = dbNode.ssh_port ?? DEFAULT_SSH_PORT;

--- a/cloud/packages/lib/services/docker-sandbox-provider.ts
+++ b/cloud/packages/lib/services/docker-sandbox-provider.ts
@@ -44,11 +44,7 @@ import {
   WEBUI_PORT_MIN,
 } from "./docker-sandbox-utils";
 import { headscaleIntegration } from "./headscale-integration";
-import type {
-  SandboxCreateConfig,
-  SandboxHandle,
-  SandboxProvider,
-} from "./sandbox-provider-types";
+import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
 
 // ---------------------------------------------------------------------------
 // Exported metadata type for strongly-typed provider metadata
@@ -107,10 +103,7 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(
-    resolveStewardHostUrl(),
-    env.STEWARD_CONTAINER_URL,
-  );
+  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
 }
 
 /**
@@ -119,9 +112,7 @@ function resolveStewardContainerEnvUrl(): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(
-  env: NodeJS.ProcessEnv = process.env,
-): Record<string, string> {
+export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -152,9 +143,7 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(
-      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
-    );
+    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
   }
   // /api/health returns 200 or 401 (auth required) — both mean the server is up.
   // Use curl with -o /dev/null and check status code to accept either.
@@ -164,9 +153,7 @@ function getDockerHealthCmd(port: string): string {
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error(
-      "[docker-sandbox] Steward token endpoint returned an empty response",
-    );
+    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
   }
 
   try {
@@ -350,10 +337,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw (
-      lastError ??
-      new Error("[docker-sandbox] create exhausted all retry attempts")
-    );
+    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
   }
 
   /**
@@ -364,18 +348,14 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(
-    config: SandboxCreateConfig,
-  ): Promise<SandboxHandle> {
+  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
     const { agentId, agentName, environmentVars, organizationId } = config;
 
     // Resolve Docker image: operator env override > per-agent DB override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
     // overrides are not accidentally shadowed by the generic Eliza default.
     const resolvedImage =
-      DOCKER_IMAGE_OVERRIDE ||
-      config.dockerImage ||
-      "ghcr.io/elizaos/eliza:latest";
+      DOCKER_IMAGE_OVERRIDE || config.dockerImage || "ghcr.io/elizaos/eliza:latest";
     const imagePlatform = containersEnv.defaultAgentImagePlatform();
     const platformFlags = dockerPlatformFlag(imagePlatform);
 
@@ -437,11 +417,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(
-      BRIDGE_PORT_MIN,
-      BRIDGE_PORT_MAX,
-      usedPorts,
-    );
+    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -468,8 +444,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     let vpnEnvVars: Record<string, string> = {};
     if (headscaleEnabled) {
       try {
-        const vpnSetup =
-          await headscaleIntegration.prepareContainerVPN(agentId);
+        const vpnSetup = await headscaleIntegration.prepareContainerVPN(agentId);
         vpnEnvVars = vpnSetup.envVars;
         logger.info(`[docker-sandbox] Headscale VPN enabled for ${agentId}`);
       } catch (err) {
@@ -507,12 +482,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(
-      hostname,
-      sshPort,
-      hostKeyFingerprint,
-      sshUser,
-    );
+    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
 
     try {
       // Ensure volume directory exists
@@ -522,14 +492,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
 
       // Pull image (may take a while on first run)
-      logger.info(
-        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
-      );
+      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
       try {
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
-            " ",
-          ),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -572,8 +538,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         // (no D-Bus keychain). Generate one per container — the vault state
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
-        ELIZA_VAULT_PASSPHRASE:
-          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
       };
 
       // Validate env keys/values before they are interpolated into remote shell commands.
@@ -594,8 +559,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--name ${shellQuote(containerName)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) ||
-        Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || DEFAULT_AGENT_PORT))}`,
@@ -603,9 +567,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-timeout 5s",
         "--health-start-period 15s",
         "--health-retries 6",
-        ...(headscaleEnabled
-          ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"]
-          : []),
+        ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 3000).
@@ -620,10 +582,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
       );
-      await ssh.exec(
-        `docker start ${shellQuote(containerName)}`,
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
@@ -638,24 +597,18 @@ export class DockerSandboxProvider implements SandboxProvider {
           cloud: {
             enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
             apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl:
-              allEnv.ELIZAOS_CLOUD_BASE_URL ||
-              "https://www.elizacloud.ai/api/v1",
+            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "https://www.elizacloud.ai/api/v1",
           },
         });
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
-          "base64",
-        );
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(
-          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
-        );
+        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
@@ -669,9 +622,7 @@ export class DockerSandboxProvider implements SandboxProvider {
           `curl -s -X DELETE -H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)} ${stewardTenant.apiKey ? `-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}` : ""} ${shellQuote(`${resolveStewardHostUrl()}/agents/${agentId}`)} || true`,
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(
-          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
-        );
+        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -679,10 +630,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       await ssh
-        .exec(
-          `docker rm -f ${shellQuote(containerName)}`,
-          DOCKER_CMD_TIMEOUT_MS,
-        )
+        .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
         .catch(() => {});
 
       // Rollback allocated_count on failure
@@ -691,13 +639,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {
-        await headscaleIntegration
-          .cleanupContainerVPN(agentId)
-          .catch((cleanupErr) => {
-            logger.warn(
-              `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
-            );
-          });
+        await headscaleIntegration.cleanupContainerVPN(agentId).catch((cleanupErr) => {
+          logger.warn(
+            `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+          );
+        });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -707,10 +653,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
       try {
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
-          agentId,
-          60_000,
-        );
+        headscaleIp = await headscaleIntegration.waitForVPNRegistration(agentId, 60_000);
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -776,24 +719,18 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn(
-        "[docker-sandbox] No Docker capacity and autoscale is not configured",
-        {
-          hasHcloudToken: Boolean(hcloudToken),
-          hasPublicKey: Boolean(publicKey),
-        },
-      );
+      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
+        hasHcloudToken: Boolean(hcloudToken),
+        hasPublicKey: Boolean(publicKey),
+      });
       return null;
     }
 
     try {
-      logger.info(
-        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
-        {
-          image,
-          platform,
-        },
-      );
+      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
+        image,
+        platform,
+      });
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -808,9 +745,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(
-          provisioned.nodeId,
-        );
+        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -823,26 +758,18 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) =>
-          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
-        );
+        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
       }
 
-      logger.warn(
-        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
-        {
-          nodeId: provisioned.nodeId,
-          hostname: provisioned.hostname,
-        },
-      );
+      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
+        nodeId: provisioned.nodeId,
+        hostname: provisioned.hostname,
+      });
       return null;
     } catch (error) {
-      logger.warn(
-        "[docker-sandbox] Autoscaled Docker node provisioning failed",
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return null;
     }
   }
@@ -867,10 +794,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(
-        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (stopErr) {
       logger.warn(
@@ -879,10 +803,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(
-        `docker rm -f ${shellQuote(meta.containerName)}`,
-        DOCKER_CMD_TIMEOUT_MS,
-      );
+      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (rmErr) {
       logger.error(
@@ -899,13 +820,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Clean up Headscale VPN registration if enabled
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
-      await headscaleIntegration
-        .cleanupContainerVPN(meta.agentId)
-        .catch((err) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+      await headscaleIntegration.cleanupContainerVPN(meta.agentId).catch((err) => {
+        logger.warn(
+          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     }
 
     // Remove from in-memory registry
@@ -976,14 +895,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
-        );
+        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) =>
-          setTimeout(resolve, Math.min(remaining, 1000)),
-        );
+        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
       } else {
         break;
       }
@@ -1010,16 +925,11 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn(
-        "[docker-sandbox] Failed to collect health timeout diagnostics",
-        {
-          containerName: meta.containerName,
-          error:
-            diagnosticsError instanceof Error
-              ? diagnosticsError.message
-              : String(diagnosticsError),
-        },
-      );
+      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
+        containerName: meta.containerName,
+        error:
+          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
+      });
     }
     return false;
   }
@@ -1028,19 +938,12 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(
-    sandboxId: string,
-    cmd: string,
-    args?: string[],
-  ): Promise<string> {
+  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs =
-      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs
-      ? `${shellQuote(cmd)} ${escapedArgs}`
-      : shellQuote(cmd);
+    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -1087,9 +990,7 @@ export class DockerSandboxProvider implements SandboxProvider {
         let sshUser = DEFAULT_SSH_USERNAME;
         let hostKeyFingerprint: string | undefined;
 
-        const dbNode = await dockerNodesRepository.findByNodeId(
-          sandbox.node_id,
-        );
+        const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
         if (dbNode) {
           hostname = dbNode.hostname;
           sshPort = dbNode.ssh_port ?? DEFAULT_SSH_PORT;


### PR DESCRIPTION
## Summary

Five fixes uncovered while running the V2 image rollout from PR #7616 end-to-end on prod. Without them, fresh sandbox provisioning systematically fails (image broken at the `plugin-sql` import, then again at `Steward 403`, then again at `vault keychain unavailable`, then again at health-probe timeout).

## What's broken without these fixes

- **`build-agent-image.yml` ships a broken image.** The runner doesn't have `jq`, so the `if jq -e '.scripts.build'` gate in `docker-ci-smoke.sh` silently skips every workspace plugin. The Docker image is published with `plugins/plugin-sql/src/dist/` missing and the agent crashes on `import "@elizaos/plugin-sql"` at boot.
- **Both workflows point at `Dockerfile.cloud`.** That Dockerfile expects the legacy `eliza/packages` submodule layout that doesn't exist here. The actual production Dockerfile is `Dockerfile.ci` (already used by the smoke workflow).
- **Steward register always returns 403** because the Python `urllib` user agent gets caught by Cloudflare WAF Browser Integrity Check on `api.steward.fi` (CF error 1010 → returned to the script as `Forbidden`).
- **V2 image refuses to boot.** Headless Linux containers without a D-Bus keychain need `ELIZA_VAULT_PASSPHRASE` set; otherwise vault-bootstrap throws and the agent never starts.
- **Health probe always times out.** The V2 image binds `eliza-api` to `ELIZA_PORT`, while the provisioner publishes the host port mapped to container `PORT`. With `ELIZA_PORT=DEFAULT_LEGACY_PORT (2138)` and `PORT=DEFAULT_AGENT_PORT (3000)`, the listener is on a different port than what the probe checks.

## Validated end-to-end in prod

With these five fixes applied locally on the manager VM, an agent went all the way through:

```
create → provision → image pull (V2) → Steward register → docker create → bridge URL reachable → status=running
```

Then I called `POST /api/v1/chat/completions` with my user `eliza_*` token; got back `PONG` from `claude-haiku-4-5` via the cloud LLM gateway. So the whole flow login → agent → LLM works with this fix-up applied.

## Known follow-ups (not in this PR)

- `agent_sandboxes.environment_vars` still ends up with `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`AI_GATEWAY_API_KEY`/`ELIZAOS_API_KEY` after provisioning, even though the source code on develop strips them per the original PR #7616. Source unknown; investigation tracked separately.
- The two stale V2 entries in `docker_nodes` (`178.105.27.5`, `88.99.82.102`) don't accept the daemon's SSH key and waste the first provision attempt every time. Should be `UPDATE docker_nodes SET enabled = FALSE` for those rows.
- `develop` HEAD (`93d3afcbe "updates"`) breaks `packages/core/src/runtime/sub-planner.ts` by removing the `PLAN_ACTIONS_TOOL` export from `to-tool.ts`. Independent core regression.

## Test plan

- [ ] CI: `Build Agent Image (develop/main)` succeeds on a push to develop + image pull on a node shows `plugin-sql/src/dist/node/index.node.js` present
- [ ] CI: `Cloud Image` (image.yaml) succeeds on a tagged release with `Dockerfile.ci`
- [ ] E2E: create a fresh agent on prod, provision it, expect `status=running` and bridge URL reachable within ~60s
- [ ] E2E: `POST /api/v1/chat/completions` with a user `eliza_*` token returns 200
- [ ] Smoke locally: `docker run -e ELIZA_VAULT_PASSPHRASE=test -e ELIZA_PORT=3000 -e PORT=3000 ghcr.io/elizaos/eliza:stable` reaches `eliza-api Listening on http://0.0.0.0:3000`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies five targeted fixes to unblock V2 agent image builds and sandbox provisioning: installing `jq` and adding pre-build steps in `build-agent-image.yml`; switching both workflows from `Dockerfile.cloud` to `Dockerfile.ci`; fixing the Steward registration User-Agent to avoid Cloudflare WAF rejection; aligning `ELIZA_PORT` with `DEFAULT_AGENT_PORT` so the health probe reaches the actual listener; and adding `ELIZA_VAULT_PASSPHRASE` so headless containers can boot their vault.

- **`build-agent-image.yml`** now correctly installs `jq` and runs all workspace plugin/UI/agent builds before `docker build`, ensuring `plugin-sql` and friends land in the image with their `dist/` artifacts.
- **`docker-sandbox-provider.ts`** aligns port env vars, injects a vault passphrase, fixes the Steward User-Agent, removes the duplicate volume mount, and removes the redundant `mkdir -p` path argument.
- **`image.yaml`** is updated to use `Dockerfile.ci` but still lacks the prerequisite build steps; release-tagged images produced by this workflow will be missing all `dist/` directories.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the provisioner and build-agent-image workflow; image.yaml still produces broken release images without the prerequisite build steps.

The provisioner and build-agent-image workflow changes are well-scoped and address real failures end-to-end. The one remaining gap is image.yaml, which was switched to Dockerfile.ci but never received the bun install / plugin / UI / agent build steps that Dockerfile.ci requires — any release tag pushed after this merge will publish an image missing every dist/ directory, reproducing the plugin-sql crash that this PR fixes for the develop branch workflow.

.github/workflows/image.yaml — needs the same pre-build steps added to build-agent-image.yml before this workflow will produce a working release image.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Adds jq install, plugin/UI/agent build steps before docker build, and switches to Dockerfile.ci — correctly mirrors the smoke-test workflow's pre-build chain so plugin-sql and other workspace plugins land in the image. |
| .github/workflows/image.yaml | Switches Dockerfile.cloud → Dockerfile.ci but adds none of the prerequisite bun install / plugin / UI / agent build steps that Dockerfile.ci requires; release-tagged images will be published with all dist/ directories missing. |
| cloud/packages/lib/services/docker-sandbox-provider.ts | Aligns ELIZA_PORT with DEFAULT_AGENT_PORT, adds ELIZA_VAULT_PASSPHRASE, fixes User-Agent header, removes duplicate volume mount and duplicate mkdir arg — all targeted fixes with low blast radius. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant BUN as Bun Build
    participant Docker as Docker Build/Push
    participant Node as Docker Node (SSH)
    participant Steward as api.steward.fi
    participant Container as Agent Container

    GHA->>GHA: apt-get install jq
    GHA->>BUN: bun install
    GHA->>BUN: build workspace plugins (jq-gated loop)
    GHA->>BUN: build:client (UI)
    GHA->>BUN: build:docker-dist (agent)
    GHA->>BUN: build:web (app UI)
    GHA->>Docker: docker build Dockerfile.ci
    Docker->>GHA: push image to GHCR

    GHA->>Node: SSH docker create
    Note over Node: ELIZA_PORT=3000, PORT=3000
    Node->>Steward: POST /register User-Agent: eliza-cloud-provisioner/1.0
    Steward-->>Node: 200 OK (no WAF block)
    Node->>Container: docker start
    Container->>Container: vault bootstrap (passphrase OK)
    Container->>Container: eliza-api listens on :3000
    Node->>Container: health probe to :3000
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/image.yaml`, line 73-88 ([link](https://github.com/elizaos/eliza/blob/efe6e7ce0c5b93ca91303cf2c8d0e01d52317f3d/.github/workflows/image.yaml#L73-L88)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`image.yaml` missing prerequisite build steps for `Dockerfile.ci`**

   `Dockerfile.ci` is a copy-only image builder — its header explicitly states "Pre-built artifacts come from GHA (bun install + tsdown + vite build done before docker)". The `build-agent-image.yml` workflow was correctly updated to add `bun install`, plugin builds, UI build, and agent workspace build before calling `docker build`. `image.yaml` (the release-triggered workflow) was only changed to swap the Dockerfile name, with no corresponding build steps added. Any release-tagged image produced by this workflow will be missing every `plugins/*/dist/` directory, reproducing the same broken `import "@elizaos/plugin-sql"` crash that this PR set out to fix — but now for all production release tags.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["style(cloud): format docker sandbox prov..."](https://github.com/elizaos/eliza/commit/22a00a85a99ecdc32d6eb7de916de20780efa7ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32059911)</sub>

<!-- /greptile_comment -->