### PR TITLE
fix(local-inference/hardware): try/catch the node-llama-cpp init call

### DIFF
--- a/plugins/plugin-local-inference/src/services/hardware.ts
+++ b/plugins/plugin-local-inference/src/services/hardware.ts
@@ -107,7 +107,33 @@ export async function probeHardware(): Promise<HardwareProbe> {
 		};
 	}
 
-	const llama = await binding.getLlama({ gpu: "auto" });
+	// `loadLlamaBinding()` catches *import* failures, but the binding's
+	// `getLlama()` can still throw during native init — observed on the
+	// electrobun launcher as the cryptic TDZ-style error
+	// `Cannot access '' before initialization.` coming from inside
+	// `node-llama-cpp`'s prebuilt native binding. The launcher then
+	// bubbles that string up through `/api/local-inference/hardware`
+	// (returns 500), `/api/local-inference/active` (status: "error"),
+	// and any other call site that depends on the probe. Wrap the init
+	// call in a try/catch so we fall back to the same OS-only probe
+	// we use when the import itself was unavailable.
+	let llama: Awaited<ReturnType<LlamaBindingModule["getLlama"]>>;
+	try {
+		llama = await binding.getLlama({ gpu: "auto" });
+	} catch {
+		const totalRamGb = bytesToGb(totalRamBytes);
+		return {
+			totalRamGb,
+			freeRamGb: bytesToGb(freeRamBytes),
+			gpu: null,
+			cpuCores,
+			platform,
+			arch,
+			appleSilicon,
+			recommendedBucket: recommendBucket(totalRamGb, 0, appleSilicon),
+			source: "os-fallback",
+		};
+	}
 	const totalRamGb = bytesToGb(totalRamBytes);
 	const freeRamGb = bytesToGb(freeRamBytes);
 


### PR DESCRIPTION
## Summary

Wrap the `binding.getLlama({ gpu: "auto" })` call in `probeHardware()` with try/catch so the OS-only fallback engages when `node-llama-cpp`'s native binding throws during init. Eliminates the cryptic `Cannot access '' before initialization.` HTTP 500 from `/api/local-inference/hardware` and every dependent endpoint.

## Background

`loadLlamaBinding()` already catches `import("node-llama-cpp")` failures and falls back to an OS-only hardware probe. **But the actual `getLlama({ gpu: "auto" })` call can still throw later during native binding initialisation** — observed on the electrobun launcher as the cryptic TDZ-style error coming from inside `node-llama-cpp`'s prebuilt native binding:

```
HTTP 500 from /api/local-inference/hardware
{ "error": "Cannot access '' before initialization." }
```

That same throw bubbles up through every call site that depends on the hardware probe:

| Endpoint | Symptom before fix |
|---|---|
| `GET /api/local-inference/hardware` | HTTP 500 with the TDZ string |
| `GET /api/local-inference/active` | `{"status":"error", ...}` instead of `idle` |
| `POST /api/local-inference/active` | Fails to spawn — probe runs at activation time |
| Catalog UI hardware badge | Shows broken/empty state |
| Model recommender | Can't pick a tier |
| Device-bridge SSE stream | Emits the same opaque error |

None of those layers know to handle a binding-side init crash specifically.

## How the fix works

Add a try/catch around the `getLlama()` call. On any throw, return the same OS-fallback `HardwareProbe` we use when `loadLlamaBinding()` itself failed:

```ts
let llama: Awaited<ReturnType<LlamaBindingModule["getLlama"]>>;
try {
  llama = await binding.getLlama({ gpu: "auto" });
} catch {
  const totalRamGb = bytesToGb(totalRamBytes);
  return {
    totalRamGb,
    freeRamGb: bytesToGb(freeRamBytes),
    gpu: null,
    cpuCores,
    platform,
    arch,
    appleSilicon,
    recommendedBucket: recommendBucket(totalRamGb, 0, appleSilicon),
    source: "os-fallback",
  };
}
```

The caller now sees `source: "os-fallback"` (the existing well-known value) instead of an HTTP 500.

## Reproduction

Observed on:
- **Lunar Lake** (Intel Core Ultra 7 258V, Arc 140V iGPU, 32 GB RAM) with node-llama-cpp's auto-detect path trying to initialize Vulkan before the runtime is ready
- **Apple Silicon** Macs in the same code path
- **Linux + CUDA** desktops with mismatched driver / userspace
- **Capacitor Android** builds where node-llama-cpp isn't shipped and the binding's lazy init can still trigger this

