### PR TITLE
fix(app-core): complete the @elizaos/plugin-elizacloud browser stub

### DIFF
--- a/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
+++ b/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
@@ -1,16 +1,52 @@
-// Browser-side stub for @elizaos/plugin-elizacloud. The plugins runtime
-// surface (cloud secrets, TTS routes, ElevenLabs key resolver) only runs
-// server-side; the renderer just needs the named imports to statically
-// resolve. Every export is a noop / empty stub.
+// Browser-side stub for @elizaos/plugin-elizacloud. The plugin's runtime
+// surface (cloud secrets, TTS/billing/relay routes, wallet provisioning, the
+// cloud client) only runs server-side; the renderer just needs the named
+// imports to statically resolve. Every export here is an inert stub.
 
 const noop = () => undefined;
+
+// Sync void / secret / URL resolvers — server-only, nothing to resolve or
+// mutate in a renderer.
 export const clearCloudSecrets = noop;
 export const ensureCloudTtsApiKeyAlias = noop;
 export const getCloudSecret = noop;
-export const handleCloudTtsPreviewRoute = noop;
 export const mirrorCompatHeaders = noop;
 export const normalizeCloudSiteUrl = noop;
-export const __resetCloudBaseUrlCache = noop;
+export const normalizeCloudSecret = noop;
+export const validateCloudBaseUrl = noop;
+export const resolveCloudApiBaseUrl = noop;
+export const resolveCloudApiKey = noop;
 export const resolveCloudTtsBaseUrl = noop;
 export const resolveElevenLabsApiKeyForCloudMode = noop;
+export const persistCloudWalletCache = noop;
+export const __resetCloudBaseUrlCache = noop;
+
+// Async cloud-route handlers — `false` means "route not handled here", which
+// is the correct answer in a renderer: there is no cloud server to dispatch to.
+const routeNotHandled = async (): Promise<boolean> => false;
+export const handleCloudBillingRoute = routeNotHandled;
+export const handleCloudCompatRoute = routeNotHandled;
+export const handleCloudRelayRoute = routeNotHandled;
+export const handleCloudRoute = routeNotHandled;
+export const handleCloudStatusRoutes = routeNotHandled;
+export const handleCloudTtsPreviewRoute = routeNotHandled;
+
+// Async data fetchers — empty results; there is no cloud backend in a renderer.
+export const fetchCloudVoiceCatalog = async (): Promise<never[]> => [];
+export const getOrCreateClientAddressKey = async (): Promise<{
+  address: string;
+}> => ({ address: "" });
+export const provisionCloudWalletsBestEffort = async (): Promise<{
+  descriptors: Record<string, never>;
+  failures: never[];
+  warnings: never[];
+}> => ({ descriptors: {}, failures: [], warnings: [] });
+
+// Server-only predicate — a browser/renderer context is never a
+// cloud-provisioned container, so the stub is a hard `false`.
+export const isCloudProvisionedContainer = (): boolean => false;
+
+// Cloud client — server-only; the renderer never opens a cloud connection.
+export class ElizaCloudClient {}
+
 export default new Proxy(noop, { get: () => noop, apply: () => undefined });


### PR DESCRIPTION
## Summary

`packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts` is the browser-side stub that `@elizaos/plugin-elizacloud` is aliased to when `app-core` is bundled for a renderer (the plugin's runtime surface — cloud secrets, TTS/billing/relay routes, wallet provisioning, the cloud client — only runs server-side).

The stub only exported **7** of the **~21** value names that browser-bundled `agent` + `app-core` code imports from `@elizaos/plugin-elizacloud`. Any renderer bundle that pulls in `app-core` (e.g. the Milady mobile build) fails at the Rollup stage:

```
"normalizeCloudSecret" is not exported by "...elizaos-plugin-elizacloud-browser-stub.ts"
"isCloudProvisionedContainer" is not exported by "..."
```

## What this PR does

Cross-referenced every named import of `@elizaos/plugin-elizacloud` across `packages/agent/src` and `packages/app-core/src` against the ambient module declaration in `packages/agent/src/external-modules.d.ts`, and completed the stub with all missing value exports — each given an inert but correctly-shaped implementation rather than a blanket noop:

| Group | Stub shape | Why |
|---|---|---|
| sync void / secret / URL resolvers | `noop` | nothing to resolve or mutate in a renderer |
| async cloud-route handlers (`handleCloud*Route`) | `async () => false` | `false` = "route not handled here" — the correct answer when there is no cloud server to dispatch to |
| async fetchers (`fetchCloudVoiceCatalog`, `getOrCreateClientAddressKey`, `provisionCloudWalletsBestEffort`) | empty results | no cloud backend in a renderer |
| `isCloudProvisionedContainer` | `(): boolean => false` | a browser/renderer context is never a cloud-provisioned container |
| `ElizaCloudClient` | empty `class` | server-only; the renderer never opens a cloud connection |

Type-only imports (`CloudConfigLike`, `CloudRouteState`, `CloudOnboardingResult`, `CloudVoiceCatalogEntry`, `CloudWalletDescriptor`, `CloudWalletProvider`) are erased at compile time and need no runtime stub.

## Verification

With the completed stub, a renderer build that bundles `app-core` resolves all `@elizaos/plugin-elizacloud` named imports and proceeds past the Rollup static-analysis stage. No server-side / packages-mode behavior changes — this file is only reached by browser-target bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the browser-side stub for `@elizaos/plugin-elizacloud`, which is aliased in renderer bundles so that Rollup can statically resolve all named imports from the plugin without pulling in its server-only runtime. The previous stub covered only 7 of ~21 exported names, causing build failures in renderer bundles.

- **15+ missing exports added** — each given an inert but correctly-shaped implementation: sync helpers as `noop`, route handlers as `async () => false`, async fetchers returning empty collections, `isCloudProvisionedContainer` as `() => false`, and `ElizaCloudClient` as an empty class.
- **`handleCloudTtsPreviewRoute` corrected** — was previously a synchronous `noop` returning `undefined`; it now returns `Promise<false>` to match its declared `Promise<boolean>` signature.
- **Dynamically-imported symbols (`CloudManager`, `runCloudOnboarding`, `ClackObserver`, `NullCloudOnboardingObserver`) are intentionally absent** — they are only accessed via `await import()` and never trigger Rollup's static-analysis check.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is confined to a single browser-only stub file with no effect on server-side or packaged-mode behavior.

The fix correctly addresses the Rollup static-analysis failures. Type annotations on a couple of stubs diverge from the ambient declaration in minor ways that won't affect the browser bundle but could surface in direct-import scenarios.

packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts — verify type annotations on provisionCloudWalletsBestEffort and fetchCloudVoiceCatalog match what callers expect if the file is ever used outside the Rollup alias context.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts | Completes the browser stub by adding 15+ missing named exports; all are correctly shaped inert implementations. Minor type-annotation inconsistencies and undocumented intentional omissions for dynamically-imported symbols. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): complete the @elizaos/plu..."](https://github.com/elizaos/eliza/commit/5ac495a053c891123dd2763b3b55b1bfde85a7b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32106776)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->