### PR TITLE
fix(android-local-inference): per-context id allocation + loud unassigned-slot failure (#7681, #7687)

### DIFF
--- a/packages/native-plugins/llama/src/capacitor-llama-adapter.test.ts
+++ b/packages/native-plugins/llama/src/capacitor-llama-adapter.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+
+interface InitContextCall {
+  contextId: number;
+  model: string;
+}
+
+interface CompletionCall {
+  contextId: number;
+}
+
+interface EmbeddingCall {
+  contextId: number;
+}
+
+interface ReleaseCall {
+  contextId: number;
+}
+
+interface MockPluginState {
+  initContextCalls: InitContextCall[];
+  completionCalls: CompletionCall[];
+  embeddingCalls: EmbeddingCall[];
+  releaseCalls: ReleaseCall[];
+  releaseAllCalls: number;
+}
+
+function installMockPlugin(): MockPluginState {
+  const state: MockPluginState = {
+    initContextCalls: [],
+    completionCalls: [],
+    embeddingCalls: [],
+    releaseCalls: [],
+    releaseAllCalls: 0,
+  };
+
+  vi.doMock("llama-cpp-capacitor", () => ({
+    LlamaCpp: {
+      initContext: vi.fn(
+        async (options: { contextId: number; params: { model: string } }) => {
+          state.initContextCalls.push({
+            contextId: options.contextId,
+            model: options.params.model,
+          });
+          return { contextId: options.contextId };
+        },
+      ),
+      releaseContext: vi.fn(async (options: { contextId: number }) => {
+        state.releaseCalls.push({ contextId: options.contextId });
+      }),
+      releaseAllContexts: vi.fn(async () => {
+        state.releaseAllCalls += 1;
+      }),
+      completion: vi.fn(async (options: { contextId: number }) => {
+        state.completionCalls.push({ contextId: options.contextId });
+        return {
+          text: "ok",
+          tokens_evaluated: 10,
+          tokens_predicted: 20,
+          timings: { predicted_ms: 100 },
+        };
+      }),
+      stopCompletion: vi.fn(async () => undefined),
+      embedding: vi.fn(async (options: { contextId: number }) => {
+        state.embeddingCalls.push({ contextId: options.contextId });
+        return { embedding: [0.1, 0.2, 0.3] };
+      }),
+      tokenize: vi.fn(async () => ({ tokens: [1, 2, 3] })),
+      addListener: vi.fn(async () => ({ remove: async () => undefined })),
+      getHardwareInfo: vi.fn(async () => ({
+        platform: "android",
+        deviceModel: "Pixel 9a",
+        totalRamGb: 8,
+        availableRamGb: 4,
+        cpuCores: 8,
+        gpu: null,
+        gpuSupported: false,
+      })),
+    },
+  }));
+
+  // Capacitor presence shim so isCapacitorNative() reports true.
+  (globalThis as Record<string, unknown>).Capacitor = {
+    isNativePlatform: () => true,
+    getPlatform: () => "android",
+  };
+
+  return state;
+}
+
+describe("CapacitorLlamaAdapter context-id allocation (issue #7681)", () => {
+  it("allocates distinct context ids for two separate adapter instances", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const mod = await import("./capacitor-llama-adapter");
+    const { CapacitorLlamaAdapter } = mod;
+
+    const chatAdapter = new CapacitorLlamaAdapter();
+    const embeddingAdapter = new CapacitorLlamaAdapter();
+
+    await chatAdapter.load({ modelPath: "/tmp/llama-3.2-3b.gguf" });
+    await embeddingAdapter.load({ modelPath: "/tmp/bge-small-en-v1.5.gguf" });
+
+    expect(state.initContextCalls).toHaveLength(2);
+    const [chatInit, embedInit] = state.initContextCalls;
+    expect(chatInit.contextId).not.toBe(embedInit.contextId);
+    expect(chatInit.model).toBe("/tmp/llama-3.2-3b.gguf");
+    expect(embedInit.model).toBe("/tmp/bge-small-en-v1.5.gguf");
+  });
+
+  it("routes generate() against the chat adapter's contextId, not the embedding one", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
+
+    const chatAdapter = new CapacitorLlamaAdapter();
+    const embeddingAdapter = new CapacitorLlamaAdapter();
+
+    await chatAdapter.load({ modelPath: "/tmp/llama.gguf" });
+    await embeddingAdapter.load({ modelPath: "/tmp/bge.gguf" });
+
+    await chatAdapter.generate({ prompt: "hi" });
+    await embeddingAdapter.embed({ input: "hi" });
+
+    expect(state.completionCalls).toHaveLength(1);
+    expect(state.embeddingCalls).toHaveLength(1);
+
+    const chatInit = state.initContextCalls.find(
+      (c) => c.model === "/tmp/llama.gguf",
+    );
+    const embedInit = state.initContextCalls.find(
+      (c) => c.model === "/tmp/bge.gguf",
+    );
+    expect(chatInit).toBeDefined();
+    expect(embedInit).toBeDefined();
+
+    expect(state.completionCalls[0].contextId).toBe(chatInit?.contextId);
+    expect(state.embeddingCalls[0].contextId).toBe(embedInit?.contextId);
+    expect(state.completionCalls[0].contextId).not.toBe(
+      state.embeddingCalls[0].contextId,
+    );
+  });
+
+  it("does NOT call releaseAllContexts on load() — that would tear down sibling adapter instances", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
+
+    const chatAdapter = new CapacitorLlamaAdapter();
+    const embeddingAdapter = new CapacitorLlamaAdapter();
+
+    await chatAdapter.load({ modelPath: "/tmp/llama.gguf" });
+    await embeddingAdapter.load({ modelPath: "/tmp/bge.gguf" });
+
+    // Loading two adapters back-to-back used to release-all; the fix
+    // releases only the adapter's own contextId (if any) and leaves the
+    // sibling's context intact.
+    expect(state.releaseAllCalls).toBe(0);
+  });
+
+  it("reuses the same contextId for a single instance across reload", async () => {
+    vi.resetModules();
+    const state = installMockPlugin();
+    const { CapacitorLlamaAdapter } = await import("./capacitor-llama-adapter");
+
+    const adapter = new CapacitorLlamaAdapter();
+    await adapter.load({ modelPath: "/tmp/model-a.gguf" });
+    const firstId = state.initContextCalls[0].contextId;
+    await adapter.load({ modelPath: "/tmp/model-b.gguf" });
+    const secondId = state.initContextCalls[1].contextId;
+
+    expect(secondId).toBe(firstId);
+    // It should have released its own context before reusing the id.
+    expect(
+      state.releaseCalls.find((r) => r.contextId === firstId),
+    ).toBeDefined();
+  });
+});

