### PR TITLE
feat(android): FLAG_KEEP_SCREEN_ON while agent app is foregrounded

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -77,8 +77,9 @@ public class MainActivity extends BridgeActivity {
         // Voice turns (ASR → LLM → TTS) on local-runtime builds regularly
         // take 1-5 seconds; screen-off mid-turn breaks the "is the agent
         // still working?" feedback and confuses the user. The flag is
-        // window-scoped — Android lifts it automatically on `onPause`, so
-        // background instances don't drain battery. Same flag set by
+        // window-scoped — Android releases it automatically when the window
+        // is no longer visible (app moved to background or fully covered),
+        // so background instances don't drain battery. Same flag set by
         // every video / voice-calling app (Snapchat, YouTube, Zoom, Meet).
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.WindowManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -71,6 +72,15 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AgentPlugin.class);
         registerPlugin(BatteryOptimizationPlugin.class);
         super.onCreate(savedInstanceState);
+
+        // Keep the screen on while the agent app is in the foreground.
+        // Voice turns (ASR → LLM → TTS) on local-runtime builds regularly
+        // take 1-5 seconds; screen-off mid-turn breaks the "is the agent
+        // still working?" feedback and confuses the user. The flag is
+        // window-scoped — Android lifts it automatically on `onPause`, so
+        // background instances don't drain battery. Same flag set by
+        // every video / voice-calling app (Snapchat, YouTube, Zoom, Meet).
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         // The Capacitor WebView serves the renderer at https://localhost
         // (its default secure-context origin); the on-device Eliza agent


### PR DESCRIPTION
## Summary

Set `FLAG_KEEP_SCREEN_ON` on the Capacitor `MainActivity` window so the Android phone screen stays awake while the agent app is foregrounded.

Voice turns on local-runtime builds (ASR → LLM → TTS) regularly take 1-5 seconds end-to-end. If the screen sleeps mid-turn, the user loses the visible "agent is working" feedback and can't tell whether the request died or is still generating. This is the same flag every voice/video app sets (Snapchat, YouTube, Zoom, Meet, etc.).

Window-scoped flag — Android lifts it automatically on `onPause`, so backgrounded instances don't drain battery.

## Change

`packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java`:
- New import: `android.view.WindowManager`
- One line in `onCreate` after `super.onCreate(...)`:
  ```java
  getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
  ```

The template lives in `app-core` because `apps/app/android/app/src/main/java/ai/milady/milady/MainActivity.java` is gitignored and regenerated by `cap sync` from this source. Editing only the downstream copy in the Capacitor-output dir would not survive a clean checkout.

## Verification

Rebuilt the Milady Android APK with `MILADY_ELIZA_SOURCE=local bun run build:android` — `BUILD SUCCESSFUL`, 494 MB APK. Inspected `classes.dex` to confirm `addFlags(I)V` with the `0x80` (`FLAG_KEEP_SCREEN_ON`) constant in `MainActivity.onCreate`.

## Related

- Companion to [RFC #7666](https://github.com/elizaOS/eliza/issues/7666) (AOSP local TTS wiring) — once local Kokoro fires on-device, voice turns will be long enough that an always-awake screen during a turn is essential for the UX.
- No interaction with [RFC #7667](https://github.com/elizaOS/eliza/issues/7667).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `FLAG_KEEP_SCREEN_ON` to the Capacitor `MainActivity` window so the screen stays awake while the app is foregrounded. The flag is window-scoped and Android lifts it automatically once the window is no longer visible, so backgrounded instances are unaffected.

- `WindowManager` is imported and `addFlags(FLAG_KEEP_SCREEN_ON)` is called in `onCreate` immediately after `super.onCreate()`, which is the correct placement since the window is guaranteed to exist at that point.
- The flag is set unconditionally for the entire foreground session; if finer-grained control (only during active voice turns) is ever needed, `addFlags`/`clearFlags` would need to be called dynamically from the plugin layer.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single, well-understood window flag set in the correct lifecycle method with no side effects on other code paths.

The change is a single addFlags call placed after super.onCreate(), which is the standard and correct location. The flag is window-scoped and Android releases it automatically when the window is no longer visible, so there is no battery-drain risk for backgrounded instances. The implementation matches the established Android pattern used by video and voice apps.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java | Adds FLAG_KEEP_SCREEN_ON in onCreate after super.onCreate(); correct placement and well-commented. Screen stays on unconditionally for the entire foreground session, not only during active voice turns. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Activity.attach — window created] --> B[onCreate called]
    B --> C[WebView debug / plugin registration]
    C --> D[super.onCreate — Capacitor WebView initialized]
    D --> E["getWindow().addFlags(FLAG_KEEP_SCREEN_ON)"]
    E --> F[App foregrounded — screen stays awake]
    F --> G{Activity lifecycle event}
    G -- onStop / onDestroy --> H[Window no longer visible]
    H --> I[Android removes FLAG_KEEP_SCREEN_ON automatically]
    I --> J[Normal screen-timeout resumes]
    G -- Still foregrounded --> F
```

<sub>Reviews (2): Last reviewed commit: ["fix(android): clarify keep-screen-on win..."](https://github.com/elizaos/eliza/commit/a02d6abd8c5fd167fecb9f2948a1a841161be53c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32064008)</sub>

<!-- /greptile_comment -->