### PR TITLE
fix(discord): avoid false success and timeout receipts

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5313,6 +5313,18 @@ function _shouldAttemptActionRescue(
 		return false;
 	}
 
+	const draftText = String(responseContent.text ?? "").trim();
+	const source =
+		typeof message.content === "object" && message.content
+			? (message.content as { source?: unknown }).source
+			: undefined;
+	if (source === "discord" && draftText.length > 0) {
+		return false;
+	}
+	if (hasExplicitReplyIntent(responseContent) && draftText.length > 0) {
+		return false;
+	}
+
 	if (looksLikeNonActionableChatter(message)) {
 		return false;
 	}

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1064,7 +1064,9 @@ export class MessageManager {
 						await this.runtime.createMemory(m, "messages");
 					}
 
-					responseEmitted = memories.length > 0;
+					if (memories.length > 0) {
+						responseEmitted = true;
+					}
 					typingController.stop();
 					statusReactions?.setDone();
 

--- a/plugins/plugin-discord/status-reactions.ts
+++ b/plugins/plugin-discord/status-reactions.ts
@@ -12,7 +12,6 @@ export interface StatusReactionController {
 
 const EMOJI_QUEUED = "⏳";
 const EMOJI_THINKING = "🤔";
-const EMOJI_DONE = "✅";
 const EMOJI_ERROR = "❌";
 
 export function shouldShowStatusReaction(
@@ -47,6 +46,21 @@ export function createStatusReactionController(
 	let chain: Promise<void> = Promise.resolve();
 	const botId = message.client?.user?.id;
 
+	const clearCurrentReaction = async () => {
+		if (!currentEmoji || !botId) {
+			return;
+		}
+		try {
+			const reaction = message.reactions.resolve(currentEmoji);
+			if (reaction) {
+				await reaction.users.remove(botId);
+			}
+		} catch {
+			// Ignore missing permissions or already-removed reactions.
+		}
+		currentEmoji = null;
+	};
+
 	const transition = (emoji: string, terminal = false) => {
 		if (finished) {
 			return;
@@ -80,10 +94,20 @@ export function createStatusReactionController(
 		});
 	};
 
+	const finishWithoutSuccessReaction = () => {
+		if (finished) {
+			return;
+		}
+		chain = chain.then(async () => {
+			await clearCurrentReaction();
+			finished = true;
+		});
+	};
+
 	return {
 		setQueued: () => transition(EMOJI_QUEUED),
 		setThinking: () => transition(EMOJI_THINKING),
-		setDone: () => transition(EMOJI_DONE, true),
+		setDone: () => finishWithoutSuccessReaction(),
 		setError: () => transition(EMOJI_ERROR, true),
 	};
 }


### PR DESCRIPTION
## Summary
- mark Discord replies as emitted only after the outbound message is actually created
- stop success reactions from appearing as false green-check receipts
- avoid action-rescue fallback when the model already produced a valid Discord text reply

## Validation
- git diff --check origin/develop...HEAD passed

## Notes
Fresh-worktree package typechecks are blocked by dependency/module-resolution setup issues unrelated to this patch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three distinct correctness issues in the Discord plugin's message flow: false ✅ success reactions appearing after every reply, a `responseEmitted` flag that could be incorrectly reset to `false` when a callback fires with empty memories, and the action-rescue fallback triggering even when the model already produced a valid text reply.

- **`status-reactions.ts`**: `setDone()` now calls `finishWithoutSuccessReaction()`, which clears the in-progress emoji (⏳/🤔) and marks the controller finished without ever adding a ✅ reaction.
- **`messages.ts`**: `responseEmitted` is now only ever set to `true` inside the callback, preventing a zero-memory invocation from overwriting an earlier `true` set by a prior successful send.
- **`packages/core/src/services/message.ts`**: `_shouldAttemptActionRescue` gains two new early-exit guards — one keyed to `source === "discord"` with non-empty text, and one keyed to explicit REPLY/RESPOND intent with non-empty text — so the rescue path is skipped when the model has already committed to a conversational reply.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all three changes address observable Discord misbehaviors with no meaningful regression risk.

The status-reactions and messages.ts plugin changes are straightforward and well-scoped. The one thing worth a second look is the `source === "discord"` string introduced into the platform-agnostic core rescue function — it works correctly today but creates a precedent for per-platform strings accumulating in core over time.

packages/core/src/services/message.ts — the new Discord-specific source check is the only platform-named string in this generic module.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Adds two early-returns in `_shouldAttemptActionRescue` to skip action rescue when the model already produced text; the Discord-specific source check is the only platform-hardcoded string in this otherwise generic module. |
| plugins/plugin-discord/messages.ts | Guards `responseEmitted = true` so a successful callback with non-empty memories can no longer be overwritten back to `false` by a subsequent empty-memories callback invocation. |
| plugins/plugin-discord/status-reactions.ts | Replaces `setDone -> success reaction` with `finishWithoutSuccessReaction` that clears the in-progress emoji and sets `finished = true` without adding a green-check, eliminating false success receipts. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Discord User
    participant MM as MessageManager
    participant SC as StatusReactions
    participant MS as MessageService (core)
    participant CB as onMessage Callback

    User->>MM: Incoming message
    MM->>SC: setQueued()
    MM->>SC: setThinking()
    MM->>MS: processMessage()
    MS->>MS: "_shouldAttemptActionRescue() returns false if source=discord + text"
    MS-->>MM: responseContent
    MM->>CB: invoke with sent Discord messages
    CB->>CB: createMemory() for each
    CB->>SC: setDone() clears emoji, no success reaction added
    CB->>CB: "if memories.length > 0 then responseEmitted = true"
    CB-->>MM: return memories
    MM->>MM: if not responseEmitted then finalizePendingDraft()
```

<sub>Reviews (1): Last reviewed commit: ["fix(discord): avoid false success and ti..."](https://github.com/elizaos/eliza/commit/d68786925863387ee66bd66af68041da369b63d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32111124)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->