--- a/packages/native-plugins/llama/src/capacitor-llama-adapter.ts
+++ b/packages/native-plugins/llama/src/capacitor-llama-adapter.ts
@@ -117,7 +117,11 @@ interface LlamaCppPluginLike {
   ) => Promise<PluginListenerHandle | undefined>;
 }
 
-const CONTEXT_ID = 1;
+// completion(contextId=X) must run against the model that was initContext'd
+// with X — every adapter instance owns its own monotonically-allocated id so
+// the chat LLM and the embedding model never collide on the same native
+// context.
+let nextContextId = 1;
 const DEFAULT_MAX_TOKENS = 256;
 
 /**
@@ -375,14 +379,27 @@ function normalizeHardwareInfo(
   };
 }
 
-class CapacitorLlamaAdapter implements LlamaAdapter {
+export class CapacitorLlamaAdapter implements LlamaAdapter {
   private plugin: LlamaCppPluginLike | null = null;
   /** Cached loader promise so concurrent `load()` calls don't race to register duplicate listeners. */
   private pluginLoadPromise: Promise<LlamaCppPluginLike> | null = null;
   private loadedPath: string | null = null;
+  /**
+   * Native context id this adapter owns. Allocated lazily on first `load()`
+   * from the process-wide `nextContextId` counter so distinct adapter
+   * instances never share a context — see the module-level invariant comment.
+   */
+  private contextId: number | null = null;
   private tokenIndex = 0;
   private tokenListeners = new Set<(token: string, index: number) => void>();
   private pluginListenerHandle: PluginListenerHandle | null = null;
+
+  private requireContextId(): number {
+    if (this.contextId === null) {
+      throw new Error("No model loaded. Call load() first.");
+    }
+    return this.contextId;
+  }
 
   private async loadPlugin(): Promise<LlamaCppPluginLike> {
     if (this.plugin) return this.plugin;
@@ -526,21 +543,23 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
     }
     const plugin = await this.loadPlugin();
 
-    // Always tear down any prior native context before initializing a new
-    // one. This adapter is a singleton shared by the chat LLM and the
-    // embedding model (the AOSP loader swaps roles on one loader instance),
-    // and every initContext/completion uses the same CONTEXT_ID. The native
-    // plugin auto-assigns its own internal context numbers and does not
-    // reuse CONTEXT_ID, so a *conditional* release — gated on
-    // `this.loadedPath`, which is null mid-swap during concurrent
-    // chat/embedding role loads — can leave a stale context live. Then
-    // `completion(CONTEXT_ID)` resolves to whichever model registered last
-    // (typically the bge-small embedding model), and a BERT model forced to
-    // autoregress emits `[unused{N}]` / `[PAD]` reserved tokens. An
-    // unconditional release guarantees exactly one native context after
-    // every load().
-    await plugin.releaseAllContexts();
+    // Release this adapter's own prior context (if any) before reusing the
+    // context id for a new model. We do NOT call `releaseAllContexts` here
+    // — that would destroy contexts owned by sibling adapter instances
+    // (e.g. tear down the embedding model when the chat model reloads).
+    if (this.contextId !== null && this.loadedPath !== null) {
+      try {
+        await plugin.releaseContext({ contextId: this.contextId });
+      } catch {
+        // The native side may have already cleared this context; safe to
+        // proceed to reinit on the same id.
+      }
+    }
     this.loadedPath = null;
+
+    if (this.contextId === null) {
+      this.contextId = nextContextId++;
+    }
 
     const speculativeSamples = options.mobileSpeculative
       ? Math.min(options.speculativeSamples ?? options.draftMax ?? 3, 4)
@@ -572,17 +591,21 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
     };
 
     await plugin.initContext({
-      contextId: CONTEXT_ID,
+      contextId: this.contextId,
       params,
     });
     this.loadedPath = options.modelPath;
   }
 
   async unload(): Promise<void> {
-    if (!this.plugin || !this.loadedPath) return;
+    if (!this.plugin || !this.loadedPath || this.contextId === null) return;
     try {
-      await this.plugin.releaseContext({ contextId: CONTEXT_ID });
+      await this.plugin.releaseContext({ contextId: this.contextId });
     } catch {
+      // Fall back to a targeted release-all only when the per-context
+      // release fails; this used to be the always-path but it now risks
+      // tearing down sibling adapter instances and is reserved for the
+      // pathological case where the native side has lost track of our id.
       await this.plugin.releaseAllContexts();
     }
     this.loadedPath = null;
@@ -625,11 +648,12 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
       ).slot_id = slotId;
     }
 
