### PR TITLE
fix(cloud): normalize cli auth browser host

### DIFF
--- a/cloud/packages/sdk/src/client.test.ts
+++ b/cloud/packages/sdk/src/client.test.ts
@@ -128,3 +128,31 @@ describe("ElizaCloudClient payment and monetization helpers", () => {
     );
   });
 });
+
+describe("ElizaCloudClient CLI login", () => {
+  it("uses the API host for session creation but the web host for browser auth", async () => {
+    let requestedUrl: string | undefined;
+    const fetchImpl = (async (input) => {
+      requestedUrl = String(input);
+      return new Response(
+        JSON.stringify({ status: "pending", expiresAt: "2026-05-14T08:00:00.000Z" }),
+        {
+          status: 201,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+
+    const client = new ElizaCloudClient({
+      baseUrl: "https://api.elizacloud.ai",
+      fetchImpl,
+    });
+
+    const result = await client.startCliLogin({ sessionId: "cli-test-session" });
+
+    expect(requestedUrl).toBe("https://api.elizacloud.ai/api/auth/cli-session");
+    expect(result.browserUrl).toBe(
+      "https://www.elizacloud.ai/auth/cli-login?session=cli-test-session",
+    );
+  });
+});

--- a/cloud/packages/sdk/src/client.ts
+++ b/cloud/packages/sdk/src/client.ts
@@ -98,6 +98,18 @@ function apiOriginFromApiBaseUrl(value: string): string {
   return value.replace(/\/api\/v1\/?$/, "");
 }
 
+function browserBaseUrlForCliLogin(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname.toLowerCase() === "api.elizacloud.ai") {
+      return DEFAULT_ELIZA_CLOUD_BASE_URL;
+    }
+  } catch {
+    // Fall through to the configured base URL.
+  }
+  return baseUrl;
+}
+
 function encodePathParam(value: string | number): string {
   return encodeURIComponent(String(value));
 }
@@ -192,7 +204,8 @@ export class ElizaCloudClient {
   startCliLogin(options: CliLoginStartOptions = {}): Promise<CliLoginStartResponse> {
     const sessionId = options.sessionId ?? getCryptoRandomUuid();
     const query = options.returnTo ? `?returnTo=${encodeURIComponent(options.returnTo)}` : "";
-    const browserUrl = `${this.baseUrl}/auth/cli-login?session=${encodeURIComponent(
+    const browserBaseUrl = browserBaseUrlForCliLogin(this.baseUrl);
+    const browserUrl = `${browserBaseUrl}/auth/cli-login?session=${encodeURIComponent(
       sessionId,
     )}${query}`;
 

--- a/packages/shared/src/elizacloud/base-url.test.ts
+++ b/packages/shared/src/elizacloud/base-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCloudSiteUrl, resolveCloudApiBaseUrl } from "./base-url";
+
+describe("Eliza Cloud base URL normalization", () => {
+  it("normalizes the API host back to the browser site host", () => {
+    expect(normalizeCloudSiteUrl("https://api.elizacloud.ai")).toBe(
+      "https://www.elizacloud.ai",
+    );
+    expect(normalizeCloudSiteUrl("https://api.elizacloud.ai/api/v1")).toBe(
+      "https://www.elizacloud.ai",
+    );
+  });
+
+  it("resolves canonical API paths from API host input", () => {
+    expect(resolveCloudApiBaseUrl("https://api.elizacloud.ai")).toBe(
+      "https://www.elizacloud.ai/api/v1",
+    );
+  });
+});

--- a/packages/shared/src/elizacloud/base-url.ts
+++ b/packages/shared/src/elizacloud/base-url.ts
@@ -5,6 +5,7 @@
 const DEFAULT_CLOUD_SITE_URL = "https://www.elizacloud.ai";
 
 const LEGACY_CLOUD_HOST_ALIASES = new Set([
+  "api.elizacloud.ai",
   "elizacloud.ai",
   "www.elizacloud.ai",
 ]);

--- a/plugins/plugin-elizacloud/src/utils/cloud-sdk/client.ts
+++ b/plugins/plugin-elizacloud/src/utils/cloud-sdk/client.ts
@@ -98,6 +98,18 @@ function apiOriginFromApiBaseUrl(value: string): string {
   return value.replace(/\/api\/v1\/?$/, "");
 }
 
+function browserBaseUrlForCliLogin(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    if (url.hostname.toLowerCase() === "api.elizacloud.ai") {
+      return DEFAULT_ELIZA_CLOUD_BASE_URL;
+    }
+  } catch {
+    // Fall through to the configured base URL.
+  }
+  return baseUrl;
+}
+
 function encodePathParam(value: string | number): string {
   return encodeURIComponent(String(value));
 }
@@ -192,7 +204,8 @@ export class ElizaCloudClient {
   startCliLogin(options: CliLoginStartOptions = {}): Promise<CliLoginStartResponse> {
     const sessionId = options.sessionId ?? getCryptoRandomUuid();
     const query = options.returnTo ? `?returnTo=${encodeURIComponent(options.returnTo)}` : "";
-    const browserUrl = `${this.baseUrl}/auth/cli-login?session=${encodeURIComponent(
+    const browserBaseUrl = browserBaseUrlForCliLogin(this.baseUrl);
+    const browserUrl = `${browserBaseUrl}/auth/cli-login?session=${encodeURIComponent(
       sessionId,
     )}${query}`;
 


### PR DESCRIPTION
## Summary
- keep CLI auth session create/poll calls on the configured API origin
- normalize generated browser login URLs away from api.elizacloud.ai to www.elizacloud.ai, where /auth/cli-login exists
- normalize shared Eliza Cloud site URLs when the API host is provided
- add regression coverage for SDK CLI login URL generation and shared URL normalization

## Why
When clients are configured with https://api.elizacloud.ai as the Cloud base, CLI auth creates the session successfully but opens https://api.elizacloud.ai/auth/cli-login?... in the browser. The API host returns 404 for that SPA route, so auth looks broken even though the session endpoints are healthy.

## Validation
- curl prod create/poll endpoints: POST/GET /api/auth/cli-session work
- curl prod browser route: api.elizacloud.ai/auth/cli-login returns 404, www.elizacloud.ai/auth/cli-login returns 200
- bunx biome check packages/shared/src/elizacloud/base-url.ts packages/shared/src/elizacloud/base-url.test.ts cloud/packages/sdk/src/client.ts cloud/packages/sdk/src/client.test.ts plugins/plugin-elizacloud/src/utils/cloud-sdk/client.ts
- cd packages/shared && bunx vitest run --config ./vitest.config.ts src/elizacloud/base-url.test.ts
- cd cloud/packages/sdk && bunx vitest run src/client.test.ts
- codex review --uncommitted -c sandbox_mode='danger-full-access'

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CLI authentication UX bug where clients configured with `https://api.elizacloud.ai` as their cloud base would open the browser at `api.elizacloud.ai/auth/cli-login`, which returns 404 (the SPA route only exists on the www host). Session creation and polling remain on the API host; only the browser-facing URL is redirected to `www.elizacloud.ai`.

- **SDK & plugin client (`client.ts`)**: Adds `browserBaseUrlForCliLogin()` that rewrites the browser URL origin to `www.elizacloud.ai` when the configured host is `api.elizacloud.ai`, while all `/api/auth/cli-session` requests continue to go to the original API host.
- **Shared URL utilities (`base-url.ts`)**: Adds `api.elizacloud.ai` to `LEGACY_CLOUD_HOST_ALIASES` so `normalizeCloudSiteUrl` and `resolveCloudApiBaseUrl` map the API host to the canonical `www.elizacloud.ai` origin.
- **Tests**: New tests confirm API calls stay on `api.elizacloud.ai` while `browserUrl` is rewritten to the www host.

<h3>Confidence Score: 4/5</h3>

The core browser-URL rewrite is correct and well-tested; a pre-existing returnTo double-? bug flagged in prior review threads remains unfixed in both client files.

The main fix keeps API calls on api.elizacloud.ai while correctly redirecting browser auth URLs to www.elizacloud.ai. The unfixed returnTo URL construction means any CLI login flow requesting a post-login redirect silently fails to deliver the redirect target to the server.

cloud/packages/sdk/src/client.ts and plugins/plugin-elizacloud/src/utils/cloud-sdk/client.ts both still carry the malformed returnTo query-string construction.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/sdk/src/client.ts | Adds browserBaseUrlForCliLogin() to rewrite browser auth URL; API session calls correctly kept on configured origin. Pre-existing returnTo double-? bug remains unfixed. |
| plugins/plugin-elizacloud/src/utils/cloud-sdk/client.ts | Mirror of SDK client change; same browserBaseUrlForCliLogin() addition and same unfixed returnTo double-? carry-over. |
| packages/shared/src/elizacloud/base-url.ts | Adds api.elizacloud.ai to LEGACY_CLOUD_HOST_ALIASES; consistent with existing elizacloud.ai/www.elizacloud.ai aliases. |
| cloud/packages/sdk/src/client.test.ts | New test verifies API session creation stays on API host while browserUrl is rewritten. returnTo branch still uncovered. |
| packages/shared/src/elizacloud/base-url.test.ts | New test file covering normalizeCloudSiteUrl and resolveCloudApiBaseUrl for the api.elizacloud.ai alias. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI / Plugin
    participant Client as ElizaCloudClient
    participant API as api.elizacloud.ai
    participant Browser as Browser
    participant WWW as www.elizacloud.ai

    CLI->>Client: "startCliLogin({ sessionId })"
    Note over Client: browserBaseUrlForCliLogin() rewrites host to www.elizacloud.ai
    Client->>API: POST /api/auth/cli-session
    API-->>Client: "{ status, expiresAt }"
    Client-->>CLI: "{ sessionId, browserUrl }"
    CLI->>Browser: open(browserUrl)
    Browser->>WWW: "GET /auth/cli-login?session=..."
    WWW-->>Browser: 200 OK
    loop Poll
        CLI->>API: "GET /api/auth/cli-session/{sessionId}"
        API-->>CLI: "{ status }"
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(cloud): normalize cli auth browser h..."](https://github.com/elizaos/eliza/commit/d09edf6fe4f02a42ae926ed0a6f51f8075e35d8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32107696)</sub>

<!-- /greptile_comment -->