### PR TITLE
chore(cloud): drop Local Steward fallback after Railway canonicalization

### DIFF
--- a/cloud/packages/lib/services/docker-sandbox-utils.ts
+++ b/cloud/packages/lib/services/docker-sandbox-utils.ts
@@ -63,8 +63,10 @@ export function normalizeDockerArchitecture(
 ): DockerNodeArchitecture | null {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return null;
-  if (["amd64", "x86", "x86_64", "x86-64", "x64"].includes(normalized)) return "amd64";
-  if (["arm", "arm64", "aarch64", "arm64/v8"].includes(normalized)) return "arm64";
+  if (["amd64", "x86", "x86_64", "x86-64", "x64"].includes(normalized))
+    return "amd64";
+  if (["arm", "arm64", "aarch64", "arm64/v8"].includes(normalized))
+    return "arm64";
   return null;
 }
 
@@ -73,8 +75,10 @@ export function requiredArchitectureForPlatform(
 ): DockerNodeArchitecture | null {
   const normalized = platform?.trim().toLowerCase();
   if (!normalized) return null;
-  if (normalized.includes("amd64") || normalized.includes("x86_64")) return "amd64";
-  if (normalized.includes("arm64") || normalized.includes("aarch64")) return "arm64";
+  if (normalized.includes("amd64") || normalized.includes("x86_64"))
+    return "amd64";
+  if (normalized.includes("arm64") || normalized.includes("aarch64"))
+    return "arm64";
   return null;
 }
 
