### PR TITLE
fix(orchestrator,response-handler): suppress Cerebras refusal + tolerant PLAN_ACTIONS-in-text parser (#7620)

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -195,6 +195,12 @@ export {
 	SIMPLE_CONTEXT_ID,
 	type V5MessageHandlerOutput,
 } from "./runtime/message-handler";
+export {
+	type ExtractedPlanAction,
+	extractPlanActionsFromContent,
+	type PlanActionRecoverySource,
+} from "./runtime/plan-actions-extractor";
+export { looksLikeRefusal } from "./runtime/refusal-detector";
 export * from "./runtime/response-grammar";
 export * from "./runtime/response-handler-evaluators";
 export * from "./runtime/response-handler-field-evaluator";

--- a/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Refusal-suppression regression for `parseMessageHandlerOutput`.
+ *
+ * The fix for elizaOS/eliza#7620 — Cerebras-hosted `gpt-oss-120b` and
+ * `qwen-3-235b-a22b-instruct-2507` emit identical refusal text in Stage-1
+ * `replyText` even on turns whose `contexts` / `candidateActions` route to
+ * the planner. The runtime previously shipped that refusal to the user. We
+ * blank `plan.reply` when:
+ *
+ *   (a) `looksLikeRefusal(replyText)` matches, AND
+ *   (b) the turn routes to a non-simple context OR populates `candidateActions`
+ *
+ * Refusals on the simple path are left intact (model may legitimately
+ * decline an unsafe request).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { parseMessageHandlerOutput } from "../message-handler";
+
+describe("parseMessageHandlerOutput — refusal suppression on the planning path (#7620)", () => {
+	it("blanks plan.reply when refusal text routes to a non-simple context", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["tasks"],
+			candidateActions: ["TASKS_SPAWN_AGENT"],
+			replyText:
+				"I'm unable to spawn a sub-agent in this context. I can create /tmp/foo.py directly with the line: print('hello')",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result).not.toBeNull();
+		expect(result?.plan.contexts).toEqual(["tasks"]);
+		expect(result?.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
+		// The refusal must have been suppressed.
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("blanks plan.reply when refusal text rides on candidateActions even with empty contexts", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: [],
+			candidateActions: ["TASKS_SPAWN_AGENT"],
+			replyText: "I cannot delegate that in this session.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("blanks plan.reply for the second Cerebras refusal variant from #7620", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["code"],
+			replyText:
+				"I am unable to spawn a sub-agent in this context. I can create /tmp/foo.py directly with the line: print('hello')",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("preserves plan.reply on the simple path (refusal may be legitimate)", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["simple"],
+			replyText: "I cannot help with that request.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		// Simple path: caller-visible refusal stays — Stage-1 IS the reply.
+		expect(result?.plan.reply).toBe("I cannot help with that request.");
+	});
+
+	it("preserves plan.reply when the model emits a normal acknowledgement on the planning path", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["tasks"],
+			candidateActions: ["TASKS_SPAWN_AGENT"],
+			replyText: "On it — spawning a coding sub-agent.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("On it — spawning a coding sub-agent.");
+	});
+
+	it("preserves plan.reply when no plan-context or candidateActions are present (pure shouldRespond=IGNORE-style)", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "IGNORE",
+			contexts: [],
+			replyText: "I cannot do that.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		// No planning path → no suppression. Caller's downstream routing
+		// handles IGNORE explicitly anyway.
+		expect(result?.plan.reply).toBe("I cannot do that.");
+	});
+});

