### PR TITLE
fix(actions): bound validation and preserve image tools

### DIFF
--- a/cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts
+++ b/cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts
@@ -134,8 +134,15 @@ function getMessageText(message: Memory): string {
 }
 
 function isImageGenerationRequest(message: Memory): boolean {
-  return /\b(generate|create|make|draw|render)\b[\s\S]{0,80}\b(image|picture|poster|meme|png|photo|illustration|ad creative)\b/i.test(
-    getMessageText(message),
+  const text = getMessageText(message);
+  return (
+    /\b(generate|create|make|draw|render|produce|publish)\b[\s\S]{0,100}\b(image|picture|poster|meme|png|photo|illustration|ad creative|creative pack|ad pack|advertisement|campaign creative)\b/i.test(
+      text,
+    ) ||
+    /\b(image|picture|poster|meme|png|photo|illustration|ad creative|creative pack|ad pack|advertisement|campaign creative)\b[\s\S]{0,100}\b(generate|create|make|draw|render|produce|publish)\b/i.test(
+      text,
+    ) ||
+    /\bfal\b/i.test(text)
   );
 }
 
@@ -150,7 +157,18 @@ function narrowActionsForIntent(actions: Action[], message: Memory): Action[] {
     return actions;
   }
 
-  const wanted = new Set(["GENERATE_MEDIA", "GENERATE_IMAGE", "CREATE_IMAGE", "REPLY", "NONE", "FINISH"]);
+  const wanted = new Set([
+    "GENERATE_MEDIA",
+    "GENERATE_IMAGE",
+    "CREATE_IMAGE",
+    "CAPTURE_IMAGE",
+    "PRODUCE_AGENT_AD_CREATIVE",
+    "PUBLISH_AGENT_AD_PACK",
+    "MANAGE_AGENT_ADS",
+    "REPLY",
+    "NONE",
+    "FINISH",
+  ]);
   const narrowed = actions.filter((action) => keepAction(action, wanted));
   return narrowed.length > 0 ? narrowed : actions;
 }
