### PR TITLE
fix(aosp/compile-libllama): skip extra cmake targets absent from the checkout

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -857,15 +857,45 @@ export function buildLibllamaForAbi({
   // out `llama` + `llama-server` upstream (the dedicated build steps below
   // already handle those), so the extra-target invocation only adds NEW
   // CMake target names. The non-fused path passes an empty list.
-  for (const extraTarget of extraBuildTargets) {
-    log(
-      `[compile-libllama] Building extra cmake target ${extraTarget} for ${abi}`,
-    );
-    spawn(
+  //
+  // Targets are filtered against what the configured build tree actually
+  // exposes. The eliza llama.cpp fork's target set drifts from the script's
+  // pinned expectations — e.g. `llama-speculative-simple` is an upstream
+  // example the fork drops in favour of DFlash spec-decode. A
+  // requested-but-absent *auxiliary* target must not abort the whole
+  // libllama build: the libllama.so + libggml*.so family is the critical
+  // output and is fully built by the `llama` target above. We warn on the
+  // gap and continue. A target that *exists* but fails to build still
+  // hard-errors via `spawn()`.
+  if (extraBuildTargets.length > 0) {
+    const helpProbe = spawnSync(
       "cmake",
-      ["--build", buildDir, "--target", extraTarget, "-j", String(jobs)],
-      {},
+      ["--build", buildDir, "--target", "help"],
+      { encoding: "utf8" },
     );
+    const availableTargets = new Set(
+      (helpProbe.stdout || "")
+        .split("\n")
+        .map((line) => line.replace(/^\.\.\.\s*/, "").trim())
+        .filter(Boolean),
+    );
+    for (const extraTarget of extraBuildTargets) {
+      if (availableTargets.size > 0 && !availableTargets.has(extraTarget)) {
+        log(
+          `[compile-libllama] Skipping extra cmake target ${extraTarget} for ${abi} — ` +
+            `not defined in this llama.cpp checkout (auxiliary target; libllama.so is unaffected).`,
+        );
+        continue;
+      }
+      log(
+        `[compile-libllama] Building extra cmake target ${extraTarget} for ${abi}`,
+      );
+      spawn(
+        "cmake",
+        ["--build", buildDir, "--target", extraTarget, "-j", String(jobs)],
+        {},
+      );
+    }
   }
 
   // llama-server target. Built in a second --target invocation so a future


### PR DESCRIPTION
## Summary

`aosp/compile-libllama.mjs` hard-aborts the entire `libllama.so` build when an *auxiliary* cmake target from `fusedCmakeBuildTargets()` is missing from the checked-out `llama.cpp` source.

`buildLibllamaForAbi()` builds the core `llama` target (which produces `libllama.so` + the `libggml*.so` family — the artifacts the on-device runtime actually `dlopen`s), then loops over the extra fused targets: `omnivoice-core`, `elizainference`, `llama-omnivoice-server`, `llama-cli`, `llama-mtmd-cli`, `llama-server`, `llama-speculative-simple`.

That list is written against the script's pinned `LLAMA_CPP_TAG = "v1.2.0-eliza"`, but the `elizaOS/llama.cpp` submodule **gitlink drifts from that pin**. With the current gitlink, `llama-speculative-simple` doesn't exist (the fork drops the upstream speculative example in favour of DFlash spec-decode). `cmake --build --target llama-speculative-simple` then exits with `gmake: *** No rule to make target 'llama-speculative-simple'`, `run()` throws, and the build dies — **even though `libllama.so` and the full `libggml*.so` family were already built successfully by the `llama` target.**

## Fix

Probe `cmake --build <dir> --target help` once, filter the extra-target list to those the configured build tree actually exposes, and skip absent auxiliary targets with a warning. A target that *exists* but fails to build still hard-errors (unchanged). The non-fused `--abi` bulk path is unaffected — it passes an empty extra-target list.

## Verification

`node packages/app-core/scripts/aosp/compile-libllama.mjs --target android-arm64-cpu-fused` against the current submodule checkout now **completes**:
- `llama-speculative-simple` is skipped with a clear warning; the other 6 extra targets build.
- `libggml-cpu.so` ships the full eliza kernel set — `qjl1_256`, `q4_polar`, `tbq3_0` / `tbq4_0` / `tbq3_tcq`, `fused_attn_qjl_tbq`.
- `libllama.so` carries `qwen35` architecture support.

Both are required for the `eliza-1-*` model tiers (Qwen3.5 arch, qjl/w4b-quantized) to load — a stock or partially-built `libllama` returns `loadModel() == false` on those GGUFs.

## Follow-up (not in this PR)

The underlying drift — submodule gitlink vs `LLAMA_CPP_TAG` — should be reconciled separately (either bump the gitlink to `v1.2.0-eliza`, or drop `llama-speculative-simple` from `fusedCmakeBuildTargets()` if the fork has permanently removed it). This PR makes the build *resilient* to that drift; it doesn't paper over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a hard build abort in `compile-libllama.mjs` caused by auxiliary cmake targets (e.g., `llama-speculative-simple`) that are listed in `fusedCmakeBuildTargets()` but absent from the current submodule checkout. The fix probes `cmake --build --target help` once before the extra-target loop, filters the requested targets to those the build tree actually exposes, and skips absent ones with a warning rather than letting `gmake: *** No rule to make target` propagate as a fatal error.

- Adds a `spawnSync` probe for `cmake --build --target help`, parses the `... target-name` lines from Makefile generator output into a Set, and guards each extra-target invocation with a membership check.
- Falls back to attempting all extra targets (original behaviour) when the probe returns empty output, keeping the fix resilient if the help target itself is unavailable (e.g., Ninja generator).
- Critical output (`libllama.so` + `libggml*.so` family) is unaffected; only the auxiliary binary targets are subject to the new skip logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change only affects auxiliary cmake targets and leaves the critical libllama.so/libggml build path untouched.

The logic is sound and the fallback (attempt all targets when the probe yields nothing) matches original behaviour. The two minor gaps — no diagnostic log when the probe itself fails, and using console.log instead of console.warn for a drift signal — don't affect correctness. No critical output paths are at risk.

packages/app-core/scripts/aosp/compile-libllama.mjs — specifically the new probe/filter block around lines 870–898.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/aosp/compile-libllama.mjs | Adds a cmake --build --target help probe to filter absent extra targets before building; falls back to attempting all targets when the probe yields empty output. Logic is sound for the Makefile generator; minor diagnostic gaps when the probe itself fails. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildLibllamaForAbi called] --> B{extraBuildTargets\nlength > 0?}
    B -- No --> G[Build llama-server target]
    B -- Yes --> C[spawnSync: cmake --build --target help]
    C --> D{Parse stdout\ninto availableTargets Set}
    D --> E{availableTargets.size > 0?}
    E -- No --> F[Attempt ALL extra targets\nvia spawn/run]
    E -- Yes --> H{target in\navailableTargets?}
    H -- No --> I[log warning,\nskip target]
    H -- Yes --> J[spawn: cmake --build\n--target extraTarget -j N]
    J --> K{build success?}
    K -- Yes --> L[continue loop]
    K -- No --> M[throw Error\nhard abort]
    I --> L
    F --> G
    L --> G
    G --> N[Locate libllama.so + libggml*.so\nand copy to abiAssetDir]
```

<sub>Reviews (1): Last reviewed commit: ["fix(aosp/compile-libllama): skip extra c..."](https://github.com/elizaos/eliza/commit/e5f70da89511c448423a5f9c0ae7522412d9879b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32114269)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->