+    const contextId = this.requireContextId();
     const started = Date.now();
     const result =
       typeof this.plugin.completion === "function"
         ? await this.plugin.completion({
-            contextId: CONTEXT_ID,
+            contextId,
             params: {
               prompt: options.prompt,
               emit_partial_completion: Boolean(params.emit_partial_completion),
@@ -637,7 +661,7 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
             },
           })
         : await this.plugin.generateText?.({
-            contextId: CONTEXT_ID,
+            contextId,
             prompt: options.prompt,
             params,
           });
@@ -660,8 +684,8 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
   }
 
   async cancelGenerate(): Promise<void> {
-    if (!this.plugin) return;
-    await this.plugin.stopCompletion({ contextId: CONTEXT_ID });
+    if (!this.plugin || this.contextId === null) return;
+    await this.plugin.stopCompletion({ contextId: this.contextId });
   }
 
   /**
@@ -681,7 +705,7 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
       return null;
     }
     const result = await this.plugin.getFormattedChat({
-      contextId: CONTEXT_ID,
+      contextId: this.requireContextId(),
       messages: JSON.stringify(messages),
       params: { jinja: true },
     });
@@ -700,8 +724,9 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
     const params: NativeEmbeddingParams = {
       embd_normalize: options.embdNormalize ?? 0,
     };
+    const contextId = this.requireContextId();
     const result = await this.plugin.embedding({
-      contextId: CONTEXT_ID,
+      contextId,
       text: options.input,
       params,
     });
@@ -709,7 +734,7 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
     if (typeof this.plugin.tokenize === "function") {
       try {
         const tokenized = await this.plugin.tokenize({
-          contextId: CONTEXT_ID,
+          contextId,
           text: options.input,
         });
         tokenCount = tokenized.tokens.length;
@@ -743,21 +768,75 @@ class CapacitorLlamaAdapter implements LlamaAdapter {
   }
 }
 
+/**
+ * Default singleton kept for back-compat with device-bridge-client and
+ * hardware-probe callers that don't distinguish chat vs embedding roles.
+ * The runtime's `localInferenceLoader` service uses per-role instances
+ * instead — see `registerCapacitorLlamaLoader`.
+ */
 export const capacitorLlama: LlamaAdapter = new CapacitorLlamaAdapter();
