### PR TITLE
fix(local-inference): refuse to activate candidate-only models (#7679)

### DIFF
--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -29,6 +29,10 @@ import {
 	LOCAL_INFERENCE_PROVIDER_ID,
 	LOCAL_INFERENCE_TEXT_MODEL_TYPES,
 } from "./provider.js";
+import {
+	assertManifestEvalsPassed,
+	CandidateModelActivationError,
+} from "./services/active-model.js";
 
 type ModelRole = "chat" | "embedding" | "drafter";
 type DownloadState =
@@ -1286,6 +1290,32 @@ export async function handleLocalInferenceRoutes(
 		if (!installed) {
 			sendJsonError(res, `Model not installed: ${body.modelId}`, 404);
 			return true;
+		}
+		// #7679: refuse to activate a candidate-only / weights-staged bundle
+		// whose manifest reports `evals.textEval.passed=false`. Runs before
+		// any assignment write or device-bridge load so a known-bad bundle
+		// can't take over the assignment slots nor leave the bridge holding
+		// a half-loaded model. The gate only fires for tiers whose
+		// `eliza-1.manifest.json` is reachable next to the installed bundle
+		// (see `defaultManifestLoader`); external-scan / non-bundle installs
+		// are passed through.
+		try {
+			assertManifestEvalsPassed(installed);
+		} catch (err) {
+			if (err instanceof CandidateModelActivationError) {
+				sendJson(
+					res,
+					{
+						error: err.message,
+						modelId: err.modelId,
+						manifestVersion: err.manifestVersion,
+						failedEvals: err.failedEvals,
+					},
+					422,
+				);
+				return true;
+			}
+			throw err;
 		}
 		const catalog = CATALOG.find((model) => model.id === installed.id);
 		if (catalog) await assignModel(catalog, true);

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
@@ -351,4 +351,68 @@ describe("POST /api/local-inference/active", () => {
 			/overrides must be an object/,
 		);
 	});
+
+	// #7679: refuse to activate a candidate-only / weights-staged bundle
+	// whose own manifest reports `evals.textEval.passed=false`.
+	it("returns 422 with manifestVersion + failedEvals when the bundle is candidate-only", async () => {
+		const { CandidateModelActivationError } = await import(
+			"../services/active-model"
+		);
+		setActiveMock.mockRejectedValue(
+			new CandidateModelActivationError({
+				modelId: "eliza-1-0_6b",
+				manifestVersion: "1.0.0-candidate.1",
+				failedEvals: ["textEval", "voiceRtf", "asrWer", "expressive", "dflash"],
+			}),
+		);
+
+		const res = fakeRes();
+		await handleLocalInferenceCompatRoutes(
+			fakeReq({
+				method: "POST",
+				pathname: "/api/local-inference/active",
+				body: { modelId: "eliza-1-0_6b" },
+			}),
+			res.res,
+			STATE,
+		);
+
+		expect(res.status()).toBe(422);
+		const body = res.body() as {
+			error: string;
+			modelId: string;
+			manifestVersion: string;
+			failedEvals: string[];
+		};
+		expect(body.modelId).toBe("eliza-1-0_6b");
+		expect(body.manifestVersion).toBe("1.0.0-candidate.1");
+		expect(body.failedEvals).toContain("textEval");
+		expect(body.failedEvals).toContain("voiceRtf");
+		expect(body.error).toMatch(/candidate-only/);
+		expect(body.error).toMatch(/textEval/);
+	});
+
+	it("returns 200 (delegated to setActive) when the bundle is a strict release", async () => {
+		setActiveMock.mockResolvedValue({
+			modelId: "eliza-1-2b",
+			loadedAt: "2026-05-14T00:00:00.000Z",
+			status: "ready",
+		});
+
+		const res = fakeRes();
+		await handleLocalInferenceCompatRoutes(
+			fakeReq({
+				method: "POST",
+				pathname: "/api/local-inference/active",
+				body: { modelId: "eliza-1-2b" },
+			}),
+			res.res,
+			STATE,
+		);
+
+		expect(res.status()).toBe(200);
+		const body = res.body() as { modelId: string; status: string };
+		expect(body.modelId).toBe("eliza-1-2b");
+		expect(body.status).toBe("ready");
+	});
 });

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
@@ -13,6 +13,7 @@
 
 import type http from "node:http";
 import {
+	CandidateModelActivationError,
 	type KvOffloadMode,
 	type LocalInferenceLoadOverrides,
 	validateLocalInferenceLoadArgs,
@@ -687,6 +688,21 @@ export async function handleLocalInferenceCompatRoutes(
 			);
 			sendJsonResponse(res, 200, active);
 		} catch (err) {
+			// #7679: refuse to activate a candidate-only / weights-staged
+			// bundle whose manifest reports `evals.textEval.passed=false`.
+			// Surface the structured payload (modelId, manifestVersion,
+			// failedEvals) verbatim so the UI can render an actionable
+			// "this tier isn't ready" message instead of `[unused]` tokens
+			// downstream.
+			if (err instanceof CandidateModelActivationError) {
+				sendJsonResponse(res, 422, {
+					error: err.message,
+					modelId: err.modelId,
+					manifestVersion: err.manifestVersion,
+					failedEvals: err.failedEvals,
+				});
+				return true;
+			}
 			sendJsonErrorResponse(
 				res,
 				400,

--- a/plugins/plugin-local-inference/src/services/active-model.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.test.ts
@@ -8,8 +8,8 @@ import {
 	isStockKvCacheType,
 	ModelDoesNotFitError,
 	resolveLocalInferenceLoadArgs,
-	validateLocalInferenceLoadArgs,
 	VoiceBundleDoesNotFitError,
+	validateLocalInferenceLoadArgs,
 } from "./active-model";
 import { resolveIdleUnloadMs } from "./engine";
 import type { Eliza1Manifest } from "./manifest";

--- a/plugins/plugin-local-inference/src/services/active-model.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	assertManifestEvalsPassed,
 	assertModelFitsHost,
 	assertVoiceBundleFitsHost,
+	CandidateModelActivationError,
 	isForkOnlyKvCacheType,
 	isStockKvCacheType,
 	ModelDoesNotFitError,
@@ -10,6 +12,7 @@ import {
 	VoiceBundleDoesNotFitError,
 } from "./active-model";
 import { resolveIdleUnloadMs } from "./engine";
+import type { Eliza1Manifest } from "./manifest";
 import type { InstalledModel } from "./types";
 
 function makeInstalledModel(id: string, filePath: string): InstalledModel {
@@ -326,6 +329,160 @@ describe("assertVoiceBundleFitsHost (R9 §1.4 cross-model admission)", () => {
 		});
 		expect(r.fits).toBe(true);
 		expect(r.steadyStateMb).toBe(0);
+	});
+});
+
+// #7679: refuse to activate a model whose own `eliza-1.manifest.json`
+// reports `evals.textEval.passed=false` (candidate.* / weights-staged.*).
+describe("assertManifestEvalsPassed (#7679 activation gate)", () => {
+	function makeStrictManifest(
+		overrides: Partial<Eliza1Manifest> = {},
+	): Eliza1Manifest {
+		return {
+			id: "eliza-1-2b",
+			tier: "2b",
+			version: "1.0.0",
+			publishedAt: "2026-05-14T00:00:00.000Z",
+			lineage: {
+				text: { base: "eliza-1-2b", license: "apache-2.0" },
+				voice: { base: "omnivoice", license: "apache-2.0" },
+				drafter: { base: "dflash", license: "apache-2.0" },
+			},
+			files: {
+				text: [{ path: "t.gguf", sha256: "a".repeat(64), ctx: 32768 }],
+				voice: [{ path: "v.gguf", sha256: "b".repeat(64) }],
+				asr: [],
+				vision: [],
+				dflash: [{ path: "d.gguf", sha256: "c".repeat(64) }],
+				cache: [{ path: "c.bin", sha256: "d".repeat(64) }],
+			},
+			kernels: {
+				required: ["turboquant_q4", "qjl", "polarquant", "dflash"],
+				optional: [],
+				verifiedBackends: {
+					metal: { status: "pass", atCommit: "x", report: "ok" },
+					vulkan: { status: "pass", atCommit: "x", report: "ok" },
+					cuda: { status: "pass", atCommit: "x", report: "ok" },
+					rocm: { status: "pass", atCommit: "x", report: "ok" },
+					cpu: { status: "pass", atCommit: "x", report: "ok" },
+				},
+			},
+			evals: {
+				textEval: { score: 0.9, passed: true },
+				voiceRtf: { rtf: 0.5, passed: true },
+				e2eLoopOk: true,
+				thirtyTurnOk: true,
+			},
+			ramBudgetMb: { min: 4096, recommended: 6144 },
+			defaultEligible: true,
+			...overrides,
+		} as Eliza1Manifest;
+	}
+
+	it("refuses activation when the manifest reports textEval.passed=false", () => {
+		const installed = makeInstalledModel(
+			"eliza-1-0_6b",
+			"/tmp/bundle/eliza-1-0_6b.gguf",
+		);
+		const candidateManifest = makeStrictManifest({
+			id: "eliza-1-0_6b",
+			tier: "0_8b", // candidate tier in the manifest
+			version: "1.0.0-candidate.1",
+			defaultEligible: false,
+			evals: {
+				textEval: { score: 0.2, passed: false },
+				voiceRtf: { rtf: 1.2, passed: false },
+				e2eLoopOk: false,
+				thirtyTurnOk: false,
+			},
+		});
+
+		let caught: unknown;
+		try {
+			assertManifestEvalsPassed(installed, () => candidateManifest);
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(CandidateModelActivationError);
+		const e = caught as CandidateModelActivationError;
+		expect(e.modelId).toBe("eliza-1-0_6b");
+		expect(e.manifestVersion).toBe("1.0.0-candidate.1");
+		expect(e.failedEvals).toContain("textEval");
+		expect(e.failedEvals).toContain("voiceRtf");
+		expect(e.failedEvals).toContain("e2eLoopOk");
+		expect(e.failedEvals).toContain("thirtyTurnOk");
+		// The error message names the manifest version + the failed evals so
+		// downstream HTTP callers can render an actionable refusal.
+		expect(e.message).toMatch(/candidate-only/);
+		expect(e.message).toContain("1.0.0-candidate.1");
+		expect(e.message).toContain("textEval");
+	});
+
+	it("allows activation when textEval.passed=true (strict release)", () => {
+		const installed = makeInstalledModel(
+			"eliza-1-2b",
+			"/tmp/bundle/eliza-1-2b.gguf",
+		);
+		expect(() =>
+			assertManifestEvalsPassed(installed, () => makeStrictManifest()),
+		).not.toThrow();
+	});
+
+	it("passes through bundles with no manifest (external HF blobs)", () => {
+		const installed = makeInstalledModel(
+			"external-blob-xyz",
+			"/tmp/external.gguf",
+		);
+		expect(() =>
+			assertManifestEvalsPassed(installed, () => null),
+		).not.toThrow();
+	});
+
+	it("aggregates every failed eval slot into failedEvals (not just textEval)", () => {
+		const installed = makeInstalledModel(
+			"eliza-1-0_6b",
+			"/tmp/bundle/eliza-1-0_6b.gguf",
+		);
+		const candidateManifest = makeStrictManifest({
+			version: "1.0.0-candidate.1",
+			defaultEligible: false,
+			evals: {
+				textEval: { score: 0.1, passed: false },
+				voiceRtf: { rtf: 2.0, passed: false },
+				e2eLoopOk: true,
+				thirtyTurnOk: true,
+				asrWer: { wer: 0.4, passed: false },
+				expressive: {
+					tagFaithfulness: 0.1,
+					mosExpressive: 2.0,
+					tagLeakage: 0.5,
+					passed: false,
+				},
+				dflash: { acceptanceRate: null, speedup: null, passed: false },
+			},
+		});
+
+		let caught: CandidateModelActivationError | null = null;
+		try {
+			assertManifestEvalsPassed(installed, () => candidateManifest);
+		} catch (err) {
+			caught = err as CandidateModelActivationError;
+		}
+		expect(caught).not.toBeNull();
+		const failed = caught?.failedEvals ?? [];
+		expect(failed).toEqual(
+			expect.arrayContaining([
+				"textEval",
+				"voiceRtf",
+				"asrWer",
+				"expressive",
+				"dflash",
+			]),
+		);
+		// e2eLoopOk / thirtyTurnOk passed in this fixture; they must not appear.
+		expect(failed).not.toContain("e2eLoopOk");
+		expect(failed).not.toContain("thirtyTurnOk");
 	});
 });
 

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -20,8 +20,11 @@ import {
 } from "./catalog";
 import { localInferenceEngine } from "./engine";
 import { probeHardware } from "./hardware";
+import type { Eliza1Manifest } from "./manifest";
 import {
 	assessRamFit,
+	defaultManifestLoader,
+	type ManifestLoader,
 	pickFittingContextVariant,
 	type RamFitOptions,
 } from "./ram-budget";
@@ -699,6 +702,98 @@ function hostRamMbFromProbe(probe: HardwareProbe): number {
 	return Math.round(probe.totalRamGb * MB_PER_GB);
 }
 
+/**
+ * Refusal raised when activation is asked for a model whose own
+ * `eliza-1.manifest.json` says its text eval has not passed (`candidate.*` /
+ * `weights-staged.*` tiers). Carries the structured payload the route layer
+ * surfaces verbatim to the API consumer: `manifestVersion` so the UI can
+ * say "this tier isn't ready" with the actual version string, and
+ * `failedEvals` so the user sees which checks are still red.
+ *
+ * Why we gate here, not just at download:
+ * - the bundle may already be on disk (hand-staged, manually copied, or
+ *   downloaded before a fail-state was recorded), so the download gate
+ *   alone leaves a window where a candidate-only bundle can be flipped
+ *   into the active model slot and silently emit `[unused]` tokens.
+ *
+ * See issue #7679 for the original symptom: the runtime activated the
+ * `eliza-1-0_6b` `1.0.0-candidate.1` bundle whose every `evals.*.passed`
+ * was `false`, then served BERT/WordPiece reserved tokens (`[unused0..99]`
+ * / `[PAD]`) as chat output with no actionable error.
+ */
+export class CandidateModelActivationError extends Error {
+	readonly modelId: string;
+	readonly manifestVersion: string;
+	readonly failedEvals: ReadonlyArray<string>;
+
+	constructor(args: {
+		modelId: string;
+		manifestVersion: string;
+		failedEvals: ReadonlyArray<string>;
+	}) {
+		const evalSuffix =
+			args.failedEvals.length > 0
+				? ` Failed evals: ${args.failedEvals.join(", ")}.`
+				: "";
+		super(
+			`Model "${args.modelId}" is candidate-only — its manifest (version ${args.manifestVersion}) reports evals.textEval.passed=false. Refusing to activate.${evalSuffix} Wait for the publisher to flip the manifest off candidate/weights-staged and re-fetch the bundle.`,
+		);
+		this.name = "CandidateModelActivationError";
+		this.modelId = args.modelId;
+		this.manifestVersion = args.manifestVersion;
+		this.failedEvals = args.failedEvals;
+	}
+}
+
+/**
+ * Activation eval gate. Reads the installed bundle's manifest and refuses
+ * activation when `evals.textEval.passed` is not `true`. A bundle with no
+ * `eliza-1.manifest.json` on disk (third-party HF GGUFs, external scans,
+ * pre-bundle installs) is *not* gated — the gate only applies to bundles
+ * that ship a published manifest, which is the source of truth for the
+ * publish state.
+ *
+ * Throws `CandidateModelActivationError` on a failing manifest; returns
+ * silently otherwise.
+ */
+export function assertManifestEvalsPassed(
+	installed: InstalledModel,
+	manifestLoader: ManifestLoader = defaultManifestLoader,
+): void {
+	const manifest = manifestLoader(installed.id, installed);
+	if (!manifest) return;
+	if (manifest.evals.textEval.passed === true) return;
+	throw new CandidateModelActivationError({
+		modelId: installed.id,
+		manifestVersion: manifest.version,
+		failedEvals: collectFailedEvalNames(manifest),
+	});
+}
+
+function collectFailedEvalNames(manifest: Eliza1Manifest): string[] {
+	const failed: string[] = [];
+	const evals = manifest.evals;
+	if (evals.textEval.passed !== true) failed.push("textEval");
+	if (evals.voiceRtf.passed !== true) failed.push("voiceRtf");
+	if (evals.e2eLoopOk !== true) failed.push("e2eLoopOk");
+	if (evals.thirtyTurnOk !== true) failed.push("thirtyTurnOk");
+	if (evals.asrWer && evals.asrWer.passed !== true) failed.push("asrWer");
+	if (evals.embedMteb && evals.embedMteb.passed !== true) {
+		failed.push("embedMteb");
+	}
+	if (evals.vadLatencyMs && evals.vadLatencyMs.passed !== true) {
+		failed.push("vadLatencyMs");
+	}
+	if (evals.expressive && evals.expressive.passed !== true) {
+		failed.push("expressive");
+	}
+	if (evals.dflash && evals.dflash.passed !== true) failed.push("dflash");
+	if (evals.turnDetector && evals.turnDetector.passed !== true) {
+		failed.push("turnDetector");
+	}
+	return failed;
+}
+
 function isLoader(value: unknown): value is LocalInferenceLoader {
 	if (!value || typeof value !== "object") return false;
 	const candidate = value as Partial<LocalInferenceLoader>;
@@ -781,8 +876,17 @@ export class ActiveModelCoordinator {
 		runtime: AgentRuntime | null,
 		installed: InstalledModel,
 		overrides?: LocalInferenceLoadOverrides,
-		opts: { hardware?: HardwareProbe } = {},
+		opts: { hardware?: HardwareProbe; manifestLoader?: ManifestLoader } = {},
 	): Promise<ActiveModelState> {
+		// Activation eval gate (#7679). Refuse to flip a candidate-only /
+		// weights-staged bundle into the active model slot — the manifest
+		// already says its text eval hasn't passed, so the only thing
+		// activation buys is `[unused]`/`[PAD]` tokens in chat output and
+		// a confused user. Runs BEFORE the loading state is emitted so
+		// the UI never shows "loading → error" for a known-bad bundle;
+		// it sees the 422 from the route layer directly.
+		assertManifestEvalsPassed(installed, opts.manifestLoader);
+
 		this.state = {
 			modelId: installed.id,
 			loadedAt: null,


### PR DESCRIPTION
## Summary

Fixes #7679. The runtime currently activates `eliza-1` model bundles whose own `eliza-1.manifest.json` declares them `candidate.1` / `weights-staged.1` and reports every `evals.*.passed: false`. Users then receive `[unused0..99]` / `[PAD]` tokens (or incoherent looping prose) from the OpenAI-compat endpoint with no actionable error.

**Root cause:** the existing download gate (`assertBundleInstallable` in `downloader.ts`) rejects RAM/backend mismatches but does not look at the manifest's `evals` block. A bundle hand-staged onto disk, copied across machines, or downloaded before a fail-state was recorded slips past that gate and ends up in the active model slot.

## Fix

Server-side activation eval gate that mirrors the existing download checks:

- `CandidateModelActivationError` carries `modelId`, `manifestVersion`, and the aggregated `failedEvals` list (`textEval` plus any other red eval slot the manifest declares).
- `assertManifestEvalsPassed(installed)` reads the bundle's manifest via `defaultManifestLoader` and refuses activation when `evals.textEval.passed !== true`. External-scan / non-bundle installs without an `eliza-1.manifest.json` pass through unchanged (same surface as the existing manifest-aware paths).
- `ActiveModelCoordinator.switchTo` calls the gate before emitting the `loading` state, so a known-bad bundle never half-loads and there is no `loading → error` flicker.
- Both `POST /api/local-inference/active` handlers (the compat route at `plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts` and the legacy mobile-bridge route at `plugins/plugin-local-inference/src/local-inference-routes.ts`) translate the error into a 422 with the structured body `{ error, modelId, manifestVersion, failedEvals }` so the UI can render an actionable "this tier isn't ready" message instead of garbage tokens downstream.

No feature flag / env-var bypass. Refusal is unconditional.

## Test plan

- [x] Unit tests for `assertManifestEvalsPassed`: refuses on `textEval.passed=false`, accepts on strict release, passes through for bundles with no manifest, aggregates every failing eval slot into `failedEvals`.
- [x] Route tests for `POST /api/local-inference/active`: returns 422 with `modelId` / `manifestVersion` / `failedEvals` when `setActive` throws `CandidateModelActivationError`; returns 200 on strict-release activation.
- [x] `bun x vitest run plugins/plugin-local-inference/src/services/active-model.test.ts plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts` — 39/39 pass.
- [x] `bunx @biomejs/biome check` clean across the five touched files.
- [x] `tsc --noEmit` shows no new errors in the touched files (37 pre-existing errors are all in unrelated paths: `uuid` import shape and `@huggingface/transformers` exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an activation eval gate that refuses to load eliza-1 bundles whose own `eliza-1.manifest.json` reports `evals.textEval.passed=false`, surfacing a structured 422 (`error`, `modelId`, `manifestVersion`, `failedEvals`) instead of silently activating a candidate-only model that emits `[unused]`/`[PAD]` tokens.

- `CandidateModelActivationError` + `assertManifestEvalsPassed` are introduced in `active-model.ts`; the gate fires in `ActiveModelCoordinator.switchTo` before the `loading` state is written, and is independently wired into the legacy `local-inference-routes.ts` handler before `assignModel`/`loadMobileDeviceBridgeModel`.
- Both `POST /api/local-inference/active` handlers (compat + legacy) catch `CandidateModelActivationError` and return 422 with the structured payload; non-eliza-1 / manifest-absent installs pass through unchanged.
- Test coverage is solid: four unit tests for `assertManifestEvalsPassed` and two route-level tests in the compat suite cover the 422 and 200 paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure refusal gate with no state mutation on the blocked path and thorough test coverage across both affected routes.

The gate logic correctly keys on textEval.passed !== true (a z.boolean() field, so only ever true/false), the ActiveModelCoordinator state is never dirtied on rejection, collectFailedEvalNames safely guards all optional eval fields before access, and both HTTP handlers return a structured 422 before any assignment write or bridge load. Tests cover refusal, pass-through, manifest-absent, and multi-eval aggregation paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/src/services/active-model.ts | Adds CandidateModelActivationError, assertManifestEvalsPassed gate, and collectFailedEvalNames; also wires the gate into ActiveModelCoordinator.switchTo before the loading-state write. Logic is correct: gate fires only when textEval.passed !== true, optional eval fields are guarded before access, and non-eliza-1 / manifest-absent bundles pass through unchanged. |
| plugins/plugin-local-inference/src/local-inference-routes.ts | Legacy mobile-bridge route now calls assertManifestEvalsPassed directly before assignModel/loadMobileDeviceBridgeModel and returns 422 on CandidateModelActivationError. Re-throws any non-gate error so unexpected panics still propagate. |
| plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts | Compat route catches CandidateModelActivationError propagated from setActive to switchTo and maps it to a structured 422; all other errors still fall through to the existing 400 handler. |
| plugins/plugin-local-inference/src/services/active-model.test.ts | Adds four unit tests for assertManifestEvalsPassed covering: refusal on textEval.passed=false, pass-through on strict release, pass-through with no manifest, and aggregation of all failing eval slots into failedEvals. |
| plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts | Adds two route-level tests: 422 with structured payload when setActive rejects with CandidateModelActivationError, and 200 delegation for a strict-release bundle. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(local-inference): biome import order..."](https://github.com/elizaos/eliza/commit/cea0e152cd0bff8ae9c5aef13ca31d5b6248f74e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32116934)</sub>

<!-- /greptile_comment -->