### PR TITLE
fix(core): stabilize post-turn evaluator and subagent completion

### DIFF
--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -110,8 +110,8 @@ describe("EvaluatorService", () => {
 			expect(params.responseSchema.properties).toHaveProperty("first");
 			expect(params.responseSchema.properties).toHaveProperty("second");
 			expect(params.responseFormat).toEqual({ type: "json_object" });
-			expect(params.prompt).toContain("### first");
-			expect(params.prompt).toContain("### second");
+			expect(params.messages?.[0]?.content).toContain("### first");
+			expect(params.messages?.[0]?.content).toContain("### second");
 			return {
 				first: { ok: true },
 				second: { ok: true },
@@ -219,6 +219,131 @@ describe("EvaluatorService", () => {
 					error: "processor failed",
 				}),
 			]),
+		);
+	});
+
+	it("retries without responseSchema when the provider rejects structured schemas", async () => {
+		const runtime = makeRuntime();
+		const processed: string[] = [];
+
+		runtime.registerEvaluator({
+			name: "ok",
+			description: "ok section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract ok.",
+			parse: (output) => output as never,
+			processors: [
+				{
+					name: "storeOk",
+					process: async () => {
+						processed.push("ok");
+						return { success: true };
+					},
+				},
+			],
+		});
+
+		const useModel = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce({ ok: { ok: true } });
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const result = await new EvaluatorService(runtime).run(makeMessage());
+
+		expect(useModel).toHaveBeenCalledTimes(2);
+		expect(useModel.mock.calls[0]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[1]?.[1]).not.toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[1]?.[1]?.responseFormat).toEqual({
+			type: "json_object",
+		});
+		expect(processed).toEqual(["ok"]);
+		expect(result.errors).toEqual([]);
+	});
+
+	it("falls back to a plain JSON prompt when JSON-object mode is also rejected", async () => {
+		const runtime = makeRuntime();
+		const processed: string[] = [];
+
+		runtime.registerEvaluator({
+			name: "ok",
+			description: "ok section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract ok.",
+			parse: (output) => output as never,
+			processors: [
+				{
+					name: "storeOk",
+					process: async () => {
+						processed.push("ok");
+						return { success: true };
+					},
+				},
+			],
+		});
+
+		const useModel = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockResolvedValueOnce('{"ok":{"ok":true}}');
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const result = await new EvaluatorService(runtime).run(makeMessage());
+
+		expect(useModel).toHaveBeenCalledTimes(3);
+		expect(useModel.mock.calls[0]?.[1]).toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[1]?.[1]).toHaveProperty("responseFormat");
+		expect(useModel.mock.calls[2]?.[1]).not.toHaveProperty("responseSchema");
+		expect(useModel.mock.calls[2]?.[1]).not.toHaveProperty("responseFormat");
+		expect(processed).toEqual(["ok"]);
+		expect(result.errors).toEqual([]);
+	});
+
+	it("contains provider generation failures as post-turn evaluator errors", async () => {
+		const runtime = makeRuntime();
+
+		runtime.registerEvaluator({
+			name: "ok",
+			description: "ok section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract ok.",
+			parse: (output) => output as never,
+			processors: [
+				{
+					name: "storeOk",
+					process: async () => ({ success: true }),
+				},
+			],
+		});
+
+		const useModel = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockRejectedValueOnce(new Error("Bad Request"))
+			.mockRejectedValueOnce(new Error("Bad Request"));
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const result = await new EvaluatorService(runtime).run(makeMessage());
+
+		expect(useModel).toHaveBeenCalledTimes(3);
+		expect(result.processedEvaluators).toEqual([]);
+		expect(result.results).toEqual([]);
+		expect(result.errors).toEqual([
+			{
+				evaluatorName: "post_turn",
+				error: "Bad Request",
+			},
+		]);
+		expect(runtime.emitEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				evaluatorName: "post_turn",
+				completed: false,
+			}),
 		);
 	});
 });

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -161,6 +161,60 @@ ${evaluatorSections}
 `;
 }
 
+function schemaRequestLooksUnsupported(error: unknown): boolean {
+	const message = (error instanceof Error ? error.message : String(error ?? ""))
+		.toLowerCase()
+		.trim();
+	if (!message) return false;
+	return (
+		message.includes("bad request") ||
+		message.includes("response schema") ||
+		message.includes("responseschema") ||
+		message.includes("json_schema") ||
+		message.includes("structured output")
+	);
+}
+
+async function generateEvaluationOutput(params: {
+	runtime: IAgentRuntime;
+	prompt: string;
+	schema: JSONSchema;
+}): Promise<unknown> {
+	const { runtime, prompt, schema } = params;
+	const messages = [{ role: "user" as const, content: prompt }];
+	try {
+		return await runtime.useModel(ModelType.TEXT_LARGE, {
+			messages,
+			responseSchema: schema,
+			responseFormat: { type: "json_object" },
+			temperature: 0,
+		});
+	} catch (error) {
+		if (!schemaRequestLooksUnsupported(error)) throw error;
+		runtime.logger.debug(
+			{ src: "service:evaluator" },
+			"Post-turn evaluator schema request rejected; retrying JSON-object fallback",
+		);
+		try {
+			return await runtime.useModel(ModelType.TEXT_LARGE, {
+				messages,
+				responseFormat: { type: "json_object" },
+				temperature: 0,
+			});
+		} catch (fallbackError) {
+			if (!schemaRequestLooksUnsupported(fallbackError)) throw fallbackError;
+			runtime.logger.debug(
+				{ src: "service:evaluator" },
+				"Post-turn evaluator JSON-object fallback rejected; retrying plain JSON prompt",
+			);
+			return await runtime.useModel(ModelType.TEXT_LARGE, {
+				messages,
+				temperature: 0,
+			});
+		}
+	}
+}
+
 export class EvaluatorService extends BaseService {
 	static serviceType = "evaluator" as const;
 	capabilityDescription =
@@ -186,76 +240,48 @@ export class EvaluatorService extends BaseService {
 		return this.runtime.unregisterEvaluator(name);
 	}
 
-	async run(
-		message: Memory,
-		state?: State,
-		options: EvaluatorRunOptions = {},
-	): Promise<EvaluatorRunResult> {
-		setTrajectoryPurpose("evaluation");
+	private sortEvaluators(evaluators: RegisteredEvaluator[]): RegisteredEvaluator[] {
+		return evaluators.sort(
+			(a, b) =>
+				(a.priority ?? 100) - (b.priority ?? 100) ||
+				a.name.localeCompare(b.name),
+		);
+	}
 
-		const context: EvaluatorRunContext = {
-			runtime: this.runtime,
-			message,
-			state,
-			options,
-		};
-
-		const candidates = this.runtime.evaluators
-			.slice()
-			.sort(
-				(a, b) =>
-					(a.priority ?? 100) - (b.priority ?? 100) ||
-					a.name.localeCompare(b.name),
-			);
-		if (candidates.length === 0) {
-			return {
-				skipped: true,
-				activeEvaluators: [],
-				processedEvaluators: [],
-				results: [],
-				errors: [],
-			};
-		}
-
+	private async collectActiveEvaluators(
+		candidates: RegisteredEvaluator[],
+		context: EvaluatorRunContext,
+		errors: EvaluatorRunResult["errors"],
+	): Promise<RegisteredEvaluator[]> {
 		const active: RegisteredEvaluator[] = [];
-		const errors: EvaluatorRunResult["errors"] = [];
 		await Promise.all(
 			candidates.map(async (evaluator) => {
 				try {
 					if (await evaluator.shouldRun(context)) active.push(evaluator);
 				} catch (error) {
-					errors.push({
-						evaluatorName: evaluator.name,
-						error: error instanceof Error ? error.message : String(error),
-					});
+					const messageText =
+						error instanceof Error ? error.message : String(error);
+					errors.push({ evaluatorName: evaluator.name, error: messageText });
 					this.runtime.logger.warn(
 						{
 							src: "service:evaluator",
 							agentId: this.runtime.agentId,
 							evaluator: evaluator.name,
-							err: error instanceof Error ? error.message : String(error),
+							err: messageText,
 						},
 						"Evaluator shouldRun failed",
 					);
 				}
 			}),
 		);
+		return this.sortEvaluators(active);
+	}
 
-		active.sort(
-			(a, b) =>
-				(a.priority ?? 100) - (b.priority ?? 100) ||
-				a.name.localeCompare(b.name),
-		);
-		if (active.length === 0) {
-			return {
-				skipped: true,
-				activeEvaluators: [],
-				processedEvaluators: [],
-				results: [],
-				errors,
-			};
-		}
-
+	private async composeEvaluatorState(
+		message: Memory,
+		state: State | undefined,
+		active: RegisteredEvaluator[],
+	): Promise<State> {
 		const providerNames = Array.from(
 			new Set(active.flatMap((evaluator) => evaluator.providers ?? [])),
 		);
@@ -263,8 +289,16 @@ export class EvaluatorService extends BaseService {
 			providerNames.length > 0
 				? await this.runtime.composeState(message, providerNames, true, true)
 				: EMPTY_STATE;
-		const composedState = mergeStates(state, providerState);
+		return mergeStates(state, providerState);
+	}
 
+	private async collectPreparedEntries(
+		active: RegisteredEvaluator[],
+		message: Memory,
+		state: State,
+		options: EvaluatorRunOptions,
+		errors: EvaluatorRunResult["errors"],
+	): Promise<PreparedEntry[]> {
 		const preparedEntries: PreparedEntry[] = [];
 		await Promise.all(
 			active.map(async (evaluator) => {
@@ -273,96 +307,94 @@ export class EvaluatorService extends BaseService {
 						? await evaluator.prepare({
 								runtime: this.runtime,
 								message,
-								state: composedState,
+								state,
 								options,
 							})
 						: undefined;
 					preparedEntries.push({ evaluator, prepared });
 				} catch (error) {
-					errors.push({
-						evaluatorName: evaluator.name,
-						error: error instanceof Error ? error.message : String(error),
-					});
+					const messageText =
+						error instanceof Error ? error.message : String(error);
+					errors.push({ evaluatorName: evaluator.name, error: messageText });
 					this.runtime.logger.warn(
 						{
 							src: "service:evaluator",
 							agentId: this.runtime.agentId,
 							evaluator: evaluator.name,
-							err: error instanceof Error ? error.message : String(error),
+							err: messageText,
 						},
 						"Evaluator prepare failed",
 					);
 				}
 			}),
 		);
-		preparedEntries.sort(
+		return preparedEntries.sort(
 			(a, b) =>
 				(a.evaluator.priority ?? 100) - (b.evaluator.priority ?? 100) ||
 				a.evaluator.name.localeCompare(b.evaluator.name),
 		);
-		if (preparedEntries.length === 0) {
-			return {
-				skipped: true,
-				activeEvaluators: active.map((evaluator) => evaluator.name),
-				processedEvaluators: [],
-				results: [],
-				errors,
-			};
-		}
+	}
 
-		const evaluatorId =
-			uuidv4() as `${string}-${string}-${string}-${string}-${string}`;
+	private async emitEvaluatorCompleted(
+		evaluatorId: string,
+		completed: boolean,
+		error?: Error,
+	): Promise<void> {
 		await this.runtime
-			.emitEvent(EventType.EVALUATOR_STARTED, {
+			.emitEvent(EventType.EVALUATOR_COMPLETED, {
 				runtime: this.runtime,
 				evaluatorId,
 				evaluatorName: "post_turn",
-				startTime: Date.now(),
+				completed,
+				...(error ? { error } : {}),
 			})
 			.catch(() => {});
+	}
 
-		const prompt = buildPrompt({
-			runtime: this.runtime,
-			message,
-			state: composedState,
-			active: preparedEntries,
-			options,
-		});
-		const schema = buildMergedSchema(preparedEntries);
-		const raw = await this.runtime.useModel(ModelType.TEXT_LARGE, {
-			prompt,
-			responseSchema: schema,
-			responseFormat: { type: "json_object" },
-			temperature: 0,
-		});
-		const output = coerceObjectOutput(raw);
-		if (!output) {
-			await this.runtime
-				.emitEvent(EventType.EVALUATOR_COMPLETED, {
-					runtime: this.runtime,
-					evaluatorId,
-					evaluatorName: "post_turn",
-					completed: false,
-					error: new Error("Evaluator model returned non-object output"),
-				})
-				.catch(() => {});
-			return {
-				skipped: false,
-				activeEvaluators: preparedEntries.map(
-					({ evaluator }) => evaluator.name,
-				),
-				processedEvaluators: [],
-				results: [],
-				errors: [
-					...errors,
-					{
-						evaluatorName: "post_turn",
-						error: "Evaluator model returned non-object output",
-					},
-				],
-			};
+	private async readEvaluatorOutput(params: {
+		evaluatorId: string;
+		prompt: string;
+		schema: JSONSchema;
+	}): Promise<{ output: Record<string, unknown> | null; error?: string }> {
+		const { evaluatorId, prompt, schema } = params;
+		let raw: unknown;
+		try {
+			raw = await generateEvaluationOutput({
+				runtime: this.runtime,
+				prompt,
+				schema,
+			});
+		} catch (error) {
+			const messageText = error instanceof Error ? error.message : String(error);
+			await this.emitEvaluatorCompleted(
+				evaluatorId,
+				false,
+				error instanceof Error ? error : new Error(messageText),
+			);
+			return { output: null, error: messageText };
 		}
 
+		const output = coerceObjectOutput(raw);
+		if (!output) {
+			const messageText = "Evaluator model returned non-object output";
+			await this.emitEvaluatorCompleted(evaluatorId, false, new Error(messageText));
+			return { output: null, error: messageText };
+		}
+		return { output };
+	}
+
+	private async processPreparedEntries(params: {
+		preparedEntries: PreparedEntry[];
+		output: Record<string, unknown>;
+		message: Memory;
+		state: State;
+		options: EvaluatorRunOptions;
+		errors: EvaluatorRunResult["errors"];
+	}): Promise<{
+		processedEvaluators: string[];
+		results: ActionResult[];
+	}> {
+		const { preparedEntries, output, message, state, options, errors } = params;
 		const results: ActionResult[] = [];
 		const processedEvaluators: string[] = [];
 		for (const entry of preparedEntries) {
@@ -379,56 +411,199 @@ export class EvaluatorService extends BaseService {
 				});
 				continue;
 			}
-			const processors = (evaluator.processors ?? [])
-				.slice()
-				.sort(
-					(a, b) =>
-						(a.priority ?? 100) - (b.priority ?? 100) ||
-						(a.name ?? "").localeCompare(b.name ?? ""),
-				);
-			for (const processor of processors) {
-				try {
-					const result = await processor.process({
-						runtime: this.runtime,
-						message,
-						state: composedState,
-						options,
-						prepared,
-						output: parsed,
-						evaluatorName: evaluator.name,
-					});
-					if (result) results.push(result);
-				} catch (error) {
-					const messageText =
-						error instanceof Error ? error.message : String(error);
-					errors.push({
-						evaluatorName: evaluator.name,
-						processorName: processor.name,
-						error: messageText,
-					});
-					this.runtime.logger.warn(
-						{
-							src: "service:evaluator",
-							agentId: this.runtime.agentId,
-							evaluator: evaluator.name,
-							processor: processor.name,
-							err: messageText,
-						},
-						"Evaluator processor failed",
-					);
-				}
-			}
+			await this.runEntryProcessors({
+				evaluator,
+				prepared,
+				parsed: parsed as JsonValue,
+				message,
+				state,
+				options,
+				results,
+				errors,
+			});
 			processedEvaluators.push(evaluator.name);
 		}
+		return { processedEvaluators, results };
+	}
 
+	private async runEntryProcessors(params: {
+		evaluator: RegisteredEvaluator;
+		prepared: unknown;
+		parsed: JsonValue;
+		message: Memory;
+		state: State;
+		options: EvaluatorRunOptions;
+		results: ActionResult[];
+		errors: EvaluatorRunResult["errors"];
+	}): Promise<void> {
+		const { evaluator, prepared, parsed, message, state, options, results, errors } =
+			params;
+		const processors = (evaluator.processors ?? [])
+			.slice()
+			.sort(
+				(a, b) =>
+					(a.priority ?? 100) - (b.priority ?? 100) ||
+					(a.name ?? "").localeCompare(b.name ?? ""),
+			);
+		for (const processor of processors) {
+			try {
+				const result = await processor.process({
+					runtime: this.runtime,
+					message,
+					state,
+					options,
+					prepared,
+					output: parsed,
+					evaluatorName: evaluator.name,
+				});
+				if (result) results.push(result);
+			} catch (error) {
+				const messageText = error instanceof Error ? error.message : String(error);
+				errors.push({
+					evaluatorName: evaluator.name,
+					processorName: processor.name,
+					error: messageText,
+				});
+				this.runtime.logger.warn(
+					{
+						src: "service:evaluator",
+						agentId: this.runtime.agentId,
+						evaluator: evaluator.name,
+						processor: processor.name,
+						err: messageText,
+					},
+					"Evaluator processor failed",
+				);
+			}
+		}
+	}
+
+	private skippedResult(params?: {
+		activeEvaluators?: string[];
+		processedEvaluators?: string[];
+		errors?: EvaluatorRunResult["errors"];
+	}): EvaluatorRunResult {
+		return {
+			skipped: true,
+			activeEvaluators: params?.activeEvaluators ?? [],
+			processedEvaluators: params?.processedEvaluators ?? [],
+			results: [],
+			errors: params?.errors ?? [],
+		};
+	}
+
+	private failedResult(params: {
+		preparedEntries: PreparedEntry[];
+		errors: EvaluatorRunResult["errors"];
+		error: string;
+	}): EvaluatorRunResult {
+		return {
+			skipped: false,
+			activeEvaluators: params.preparedEntries.map(
+				({ evaluator }) => evaluator.name,
+			),
+			processedEvaluators: [],
+			results: [],
+			errors: [
+				...params.errors,
+				{
+					evaluatorName: "post_turn",
+					error: params.error,
+				},
+			],
+		};
+	}
+
+	async run(
+		message: Memory,
+		state?: State,
+		options: EvaluatorRunOptions = {},
+	): Promise<EvaluatorRunResult> {
+		setTrajectoryPurpose("evaluation");
+
+		const context: EvaluatorRunContext = {
+			runtime: this.runtime,
+			message,
+			state,
+			options,
+		};
+
+		const candidates = this.sortEvaluators(this.runtime.evaluators.slice());
+		if (candidates.length === 0) {
+			return this.skippedResult();
+		}
+
+		const errors: EvaluatorRunResult["errors"] = [];
+		const active = await this.collectActiveEvaluators(
+			candidates,
+			context,
+			errors,
+		);
+		if (active.length === 0) {
+			return this.skippedResult({ errors });
+		}
+
+		const composedState = await this.composeEvaluatorState(
+			message,
+			state,
+			active,
+		);
+		const preparedEntries = await this.collectPreparedEntries(
+			active,
+			message,
+			composedState,
+			options,
+			errors,
+		);
+		if (preparedEntries.length === 0) {
+			return this.skippedResult({
+				activeEvaluators: active.map((evaluator) => evaluator.name),
+				errors,
+			});
+		}
+
+		const evaluatorId =
+			uuidv4() as `${string}-${string}-${string}-${string}-${string}`;
 		await this.runtime
-			.emitEvent(EventType.EVALUATOR_COMPLETED, {
+			.emitEvent(EventType.EVALUATOR_STARTED, {
 				runtime: this.runtime,
 				evaluatorId,
 				evaluatorName: "post_turn",
-				completed: true,
-			})
-			.catch(() => {});
+				startTime: Date.now(),
+				})
+				.catch(() => {});
+
+		const prompt = buildPrompt({
+			runtime: this.runtime,
+			message,
+			state: composedState,
+			active: preparedEntries,
+			options,
+		});
+		const schema = buildMergedSchema(preparedEntries);
+		const { output, error } = await this.readEvaluatorOutput({
+			evaluatorId,
+			prompt,
+			schema,
+		});
+		if (!output) {
+			return this.failedResult({
+				preparedEntries,
+				errors,
+				error: error ?? "Evaluator model returned no output",
+			});
+		}
+
+		const { processedEvaluators, results } = await this.processPreparedEntries({
+			preparedEntries,
+			output,
+			message,
+			state: composedState,
+			options,
+			errors,
+		});
+
+		await this.emitEvaluatorCompleted(evaluatorId, true);
 
 		return {
 			skipped: false,

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -1,0 +1,100 @@
+import type {
+  Memory,
+  MessageHandlerResult,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+import { SIMPLE_CONTEXT_ID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { subAgentCompletionResponseEvaluator } from "../../src/evaluators/sub-agent-completion.js";
+
+function makeContext(overrides: {
+  text?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  messageHandler?: Partial<MessageHandlerResult>;
+}): ResponseHandlerEvaluatorContext {
+  const messageHandler: MessageHandlerResult = {
+    processMessage: "RESPOND",
+    thought: "",
+    plan: {
+      contexts: ["general"],
+      reply: "Thanks, the app is live and all URLs return HTTP 200.",
+      requiresTool: true,
+      ...overrides.messageHandler?.plan,
+    },
+    ...overrides.messageHandler,
+  };
+  const message = {
+    id: "00000000-0000-0000-0000-000000000001",
+    entityId: "00000000-0000-0000-0000-000000000002",
+    agentId: "00000000-0000-0000-0000-000000000003",
+    roomId: "00000000-0000-0000-0000-000000000004",
+    content: {
+      text:
+        overrides.text ??
+        "[sub-agent: demo (opencode) — task_complete]\nhttps://example.test/apps/demo/",
+      source: overrides.source ?? "sub_agent",
+      metadata: {
+        subAgent: true,
+        subAgentEvent: "task_complete",
+        subAgentStatus: "ready",
+        ...overrides.metadata,
+      },
+    },
+  } as Memory;
+  return {
+    runtime: {} as never,
+    message,
+    state: {} as never,
+    messageHandler,
+    availableContexts: [{ id: SIMPLE_CONTEXT_ID, description: "simple" }],
+  };
+}
+
+describe("subAgentCompletionResponseEvaluator", () => {
+  it("turns verified task_complete posts into direct replies", async () => {
+    const context = makeContext({});
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      reply: "https://example.test/apps/demo/",
+      debug: [
+        "verified sub-agent completion has no requested follow-up action; using direct reply",
+      ],
+    });
+  });
+
+  it("keeps the normal action layer when Stage 1 requested a follow-up action", async () => {
+    const context = makeContext({
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "I'll ask the sub-agent for the missing detail.",
+          requiresTool: true,
+          candidateActions: ["TASKS_SEND_TO_AGENT"],
+        },
+      },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("does not suppress incomplete build reports", async () => {
+    const context = makeContext({
+      text: "[sub-agent: demo (opencode) — task_complete]\nDone: https://example.test/apps/demo/\n\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]",
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+
+  it("does not handle non-completion sub-agent events", async () => {
+    const context = makeContext({
+      metadata: { subAgentEvent: "blocked" },
+      text: "[sub-agent: demo (opencode) — blocked]\nNeed credentials.",
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -124,6 +124,31 @@ type ControlAction =
   | "reopen";
 
 type HistoryMetric = "list" | "count" | "detail";
+type HistoryWindow =
+  | "active"
+  | "today"
+  | "yesterday"
+  | "last_7_days"
+  | "last_30_days";
+
+function startOfDay(date: Date): Date {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+function endOfDay(date: Date): Date {
+  const end = new Date(date);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
 function readOp(params: Record<string, unknown>): TaskOp | null {
   const raw = typeof params.action === "string" ? params.action : undefined;

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -1,0 +1,106 @@
+import {
+  type Memory,
+  type ResponseHandlerEvaluator,
+  SIMPLE_CONTEXT_ID,
+} from "@elizaos/core";
+
+const SUB_AGENT_SOURCE = "sub_agent";
+const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`)\]*]+/g;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function contentRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(message.content);
+}
+
+function metadataRecord(message: Memory): Record<string, unknown> | undefined {
+  return asRecord(contentRecord(message)?.metadata);
+}
+
+function textOf(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function hasStrings(values: readonly string[] | undefined): boolean {
+  return (
+    Array.isArray(values) && values.some((value) => value.trim().length > 0)
+  );
+}
+
+function hasUrl(text: string): boolean {
+  URL_IN_TEXT_RE.lastIndex = 0;
+  return URL_IN_TEXT_RE.test(text);
+}
+
+function stripRouterAnnotations(text: string): string {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const body =
+    lines[0]?.startsWith("[sub-agent:") === true ? lines.slice(1) : lines;
+  const annotationIndex = body.findIndex((line) =>
+    line.startsWith("[verification:"),
+  );
+  return (annotationIndex >= 0 ? body.slice(0, annotationIndex) : body)
+    .join("\n")
+    .trim();
+}
+
+function completionHasVerificationFailure(text: string): boolean {
+  return (
+    text.includes("[verification:") ||
+    text.includes("NOT reachable") ||
+    text.includes("do NOT tell the user the app is live")
+  );
+}
+
+function isSuccessfulSubAgentCompletion(message: Memory): boolean {
+  const content = contentRecord(message);
+  const metadata = metadataRecord(message);
+  if (!content || !metadata) return false;
+  const source = textOf(content.source).toLowerCase();
+  if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
+  if (textOf(metadata.subAgentEvent) !== "task_complete") return false;
+  if (metadata.subAgentCapExceeded === true) return false;
+  return !completionHasVerificationFailure(textOf(content.text));
+}
+
+function replyPatchFromCompletion(
+  currentReply: string,
+  completionText: string,
+) {
+  const body = stripRouterAnnotations(completionText);
+  if (!body) return undefined;
+  if (currentReply.length === 0) return body;
+  if (!hasUrl(currentReply) && hasUrl(body)) return body;
+  return undefined;
+}
+
+export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
+  name: "agent-orchestrator.sub-agent-completion",
+  description:
+    "Routes verified sub-agent task_complete messages to direct replies when Stage 1 did not request a concrete follow-up action.",
+  priority: 10,
+  shouldRun: ({ message, messageHandler }) => {
+    if (!isSuccessfulSubAgentCompletion(message)) return false;
+    if (messageHandler.processMessage !== "RESPOND") return false;
+    if (hasStrings(messageHandler.plan.candidateActions)) return false;
+    if (hasStrings(messageHandler.plan.parentActionHints)) return false;
+    return true;
+  },
+  evaluate: ({ message, messageHandler }) => {
+    const currentReply = textOf(messageHandler.plan.reply);
+    const completionText = textOf(contentRecord(message)?.text);
+    const reply = replyPatchFromCompletion(currentReply, completionText);
+    return {
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      ...(reply ? { reply } : {}),
+      debug: [
+        "verified sub-agent completion has no requested follow-up action; using direct reply",
+      ],
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -28,6 +28,7 @@ import {
   tasksSandboxStubAction,
 } from "./actions/sandbox-stub.js";
 import { tasksAction } from "./actions/tasks.js";
+import { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
 import { codingAgentExamplesProvider } from "./providers/action-examples.js";
 import { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 import { activeWorkspaceContextProvider } from "./providers/active-workspace-context.js";
@@ -132,6 +133,9 @@ export function createAgentOrchestratorPlugin(): Plugin {
     services: orchestratorServices,
     actions: orchestratorActions,
     providers: orchestratorProviders,
+    responseHandlerEvaluators: codeExecutionAllowed
+      ? [subAgentCompletionResponseEvaluator]
+      : [],
   };
 }
 
@@ -182,6 +186,7 @@ export {
   createTaskAgentRouteHandler,
   handleCodingAgentRoutes,
 } from "./api/routes.js";
+export { subAgentCompletionResponseEvaluator } from "./evaluators/sub-agent-completion.js";
 // Providers
 export { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 export {


### PR DESCRIPTION
## Summary

- add a response-handler evaluator that treats verified sub-agent `task_complete` events as final, so the parent does not re-plan after an app build has already been verified
- make post-turn evaluator generation tolerant of providers that reject structured-output schemas by falling back to JSON-object mode and then a plain JSON prompt
- contain evaluator provider failures as evaluator error results instead of leaking a misleading `Post-turn evaluator service unavailable`
- define the missing task-history date window helpers needed by current `develop` typecheck

## Notes

This PR is generic Eliza runtime/orchestrator work. It does not add or depend on `agent-home`; that repo is only a private/local hosting target used for live integration verification.

The existing `opencode` provider branch was validated separately, but its PR was closed unmerged by a maintainer, so this Eliza PR intentionally does not include a fork-only `vendor/opencode` submodule pointer.

Current `develop` also contains stray conflict markers in `plugin-signal`; that baseline build fix is split into #7705 so this PR stays focused on the evaluator/orchestrator follow-up logic.

## Verification

- `cd packages/core && bun vitest run src/services/evaluator.test.ts src/__tests__/message-runtime-stage1.test.ts src/runtime/__tests__/message-handler.test.ts src/runtime/__tests__/message-handler-output.test.ts src/runtime/__tests__/planner-loop.test.ts src/runtime/__tests__/json-output.test.ts` — 78 tests passed
- `cd packages/core && bun run typecheck`
- `cd packages/core && bun run build`
- `cd plugins/plugin-agent-orchestrator && bunx vitest run __tests__/unit/opencode-spawn-config-auto-detect.test.ts __tests__/unit/acp-service.test.ts __tests__/unit/sub-agent-completion-evaluator.test.ts __tests__/unit/sub-agent-router.test.ts __tests__/unit/spawn-agent.test.ts __tests__/unit/create-task.test.ts __tests__/unit/resolve-spawn-workdir.test.ts --config vitest.config.ts` — 71 tests passed
- `cd plugins/plugin-agent-orchestrator && bun run typecheck`
- `cd plugins/plugin-agent-orchestrator && bun run build`
- `timeout 1200 bun run build` — passed before splitting the `plugin-signal` conflict-marker cleanup into #7705

Live verification from the same runtime line:

- evaluator fallback trajectory `tj-b608bef4b5e591`: one-stage direct reply, `plannerIterations:0`, `toolCallsExecuted:0`, `toolCallFailures:0`, `evaluatorFailures:0`; logs showed structured-schema rejection, JSON-object fallback rejection, plain JSON prompt success, and no `Post-turn evaluator service unavailable`
- OpenCode/gpt-oss build trajectory `tj-b757c29f69e9ec`: `plannerIterations:2`, `toolCallsExecuted:2`, `toolCallFailures:0`; sub-agent completed and public assets returned HTTP 200
- completion trajectory `tj-b7cdce41aedd7d`: one-stage final reply with no re-plan after verified sub-agent completion

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the post-turn evaluator and sub-agent completion flow by adding a 3-tier schema-rejection fallback, containing provider failures as evaluator errors instead of surfacing them as service-unavailable exceptions, and introducing a new `ResponseHandlerEvaluator` that short-circuits re-planning after a verified sub-agent `task_complete` event.

- **`evaluator.ts`**: Refactors `EvaluatorService.run` into focused private helpers and wraps the model call in `generateEvaluationOutput`, which retries without `responseSchema`, then without `responseFormat`, before propagating; provider failures are now captured as evaluator errors rather than thrown as exceptions that caused the misleading "Post-turn evaluator service unavailable" log.
- **`sub-agent-completion.ts`**: New `ResponseHandlerEvaluator` that detects verified sub-agent `task_complete` messages (checking source, metadata, and verification-failure annotations) and returns `requiresTool: false` to prevent the parent agent from re-planning when the build is already confirmed live.
- **`tasks.ts`**: Adds the missing `HistoryWindow` type and `startOfDay`/`endOfDay`/`formatDate` helpers required for the `develop` typecheck to pass.

<h3>Confidence Score: 3/5</h3>

The core evaluator refactor and sub-agent completion evaluator work correctly, but two edge cases in evaluator.ts are worth addressing before merging to a busy branch.

The `"bad request"` string in `schemaRequestLooksUnsupported` is broad enough to match auth failures and content-safety 400s, causing the fallback cascade to fire when it shouldn't and potentially letting a plain-text model response bypass schema validation. Additionally, if `evaluator.parse` throws, the `EVALUATOR_STARTED` event emitted earlier in `run` never receives its paired `EVALUATOR_COMPLETED`, which could confuse any orchestrator or metrics layer that tracks event pairs. Both issues are contained to `evaluator.ts` and would only manifest under uncommon provider behaviour, but they touch the core evaluation path on every turn.

packages/core/src/services/evaluator.ts — specifically the schema-rejection heuristic and the lack of error handling around evaluator.parse in processPreparedEntries

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/evaluator.ts | Major refactor extracting run() into private helpers; adds 3-tier schema-rejection fallback and proper error containment. Two issues: the "bad request" heuristic for detecting schema rejection is too broad, and evaluator.parse is not wrapped in error handling, leaving the EVALUATOR_STARTED/COMPLETED event pair incomplete on parse errors. |
| packages/core/src/services/evaluator.test.ts | Adds four new test cases covering structured-schema rejection fallback, JSON-object fallback, plain-prompt fallback, and provider-failure containment. Tests correctly verify call counts and responseFormat fields at each fallback level. |
| plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts | New ResponseHandlerEvaluator that short-circuits re-planning after a verified sub-agent task_complete event. Logic is sound; annotation-based verification-failure strings are checked correctly. The shared global regex URL_IN_TEXT_RE resets lastIndex before use, avoiding stale state. |
| plugins/plugin-agent-orchestrator/src/actions/tasks.ts | Adds HistoryWindow type and the three date helpers (startOfDay, endOfDay, formatDate) needed to resolve the develop typecheck failure. Helpers are straightforward and correct. |
| plugins/plugin-agent-orchestrator/src/index.ts | Registers subAgentCompletionResponseEvaluator under responseHandlerEvaluators, correctly gated by codeExecutionAllowed, and exports it from the plugin's public surface. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[EvaluatorService.run] --> B{candidates?}
    B -- none --> C[skippedResult]
    B -- some --> D[collectActiveEvaluators]
    D --> E{active?}
    E -- none --> F[skippedResult + errors]
    E -- some --> G[composeEvaluatorState]
    G --> H[collectPreparedEntries]
    H --> I{preparedEntries?}
    I -- none --> J[skippedResult + active + errors]
    I -- some --> K[emit EVALUATOR_STARTED]
    K --> L[generateEvaluationOutput]
    L --> M{schema call ok?}
    M -- yes --> P[coerceObjectOutput]
    M -- no, schema error --> N[retry json_object mode]
    N --> O{ok?}
    O -- yes --> P
    O -- no, schema error --> Q[retry plain prompt]
    Q --> P
    M -- no, other error --> R[emitEvaluatorCompleted false - return failedResult]
    P --> S{output object?}
    S -- no --> R
    S -- yes --> T[processPreparedEntries]
    T --> U[emitEvaluatorCompleted true]
    U --> V[return result]

    subgraph ResponseHandler
        W[subAgentCompletionResponseEvaluator.shouldRun] --> X{verified task_complete?}
        X -- no --> Y[normal action layer]
        X -- yes, no follow-up actions --> Z[requiresTool=false - skip re-plan]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/services/evaluator.ts`, line 154-166 ([link](https://github.com/elizaos/eliza/blob/e8011e9cfd386a8e7b3510eb5e9f70c64653d434/packages/core/src/services/evaluator.ts#L154-L166)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`"bad request"` heuristic is too broad for schema-rejection detection**

   `message.includes("bad request")` will match any HTTP 400 response, including authentication failures, content-safety rejections, and malformed-body errors that have nothing to do with structured-output support. When such an error occurs on the first call, `schemaRequestLooksUnsupported` returns `true` and the fallback cascade exhausts all three attempts before propagating the original error. In the worst case — e.g., a provider that rejects the *schema* parameter with 400 but accepts plain requests — a safety-filtered prompt could succeed on the third attempt and return an output that was never validated against the evaluator's schema, producing silently incorrect evaluator results.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): define task history w..."](https://github.com/elizaos/eliza/commit/e8011e9cfd386a8e7b3510eb5e9f70c64653d434) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32244645)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->