@@ -84,7 +88,11 @@ export function inferArchitectureFromHetznerServerType(
   const normalized = serverType?.trim().toLowerCase();
   if (!normalized) return null;
   if (normalized.startsWith("cax")) return "arm64";
-  if (normalized.startsWith("cx") || normalized.startsWith("cpx") || normalized.startsWith("ccx")) {
+  if (
+    normalized.startsWith("cx") ||
+    normalized.startsWith("cpx") ||
+    normalized.startsWith("ccx")
+  ) {
     return "amd64";
   }
   return null;
@@ -113,7 +121,9 @@ export function isArchitectureCompatibleWithPlatform(
   return !required || !architecture || architecture === required;
 }
 
-export function dockerPlatformFlag(platform: string | undefined | null): string[] {
+export function dockerPlatformFlag(
+  platform: string | undefined | null,
+): string[] {
   const trimmed = platform?.trim();
   if (!trimmed) return [];
   validateDockerPlatform(trimmed);
@@ -153,7 +163,9 @@ export function validateAgentName(name: string): void {
   }
   // Block characters that could break shell commands even inside quotes
   if (hasControlChars(name)) {
-    throw new Error(`Invalid agent name "${name}": contains control characters.`);
+    throw new Error(
+      `Invalid agent name "${name}": contains control characters.`,
+    );
   }
 }
 
@@ -181,7 +193,10 @@ export function validateEnvValue(key: string, value: string): void {
 
 /** Docker container names must be simple shell-safe identifiers. */
 export function validateContainerName(containerName: string): void {
-  if (hasControlChars(containerName) || !/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/.test(containerName)) {
+  if (
+    hasControlChars(containerName) ||
+    !/^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/.test(containerName)
+  ) {
     throw new Error(
       `Invalid container name "${containerName}": must match ^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$.`,
     );
@@ -208,7 +223,9 @@ export function validateVolumePath(volumePath: string): void {
     volumePath.endsWith("/..") ||
     (volumePath.length > 1 && volumePath.endsWith("/"))
   ) {
-    throw new Error(`Invalid volume path "${volumePath}": path must be normalized.`);
+    throw new Error(
+      `Invalid volume path "${volumePath}": path must be normalized.`,
+    );
   }
 }
 
@@ -225,7 +242,8 @@ export function validateVolumePath(volumePath: string): void {
  * - Non-loopback host URLs pass through unchanged.
  */
 export function resolveStewardContainerUrl(
-  stewardHostUrl: string = process.env.STEWARD_API_URL || "http://localhost:8787/steward",
+  stewardHostUrl: string = process.env.STEWARD_API_URL ||
+    "http://localhost:8787/steward",
   stewardContainerUrl?: string,
 ): string {
   const override = stewardContainerUrl?.trim();
@@ -233,18 +251,11 @@ export function resolveStewardContainerUrl(
     return override.replace(/\/$/, "");
   }
 
-  try {
-    const url = new URL(stewardHostUrl);
-    if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
-      url.hostname = "host.docker.internal";
-    }
-    return url.toString().replace(/\/$/, "");
-  } catch {
-    logger.warn(
-      `[docker-sandbox] Invalid STEWARD host URL ${JSON.stringify(stewardHostUrl)}; falling back to http://host.docker.internal:3200`,
-    );
-    return "http://host.docker.internal:3200";
+  const url = new URL(stewardHostUrl);
+  if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
+    url.hostname = "host.docker.internal";
   }
+  return url.toString().replace(/\/$/, "");
 }
 
 /** Linux Docker needs an explicit host-gateway alias for host.docker.internal. */
@@ -295,7 +306,11 @@ export function extractDockerCreateContainerId(output: string): string {
  * for active sandboxes, so a duplicate insert will fail and the caller
  * should retry the entire provisioning flow.
  */
-export function allocatePort(min: number, max: number, excluded: Set<number>): number {
+export function allocatePort(
+  min: number,
+  max: number,
+  excluded: Set<number>,
+): number {
   const range = max - min;
   if (excluded.size >= range) {
     throw new Error(
@@ -316,7 +331,9 @@ export function allocatePort(min: number, max: number, excluded: Set<number>): n
   return port;
 }
 
-export function readDockerHostPortFromMetadata(metadata: unknown): number | null {
+export function readDockerHostPortFromMetadata(
+  metadata: unknown,
+): number | null {
   if (!metadata || typeof metadata !== "object") return null;
   const hostPort = (metadata as Record<string, unknown>).hostPort;
   if (typeof hostPort !== "number") return null;
@@ -383,7 +400,9 @@ export function parseDockerNodes(): DockerNodeEnv[] {
 
     const parts = trimmed.split(":");
     if (parts.length < 3) {
-      logger.warn(`[docker-sandbox] Skipping malformed node entry: "${trimmed}"`);
+      logger.warn(
+        `[docker-sandbox] Skipping malformed node entry: "${trimmed}"`,
+      );
       continue;
     }
 
@@ -398,7 +417,9 @@ export function parseDockerNodes(): DockerNodeEnv[] {
   }
 
   if (nodes.length === 0) {
-    throw new Error("[docker-sandbox] No valid nodes parsed from AGENT_DOCKER_NODES");
+    throw new Error(
+      "[docker-sandbox] No valid nodes parsed from AGENT_DOCKER_NODES",
+    );
   }
 
   _cachedDockerNodes = nodes;

--- a/cloud/packages/lib/services/docker-sandbox-utils.ts
+++ b/cloud/packages/lib/services/docker-sandbox-utils.ts
@@ -251,7 +251,14 @@ export function resolveStewardContainerUrl(
     return override.replace(/\/$/, "");
   }
 
-  const url = new URL(stewardHostUrl);
+  let url: URL;
+  try {
+    url = new URL(stewardHostUrl);
+  } catch {
+    throw new Error(
+      `[docker-sandbox] Invalid STEWARD_API_URL: ${JSON.stringify(stewardHostUrl)}`,
+    );
+  }
   if (["localhost", "127.0.0.1", "::1"].includes(url.hostname)) {
     url.hostname = "host.docker.internal";
   }


### PR DESCRIPTION
## Summary

After retiring Local Steward (manager VM `localhost:3200`) earlier today and canonicalizing on Railway (`steward-api-production-115d.up.railway.app` / `eliza.steward.fi`), drop the now-dead `http://host.docker.internal:3200` fallback in `resolveStewardContainerUrl`. With Local stopped + disabled, that fallback would silently inject a dead address into sandbox containers.

## Change

`cloud/packages/lib/services/docker-sandbox-utils.ts` — remove the try/catch with the `host.docker.internal:3200` fallback. If `STEWARD_API_URL` is invalid, the URL parse now throws (fail fast on misconfiguration).

Kept: the loopback rewrite (`localhost` → `host.docker.internal`) for dev convenience — local dev still hits the Worker proxy at `localhost:8787/steward`.

## Background

Today's prod migration:
- Phase 0: audited Local vs Railway — only legacy `milady-*` / e2e cruft Local-only, all real `elizacloud-*` tenants already on Railway
- Phase 2: switched daemon `STEWARD_API_URL` / `STEWARD_CONTAINER_URL` / `STEWARD_PLATFORM_KEY` / `STEWARD_TENANT_ID` from Local to Railway. CF Worker secret `STEWARD_API_URL` also set to Railway explicitly.
- Phase 3 validation: agent `c7088b34-2b4b-41de-91a8-e69a1a4b8622` provisioned successfully via Railway, container env `STEWARD_API_URL=https://eliza.steward.fi`, LLM chat via cloud gateway returns 200.
- Phase 4: `steward-api.service` stopped + disabled, `api.steward.fi` cloudflared tunnel route removed, `/opt/steward` archived to `/opt/_archive/steward-retired-20260514-103640`.

## Follow-ups (out of this PR)

- DNS record `api.steward.fi` deletion — needs zone owner (steward.fi not in our Cloudflare account)
- Neon project `ep-wild-dawn-a4c7r311` snapshot+delete — needs project owner
- Sol's org `elizacloud-sol-6k4iprhd9c-v2` has stale Local key in DB (`steward_tenant_api_key`) — needs Railway key rotation or accept the single agent breakage at next restart
- Steward Platform API lacks `rotate-api-key` / `get-api-key` endpoints — feature request

## Test plan

- [x] Provision a new agent via prod API → `status=running`, daemon logs show Railway as target
- [x] Container env_vars contain `STEWARD_API_URL=https://eliza.steward.fi`
- [x] LLM chat via `/api/v1/chat/completions` returns 200 with `PONG`
- [x] CF Worker `/steward/auth/providers` returns providers list (proxied to Railway)
- [x] Latency baseline daemon → Railway: 240-400ms (acceptable for ~4 provisions/day)
- [ ] Web magic link end-to-end (interactive — to be checked by sol/Stan)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the now-dead `http://host.docker.internal:3200` fallback from `resolveStewardContainerUrl` following the retirement of the Local Steward VM and full canonicalization on Railway. An invalid `STEWARD_API_URL` now throws a descriptive error immediately rather than silently injecting a dead address into sandbox containers.

- **`resolveStewardContainerUrl`**: the `try/catch` fallback is replaced with a re-throw that includes the bad URL value; the loopback→`host.docker.internal` rewrite for local dev is preserved.
- The remainder of the diff is purely mechanical prettier reformatting (line-length wrapping) with no logic changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted removal of a dead fallback URL, and the remaining logic (loopback rewrite, override path) is unchanged.

The only behavioral change is that an unparseable STEWARD_API_URL now throws a descriptive error instead of silently resolving to a dead address. The loopback rewrite and explicit-override paths are untouched. The rest of the diff is reformatting only.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/docker-sandbox-utils.ts | Removes the dead `host.docker.internal:3200` fallback in `resolveStewardContainerUrl`; invalid URLs now throw with a descriptive message. The rest of the diff is prettier reformatting with no logic changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolveStewardContainerUrl(stewardHostUrl, stewardContainerUrl)"] --> B{stewardContainerUrl set?}
    B -- yes --> C["return override (trim trailing /)"]
    B -- no --> D["new URL(stewardHostUrl)"]
    D -- invalid URL --> E["throw Error: Invalid STEWARD_API_URL: <value>"]
    D -- valid --> F{hostname is loopback?}
    F -- yes --> G["rewrite hostname → host.docker.internal"]
    F -- no --> H["pass through unchanged"]
    G --> I["return url (trim trailing /)"]
    H --> I
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/packages/tests/unit/docker-infrastructure.test.ts`, line 282 ([link](https://github.com/elizaos/eliza/blob/de621550632c26b12c24d3289288d694774107bf/cloud/packages/tests/unit/docker-infrastructure.test.ts#L282)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> The test suite covers the three pre-existing happy paths but has no test for the new throwing behavior. Since the PR's stated intent is "fail fast on misconfiguration," a test like `expect(() => resolveStewardContainerUrl("not-a-url")).toThrow()` documents that contract and guards against accidentally re-introducing a silent fallback in the future.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(cloud): wrap Invalid URL throw with ..."](https://github.com/elizaos/eliza/commit/0338d374443283e0b9209086a39dadac0d5eb682) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32126022)</sub>

<!-- /greptile_comment -->