--- a/packages/core/src/runtime/__tests__/plan-actions-extractor.test.ts
+++ b/packages/core/src/runtime/__tests__/plan-actions-extractor.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { extractPlanActionsFromContent } from "../plan-actions-extractor";
+
+describe("extractPlanActionsFromContent", () => {
+	describe("bare action object shape (what the local engine's GBNF produces)", () => {
+		it("parses a well-formed bare action object", () => {
+			const text =
+				'{"action":"TASKS_SPAWN_AGENT","parameters":{"task":"write /tmp/foo.py","agentType":"opencode"},"thought":"delegating"}';
+			const result = extractPlanActionsFromContent(text);
+			expect(result).not.toBeNull();
+			expect(result?.action).toBe("TASKS_SPAWN_AGENT");
+			expect(result?.parameters).toEqual({
+				task: "write /tmp/foo.py",
+				agentType: "opencode",
+			});
+			expect(result?.thought).toBe("delegating");
+			expect(result?.recoverySource).toBe("bare-action-object");
+		});
+
+		it("tolerates fenced JSON", () => {
+			const text =
+				'```json\n{"action":"REPLY","parameters":{"text":"hi"},"thought":""}\n```';
+			const result = extractPlanActionsFromContent(text);
+			expect(result?.action).toBe("REPLY");
+			expect(result?.parameters).toEqual({ text: "hi" });
+			expect(result?.recoverySource).toBe("bare-action-object");
+		});
+
+		it("returns null when the object lacks an action field", () => {
+			const text = '{"parameters":{"task":"x"},"thought":"y"}';
+			expect(extractPlanActionsFromContent(text)).toBeNull();
+		});
+
+		it("returns null when parameters is missing (treats as empty object)", () => {
+			const text = '{"action":"REPLY"}';
+			const result = extractPlanActionsFromContent(text);
+			expect(result?.action).toBe("REPLY");
+			expect(result?.parameters).toEqual({});
+		});
+
+		it("refuses Stage-1 HANDLE_RESPONSE-shaped envelopes", () => {
+			// Defensive: a Stage-1 envelope that accidentally reached this
+			// parser should NOT be turned into a plan action.
+			const text =
+				'{"action":"RESPOND","shouldRespond":"RESPOND","contexts":["simple"],"replyText":"hello"}';
+			expect(extractPlanActionsFromContent(text)).toBeNull();
+		});
+
+		it("refuses Stage-1-shaped envelope with candidateActionNames", () => {
+			const text =
+				'{"action":"TASKS_SPAWN_AGENT","candidateActionNames":["TASKS_SPAWN_AGENT"],"replyText":"on it"}';
+			expect(extractPlanActionsFromContent(text)).toBeNull();
+		});
+	});
+
+	describe("PLAN_ACTIONS({...}) envelope shape (what hosted gpt-oss-120b emits)", () => {
+		it("recovers the call when emitted as message text (#7620)", () => {
+			const text = `Sure, I'll delegate that:
+
+PLAN_ACTIONS({
+  "action": "TASKS_SPAWN_AGENT",
+  "parameters": { "task": "write /tmp/foo.py that prints hello", "agentType": "opencode" },
+  "thought": "user asked for delegation"
+})`;
+			const result = extractPlanActionsFromContent(text);
+			expect(result).not.toBeNull();
+			expect(result?.action).toBe("TASKS_SPAWN_AGENT");
+			expect(result?.parameters).toEqual({
+				task: "write /tmp/foo.py that prints hello",
+				agentType: "opencode",
+			});
+			expect(result?.thought).toBe("user asked for delegation");
+			expect(result?.recoverySource).toBe("plan-actions-envelope");
+		});
+
+		it("handles whitespace and minimal spacing variants", () => {
+			const text =
+				'PLAN_ACTIONS({"action":"REPLY","parameters":{"text":"x"},"thought":""})';
+			const result = extractPlanActionsFromContent(text);
+			expect(result?.action).toBe("REPLY");
+			expect(result?.recoverySource).toBe("plan-actions-envelope");
+		});
+
+		it("brace-balances correctly when parameters contain nested objects", () => {
+			const text = `PLAN_ACTIONS({"action":"COMPLEX","parameters":{"nested":{"a":1,"b":{"c":2}}},"thought":"nested"})`;
+			const result = extractPlanActionsFromContent(text);
+			expect(result?.action).toBe("COMPLEX");
+			expect(result?.parameters).toEqual({ nested: { a: 1, b: { c: 2 } } });
+		});
+
+		it("brace-balances correctly when string values contain braces", () => {
+			const text = `PLAN_ACTIONS({"action":"REPLY","parameters":{"text":"unbalanced } ignored"},"thought":""})`;
+			const result = extractPlanActionsFromContent(text);
+			expect(result?.action).toBe("REPLY");
+			expect(result?.parameters).toEqual({ text: "unbalanced } ignored" });
+		});
+
+		it("returns null when the envelope is incomplete", () => {
+			const text = 'PLAN_ACTIONS({"action":"REPLY"';
+			expect(extractPlanActionsFromContent(text)).toBeNull();
+		});
+	});
+
+	describe("input guards", () => {
+		it("returns null for null/undefined/empty/non-string input", () => {
+			expect(extractPlanActionsFromContent(null)).toBeNull();
+			expect(extractPlanActionsFromContent(undefined)).toBeNull();
+			expect(extractPlanActionsFromContent("")).toBeNull();
+			expect(extractPlanActionsFromContent("   ")).toBeNull();
+		});
+
+		it("returns null for plain prose without a recognizable envelope", () => {
+			const text = "I'd be happy to help you with that task.";
+			expect(extractPlanActionsFromContent(text)).toBeNull();
+		});
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Regression for the tolerant `PLAN_ACTIONS`-in-text recovery in
+ * `parsePlannerOutput` (elizaOS/eliza#7620 / linked feature request).
+ *
+ * The v5 planner contract is that the model emits a native tool call. Some
+ * hosted models — Cerebras-served `gpt-oss-120b` in particular — instead
+ * emit the same envelope as message-content text. The planner-loop's second
+ * pass extracts the envelope so the downstream resolver still dispatches.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { GenerateTextResult } from "../../types/model";
+import { parsePlannerOutput } from "../planner-loop";
+
+describe("parsePlannerOutput — PLAN_ACTIONS-in-text recovery (#7620)", () => {
+	it("recovers PLAN_ACTIONS({...}) envelopes emitted as message text", () => {
+		const raw: GenerateTextResult = {
+			text: `PLAN_ACTIONS({"action":"TASKS_SPAWN_AGENT","parameters":{"task":"write /tmp/foo.py","agentType":"opencode"},"thought":"delegating"})`,
+			finishReason: "stop",
+			toolCalls: [],
+		};
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls).toHaveLength(1);
+		expect(parsed.toolCalls[0]?.name).toBe("TASKS_SPAWN_AGENT");
+		expect(parsed.toolCalls[0]?.params).toEqual({
+			task: "write /tmp/foo.py",
+			agentType: "opencode",
+		});
+		// When we recovered the call from text, messageToUser is blanked:
+		// the text WAS the call envelope, not a user-facing message.
+		expect(parsed.messageToUser).toBeUndefined();
+		// The recovery source is recorded for trajectory observability.
+		expect(parsed.raw.textRecoverySource).toBe("plan-actions-envelope");
+	});
+
+	it("recovers bare-action-object envelopes emitted as message text", () => {
+		const raw: GenerateTextResult = {
+			text: '{"action":"REPLY","parameters":{"text":"hi"},"thought":""}',
+			finishReason: "stop",
+			toolCalls: [],
+		};
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls[0]?.name).toBe("REPLY");
+		expect(parsed.toolCalls[0]?.params).toEqual({ text: "hi" });
+		expect(parsed.raw.textRecoverySource).toBe("bare-action-object");
+	});
+
+	it("prefers native tool calls when both native tool calls AND in-text envelopes exist", () => {
+		const raw: GenerateTextResult = {
+			text: 'PLAN_ACTIONS({"action":"NOT_THIS","parameters":{},"thought":""})',
+			finishReason: "tool-calls",
+			toolCalls: [
+				{
+					id: "call_1",
+					toolName: "REAL_ACTION",
+					input: { x: 1 },
+				} as unknown as NonNullable<GenerateTextResult["toolCalls"]>[number],
+			],
+		};
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls[0]?.name).toBe("REAL_ACTION");
+		expect(parsed.toolCalls[0]?.params).toEqual({ x: 1 });
+		// No text recovery happened, so no recoverySource marker.
+		expect(parsed.raw.textRecoverySource).toBeUndefined();
+	});
+
+	it("falls through to messageToUser when text is plain prose without an envelope", () => {
+		const raw: GenerateTextResult = {
+			text: "I'd be happy to help you with that task.",
+			finishReason: "stop",
+			toolCalls: [],
+		};
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls).toEqual([]);
+		expect(parsed.messageToUser).toBe(
+			"I'd be happy to help you with that task.",
+		);
+	});
+
+	it("recovers from plain-string raw outputs with embedded envelope (legacy JSON-mode path)", () => {
+		// The string-mode parser also gains the in-text recovery. When the raw
+		// is plain prose without a recognizable JSON object, the extractor
+		// runs and recovers the PLAN_ACTIONS envelope as a tool call.
+		const raw =
+			'Sure, delegating now. PLAN_ACTIONS(action=TASKS_SPAWN_AGENT, parameters={task: "x"})';
+		// This shape is not valid JSON so `parseJsonObject` returns null; the
+		// in-text extractor is the only fallback. It does NOT recover because
+		// the inner shape isn't a JSON object — and that's intentional. Test
+		// the assertion accordingly: parser returns toolCalls=[] + messageToUser.
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls).toEqual([]);
+		expect(parsed.messageToUser).toBe(raw);
+	});
+
+	it("string-mode recovers a well-formed PLAN_ACTIONS envelope in surrounding prose", () => {
+		// Well-formed JSON envelope embedded in prose: `parseJsonObject`'s
+		// `extractFirstJsonObject` pulls the inner `{...}`, then the
+		// existing `normalizeBarePlannerAction` path turns it into a tool call.
+		// This test pins that existing behaviour stays intact — the in-text
+		// recovery in `parsePlannerOutput` is the SAFETY net for cases the
+		// bare extractor misses.
+		const raw =
+			'I will delegate this: {"action":"TASKS_SPAWN_AGENT","parameters":{"task":"x"},"thought":""}';
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls[0]?.name).toBe("TASKS_SPAWN_AGENT");
+		expect(parsed.toolCalls[0]?.params).toEqual({ task: "x" });
+	});
+});

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -6,6 +6,7 @@ import type {
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
 import { parseJsonObject } from "./json-output";
+import { looksLikeRefusal } from "./refusal-detector";
 
 export type V5MessageHandlerOutput = MessageHandlerResult;
 
@@ -54,7 +55,7 @@ export function parseMessageHandlerOutput(
 	const contexts = Array.isArray(parsed.contexts)
 		? parsed.contexts.map((context) => String(context).trim()).filter(Boolean)
 		: [];
-	const reply =
+	const replyRaw =
 		typeof parsed.replyText === "string" ? parsed.replyText : undefined;
 	const requiresTool =
 		typeof parsed.requiresTool === "boolean" ? parsed.requiresTool : undefined;
@@ -63,6 +64,23 @@ export function parseMessageHandlerOutput(
 	const parentActionHints = normalizeStringHints(parsed.parentActionHints, 6);
 
 	const extract = parseExtract(parsed.extract);
+
+	// Refusal suppression for the planning path (elizaOS/eliza#7620).
+	// When the model routes to a non-simple context OR populates candidate
+	// actions, the planner stage will produce the user-facing message and the
+	// Stage-1 `replyText` is intended to be a brief acknowledgement. Some
+	// safety-tuned hosted models (Cerebras-served `gpt-oss-120b`,
+	// `qwen-3-235b-a22b-instruct-2507`) still emit a refusal here even with
+	// anti-refusal language in the system prompt. We blank the reply when it
+	// looks like a refusal AND a planning path is selected — the user sees
+	// the planner's message instead. Refusals on the simple path pass through
+	// unchanged (the model may legitimately decline e.g. unsafe requests).
+	const nonSimpleContexts = contexts.filter(
+		(context) => context !== SIMPLE_CONTEXT_ID,
+	);
+	const planningPath =
+		nonSimpleContexts.length > 0 || candidateActions.length > 0;
+	const reply = planningPath && looksLikeRefusal(replyRaw) ? "" : replyRaw;
 
 	const normalizedPlan: V5MessageHandlerOutput["plan"] = {
 		contexts,

--- a/packages/core/src/runtime/plan-actions-extractor.ts
+++ b/packages/core/src/runtime/plan-actions-extractor.ts
@@ -1,0 +1,191 @@
+/**
+ * Tolerant `PLAN_ACTIONS`-in-text extractor.
+ *
+ * Background: the v5 planner asks models to emit a native tool call with the
+ * envelope `{action, parameters, thought}` (see `buildPlannerActionGrammar` in
+ * `response-grammar.ts`). Cloud cloud-hosted open-weights models — most
+ * notably Cerebras-hosted `gpt-oss-120b` and `qwen-3-235b-a22b-instruct-2507`
+ * — sometimes emit the SAME envelope as message-content text instead of as a
+ * native tool call. The dispatcher then drops the turn because
+ * `raw.toolCalls` is empty. See elizaOS/eliza#7620 and the feature request
+ * linked from that issue.
+ *
+ * This module is the second-pass parser. The planner-loop calls it when
+ * `parsePlannerOutput` returns zero tool calls but `raw.text` carries one of
+ * the supported shapes:
+ *
+ *   1. Bare action object — `{"action":"NAME","parameters":{...},"thought":"..."}`
+ *      with optional fencing / surrounding prose. This is the shape the local
+ *      engine's GBNF produces and the shape `buildPlannerActionGrammar`
+ *      encodes — when a hosted provider streams it as text, the bytes are
+ *      identical.
+ *
+ *   2. Envelope call shape — `PLAN_ACTIONS({...})` literally written as text,
+ *      which the character prompt happens to use as a worked example and
+ *      which `gpt-oss-120b` mimics. The inner `{...}` is the same bare
+ *      action object as (1).
+ *
+ * The extractor is intentionally conservative. It refuses ambiguous shapes
+ * (HANDLE_RESPONSE envelopes with `shouldRespond`, `replyText`, `contexts`,
+ * etc. — which would mis-fire on Stage-1 outputs that accidentally reach the
+ * Stage-2 path). It does NOT validate `action` against any registry — the
+ * planner-loop's downstream resolver does that.
+ */
+
+import { parseJsonObject } from "./json-output";
+
+/**
+ * Where in the wire output the extractor recovered a plan action. Used by
+ * tests + trajectory logs to distinguish a native tool call (no recovery
+ * needed) from a text-recovered call (which we record because it's
+ * model-bias evidence).
+ */
+export type PlanActionRecoverySource =
+	| "bare-action-object"
+	| "plan-actions-envelope";
+
+export interface ExtractedPlanAction {
+	action: string;
+	parameters: Record<string, unknown>;
+	thought?: string;
+	recoverySource: PlanActionRecoverySource;
+}
+
+/**
+ * Fields that, when present, indicate the JSON object is a Stage-1
+ * HANDLE_RESPONSE envelope rather than a Stage-2 plan-action envelope. We
+ * refuse to recover those — letting them through would cause the planner to
+ * dispatch random action names sampled from `candidateActionNames`.
+ */
+const STAGE_1_DISCRIMINATORS = new Set([
+	"shouldRespond",
+	"replyText",
+	"contexts",
+	"candidateActionNames",
+	"candidateActions",
+	"parentActionHints",
+]);
+
+function looksLikeStage1Envelope(record: Record<string, unknown>): boolean {
+	for (const key of Object.keys(record)) {
+		if (STAGE_1_DISCRIMINATORS.has(key)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function normalizeParameters(value: unknown): Record<string, unknown> {
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		return value as Record<string, unknown>;
+	}
+	return {};
+}
+
+function buildExtracted(
+	record: Record<string, unknown>,
+	recoverySource: PlanActionRecoverySource,
+): ExtractedPlanAction | null {
+	const actionRaw = record.action;
+	if (typeof actionRaw !== "string") {
+		return null;
+	}
+	const action = actionRaw.trim();
+	if (!action) {
+		return null;
+	}
+	if (looksLikeStage1Envelope(record)) {
+		return null;
+	}
+	const parameters = normalizeParameters(record.parameters);
+	const thoughtRaw = record.thought;
+	const thought = typeof thoughtRaw === "string" ? thoughtRaw : undefined;
+	const result: ExtractedPlanAction = {
+		action,
+		parameters,
+		recoverySource,
+	};
+	if (thought !== undefined) {
+		result.thought = thought;
+	}
+	return result;
+}
+
+/**
+ * Match a `PLAN_ACTIONS(<json object>)` envelope anywhere in the text. We
+ * capture the inner JSON via brace-balancing rather than a single regex
+ * because the parameters object is free-form JSON that may itself contain
+ * `{`, `}`, quoted braces, etc.
+ */
+function extractEnvelopeBody(raw: string): string | null {
+	const match = raw.match(/PLAN_ACTIONS\s*\(\s*/);
+	if (!match || match.index === undefined) return null;
+	const start = match.index + match[0].length;
+	if (raw[start] !== "{") return null;
+
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let index = start; index < raw.length; index++) {
+		const char = raw[index];
+		if (inString) {
+			if (escaped) {
+				escaped = false;
+			} else if (char === "\\") {
+				escaped = true;
+			} else if (char === '"') {
+				inString = false;
+			}
+			continue;
+		}
+		if (char === '"') {
+			inString = true;
+			continue;
+		}
+		if (char === "{") {
+			depth++;
+			continue;
+		}
+		if (char === "}") {
+			depth--;
+			if (depth === 0) {
+				return raw.slice(start, index + 1);
+			}
+		}
+	}
+	return null;
+}
+
+/**
+ * Extract a plan-action envelope from raw message content.
+ *
+ * Returns `null` when the text contains no recognizable envelope, when the
+ * envelope is missing a non-empty `action`, or when the envelope looks like
+ * a Stage-1 HANDLE_RESPONSE payload (defensive — see `STAGE_1_DISCRIMINATORS`).
+ *
+ * The returned `recoverySource` distinguishes the two recognized shapes so
+ * the planner-loop / trajectory recorder can attribute the recovery in logs.
+ */
+export function extractPlanActionsFromContent(
+	text: string | null | undefined,
+): ExtractedPlanAction | null {
+	if (typeof text !== "string") return null;
+	const trimmed = text.trim();
+	if (!trimmed) return null;
+
+	const envelopeBody = extractEnvelopeBody(trimmed);
+	if (envelopeBody) {
+		const parsed = parseJsonObject<Record<string, unknown>>(envelopeBody);
+		if (parsed) {
+			const extracted = buildExtracted(parsed, "plan-actions-envelope");
+			if (extracted) return extracted;
+		}
+	}
+
+	const bare = parseJsonObject<Record<string, unknown>>(trimmed);
+	if (bare) {
+		return buildExtracted(bare, "bare-action-object");
+	}
+
+	return null;
+}

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -43,6 +43,7 @@ import {
 	type ModelInputBudget,
 	withModelInputBudgetProviderOptions,
 } from "./model-input-budget";
+import { extractPlanActionsFromContent } from "./plan-actions-extractor";
 import {
 	cacheProviderOptions,
 	toolMessageContent,
@@ -649,13 +650,42 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 	}
 
 	const nativeToolCalls = normalizeToolCalls(raw.toolCalls);
+	const text = getNonEmptyString(raw.text);
+
+	// Tolerant PLAN_ACTIONS-in-text fallback (elizaOS/eliza#7620). When a
+	// hosted model emits the planner envelope as message content instead of
+	// as a native tool call — observed with Cerebras-served `gpt-oss-120b`,
+	// where the character prompt's worked example seeds the bytes — recover
+	// the call here so the planner-loop's downstream resolver still
+	// dispatches the action.
+	let textRecoveredCalls: PlannerToolCall[] = [];
+	let recoverySource: string | undefined;
+	let recoveredThought: string | undefined;
+	if (nativeToolCalls.length === 0 && typeof text === "string") {
+		const extracted = extractPlanActionsFromContent(text);
+		if (extracted) {
+			textRecoveredCalls = [
+				{
+					name: extracted.action,
+					params: extracted.parameters,
+				},
+			];
+			recoverySource = extracted.recoverySource;
+			recoveredThought = extracted.thought;
+		}
+	}
+
 	return {
-		thought: undefined,
-		toolCalls: nativeToolCalls,
-		messageToUser: getNonEmptyString(raw.text),
+		thought: recoveredThought,
+		toolCalls:
+			nativeToolCalls.length > 0 ? nativeToolCalls : textRecoveredCalls,
+		// When we recovered a tool call from the text, blank `messageToUser`:
+		// the text WAS the tool call envelope, not a user-facing message.
+		messageToUser: textRecoveredCalls.length > 0 ? undefined : text,
 		raw: {
 			text: raw.text,
 			toolCalls: raw.toolCalls,
+			...(recoverySource ? { textRecoverySource: recoverySource } : {}),
 		} as Record<string, unknown>,
 	};
 }
@@ -669,6 +699,19 @@ function parseJsonPlannerOutput(raw: string): {
 	const trimmed = raw.trim();
 	const parsed = parseJsonObject<RawPlannerOutput>(trimmed);
 	if (!parsed) {
+		// Tolerant in-text fallback (elizaOS/eliza#7620): the raw output isn't
+		// JSON, but it might contain a `PLAN_ACTIONS({...})` envelope as text.
+		const extracted = extractPlanActionsFromContent(trimmed);
+		if (extracted) {
+			return {
+				thought: extracted.thought,
+				toolCalls: [{ name: extracted.action, params: extracted.parameters }],
+				raw: {
+					text: trimmed,
+					textRecoverySource: extracted.recoverySource,
+				},
+			};
+		}
 		return {
 			toolCalls: [],
 			messageToUser: getNonEmptyString(trimmed),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -82,6 +82,7 @@ import {
 	type PlannerTrajectory,
 	runPlannerLoop,
 } from "../runtime/planner-loop";
+import { looksLikeRefusal } from "../runtime/refusal-detector";
 import {
 	buildResponseGrammar,
 	buildSpanSamplerPlan,
@@ -2663,7 +2664,7 @@ function messageHandlerFromFieldResult(
 					: "RESPOND";
 	const preemptDirect =
 		preempt?.mode === "ack-and-stop" || preempt?.mode === "direct-reply";
-	const replyText =
+	const replyTextRaw =
 		typeof result.replyText === "string" ? result.replyText : "";
 	const routedContexts = preemptDirect
 		? Array.from(new Set([...contexts, SIMPLE_CONTEXT_ID]))
@@ -2685,6 +2686,12 @@ function messageHandlerFromFieldResult(
 					]),
 				)
 			: routedContexts;
+	// Refusal suppression for the planning path (elizaOS/eliza#7620). Mirrors
+	// the logic in `parseMessageHandlerOutput`: when the planner is about to
+	// run, a refusal-shaped `replyText` from a safety-tuned hosted model is
+	// dropped so the planner's own message reaches the user instead.
+	const replyText =
+		shouldPlan && looksLikeRefusal(replyTextRaw) ? "" : replyTextRaw;
 	const plan: MessageHandlerResult["plan"] = {
 		contexts: finalContexts,
 		reply: replyText,

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2160,12 +2160,12 @@ export const tasksAction: Action & { suppressPostActionContinuation: true } = {
     "RESUME_CODING_TASK",
   ],
   description:
-    "Orchestrator surface for delegating coding work to dedicated sub-agents (claude / codex / opencode / gemini / aider). " +
-    "Pick `action` to dispatch the right sub-action: create or spawn_agent (delegate new coding work), send (forward a message to an existing sub-agent), list_agents / history (read state), " +
-    "control (pause | resume | continue | archive | reopen a task), share (surface task output), provision_workspace / submit_workspace (workspace setup and PR submission), manage_issues (GitHub issue operations), cancel / stop_agent (end a sub-agent run when the user asks to). " +
-    "Choose this when the user asks to delegate, spawn, fire up, use a coding adapter, or run multi-step development work — it is the canonical path for coding sub-agents and is preferred over inline FILE / BASH for delegated work.",
+    "Planner surface for orchestrator workspace operations and coding task delegation to dedicated coding sub-agents (claude / codex / opencode / gemini / aider). " +
+    "Available operations (pick via `action`): create or spawn_agent (delegate new coding work), send (forward a message to an existing coding sub-agent), list_agents / history (read state), " +
+    "control (pause | resume | continue | archive | reopen a task), share (surface task output), provision_workspace / submit_workspace (workspace setup and PR submission), manage_issues (GitHub issue operations), cancel / stop_agent (end a coding sub-agent run when the user asks to). " +
+    "Choose this when the user asks to delegate coding work, use a coding adapter by name, or run multi-step development work — it is the canonical path for coding sub-agents and is preferred over inline FILE / BASH for delegated work.",
   descriptionCompressed:
-    "delegate coding work to a sub-agent (claude/codex/opencode/gemini/aider). action=spawn_agent for new work, send to talk to one, control to pause/resume, list_agents/history to read state",
+    "delegate coding work to a coding sub-agent (claude/codex/opencode/gemini/aider). action=spawn_agent for new work, send to talk to one, control to pause/resume, list_agents/history to read state",
   suppressPostActionContinuation: true,
   parameters: [
     {

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -97,14 +97,14 @@ export function createAgentOrchestratorPlugin(): Plugin {
           overrides: {
             spawn_agent: {
               description:
-                "Delegate a coding task to a dedicated coding sub-agent (claude / codex / opencode / gemini / aider — selected from configured providers). USE THIS when the user explicitly asks to delegate, spawn, fire up, use a coding adapter by name, or for substantial multi-step coding work that benefits from a dedicated workspace and its own tool loop. The sub-agent runs in its own workspace, can read / write / edit files and run tests, and reports back when done. Prefer this over inline FILE / BASH tools whenever delegation is the user's intent — even for single-file tasks if delegation is explicitly requested.",
+                "Delegate a coding task to a dedicated coding sub-agent (claude / codex / opencode / gemini / aider — selected from configured providers). USE THIS when the user explicitly asks to delegate coding work, use a coding adapter by name, or run substantial multi-step coding work that benefits from a dedicated workspace and its own tool loop. The coding sub-agent runs in its own workspace, can read / write / edit files and run tests, and reports back when done. Prefer this over inline FILE / BASH tools whenever delegation is the user's intent — even for single-file tasks if delegation is explicitly requested.",
               // Compressed blurb is what the planner sees in tier-A
               // summaries; if we don't override it, it inherits the
               // generic parent enum dump and the planner can't tell
               // `TASKS_SPAWN_AGENT` apart from inline `FILE.write` for
               // delegation requests. See the parent comment above.
               descriptionCompressed:
-                "delegate coding work to a coding sub-agent (claude/codex/opencode/gemini/aider) — use when the user asks to delegate / fire up a coder / use an adapter by name / for any multi-step dev work; prefer over inline FILE/BASH when delegation is the user's intent",
+                "delegate coding work to a coding sub-agent (claude/codex/opencode/gemini/aider) — use when the user asks to delegate coding work / use an adapter by name / for any multi-step dev work; prefer over inline FILE/BASH when delegation is the user's intent",
             },
           },
         }),
@@ -127,7 +127,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
   return {
     name: "@elizaos/plugin-agent-orchestrator",
     description: codeExecutionAllowed
-      ? "Spawn and orchestrate coding agents via the Agent Client Protocol (acpx) with workspace lifecycle, GitHub integration, task history, sub-agent routing, and skill-recommender support. Single TASKS parent action covers create / spawn_agent / send / stop_agent / list_agents / cancel / history / control / share / provision_workspace / submit_workspace / manage_issues / archive / reopen."
+      ? "Orchestrate coding sub-agents via the Agent Client Protocol (acpx) with workspace operations, GitHub integration, task history, sub-agent routing, and skill-recommender support. Single TASKS parent action covers create / spawn_agent / send / stop_agent / list_agents / cancel / history / control / share / provision_workspace / submit_workspace / manage_issues / archive / reopen."
       : (terminalSupport.message ??
         "Coding-agent orchestrator is unavailable in this runtime. Exposes a single TASKS stub that explains the limitation when the planner reaches for a coding-agent action."),
     // Services manage ACPX subprocesses, PTY sessions, workspaces, and sub-agent routing.


### PR DESCRIPTION
Fixes #7620.

## Root cause

Cerebras-hosted `gpt-oss-120b` and `qwen-3-235b-a22b-instruct-2507` running as the V5 response handler emit **word-for-word identical** refusal text — *\"I'm unable to spawn a sub-agent in this context. I can create /tmp/foo.py directly...\"* — for clear delegation prompts even though `candidateActions` already includes `TASKS_SPAWN_AGENT`. Identical bytes across two model families point at template / action-surface JSON priming the refusal rather than pure model bias. The runtime had a refusal-detector module checked in but never wired into the message handler.

## Fix

Three coordinated changes:

**(A) Reword TASKS action description** in `plugins/plugin-agent-orchestrator/src/actions/tasks.ts` and the plugin top-level description in `src/index.ts`. Drops `\"spawn / fire up / lifecycle\"` framing that reads as a privileged operation to safety-tuned models.

**(B) Wire `looksLikeRefusal()` into both Stage-1 parse paths:**
- `parseMessageHandlerOutput` (`packages/core/src/runtime/message-handler.ts`)
- `messageHandlerFromFieldResult` (`packages/core/src/services/message.ts`)

When a turn routes to a planning context (non-simple contexts OR candidateActions present) AND the model's `replyText` opens with a refusal pattern, `plan.reply` is blanked so the planner's own message reaches the user instead of the refusal. Refusals on the simple path pass through untouched (model may legitimately decline an unsafe request).

**(C) Tolerant `PLAN_ACTIONS`-in-text parser** in `packages/core/src/runtime/plan-actions-extractor.ts`, wired into `parsePlannerOutput`. When a hosted model emits the planner envelope as message content instead of as a native tool call (observed with `gpt-oss-120b`, where the character prompt's worked example seeds the bytes), the recovery extracts the call from text so the downstream resolver still dispatches. Defensive against Stage-1 HANDLE_RESPONSE envelopes leaking into the parser.

New exports from `@elizaos/core`:
- `extractPlanActionsFromContent`, `ExtractedPlanAction`, `PlanActionRecoverySource`
- `looksLikeRefusal`

## Verification

- `bunx vitest run src/runtime/__tests__/` — 591 tests pass
- `bunx vitest run src/services/ src/__tests__/` (core) — 150 tests pass
- `bunx vitest run` (plugin-agent-orchestrator) — 216 pass + 7 pre-existing skips
- Lint clean on all changed files (`bunx @biomejs/biome check`)

Fix is template-and-parser-only; no live model validation performed in this environment. The pre-existing `plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts` exercises the now-wired `parseMessageHandlerOutput` suppression and is the live regression for this fix.

## Test plan

- [ ] Set `CEREBRAS_API_KEY` and `ELIZA_RUN_LIVE_TESTS=1`; run `plugins/plugin-openai/__tests__/cerebras-spawn-subagent-refusal.live.test.ts` against both models; expect `leakedRefusalCount=0` and `withSpawnCandidateCount >= 1`
- [ ] Drive the orchestrator-enabled runtime with the original repro prompt (`@bot spawn a coding sub-agent using opencode to write /tmp/foo.py that prints hello`) on Cerebras `gpt-oss-120b`; confirm no refusal text reaches the user and `TASKS_SPAWN_AGENT` dispatches
- [ ] Same prompt with Claude as response handler; confirm no behaviour regression on the existing-good path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes #7620 cleanly through three coordinated changes — action description rewording, refusal suppression wiring, and a tolerant `PLAN_ACTIONS`-in-text parser. The core logic is sound: the brace-balancer handles edge cases correctly, the `STAGE_1_DISCRIMINATORS` guard reliably prevents Stage-1 envelopes from being misfired as Stage-2 plan actions, and planning-path scoping ensures simple-context refusals are never suppressed.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the intended fix; the new extractor and refusal suppression are both well-guarded and have minimal blast radius on existing paths

The brace-balancer, STAGE_1_DISCRIMINATORS guard, and planning-path scoping are all correct. The main gap is the hedge+secondary-verb path in looksLikeRefusal, which can silence a legitimate Stage-1 acknowledgement that happens to contain 'I cannot/can't' anywhere in the same reply as a context phrase; the missing targeted regression test for messageHandlerFromFieldResult means divergence between the two suppression sites could go unnoticed.

packages/core/src/runtime/refusal-detector.ts (hedge+secondary false-positive boundary) and packages/core/src/services/message.ts (no dedicated test for the refusal-suppression block in messageHandlerFromFieldResult)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/refusal-detector.ts | Pre-existing module newly wired in; well-covered by tests, but the hedge+secondary-verb fallback path can produce false positives on planning-path acknowledgements that incidentally contain "I cannot/can't" + a context phrase |
| packages/core/src/runtime/plan-actions-extractor.ts | New tolerant extractor for PLAN_ACTIONS-in-text and bare-action-object shapes; brace-balancer correctly handles nested objects and escape sequences; STAGE_1_DISCRIMINATORS guard prevents Stage-1 envelope misfire; well-tested |
| packages/core/src/runtime/message-handler.ts | Refusal suppression wired into parseMessageHandlerOutput; only active on planning path (non-simple context or candidateActions present); simple-path refusals pass through unchanged |
| packages/core/src/runtime/planner-loop.ts | Two recovery points added: GenerateTextResult path and string/JSON-mode path; native calls always take priority; messageToUser correctly blanked on recovery |
| packages/core/src/services/message.ts | Refusal suppression mirrors message-handler.ts logic; correctly uses shouldPlan (which already excludes preemptDirect); no dedicated unit test for this path in this PR |
| packages/core/src/index.node.ts | Exports extractPlanActionsFromContent, ExtractedPlanAction, PlanActionRecoverySource, and looksLikeRefusal from @elizaos/core |
| plugins/plugin-agent-orchestrator/src/actions/tasks.ts | Removed 'spawn / fire up / lifecycle' framing from TASKS action description to avoid triggering safety-tuned model refusals; no logic change |
| plugins/plugin-agent-orchestrator/src/index.ts | Plugin-level description and spawn_agent sub-action descriptions updated to remove trigger phrasing; behaviorally inert |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/runtime/refusal-detector.ts`, line 102-105 ([link](https://github.com/elizaos/eliza/blob/a3cc485e21366e1e3355e8aeeb1d3bd085617327/packages/core/src/runtime/refusal-detector.ts#L102-L105)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Hedge path can suppress legitimate planning-path acknowledgements**

   `SECONDARY_REFUSAL_VERBS` matches `I cannot/can't/unable` anywhere in the reply — not just at the start. A planning-path acknowledgement like "I'll try to spawn the agent. I'm unable to guarantee success in this environment." has `HEDGE_PATTERNS` match ("in this environment") and `SECONDARY_REFUSAL_VERBS` match ("I'm unable"), so `looksLikeRefusal` returns `true` and `plan.reply` is silently blanked. The user loses the preliminary caveat, and if the planner subsequently fails (e.g. provider timeout), they receive no feedback at all. The existing test suite exercises `REFUSAL_OPENERS` anchored cases well but has no test covering a false-positive in the hedge+secondary path — adding one like the above would pin the boundary and catch any future regex drift.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator,response-handler): rewo..."](https://github.com/elizaos/eliza/commit/a3cc485e21366e1e3355e8aeeb1d3bd085617327) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32116801)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->