### PR TITLE
fix(local-inference/voice/kokoro): reject over-length input with clear error

### DIFF
--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts
@@ -198,6 +198,19 @@ export class KokoroOnnxRuntime implements KokoroRuntime {
 	}
 
 	async synthesize(args: KokoroRuntimeInputs): Promise<{ cancelled: boolean }> {
+		// Kokoro's BERT encoder is exported with a fixed max sequence length of
+		// 510 phoneme tokens (matches `kokoro-onnx` upstream
+		// `kokoro_onnx/__init__.py:MAX_PHONEME_LENGTH`). Anything longer trips
+		// an unhelpful "invalid expand shape" failure deep inside ORT's
+		// `/encoder/bert/Expand` node and surfaces to callers as an opaque 502.
+		// Reject early with a clear message so the API layer can map it to a
+		// 4xx and so the user sees what to do about it (split into chunks).
+		if (args.phonemes.ids.length > 510) {
+			throw new Error(
+				`[kokoro] phoneme sequence is too long: ${args.phonemes.ids.length} > 510. ` +
+					`The Kokoro ONNX export caps the BERT encoder at 510 tokens; split the input into shorter chunks before synthesizing.`,
+			);
+		}
 		const { ort, session } = await this.ensureSession();
 		const fullStyle = await this.loadVoiceStyle(args.voice);
 		const inputIds = new BigInt64Array(args.phonemes.ids.length);


### PR DESCRIPTION
## Summary

Reject Kokoro phoneme inputs longer than 510 tokens with a clear, actionable error message *before* attempting tensor work. Replaces the cryptic `invalid expand shape` failure that surfaces today as an opaque HTTP 502.

## Background

The Kokoro ONNX export caps its BERT encoder at 510 phoneme tokens — this matches `kokoro-onnx` upstream's `MAX_PHONEME_LENGTH = 510`. Anything longer trips a deeply nested ORT failure inside `/encoder/bert/Expand`:

```
Non-zero status code returned while running Expand node.
Name:'/encoder/bert/Expand' Status Message: invalid expand shape
```

That's wrapped by the API layer as HTTP 502 with the raw ORT message, which is **useless for anyone trying to figure out what to do about it**. The error doesn't even mention input length, BERT, or token counts — just talks about Expand-node shapes.

Reproduces with any input that phonemizes to >510 tokens; on this codebase a 759-character prompt phonemizes to 745 tokens and is enough to trigger the failure.

## The fix

Add a length guard at the top of `KokoroOnnxRuntime.synthesize` that fires before any tensor work:

```ts
async synthesize(args: KokoroRuntimeInputs): Promise<{ cancelled: boolean }> {
  if (args.phonemes.ids.length > 510) {
    throw new Error(
      `[kokoro] phoneme sequence is too long: ${args.phonemes.ids.length} > 510. ` +
        `The Kokoro ONNX export caps the BERT encoder at 510 tokens; split the input into shorter chunks before synthesizing.`,
    );
  }
  // ... existing code
}
```

The thrown message points at the actual cause (BERT encoder cap) and the fix (split into chunks).

## Before / after

```
POST /api/tts/local-inference {"text": "<759 character prompt>"}

→ before: HTTP 502
  {"error":"Local inference TTS error: Non-zero status code returned
   while running Expand node. Name:'/encoder/bert/Expand' Status
   Message: invalid expand shape"}

→ after:  HTTP 502
  {"error":"Local inference TTS error: [kokoro] phoneme sequence is
   too long: 745 > 510. The Kokoro ONNX export caps the BERT encoder
   at 510 tokens; split the input into shorter chunks before
   synthesizing."}
```

The status code stays 502 because the route layer wraps every `useLocalInferenceTts` rejection that way. A separate change to map this typed too-long error to **413 Payload Too Large** belongs in the route handler (not in this runtime file) — I can follow up on that as a separate PR if you'd like.

## What this is NOT

This is **not** a sentence-chunker. A real chunker that splits long text on sentence boundaries and concatenates the resulting waveforms would be a better long-term fix; this commit is the cheap "stop showing users a confusing crash" deliverable while that bigger change waits. The chunker fix touches the API/route layer + phonemizer; this fix touches only the runtime. I split them so this can ship today.

## Path note

Ported to the new `plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts` location from the original commit in `packages/app-core/src/services/local-inference/voice/kokoro/`. The recent refactor `f51c36f0c1` moved kokoro-runtime.ts between the original work and this push.

## Files changed

- `plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts` (+13 / 0)
  - 12 lines of guard + comment at the top of `synthesize()`

## Test plan

- [x] Manual: 759-char prompt now shows clean error message
- [x] Manual: <510-char prompts still synthesize OK (no regression)
- [ ] Maintainer: unit test asserting `args.phonemes.ids.length === 511` throws with the documented message; happy to add it.

## Relationship to other PRs in this series

Part of a 6-PR push:
- `nubs/compat-runtime-state-singleton` + `nubs/compat-http-wrapper-pre-boot` — compat dispatcher fixes
- `nubs/kokoro-speed-tensor-metadata-probe` — supersedes my merged #7664 with metadata probe
- `nubs/kokoro-intra-op-parallelism` — 1.24× RTF speedup
- **This PR**: clear 510-token error
- `nubs/hardware-probe-tdz-fix` — try/catch around `getLlama()` init

All five are independent. This one ships standalone with zero behavior change for short inputs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pre-flight length guard to `KokoroOnnxRuntime.synthesize` that rejects phoneme sequences exceeding the Kokoro BERT encoder's hard 510-token cap before any tensor work begins, replacing an opaque ORT crash (`invalid expand shape`) with a clear, actionable error message.

- The guard fires before `ensureSession()`, so no model load or tensor allocation is wasted on oversized inputs.
- The error message names the BERT encoder cap and instructs callers to split the input, which is a meaningful improvement over the existing HTTP 502 with a raw ORT node failure string.
- The PR explicitly defers the follow-up work (sentence chunking, 413 status mapping) to separate PRs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, additive guard that only affects inputs already broken at runtime.

The change touches a single method with a simple conditional that fires before any stateful work. Short inputs are unaffected; long inputs that previously caused a confusing crash now receive a clear error instead. No logic is altered for the passing case.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-runtime.ts | Adds an early-exit guard at the top of `synthesize()` that rejects phoneme sequences longer than 510 tokens with an actionable error message, preventing an opaque ORT "invalid expand shape" crash. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[synthesize called] --> B{phonemes.ids.length > 510?}
    B -- Yes --> C[throw Error with actionable message]
    B -- No --> D[ensureSession / load ONNX model]
    D --> E[loadVoiceStyle]
    E --> F[build ORT tensors]
    F --> G[session.run]
    G --> H{waveform returned?}
    H -- No --> I[throw Error: no float32 waveform]
    H -- Yes --> J[write PCM to stream]
    J --> K[return cancelled: false]
```

<sub>Reviews (2): Last reviewed commit: ["fix(local-inference/voice/kokoro): rejec..."](https://github.com/elizaos/eliza/commit/4c25cc9828965a928f2000884fdef5ccde3aedf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32087175)</sub>

<!-- /greptile_comment -->