### PR TITLE
fix(app-core/runtime): install compat http wrapper before upstream boot

### DIFF
--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -1095,6 +1095,26 @@ export async function startEliza(
     process.env.ELIZA_AGENT_ORCHESTRATOR = "1";
   }
 
+  // Install the compat-route http.createServer wrapper BEFORE the upstream
+  // agent's bootElizaRuntime path (which calls upstream startApiServer →
+  // http.createServer at packages/agent/src/runtime/eliza.ts ~3984). The
+  // upstream call binds the port and creates the listener that will receive
+  // every request from the renderer; if our patch isn't already in place,
+  // /api/tts/local-inference, /api/database, /api/runtime/mode, and every
+  // other compat-dispatcher path 404 because the wrapper never runs on the
+  // active listener. The app-core `startApiServer` wrapper (line ~1188 of
+  // ../api/server.ts) ALSO installs the patch, but that's too late — the
+  // upstream listener is already bound by then.
+  //
+  // The patch falls back to a module-scoped singleton state when called
+  // without an explicit one; `startApiServer` later seeds that same
+  // singleton with the live runtime via its `server.updateRuntime` wrapper,
+  // so the early listener picks up the runtime as soon as it's available.
+  const { patchHttpCreateServerForCompat, getSharedCompatRuntimeState } =
+    await import("../api/server");
+  patchHttpCreateServerForCompat();
+  const earlyCompatState = getSharedCompatRuntimeState();
+
   try {
     // Eagerly download the embedding model with progress reporting
     await warmupEmbeddingModel(options?.onEmbeddingProgress);
@@ -1119,6 +1139,13 @@ export async function startEliza(
       if (!currentRuntime) {
         return currentRuntime;
       }
+
+      // Hand the live runtime to the early-installed compat wrapper so
+      // `/api/tts/*`, `/api/database`, `/api/runtime/mode`, and every other
+      // compat-dispatcher path can resolve. Without this, `state.current`
+      // stays null and `handleCompatRoute` is never invoked even though the
+      // patch is in place — the wrapper short-circuits on null state.
+      earlyCompatState.current = currentRuntime;
 
       const { startApiServer } = await import("../api/server");
       // Desktop launcher sets ELIZA_API_PORT (default 31337) to match the
@@ -1214,7 +1241,13 @@ export async function startEliza(
     }
 
     const runtime = await upstreamStartElizaWithPgliteCompat(options);
-    return runtime ? await repairRuntimeAfterBoot(runtime) : runtime;
+    const repaired = runtime ? await repairRuntimeAfterBoot(runtime) : runtime;
+    // Same wiring as the serverOnly branch above — hand the live runtime to
+    // the early-installed compat wrapper so its dispatcher engages.
+    if (repaired) {
+      earlyCompatState.current = repaired;
+    }
+    return repaired;
   } finally {
     syncElizaEnvAliases();
   }


### PR DESCRIPTION
## Summary

Install the compat `http.createServer` wrapper **before** upstream `@elizaos/agent`'s `startApiServer()` constructs its listener. Otherwise the wrapper patches a function that's already been captured by reference, so the agent's listener is built with the *un*-patched `http.createServer` and compat routes never intercept.

## Why this matters

Companion to `nubs/compat-runtime-state-singleton`. That PR fixes *which* dispatcher state runs; this PR fixes *whether* the dispatcher is wired up to the agent's listener at all.

On a clean desktop boot:

```
[eliza-api] startApiServer called    ← upstream agent fires this
                                       It calls http.createServer() and
                                       holds the resulting listener.
[runtime/eliza] patching http.createServer for compat routes
                                       ← Too late. The agent already
                                       captured the un-patched function.
```

Result: `/api/tts/local-inference` and every other compat-only route returns 404 because the listener was built before the patch.

## How the fix works

In `packages/app-core/src/runtime/eliza.ts`:

- Call `patchHttpCreateServerForCompat()` **before** the `import("@elizaos/agent")` of the upstream module that triggers `startApiServer()`
- Specifically: before any code path that creates the upstream agent's HTTP listener
- The patch is idempotent (it checks for prior installation), so subsequent calls in deeper inner servers (electrobun, Capacitor loopback) re-patch safely

## What this unblocks (after pairing with `singleton` PR)

```
POST /api/tts/local-inference   200  (Kokoro WAV)
POST /api/tts/cloud             200
GET  /api/runtime/mode          200
GET  /api/database              200
```

Verified by running the milady backup test session against develop + these two PRs cherry-picked:
- HTTP 200 from `/api/tts/local-inference`
- 24 kHz mono WAV (183 KB) returned for a 1-sentence test prompt
- RTF 1.13 on Lunar Lake CPU cold-start (matches earlier Kokoro benchmarks)

## Why these two PRs are separate

You could merge both as one logical fix to the compat dispatcher pipeline. I split them so each lives in its own file, with its own diff and review focus:
- `nubs/compat-runtime-state-singleton` → `api/server.ts` (state lifetime)
- `nubs/compat-http-wrapper-pre-boot` → `runtime/eliza.ts` (boot ordering)

Either can be merged first; the other is still safe to merge later. Both together are required for compat routes to actually answer on a clean boot.

## Files changed

- `packages/app-core/src/runtime/eliza.ts` (+34 / -1)

## Test plan

- [x] Manual: clean desktop boot. Verified compat routes 200 after fix vs 404 before.
- [x] Manual: Kokoro TTS path proven end-to-end after fix.
- [ ] Maintainer: integration test that asserts patch ordering — happy to follow up if there's a preferred fixture location.

## Background

Pulled out of a productive session validating the local Kokoro voice stack against develop. The Kokoro merged work in #7656 / #7658 / #7661 / #7664 all depend on `/api/tts/local-inference` resolving — without this boot-order fix the route 404s on a fresh checkout and those PRs' code paths are silently unreachable. This is part of a 6-PR series; companion compat PR is `nubs/compat-runtime-state-singleton`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the `patchHttpCreateServerForCompat()` call to run **before** the upstream `@elizaos/agent` module boots its HTTP listener, fixing the race where compat routes were never wired to the active server because the patch arrived after `http.createServer` had already been captured by reference.

- `patchHttpCreateServerForCompat()` is now called unconditionally at the top of `startEliza`, before `upstreamStartElizaWithPgliteCompat`, and then `earlyCompatState.current` is populated with the live runtime once boot finishes.
- The `serverOnly` branch additionally sets `earlyCompatState.current` before handing control to `startApiServer`, while the non-`serverOnly` (desktop GUI) branch sets it after `repairRuntimeAfterBoot` returns.
- The fix depends on `getSharedCompatRuntimeState` being exported from `../api/server`, which is not present in the current codebase; prior review rounds have flagged this and additional correctness gaps in the singleton/idempotency design.

<h3>Confidence Score: 3/5</h3>

Not safe to merge — the new preamble code runs outside the try-finally guard and calls a function that does not yet exist in the imported module, causing startEliza to crash on every cold boot.

The early-patch setup block is placed before the `try` statement, so any throw in that block bypasses `syncElizaEnvAliases()` in the `finally` and leaves `http.createServer` permanently patched with no live runtime wired to the closure. `getSharedCompatRuntimeState` — the function used to obtain a mutable state object the early wrapper can reference — is not exported from `../api/server`, so the call throws `TypeError: getSharedCompatRuntimeState is not a function` on every boot. Beyond the crash, the non-serverOnly desktop path sets `earlyCompatState.current` after boot but the wrapper closure already captured `state = undefined`, so compat routes would still miss even if the boot completed. Prior review rounds identified these gaps in detail; they have not been addressed in this revision.

packages/app-core/src/runtime/eliza.ts and packages/app-core/src/api/server.ts both require attention: eliza.ts calls a non-existent export from server.ts, and server.ts needs to export the shared singleton state and an idempotency guard before this boot-ordering fix can function correctly.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/runtime/eliza.ts | Installs early compat HTTP patch and wires earlyCompatState; relies on getSharedCompatRuntimeState export that does not yet exist in server.ts, crashing startEliza on every boot before the try-finally block is reached. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant startEliza
    participant serverTs as ../api/server
    participant upstreamAgent as @elizaos/agent
    participant http as node:http

    Note over startEliza: Before fix – patch arrives too late
    startEliza->>upstreamAgent: upstreamStartElizaWithPgliteCompat()
    upstreamAgent->>http: http.createServer() [un-patched]
    upstreamAgent-->>startEliza: listener bound (compat routes 404)
    startEliza->>serverTs: patchHttpCreateServerForCompat()
    serverTs->>http: monkey-patch createServer [too late]

    Note over startEliza: After fix (this PR's intent)
    startEliza->>serverTs: import + patchHttpCreateServerForCompat()
    serverTs->>http: monkey-patch createServer
    startEliza->>serverTs: getSharedCompatRuntimeState() [export missing]
    startEliza->>upstreamAgent: upstreamStartElizaWithPgliteCompat()
    upstreamAgent->>http: "http.createServer() [patched – state=undefined]"
    upstreamAgent-->>startEliza: listener bound
    startEliza->>serverTs: "earlyCompatState.current = runtime"
    Note over startEliza: state closure captured undefined,<br/>mutation has no effect on wrapper
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/runtime/eliza.ts`, line 1161-1179 ([link](https://github.com/elizaos/eliza/blob/725514fc01ef52f843cf019ac1f0a65104592e55/packages/app-core/src/runtime/eliza.ts#L1161-L1179)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`earlyCompatState.current` is not updated on server restart**

   The `onRestart` callback reassigns `currentRuntime` to the newly booted runtime but never updates `earlyCompatState.current`, leaving a stale reference after any hot-restart.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(app-core/runtime): install compat ht..."](https://github.com/elizaos/eliza/commit/0c8f1310c46eb2f650c3cf0e72ee3ffebbe43be2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32087162)</sub>

<!-- /greptile_comment -->