@@ -214,10 +232,14 @@ export const actionsProvider: Provider = {
             : null;
 
         let actionsData: Action[];
-        if (freshLastGood) {
-          actionsData = freshLastGood.actions;
-        } else if (isImageGenerationRequest(message)) {
+        if (isImageGenerationRequest(message)) {
+          // Media/ad turns need a deterministic tiny catalog. Do this before
+          // consulting the last-good full cache so we do not spend the Discord
+          // reply window filtering/formatting hundreds of unrelated actions
+          // and then hide the image/ad action behind a provider timeout.
           actionsData = narrowActionsForIntent(runtime.actions, message);
+        } else if (freshLastGood) {
+          actionsData = freshLastGood.actions;
         } else {
           const validation = Promise.all(
             runtime.actions.map((action: Action) =>

--- a/cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts
+++ b/cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts
@@ -101,6 +101,85 @@ type ValidationCacheEntry = {
 
 const validationCache = new Map<string, ValidationCacheEntry>();
 
+function numberSetting(
+  runtime: IAgentRuntime,
+  key: string,
+  fallback: number,
+): number {
+  const env =
+    typeof globalThis === "object" && "process" in globalThis
+      ? (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
+      : undefined;
+  const raw = runtime.getSetting?.(key) ?? env?.[key];
+  const value = typeof raw === "string" ? Number(raw) : raw;
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function unrefTimer(handle: ReturnType<typeof setTimeout>): void {
+  (handle as { unref?: () => void }).unref?.();
+}
+
+type LastGoodValidation = {
+  actions: Action[];
+  discoverableToolCount: number;
+  createdAt: number;
+};
+
+let lastGoodValidation: LastGoodValidation | null = null;
+
+function getMessageText(message: Memory): string {
+  const content = message.content;
+  if (typeof content === "string") return content;
+  return typeof content?.text === "string" ? content.text : "";
+}
+
+function isImageGenerationRequest(message: Memory): boolean {
+  return /\b(generate|create|make|draw|render)\b[\s\S]{0,80}\b(image|picture|poster|meme|png|photo|illustration|ad creative)\b/i.test(
+    getMessageText(message),
+  );
+}
+
+function keepAction(action: Action, wanted: Set<string>): boolean {
+  const name = action.name.trim().toUpperCase();
+  const similes = (action.similes ?? []).map((value) => String(value).trim().toUpperCase());
+  return wanted.has(name) || similes.some((simile) => wanted.has(simile));
+}
+
+function narrowActionsForIntent(actions: Action[], message: Memory): Action[] {
+  if (!isImageGenerationRequest(message)) {
+    return actions;
+  }
+
+  const wanted = new Set(["GENERATE_MEDIA", "GENERATE_IMAGE", "CREATE_IMAGE", "REPLY", "NONE", "FINISH"]);
+  const narrowed = actions.filter((action) => keepAction(action, wanted));
+  return narrowed.length > 0 ? narrowed : actions;
+}
+
+async function validateActionFast(
+  action: Action,
+  runtime: IAgentRuntime,
+  message: Memory,
+  state: State,
+  timeoutMs: number,
+): Promise<Action | null> {
+  const timeout = new Promise<null>((resolve) => {
+    const handle = setTimeout(() => resolve(null), timeoutMs);
+    unrefTimer(handle);
+  });
+
+  const validation = (async () => {
+    try {
+      return (await action.validate(runtime, message, state)) ? action : null;
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      logger.error(`[ACTIONS] validate error: ${action.name}`, errorMessage);
+      return null;
+    }
+  })();
+
+  return Promise.race([validation, timeout]);
+}
+
 /** Invalidate cached validation for a message (e.g., after SEARCH_ACTIONS registers new tools). */
 export function invalidateActionValidationCache(messageId: string): void {
   const cached = validationCache.get(messageId);
@@ -126,19 +205,41 @@ export const actionsProvider: Provider = {
       let cached = cacheKey ? validationCache.get(cacheKey) : undefined;
 
       if (!cached) {
-        const actionsData = (
-          await Promise.all(
-            runtime.actions.map(async (action: Action) => {
-              try {
-                return (await action.validate(runtime, message, state)) ? action : null;
-              } catch (e) {
-                const errorMessage = e instanceof Error ? e.message : String(e);
-                logger.error(`[ACTIONS] validate error: ${action.name}`, errorMessage);
-                return null;
-              }
-            }),
-          )
-        ).filter((a): a is Action => a !== null);
+        const actionValidateTimeoutMs = numberSetting(runtime, "ACTIONS_VALIDATE_TIMEOUT_MS", 250);
+        const providerValidationBudgetMs = numberSetting(runtime, "ACTIONS_PROVIDER_VALIDATION_BUDGET_MS", 1200);
+        const lastGoodCacheTtlMs = numberSetting(runtime, "ACTIONS_LAST_GOOD_CACHE_TTL_MS", 120_000);
+        const freshLastGood =
+          lastGoodValidation && Date.now() - lastGoodValidation.createdAt < lastGoodCacheTtlMs
+            ? lastGoodValidation
+            : null;
+
+        let actionsData: Action[];
+        if (freshLastGood) {
+          actionsData = freshLastGood.actions;
+        } else if (isImageGenerationRequest(message)) {
+          actionsData = narrowActionsForIntent(runtime.actions, message);
+        } else {
+          const validation = Promise.all(
+            runtime.actions.map((action: Action) =>
+              validateActionFast(action, runtime, message, state, actionValidateTimeoutMs),
+            ),
+          ).then((actions) => actions.filter((a): a is Action => a !== null));
+
+          const timed = new Promise<"timeout">((resolve) => {
+            const handle = setTimeout(() => resolve("timeout"), providerValidationBudgetMs);
+            unrefTimer(handle);
+          });
+
+          const validationResult = await Promise.race([validation, timed]);
+          if (validationResult === "timeout") {
+            logger.warn(
+              `[ACTIONS] validation exceeded ${providerValidationBudgetMs}ms; using unvalidated action catalog for this turn`,
+            );
+            actionsData = runtime.actions;
+          } else {
+            actionsData = validationResult;
+          }
+        }
 
         let discoverableToolCount = 0;
         try {
@@ -152,20 +253,26 @@ export const actionsProvider: Provider = {
           /* MCP service may not be available */
         }
 
+        if (actionsData.length > 0) {
+          lastGoodValidation = {
+            actions: actionsData,
+            discoverableToolCount,
+            createdAt: Date.now(),
+          };
+        }
+
         cached = { actions: actionsData, discoverableToolCount };
         if (cacheKey) {
           const timeoutHandle = setTimeout(() => validationCache.delete(cacheKey), 120_000);
-          if (typeof timeoutHandle === "object" && typeof timeoutHandle?.unref === "function") {
-            timeoutHandle.unref();
-          }
+          unrefTimer(timeoutHandle);
           cached.timeoutHandle = timeoutHandle;
           validationCache.set(cacheKey, cached);
         }
       }
 
-      const actionsData = filterActionsByRouting(
-        cached.actions,
-        getContextRoutingFromMessage(message),
+      const actionsData = narrowActionsForIntent(
+        filterActionsByRouting(cached.actions, getContextRoutingFromMessage(message)),
+        message,
       ).filter((action) => !HIDDEN_NATIVE_PLANNER_ACTIONS.has(action.name.trim().toUpperCase()));
       const discoverableToolCount = cached.discoverableToolCount;
       const hasActions = actionsData.length > 0;

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4269,11 +4269,25 @@ const ACTION_REPAIR_PASSIVE_ACTIONS = new Set(
 // "Google Calendar is not connected" in response to a code request. Same
 // precedent as SPAWN_AGENT, the sibling delegation action that's already
 // protected here.
+//
+// Media and advertising actions are also explicit artifact-producing intent.
+// Requests like "generate an image", "make an ad creative", or "publish the
+// ad pack" can contain generic workflow/productivity words that fuzzy metadata
+// scoring over-values for owner/life actions. If the planner already selected
+// a concrete media/ad action, do not rewrite it to LIFE/CALENDAR/etc. based on
+// incidental overlap.
 const EXPLICIT_INTENT_ACTIONS = new Set(
 	[
 		"SPAWN_AGENT",
 		"START_CODING_TASK",
 		"CREATE_TASK",
+		"GENERATE_IMAGE",
+		"GENERATE_MEDIA",
+		"CREATE_IMAGE",
+		"CAPTURE_IMAGE",
+		"PRODUCE_AGENT_AD_CREATIVE",
+		"PUBLISH_AGENT_AD_PACK",
+		"MANAGE_AGENT_ADS",
 		"ATTACHMENT",
 		"TRANSCRIBE_MEDIA",
 		"DOWNLOAD_MEDIA",


### PR DESCRIPTION
## Summary
- bound action validation so slow validators do not stall state composition
- keep a last-good action catalog fallback
- preserve image-generation/action tools for image requests instead of letting broad validation timeout hide them

## Validation
- git diff --check origin/develop...HEAD passed

## Notes
A standalone check of this file still hits the pre-existing Provider type mismatch around contextGate from upstream code; this PR does not introduce that field.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces per-action validation timeouts and a provider-level validation budget to prevent slow validators from stalling state composition, along with a module-level \"last-good\" action catalog fallback. It also hardcodes image/ad action names in `EXPLICIT_INTENT_ACTIONS` to protect planner picks from fuzzy-metadata correction.

- `actions.ts`: adds `validateActionFast` (per-action timeout), a `providerValidationBudgetMs` provider-wide race, and a `lastGoodValidation` module singleton that caches the most recently successful action catalog. Image/ad requests bypass validation and receive a pre-filtered catalog gated by `isImageGenerationRequest`.
- `message.ts`: extends `EXPLICIT_INTENT_ACTIONS` with media and advertising action names so the metadata corrector does not override a correct planner pick for image/ad workflows.

<h3>Confidence Score: 3/5</h3>

The provider change contains a correctness defect that silently degrades the action catalog for all non-image requests following an image request within the same TTL window, and the shared module-level cache does not isolate between multiple agent runtimes in the same process.

After any image-generation turn, `lastGoodValidation` is overwritten with the ~10-action image-only subset. Every subsequent non-image request in the next two minutes reads that subset as its complete catalog, silently losing all other actions. The module-level variable is also shared across all agent runtimes, so Agent B can receive Agent A's last action set. The `message.ts` change is clean and low-risk.

cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts — the lastGoodValidation update logic and the process-wide scope of the cache both need revisiting before this is safe to ship.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/lib/eliza/plugin-cloud-bootstrap/providers/actions.ts | Adds per-action timeout, provider-level validation budget, and a module-level last-good cache fallback. The last-good cache is shared across all agent runtimes and is overwritten by the narrowed image-only catalog, causing non-image requests within the TTL window to lose their full action catalog. |
| packages/core/src/services/message.ts | Adds media/advertising action names to EXPLICIT_INTENT_ACTIONS to prevent the fuzzy-metadata corrector from overriding a correct planner pick. Change is additive and low-risk. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[actionsProvider.get called] --> B{cache hit?}
    B -- yes --> G
    B -- no --> C{isImageGenerationRequest?}
    C -- yes --> D[narrowActionsForIntent no validation]
    C -- no --> E{freshLastGood valid?}
    E -- yes --> F[actionsData = lastGoodValidation.actions]
    E -- no --> H[validateActionFast per-action 250ms timeout]
    H --> I{provider budget 1200ms exceeded?}
    I -- yes --> J[actionsData = runtime.actions unvalidated]
    I -- no --> K[actionsData = validated actions]
    D --> L{actionsData.length > 0?}
    F --> L
    J --> L
    K --> L
    L -- yes --> M[update lastGoodValidation image-narrowed catalog can overwrite full catalog]
    L -- no --> N[skip update]
    M --> O[write validationCache]
    N --> O
    O --> G[narrowActionsForIntent + filterActionsByRouting + filter hidden]
    G --> P[return actionsData to LLM]
```

<sub>Reviews (1): Last reviewed commit: ["fix(actions): protect media and ad tool ..."](https://github.com/elizaos/eliza/commit/c05fa76496382bb34303b1863448b65e644188ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32111125)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->