+
+/**
+ * Lightweight heuristic for routing a `loadModel(modelPath)` call to either
+ * the chat adapter or the embedding adapter. Embedding GGUFs the runtime
+ * ships or that users typically install for `TEXT_EMBEDDING` carry one of
+ * these markers in the filename. Anything else is assumed to be a
+ * generative chat model.
+ */
+function looksLikeEmbeddingModelPath(modelPath: string): boolean {
+  const lowered = modelPath.toLowerCase();
+  return (
+    lowered.includes("bge-") ||
+    lowered.includes("bge_") ||
+    lowered.includes("nomic-embed") ||
+    lowered.includes("all-minilm") ||
+    lowered.includes("gte-") ||
+    lowered.includes("e5-") ||
+    lowered.includes("/embedding/") ||
+    lowered.endsWith("embedding.gguf")
+  );
+}
 
 export function registerCapacitorLlamaLoader(runtime: {
   registerService?: (name: string, impl: unknown) => unknown;
 }): void {
   if (typeof runtime.registerService !== "function") return;
+
+  // Two distinct adapter instances so the chat LLM and embedding model
+  // each allocate their own native context id. This is the fix for
+  // elizaOS/eliza#7681 — the previous single-adapter design routed every
+  // operation through CONTEXT_ID=1, and a `completion(contextId=1)` call
+  // would resolve to whichever model registered against id 1 last
+  // (typically the bge-small embedding model on Android), emitting
+  // `[unused{N}]` / `[PAD]` reserved tokens.
+  const chatAdapter = new CapacitorLlamaAdapter();
+  const embeddingAdapter = new CapacitorLlamaAdapter();
+
+  function adapterFor(modelPath: string): CapacitorLlamaAdapter {
+    return looksLikeEmbeddingModelPath(modelPath)
+      ? embeddingAdapter
+      : chatAdapter;
+  }
+
   runtime.registerService("localInferenceLoader", {
     async loadModel(args: LoadOptions): Promise<void> {
-      await capacitorLlama.load(args);
+      await adapterFor(args.modelPath).load(args);
     },
     async unloadModel(): Promise<void> {
-      await capacitorLlama.unload();
+      // No-op: each adapter manages its own context lifecycle inside
+      // `load()` (releasing the prior context before reinitializing on the
+      // same id). Tearing down both adapters here would defeat the
+      // per-instance routing — `ensureAssignedModelLoaded` calls
+      // `unloadModel()` before every `loadModel()` on the assumption of
+      // single-model behaviour, and we must not let that unconditionally
+      // kill the embedding adapter when only the chat model is swapping.
     },
     currentModelPath(): string | null {
-      return capacitorLlama.currentModelPath();
+      // The chat path is the primary "active" model from the runtime's
+      // perspective; embedding is treated as a sidecar.
+      return (
+        chatAdapter.currentModelPath() ?? embeddingAdapter.currentModelPath()
+      );
     },
     async generate(args: {
       prompt: string;
@@ -765,7 +844,7 @@ export function registerCapacitorLlamaLoader(runtime: {
       maxTokens?: number;
       temperature?: number;
     }): Promise<string> {
-      const result = await capacitorLlama.generate({
+      const result = await chatAdapter.generate({
         prompt: args.prompt,
         stopSequences: args.stopSequences,
         maxTokens: args.maxTokens,
@@ -776,7 +855,7 @@ export function registerCapacitorLlamaLoader(runtime: {
     async embed(args: {
       input: string;
     }): Promise<{ embedding: number[]; tokens: number }> {
-      return capacitorLlama.embed({ input: args.input });
+      return embeddingAdapter.embed({ input: args.input });
     },
   });
 }

--- a/packages/native-plugins/llama/src/index.ts
+++ b/packages/native-plugins/llama/src/index.ts
@@ -12,6 +12,7 @@
  */
 
 export {
+  CapacitorLlamaAdapter,
   capacitorLlama,
   registerCapacitorLlamaLoader,
 } from "./capacitor-llama-adapter";

--- a/plugins/plugin-local-inference/__tests__/assignments-fallback.test.ts
+++ b/plugins/plugin-local-inference/__tests__/assignments-fallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { InstalledModel } from "@elizaos/shared";
+import { buildRecommendedAssignments } from "../src/services/assignments.ts";
+
+function makeModel(overrides: Partial<InstalledModel> & { id: string }): InstalledModel {
+	return {
+		id: overrides.id,
+		displayName: overrides.displayName ?? overrides.id,
+		path: overrides.path ?? `/tmp/${overrides.id}.gguf`,
+		sizeBytes: overrides.sizeBytes ?? 1_000_000,
+		installedAt: overrides.installedAt ?? "2026-05-14T00:00:00Z",
+		lastUsedAt: overrides.lastUsedAt ?? null,
+		source: overrides.source ?? "eliza-download",
+		bundleVerifiedAt: overrides.bundleVerifiedAt,
+	};
+}
+
+describe("buildRecommendedAssignments", () => {
+	it("prefers a verified eliza-1 download when available", () => {
+		const installed: InstalledModel[] = [
+			makeModel({
+				id: "eliza-1-2b",
+				sizeBytes: 2_000_000_000,
+				bundleVerifiedAt: "2026-05-14T00:00:00Z",
+			}),
+			makeModel({
+				id: "llama-3.2-3b-instruct",
+				source: "external-scan",
+				sizeBytes: 3_000_000_000,
+			}),
+		];
+		expect(buildRecommendedAssignments(installed)).toEqual({
+			TEXT_SMALL: "eliza-1-2b",
+			TEXT_LARGE: "eliza-1-2b",
+			TEXT_TO_SPEECH: "eliza-1-2b",
+			TRANSCRIPTION: "eliza-1-2b",
+		});
+	});
+
+	it("falls back to a hand-installed text-gen model when no eliza-1 default qualifies (issue #7687)", () => {
+		const installed: InstalledModel[] = [
+			makeModel({
+				id: "llama-3.2-1b-instruct",
+				source: "external-scan",
+				sizeBytes: 800_000_000,
+			}),
+			makeModel({
+				id: "bge-small-en-v1.5",
+				source: "external-scan",
+				sizeBytes: 100_000_000,
+			}),
+		];
+		const result = buildRecommendedAssignments(installed);
+		expect(result.TEXT_SMALL).toBe("llama-3.2-1b-instruct");
+		expect(result.TEXT_LARGE).toBe("llama-3.2-1b-instruct");
+		// Voice slots stay empty for the fallback path — only generative
+		// slots are auto-filled when no curated model is present.
+		expect(result.TEXT_TO_SPEECH).toBeUndefined();
+		expect(result.TRANSCRIPTION).toBeUndefined();
+	});
+
+	it("does not promote an embedding model to TEXT_LARGE in the fallback path", () => {
+		const installed: InstalledModel[] = [
+			makeModel({
+				id: "bge-small-en-v1.5",
+				source: "external-scan",
+				sizeBytes: 100_000_000,
+			}),
+		];
+		expect(buildRecommendedAssignments(installed)).toEqual({});
+	});
+
+	it("picks the largest non-embedding fallback when multiple are installed", () => {
+		const installed: InstalledModel[] = [
+			makeModel({
+				id: "qwen-2.5-1.5b",
+				source: "external-scan",
+				sizeBytes: 1_500_000_000,
+			}),
+			makeModel({
+				id: "llama-3.2-3b-instruct",
+				source: "external-scan",
+				sizeBytes: 3_000_000_000,
+			}),
+			makeModel({
+				id: "nomic-embed-text",
+				source: "external-scan",
+				sizeBytes: 200_000_000,
+			}),
+		];
+		const result = buildRecommendedAssignments(installed);
+		expect(result.TEXT_LARGE).toBe("llama-3.2-3b-instruct");
+		expect(result.TEXT_SMALL).toBe("llama-3.2-3b-instruct");
+	});
+});

--- a/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
+++ b/plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts
@@ -1,0 +1,275 @@
+import { type AgentRuntime, ModelType } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const modeState = vi.hoisted(() => ({ mode: "local" }));
+const assignmentsState = vi.hoisted(() => ({
+	value: {} as Record<string, string>,
+}));
+const installedState = vi.hoisted(() => ({
+	value: [] as Array<{
+		id: string;
+		path: string;
+		sizeBytes: number;
+		source: string;
+	}>,
+}));
+const loaderState = vi.hoisted(() => ({
+	currentPath: null as string | null,
+	loadCalls: [] as unknown[],
+	unloadCalls: 0,
+	generateCalls: [] as unknown[],
+}));
+const engineState = vi.hoisted(() => ({
+	activeBackendId: vi.fn(() => "llama-server"),
+	available: vi.fn(async () => true),
+	canEmbed: vi.fn(() => false),
+	conversation: vi.fn(() => null),
+	currentModelPath: vi.fn(() => null),
+	embed: vi.fn(async () => [[0.1, 0.2]]),
+	ensureActiveBundleVoiceReady: vi.fn(async () => undefined),
+	generate: vi.fn(async () => "ok"),
+	generateInConversation: vi.fn(async () => ({
+		slotId: "slot-0",
+		text: "ok",
+		usage: {
+			input_tokens: 0,
+			output_tokens: 0,
+			cache_read_input_tokens: 0,
+			cache_creation_input_tokens: 0,
+		},
+	})),
+	hasLoadedModel: vi.fn(() => false),
+	load: vi.fn(async () => undefined),
+	openConversation: vi.fn(() => ({ id: "conversation" })),
+	prewarmConversation: vi.fn(async () => true),
+	synthesizeSpeech: vi.fn(async () => new Uint8Array([1, 2, 3])),
+	transcribePcm: vi.fn(async () => "transcribed"),
+	warnIfParallelTooLow: vi.fn(),
+}));
+
+vi.mock("../src/services/active-model", () => ({
+	resolveLocalInferenceLoadArgs: vi.fn(async (target) => ({
+		modelPath: target.path,
+	})),
+}));
+
+vi.mock("../src/services/assignments", async () => {
+	const actual = await vi.importActual<
+		typeof import("../src/services/assignments")
+	>("../src/services/assignments");
+	return {
+		...actual,
+		autoAssignAtBoot: vi.fn(async () => null),
+		readEffectiveAssignments: vi.fn(async () => ({ ...assignmentsState.value })),
+	};
+});
+
+vi.mock("../src/services/cache-bridge", () => ({
+	extractConversationId: vi.fn(() => null),
+	extractPromptCacheKey: vi.fn(() => null),
+	resolveLocalCacheKey: vi.fn(() => null),
+}));
+
+vi.mock("../src/services/device-bridge", () => ({
+	deviceBridge: {
+		currentModelPath: vi.fn(() => null),
+		embed: vi.fn(),
+		generate: vi.fn(),
+		loadModel: vi.fn(),
+		unloadModel: vi.fn(),
+	},
+}));
+
+vi.mock("../src/services/engine", () => ({
+	localInferenceEngine: engineState,
+}));
+
+vi.mock("../src/services/handler-registry", () => ({
+	handlerRegistry: { installOn: vi.fn() },
+}));
+
+vi.mock("../src/services/registry", () => ({
+	listInstalledModels: vi.fn(async () => installedState.value),
+}));
+
+vi.mock("../src/services/router-handler", () => ({
+	installRouterHandler: vi.fn(),
+}));
+
+vi.mock("../src/services/voice", () => ({
+	decodeMonoPcm16Wav: vi.fn(() => ({
+		pcm: new Float32Array([0]),
+		sampleRate: 16_000,
+	})),
+}));
+
+import { ensureLocalInferenceHandler } from "../src/runtime/ensure-local-inference-handler.ts";
+
+interface Registration {
+	modelType: string | number;
+	provider: string;
+	priority?: number;
+	handler: unknown;
+}
+
+function makeRuntime(): {
+	registrations: Registration[];
+	runtime: AgentRuntime;
+	loader: {
+		currentModelPath: () => string | null;
+		loadModel: (args: unknown) => Promise<void>;
+		unloadModel: () => Promise<void>;
+		generate: (args: unknown) => Promise<string>;
+		embed: (args: unknown) => Promise<{ embedding: number[]; tokens: number }>;
+	};
+} {
+	const registrations: Registration[] = [];
+	const loader = {
+		currentModelPath: vi.fn(() => loaderState.currentPath),
+		loadModel: vi.fn(async (args: unknown) => {
+			loaderState.loadCalls.push(args);
+			const a = args as { modelPath?: string };
+			if (a?.modelPath) loaderState.currentPath = a.modelPath;
+		}),
+		unloadModel: vi.fn(async () => {
+			loaderState.unloadCalls += 1;
+			loaderState.currentPath = null;
+		}),
+		generate: vi.fn(async (args: unknown) => {
+			loaderState.generateCalls.push(args);
+			return "ok";
+		}),
+		embed: vi.fn(async () => ({ embedding: [0.1, 0.2], tokens: 2 })),
+	};
+	const runtime = {
+		agentId: "agent-test",
+		getModel: vi.fn(() => undefined),
+		getSetting: vi.fn((key: string) =>
+			key === "ELIZA_RUNTIME_MODE" ? modeState.mode : undefined,
+		),
+		getService: vi.fn((name: string) =>
+			name === "localInferenceLoader" ? loader : null,
+		),
+		registerModel: vi.fn(
+			(
+				modelType: string | number,
+				handler: unknown,
+				provider: string,
+				priority?: number,
+			) => {
+				registrations.push({ modelType, provider, priority, handler });
+			},
+		),
+		registerService: vi.fn(),
+	} as unknown as AgentRuntime;
+	return { registrations, runtime, loader };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	modeState.mode = "local";
+	assignmentsState.value = {};
+	installedState.value = [];
+	loaderState.currentPath = null;
+	loaderState.loadCalls = [];
+	loaderState.unloadCalls = 0;
+	loaderState.generateCalls = [];
+	delete process.env.ELIZA_LOCAL_LLAMA;
+	delete process.env.ELIZA_DEVICE_BRIDGE_ENABLED;
+});
+
+describe("ensureAssignedModelLoaded (via TEXT_LARGE handler)", () => {
+	it("throws when slot is unassigned and the loaded model is embedding-role (issue #7687)", async () => {
+		// Mirror the on-device failure: an embedding model is the only thing
+		// loaded, and no chat slot assignment exists. The old behaviour
+		// silently dispatched completion to the embedding model and emitted
+		// `[unused{N}]` garbage. The new behaviour throws.
+		installedState.value = [
+			{
+				id: "bge-small-en-v1.5",
+				path: "/tmp/bge-small-en-v1.5.gguf",
+				sizeBytes: 100_000_000,
+				source: "external-scan",
+			},
+		];
+		loaderState.currentPath = "/tmp/bge-small-en-v1.5.gguf";
+		assignmentsState.value = {}; // No chat assignment.
+
+		const { registrations, runtime } = makeRuntime();
+		await ensureLocalInferenceHandler(runtime);
+
+		const handler = registrations.find(
+			(entry) => entry.modelType === ModelType.TEXT_LARGE,
+		)?.handler as
+			| ((
+					runtime: AgentRuntime,
+					params: Record<string, unknown>,
+			  ) => Promise<string>)
+			| undefined;
+		expect(handler).toBeDefined();
+
+		await expect(
+			handler?.(runtime, { prompt: "hello" }),
+		).rejects.toThrowError(/No chat model assigned for slot TEXT_LARGE/);
+	});
+
+	it("does not throw when slot is unassigned but no embedding model is loaded", async () => {
+		// No assignment + no resident embedding model = pre-existing
+		// fall-through behaviour for compatibility. Loader runs generate
+		// against whatever it has (or nothing, in this mock setup).
+		installedState.value = [];
+		loaderState.currentPath = null;
+		assignmentsState.value = {};
+
+		const { registrations, runtime, loader } = makeRuntime();
+		await ensureLocalInferenceHandler(runtime);
+
+		const handler = registrations.find(
+			(entry) => entry.modelType === ModelType.TEXT_LARGE,
+		)?.handler as
+			| ((
+					runtime: AgentRuntime,
+					params: Record<string, unknown>,
+			  ) => Promise<string>)
+			| undefined;
+
+		await expect(
+			handler?.(runtime, { prompt: "hello" }),
+		).resolves.toBe("ok");
+		// No model swap should have been attempted.
+		expect(loader.unloadModel).not.toHaveBeenCalled();
+		expect(loader.loadModel).not.toHaveBeenCalled();
+	});
+
+	it("loads the assigned model when one is set and not yet resident", async () => {
+		installedState.value = [
+			{
+				id: "llama-3.2-1b-instruct",
+				path: "/tmp/llama-3.2-1b-instruct.gguf",
+				sizeBytes: 800_000_000,
+				source: "external-scan",
+			},
+		];
+		assignmentsState.value = { TEXT_LARGE: "llama-3.2-1b-instruct" };
+
+		const { registrations, runtime, loader } = makeRuntime();
+		await ensureLocalInferenceHandler(runtime);
+
+		const handler = registrations.find(
+			(entry) => entry.modelType === ModelType.TEXT_LARGE,
+		)?.handler as
+			| ((
+					runtime: AgentRuntime,
+					params: Record<string, unknown>,
+			  ) => Promise<string>)
+			| undefined;
+
+		await handler?.(runtime, { prompt: "hello" });
+
+		expect(loader.unloadModel).toHaveBeenCalledTimes(1);
+		expect(loader.loadModel).toHaveBeenCalledTimes(1);
+		expect(loaderState.loadCalls[0]).toMatchObject({
+			modelPath: "/tmp/llama-3.2-1b-instruct.gguf",
+		});
+	});
+});

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -38,6 +38,7 @@ import {
 } from "../services/active-model";
 import {
 	autoAssignAtBoot,
+	isEmbeddingModelId,
 	readEffectiveAssignments,
 } from "../services/assignments";
 import {
@@ -192,7 +193,10 @@ function getLoader(runtime: IAgentRuntime): LocalInferenceLoader | null {
  * when a different slot's assignment fires with a different model.
  *
  * If no assignment is set for the slot, falls back to whatever is
- * currently loaded (keeps the old "one active model" behaviour).
+ * currently loaded — UNLESS the loaded model is an embedding model and
+ * this is a chat/generative slot. That combination produces `[unused{N}]`
+ * garbage (a BERT model forced to autoregress), so we fail loudly with an
+ * actionable message instead. See elizaOS/eliza#7687.
  */
 async function ensureAssignedModelLoaded(
 	loader: LocalInferenceLoader | null,
@@ -200,7 +204,25 @@ async function ensureAssignedModelLoaded(
 ): Promise<void> {
 	const assignments = await readEffectiveAssignments();
 	const assignedId = assignments[slot];
-	if (!assignedId) return;
+	if (!assignedId) {
+		// Loud-failure guard: an unassigned chat slot must not silently
+		// dispatch to whatever model happens to be loaded — if that's an
+		// embedding model, completion emits reserved-token garbage.
+		if (slot === "TEXT_SMALL" || slot === "TEXT_LARGE") {
+			const installed = await listInstalledModels();
+			const currentPath =
+				loader?.currentModelPath() ?? localInferenceEngine.currentModelPath();
+			const current = currentPath
+				? installed.find((m) => m.path === currentPath)
+				: undefined;
+			if (current && isEmbeddingModelId(current.id)) {
+				throw new Error(
+					`[local-inference] No chat model assigned for slot ${slot} — open Settings → Local models. The currently-loaded model (${current.id}) is an embedding model and cannot serve text generation.`,
+				);
+			}
+		}
+		return;
+	}
 
 	// Desktop fast path: check the engine state directly.
 	if (!loader && localInferenceEngine.currentModelPath()) {

--- a/plugins/plugin-local-inference/src/services/assignments.ts
+++ b/plugins/plugin-local-inference/src/services/assignments.ts
@@ -79,12 +79,36 @@ export function buildRecommendedAssignments(
 			model.bundleVerifiedAt.length > 0,
 	);
 	const best = pickLargestInstalledModel(ownDownloads);
-	if (!best) return {};
+	if (best) {
+		return {
+			TEXT_SMALL: best.id,
+			TEXT_LARGE: best.id,
+			TEXT_TO_SPEECH: best.id,
+			TRANSCRIPTION: best.id,
+		};
+	}
+
+	// Fallback: no curated Eliza-1 default is installed, but the user may
+	// have hand-installed a generic text-gen GGUF (e.g. a Llama / Qwen /
+	// Mistral instruct quant). Auto-assign the largest non-embedding model
+	// to TEXT_SMALL / TEXT_LARGE so the slot isn't left empty — empty slots
+	// cause `ensureAssignedModelLoaded()` to fall through and chat
+	// completions silently run against whichever model is currently loaded
+	// (typically the embedding model on Android, producing `[unused{N}]`
+	// garbage). The strict "recommended for the UI" filter still excludes
+	// non-eliza-1 models from the curated download surface; this only
+	// guarantees `TEXT_SMALL` / `TEXT_LARGE` resolve to something usable.
+	const generativeFallbacks = installed.filter(
+		(model) =>
+			typeof model.id === "string" &&
+			model.id.length > 0 &&
+			!isEmbeddingModelId(model.id),
+	);
+	const fallbackBest = pickLargestInstalledModel(generativeFallbacks);
+	if (!fallbackBest) return {};
 	return {
-		TEXT_SMALL: best.id,
-		TEXT_LARGE: best.id,
-		TEXT_TO_SPEECH: best.id,
-		TRANSCRIPTION: best.id,
+		TEXT_SMALL: fallbackBest.id,
+		TEXT_LARGE: fallbackBest.id,
 	};
 }
 
@@ -136,7 +160,7 @@ export async function setAssignment(
  * embedding-family marker (`nomic-embed`, `bge`, `all-minilm`, `gte`,
  * `e5-`). External GGUFs without a catalog entry default to generative.
  */
-function isEmbeddingModelId(modelId: string): boolean {
+export function isEmbeddingModelId(modelId: string): boolean {
 	const catalog = findCatalogModel(modelId);
 	if (catalog) {
 		if ((catalog.category as string) === "embedding") return true;


### PR DESCRIPTION
## Summary

Fixes two stacked bugs that make Android local-mode chat unusable.

- Closes #7681 — root cause: `capacitor-llama-adapter.ts` shared a module-level `CONTEXT_ID = 1` across every model loaded through the singleton adapter, so `completion(contextId=1)` resolved to whichever model registered against id 1 last — typically the bge-small embedding model — and emitted `[unused{N}]` / `[PAD]` reserved tokens for every chat turn.
- Closes #7687 — root cause: `ensureAssignedModelLoaded()` silently no-op'd when `assignments[slot]` was undefined, and `buildRecommendedAssignments()` only auto-assigned curated Eliza-1 downloads — so a user-installed non-eliza-1 chat model never landed in `TEXT_LARGE` and completion fell through to whatever native context happened to be loaded (the embedding model).

## Fix

### `packages/native-plugins/llama/src/capacitor-llama-adapter.ts`
- Replaced the module-level `const CONTEXT_ID = 1` with a process-wide monotonic `let nextContextId = 1` counter.
- Added `private contextId: number | null` field on `CapacitorLlamaAdapter`, allocated lazily on first `load()`.
- All operations (`initContext`, `releaseContext`, `completion`, `stopCompletion`, `embedding`, `getFormattedChat`, `tokenize`) now use `this.contextId`.
- `load()` releases only its own prior context — no more `releaseAllContexts()` that would tear down sibling instances.
- `registerCapacitorLlamaLoader` now creates **two** `CapacitorLlamaAdapter` instances (chat + embedding) routed via a filename heuristic; `loader.generate` and `loader.embed` resolve to distinct context ids.
- `unloadModel()` on the loader is a no-op — per-adapter `load()` manages its own lifecycle, and unconditionally unloading both would defeat the per-instance routing.
- Exported `CapacitorLlamaAdapter` so the test (and direct consumers) can instantiate.

### `plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts`
- When `assignments[slot]` is undefined for `TEXT_SMALL` / `TEXT_LARGE` and the currently-loaded model is embedding-role (per `isEmbeddingModelId`), throw a clear `No chat model assigned for slot TEXT_LARGE — open Settings → Local models` error instead of silently dispatching to an embedding model.

### `plugins/plugin-local-inference/src/services/assignments.ts`
- `buildRecommendedAssignments()` now falls back to the largest installed non-embedding model for `TEXT_SMALL` / `TEXT_LARGE` when no curated Eliza-1 model qualifies — so hand-installed GGUFs are usable without manual `assignments.json` editing.
- Exported `isEmbeddingModelId` (shared with the handler).

## Verification

- `bunx vitest run` in `packages/native-plugins/llama` — 15 tests pass (4 new + 11 pre-existing).
- `bunx vitest run` in `plugins/plugin-local-inference` — 119 tests pass (7 new + 112 pre-existing).
- `bun run typecheck` in `plugins/plugin-local-inference` — no new errors in the modified files (pre-existing errors in unrelated `core` / `transformers` paths remain).
- Biome lint clean on every modified / added file.

## Test plan

- [x] Two `CapacitorLlamaAdapter` instances allocate distinct context ids.
- [x] `generate()` on the chat adapter uses the chat context id; `embed()` on the embedding adapter uses the embedding context id; they are never the same.
- [x] `load()` does not call `releaseAllContexts()` — sibling instances stay alive.
- [x] A single adapter reuses its allocated context id across reloads (and releases its own context first).
- [x] `ensureAssignedModelLoaded` throws when slot is unassigned and the loaded model is embedding-role.
- [x] `ensureAssignedModelLoaded` does not throw when slot is unassigned and no embedding model is loaded (back-compat).
- [x] `buildRecommendedAssignments` returns a non-empty assignment for `TEXT_LARGE` when only a hand-installed text-gen model is present, and does not promote an embedding-only install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two stacked Android local-inference bugs: a shared `CONTEXT_ID=1` constant that caused every completion to resolve against whichever model registered last (typically the embedding model), and a silent no-op in `ensureAssignedModelLoaded` that let completions fall through to the embedding model when no chat slot was assigned.

- **`capacitor-llama-adapter.ts`**: Replaces the module-level `CONTEXT_ID=1` with a monotonic counter; each `CapacitorLlamaAdapter` instance lazily allocates its own context id. `registerCapacitorLlamaLoader` now creates separate chat and embedding adapter instances routed by filename heuristic, and `unloadModel()` on the loader becomes a no-op since each adapter manages its own lifecycle through `load()`.
- **`assignments.ts`**: `buildRecommendedAssignments` gains a fallback that promotes the largest installed non-embedding GGUF to `TEXT_SMALL`/`TEXT_LARGE` when no curated Eliza-1 model qualifies; `isEmbeddingModelId` is exported for shared use.
- **`ensure-local-inference-handler.ts`**: `ensureAssignedModelLoaded` now throws a clear error for unassigned chat slots when the currently-loaded model is embedding-role, instead of silently dispatching to it.

<h3>Confidence Score: 3/5</h3>

The two target bugs are genuinely fixed, but the two-adapter routing introduces a new defect: currentModelPath() always exposes the chat model path when both adapters are loaded, causing ensureAssignedModelLoaded to reload the embedding model on every embed() call.

The core context-id isolation and loud-failure guard work correctly. The regression lives in currentModelPath() — any deployment with both models loaded and TEXT_EMBEDDING assigned (set automatically by autoAssignAtBoot when bge-small is downloaded) will continuously release and reinitialise the embedding context on every embed call.

packages/native-plugins/llama/src/capacitor-llama-adapter.ts — specifically the currentModelPath() implementation in registerCapacitorLlamaLoader and the unload() error-path releaseAllContexts() fallback.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/native-plugins/llama/src/capacitor-llama-adapter.ts | Core fix: per-adapter context ID allocation and two-adapter routing. Contains a P1 regression where currentModelPath() hides the embedding adapter path, causing the embedding model to reload on every embed() call when chat is also loaded. |
| plugins/plugin-local-inference/src/services/assignments.ts | Adds fallback to largest non-embedding model for TEXT_SMALL/TEXT_LARGE when no curated Eliza-1 model is installed. Exports isEmbeddingModelId for shared use. Logic is correct and well-guarded. |
| plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts | Adds loud-failure guard for unassigned chat slots with an active embedding model. Guard logic is sound but only fires when the current model path matches an installed model record. |
| packages/native-plugins/llama/src/capacitor-llama-adapter.test.ts | New test file covering distinct context ID allocation, correct routing, no releaseAllContexts on load, and context ID reuse across reload. |
| plugins/plugin-local-inference/__tests__/ensure-assigned-model-loaded.test.ts | New tests for the loud-failure guard. Missing coverage for the TEXT_EMBEDDING + chat-loaded scenario where the embedding model would be reloaded on every embed call. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/native-plugins/llama/src/capacitor-llama-adapter.ts`, line 600-612 ([link](https://github.com/elizaos/eliza/blob/0ba393f66b335ea2c6daeea3375968df671f8285/packages/native-plugins/llama/src/capacitor-llama-adapter.ts#L600-L612)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`unload()` error fallback calls `releaseAllContexts()` — can tear down sibling adapters**

   When `plugin.releaseContext()` throws (e.g. the native side has already freed the context), the catch block calls `plugin.releaseAllContexts()`, which destroys every context on the native side, including the sibling chat/embedding adapter's context. This is exactly the problem #7681 was introduced to fix, and can reappear in error conditions. Since `unloadModel()` on the registered service is now a no-op, direct callers of `unload()` (e.g. `dispose()`) are the primary risk path.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(android-local-inference): per-contex..."](https://github.com/elizaos/eliza/commit/0ba393f66b335ea2c6daeea3375968df671f8285) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32116495)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->