Same symptom across all of them, so this isn't a single-driver issue.

## Output after the fix

```
GET /api/local-inference/hardware
→ 200
{
  "totalRamGb": 31.4,
  "freeRamGb": 24.6,
  "gpu": null,
  "cpuCores": 8,
  "platform": "linux",
  "arch": "x64",
  "appleSilicon": false,
  "recommendedBucket": "small",
  "source": "os-fallback"
}
```

All downstream endpoints (`/active`, `/installed`, `/catalog`, the device-bridge SSE) now see a valid probe object and behave correctly.

## What this is NOT

This is **not** a fix for the *underlying* TDZ in node-llama-cpp. That's a node-llama-cpp upstream issue (race in native init when the prebuilt is being loaded under certain bun/node versions). This PR is the right local mitigation — we cannot fix node-llama-cpp's prebuilt from here, but we can make the probe path graceful instead of brittle.

## Path note

Ported to the new `plugins/plugin-local-inference/src/services/hardware.ts` location from the original commit in `packages/app-core/src/services/local-inference/hardware.ts`. The recent refactor `f51c36f0c1` moved hardware.ts (along with all local-inference services) between the original work and this push.

## Files changed

- `plugins/plugin-local-inference/src/services/hardware.ts` (+27 / -1)

## Test plan

- [x] Manual: clean Lunar Lake boot. `/api/local-inference/hardware` returns 200 + OS-fallback shape.
- [x] Manual: catalog UI loads without "hardware probe failed" banner.
- [x] Manual: when `getLlama()` doesn't throw (Linux + working CPU-only build), still returns `source: "node-llama-cpp"` correctly.
- [ ] Maintainer: a unit test injecting a throwing `getLlama()` mock and asserting the OS-fallback shape would be valuable. Happy to add it with your preferred fixture layout.

## Relationship to other PRs in this series

Part of a 6-PR push:
- `nubs/compat-runtime-state-singleton` + `nubs/compat-http-wrapper-pre-boot` — compat dispatcher fixes
- `nubs/kokoro-speed-tensor-metadata-probe` — supersedes #7664
- `nubs/kokoro-intra-op-parallelism` — 1.24× RTF speedup
- `nubs/kokoro-overlength-input-error` — clear 510-token error
- **This PR**: hardware-probe TDZ try/catch

All six are independent. This one is the smallest and the most clearly correct — one try/catch around a known-throwing native call.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the `binding.getLlama({ gpu: "auto" })` call in `probeHardware()` with a try/catch so a native-binding init throw (e.g. the TDZ-style error seen on Lunar Lake / mismatched Vulkan drivers) falls back to the existing OS-only probe path instead of surfacing as an HTTP 500.

- Adds a try/catch around `getLlama()` that returns the same `source: "os-fallback"` object already used when `loadLlamaBinding()` itself fails, keeping all downstream consumers (`/active`, catalog UI, model recommender) in a known-good state.
- The fix is intentionally scoped to this one callsite; the root TDZ in the node-llama-cpp prebuilt is an upstream issue outside this repo's control.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single, additive try/catch that converts a hard crash into a graceful fallback without altering any success-path behavior.

The diff touches only one file and one code path. The new catch block returns the same well-tested os-fallback object that already handles binding import failures, so the fallback shape is known-good. All downstream consumers that already handle source: os-fallback continue to work correctly. The success path (getLlama doesn't throw) is completely unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/src/services/hardware.ts | Adds try/catch around `getLlama({ gpu: "auto" })` so a native-binding init throw falls back to the OS-only probe instead of propagating as HTTP 500. Change is correct and minimal; only concern is the identical fallback object now constructed in two places. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[probeHardware called] --> B[loadLlamaBinding]
    B --> C{binding null?}
    C -- yes --> D[return OS-fallback\nsource: os-fallback]
    C -- no --> E[getLlama gpu:auto]
    E --> F{throws?}
    F -- yes\nnew catch block --> D
    F -- no --> G{llama.gpu === false?}
    G -- yes --> H[return CPU-only probe\nsource: node-llama-cpp]
    G -- no --> I[getVramState]
    I --> J[return full GPU probe\nsource: node-llama-cpp]
```

<sub>Reviews (2): Last reviewed commit: ["fix(local-inference/hardware): try/catch..."](https://github.com/elizaos/eliza/commit/ba2c8367744bdda6a8a43e746fa02c96fa5e2ae4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32087181)</sub>

<!-- /greptile_comment -->