### PR TITLE
fix(signal): remove stray conflict markers

### DIFF
--- a/plugins/plugin-signal/src/service.ts
+++ b/plugins/plugin-signal/src/service.ts
@@ -31,6 +31,7 @@ import {
   listEnabledSignalAccounts,
   normalizeAccountId as normalizeSignalAccountId,
   resolveDefaultSignalAccountId,
+  type ResolvedSignalAccount,
 } from "./accounts";
 import {
   createSignalEventStream,
@@ -81,6 +82,19 @@ type ConnectorUserLookupParams = {
   handle?: string;
   query?: string;
   target?: TargetInfo;
+};
+
+type SignalStartupConfig = {
+  defaultAuthDir: string;
+  configuredCliPath: string;
+  startupTimeoutMs: number;
+};
+
+type SignalReactionTarget = {
+  recipient: string;
+  accountId: string;
+  targetTimestamp: number;
+  targetAuthor: string;
 };
 
 type ExtendedMessageConnectorRegistration = MessageConnectorRegistration & {
@@ -555,9 +569,7 @@ export class SignalService extends Service implements ISignalService {
       : `signal-${kind}-${accountId}-${value}`;
   }
 
-  static async start(runtime: IAgentRuntime): Promise<SignalService> {
-    const service = new SignalService(runtime);
-    const accounts = listEnabledSignalAccounts(runtime);
+  private static resolveStartupConfig(runtime: IAgentRuntime): SignalStartupConfig {
     const rawAuthDir = runtime.getSetting("SIGNAL_AUTH_DIR") as string | undefined;
     const defaultAuthDir =
       typeof rawAuthDir === "string" && rawAuthDir.trim().length > 0
@@ -574,6 +586,99 @@ export class SignalService extends Service implements ISignalService {
         ? Math.min(parsedStartupTimeout, 120_000)
         : DEFAULT_SIGNAL_DAEMON_STARTUP_TIMEOUT_MS;
 
+    return { defaultAuthDir, configuredCliPath, startupTimeoutMs };
+  }
+
+  private async initializeConfiguredAccount(
+    account: ResolvedSignalAccount,
+    config: SignalStartupConfig
+  ): Promise<void> {
+    const accountNumber = account.account;
+    if (!accountNumber) {
+      this.runtime.logger.warn(
+        { src: "plugin:signal", agentId: this.runtime.agentId, accountId: account.accountId },
+        "Signal account is missing account number, skipping"
+      );
+      return;
+    }
+
+    const normalizedNumber = normalizeE164(accountNumber);
+    if (!normalizedNumber) {
+      this.runtime.logger.error(
+        {
+          src: "plugin:signal",
+          agentId: this.runtime.agentId,
+          accountId: account.accountId,
+          accountNumber,
+        },
+        "Invalid Signal account number format"
+      );
+      return;
+    }
+
+    const baseUrl = normalizeBaseUrl(account.baseUrl);
+    const authDir = account.config.authDir?.trim() || config.defaultAuthDir;
+    const accountCliPath = account.config.cliPath?.trim() || config.configuredCliPath;
+    if (
+      !account.config.httpUrl?.trim() &&
+      !(await this.ensureAccountDaemon(account, accountCliPath, authDir, baseUrl, config))
+    ) {
+      return;
+    }
+
+    const client = new SignalApiClient(baseUrl, normalizedNumber);
+    this.clients.set(account.accountId, client);
+    this.accountNumbers.set(account.accountId, normalizedNumber);
+    if (account.accountId === this.defaultAccountId || !this.client) {
+      this.client = client;
+      this.accountNumber = normalizedNumber;
+    }
+  }
+
+  private async ensureAccountDaemon(
+    account: ResolvedSignalAccount,
+    cliPath: string,
+    authDir: string,
+    baseUrl: string,
+    config: SignalStartupConfig
+  ): Promise<boolean> {
+    if (!fs.existsSync(authDir)) {
+      this.runtime.logger.warn(
+        {
+          src: "plugin:signal",
+          agentId: this.runtime.agentId,
+          accountId: account.accountId,
+          authDir,
+        },
+        "Signal auth directory does not exist yet — run `signal-cli -a <number> link` (or set SIGNAL_AUTH_DIR to a pre-existing install) before starting the plugin"
+      );
+      return false;
+    }
+
+    try {
+      await this.ensureDaemonRunning(cliPath, authDir, baseUrl, config.startupTimeoutMs);
+      return true;
+    } catch (error) {
+      this.runtime.logger.error(
+        {
+          src: "plugin:signal",
+          agentId: this.runtime.agentId,
+          accountId: account.accountId,
+          error: String(error),
+          authDir,
+          cliPath,
+        },
+        "Failed to start signal-cli daemon"
+      );
+      return false;
+    }
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<SignalService> {
+    const service = new SignalService(runtime);
+    const accounts = listEnabledSignalAccounts(runtime);
+    const startupConfig = SignalService.resolveStartupConfig(runtime);
+
     if (accounts.length === 0) {
       runtime.logger.warn(
         { src: "plugin:signal", agentId: runtime.agentId },
@@ -585,77 +690,7 @@ export class SignalService extends Service implements ISignalService {
     service.defaultAccountId = resolveDefaultSignalAccountId(runtime);
 
     for (const account of accounts) {
-      const accountNumber = account.account;
-      if (!accountNumber) {
-        runtime.logger.warn(
-          { src: "plugin:signal", agentId: runtime.agentId, accountId: account.accountId },
-          "Signal account is missing account number, skipping"
-        );
-        continue;
-      }
-
-      const normalizedNumber = normalizeE164(accountNumber);
-      if (!normalizedNumber) {
-        runtime.logger.error(
-          {
-            src: "plugin:signal",
-            agentId: runtime.agentId,
-            accountId: account.accountId,
-            accountNumber,
-          },
-          "Invalid Signal account number format"
-        );
-        continue;
-      }
-
-      const baseUrl = normalizeBaseUrl(account.baseUrl);
-      const explicitHttpUrl = Boolean(account.config.httpUrl?.trim());
-      const authDir = account.config.authDir?.trim() || defaultAuthDir;
-      const accountCliPath = account.config.cliPath?.trim() || configuredCliPath;
-
-      if (!explicitHttpUrl) {
-        // authDir is now guaranteed non-empty (falls back to defaultSignalAuthDir()).
-        // If the directory does not exist, signal-cli would fail on startup with
-        // a confusing "No linked devices" error — pre-empt that with a clearer
-        // warning that points at the user's next action.
-        if (!fs.existsSync(authDir)) {
-          runtime.logger.warn(
-            {
-              src: "plugin:signal",
-              agentId: runtime.agentId,
-              accountId: account.accountId,
-              authDir,
-            },
-            "Signal auth directory does not exist yet — run `signal-cli -a <number> link` (or set SIGNAL_AUTH_DIR to a pre-existing install) before starting the plugin"
-          );
-          continue;
-        }
-
-        try {
-          await service.ensureDaemonRunning(accountCliPath, authDir, baseUrl, startupTimeoutMs);
-        } catch (error) {
-          runtime.logger.error(
-            {
-              src: "plugin:signal",
-              agentId: runtime.agentId,
-              accountId: account.accountId,
-              error: String(error),
-              authDir,
-              cliPath: accountCliPath,
-            },
-            "Failed to start signal-cli daemon"
-          );
-          continue;
-        }
-      }
-
-      const client = new SignalApiClient(baseUrl, normalizedNumber);
-      service.clients.set(account.accountId, client);
-      service.accountNumbers.set(account.accountId, normalizedNumber);
-      if (account.accountId === service.defaultAccountId || !service.client) {
-        service.client = client;
-        service.accountNumber = normalizedNumber;
-      }
+      await service.initializeConfiguredAccount(account, startupConfig);
     }
 
     if (service.clients.size === 0) {
@@ -893,18 +928,10 @@ export class SignalService extends Service implements ISignalService {
               return null;
             }
 
-<<<<<<< HEAD
             const signalRecentMessages: SignalRecentMessage[] = await service
               .getRecentMessages(50, targetAccountId)
               .catch((): SignalRecentMessage[] => []);
             const recentMessages = signalRecentMessages
-=======
-            const recentMessages = (
-              await service
-                .getRecentMessages(50, targetAccountId)
-                .catch((): SignalRecentMessage[] => [])
-            )
->>>>>>> 419112d320c9605a5fe24e79d472a3cf0faee893
               .filter((recent) => recent.channelId === channelId || recent.roomId === target.roomId)
               .slice(0, 10)
               .map((recent) => ({
@@ -1184,25 +1211,31 @@ export class SignalService extends Service implements ISignalService {
    */
   static unwrapEnvelope(raw: Record<string, unknown>): SignalMessage | null {
     if (!("envelope" in raw)) {
-      if (typeof raw.sender !== "string" || typeof raw.timestamp !== "number") {
-        return null;
-      }
-      return {
-        sender: raw.sender,
-        senderUuid: typeof raw.senderUuid === "string" ? raw.senderUuid : undefined,
-        message: typeof raw.message === "string" ? raw.message : undefined,
-        timestamp: raw.timestamp,
-        groupId: typeof raw.groupId === "string" ? raw.groupId : undefined,
-        attachments: Array.isArray(raw.attachments) ? (raw.attachments as SignalAttachment[]) : [],
-        reaction: raw.reaction as SignalReactionInfo | undefined,
-        expiresInSeconds:
-          typeof raw.expiresInSeconds === "number" ? raw.expiresInSeconds : undefined,
-        viewOnce: raw.viewOnce === true,
-        quote: raw.quote as SignalQuote | undefined,
-      };
+      return SignalService.unwrapFlatMessage(raw);
     }
+    return SignalService.unwrapEnvelopeMessage(raw.envelope as Record<string, unknown>);
+  }
 
-    const env = raw.envelope as Record<string, unknown>;
+  private static unwrapFlatMessage(raw: Record<string, unknown>): SignalMessage | null {
+    if (typeof raw.sender !== "string" || typeof raw.timestamp !== "number") {
+      return null;
+    }
+    return {
+      sender: raw.sender,
+      senderUuid: typeof raw.senderUuid === "string" ? raw.senderUuid : undefined,
+      message: typeof raw.message === "string" ? raw.message : undefined,
+      timestamp: raw.timestamp,
+      groupId: typeof raw.groupId === "string" ? raw.groupId : undefined,
+      attachments: Array.isArray(raw.attachments) ? (raw.attachments as SignalAttachment[]) : [],
+      reaction: raw.reaction as SignalReactionInfo | undefined,
+      expiresInSeconds:
+        typeof raw.expiresInSeconds === "number" ? raw.expiresInSeconds : undefined,
+      viewOnce: raw.viewOnce === true,
+      quote: raw.quote as SignalQuote | undefined,
+    };
+  }
+
+  private static unwrapEnvelopeMessage(env: Record<string, unknown>): SignalMessage | null {
     const dm = (env.dataMessage || {}) as Record<string, unknown>;
     const groupInfo = dm.groupInfo as Record<string, unknown> | undefined;
 
@@ -2058,6 +2091,35 @@ export class SignalService extends Service implements ISignalService {
     runtime: IAgentRuntime,
     params: ConnectorReactionParams
   ): Promise<void> {
+    const reactionTarget = await this.resolveReactionTarget(runtime, params);
+
+    if (!params.emoji) {
+      throw new Error("Signal reaction requires emoji, targetTimestamp, and targetAuthor.");
+    }
+
+    if (params.remove) {
+      await this.removeReaction(
+        reactionTarget.recipient,
+        params.emoji,
+        reactionTarget.targetTimestamp,
+        reactionTarget.targetAuthor,
+        reactionTarget.accountId
+      );
+      return;
+    }
+    await this.sendReaction(
+      reactionTarget.recipient,
+      params.emoji,
+      reactionTarget.targetTimestamp,
+      reactionTarget.targetAuthor,
+      reactionTarget.accountId
+    );
+  }
+
+  private async resolveReactionTarget(
+    runtime: IAgentRuntime,
+    params: ConnectorReactionParams
+  ): Promise<SignalReactionTarget> {
     const target = params.target;
     const accountId = this.normalizeAccountId(target?.accountId);
     const room =
@@ -2069,33 +2131,32 @@ export class SignalService extends Service implements ISignalService {
       throw new Error("Signal reaction requires a target recipient or room.");
     }
 
-    let targetTimestamp = params.targetTimestamp;
-    let targetAuthor = params.targetAuthor;
-    if ((!targetTimestamp || !targetAuthor) && params.messageId) {
-      const memory = await runtime.getMemoryById(params.messageId as UUID).catch(() => null);
-      const metadata = memory?.metadata as Record<string, unknown> | undefined;
-      const sender = metadata?.sender as Record<string, unknown> | undefined;
-      targetTimestamp =
-        targetTimestamp ??
-        Number(metadata?.messageIdFull ?? metadata?.timestamp ?? memory?.createdAt);
-      targetAuthor =
-        targetAuthor ??
-        (typeof sender?.id === "string"
-          ? sender.id
-          : typeof metadata?.fromId === "string"
-            ? metadata.fromId
-            : undefined);
-    }
-
-    if (!params.emoji || !targetTimestamp || !targetAuthor) {
+    const fallback = params.messageId
+      ? await this.lookupReactionTargetFromMemory(runtime, params.messageId as UUID)
+      : {};
+    const targetTimestamp = params.targetTimestamp ?? fallback.targetTimestamp;
+    const targetAuthor = params.targetAuthor ?? fallback.targetAuthor;
+    if (!targetTimestamp || !targetAuthor) {
       throw new Error("Signal reaction requires emoji, targetTimestamp, and targetAuthor.");
     }
+    return { recipient, accountId, targetTimestamp, targetAuthor };
+  }
 
-    if (params.remove) {
-      await this.removeReaction(recipient, params.emoji, targetTimestamp, targetAuthor, accountId);
-      return;
-    }
-    await this.sendReaction(recipient, params.emoji, targetTimestamp, targetAuthor, accountId);
+  private async lookupReactionTargetFromMemory(
+    runtime: IAgentRuntime,
+    messageId: UUID
+  ): Promise<Partial<Pick<SignalReactionTarget, "targetTimestamp" | "targetAuthor">>> {
+    const memory = await runtime.getMemoryById(messageId).catch(() => null);
+    const metadata = memory?.metadata as Record<string, unknown> | undefined;
+    const sender = metadata?.sender as Record<string, unknown> | undefined;
+    const targetTimestamp = Number(metadata?.messageIdFull ?? metadata?.timestamp ?? memory?.createdAt);
+    const targetAuthor =
+      typeof sender?.id === "string"
+        ? sender.id
+        : typeof metadata?.fromId === "string"
+          ? metadata.fromId
+          : undefined;
+    return { targetTimestamp, targetAuthor };
   }
 
   async getConnectorUser(


### PR DESCRIPTION
## Summary

- remove stray merge conflict markers from `plugins/plugin-signal/src/service.ts`
- keep the typed `SignalRecentMessage[]` temporary so the recent-message chain remains type-safe
- split a few existing high-complexity Signal helpers into smaller methods so the touched file stays CodeFactor-clean

## Notes

This is a baseline build fix for current `develop`. The small Signal helper extractions are intentionally mechanical and scoped to the methods CodeFactor checks when this file is touched.

## Verification

- `cd plugins/plugin-signal && bun run build`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes stray git merge-conflict markers from `plugins/plugin-signal/src/service.ts` that broke the build on `develop`, and takes the opportunity to extract several long methods into smaller private helpers for CodeFactor compliance.

- Conflict markers are cleanly removed; the HEAD-side version (typed `SignalRecentMessage[]` intermediary) is correctly preserved for type safety.
- Five private helpers are extracted (`resolveStartupConfig`, `initializeConfiguredAccount`, `ensureAccountDaemon`, `unwrapFlatMessage`/`unwrapEnvelopeMessage`, `resolveReactionTarget`/`lookupReactionTargetFromMemory`) — all are mechanical reformulations of the original logic.
- One subtle behavioral shift in `resolveReactionTarget`: the memory lookup is now unconditionally triggered whenever `params.messageId` is set, whereas the old code skipped the DB call when both `targetTimestamp` and `targetAuthor` were already supplied.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the primary goal (fixing broken build due to conflict markers) is achieved correctly, and all extracted helpers faithfully reproduce the original logic.

The conflict-marker removal is straightforward and correct. Every extracted helper is a mechanical reformulation of existing code with no changed branching except the unnecessary-but-harmless extra memory lookup in resolveReactionTarget.

No files require special attention beyond the minor memory-lookup efficiency note on resolveReactionTarget in service.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-signal/src/service.ts | Removes stray merge-conflict markers, extracts five private helpers (resolveStartupConfig, initializeConfiguredAccount, ensureAccountDaemon, unwrapFlatMessage/EnvelopeMessage, resolveReactionTarget/lookupReactionTargetFromMemory) from long methods; logic is mostly equivalent but the refactored resolveReactionTarget now always performs the memory lookup when messageId is set, even when targetTimestamp and targetAuthor are already supplied. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[start static] --> B[resolveStartupConfig]
    B --> C{accounts.length == 0?}
    C -- yes --> D[warn & return]
    C -- no --> E[for each account]
    E --> F[initializeConfiguredAccount]
    F --> G{accountNumber valid?}
    G -- no --> H[warn & skip]
    G -- yes --> I{httpUrl set?}
    I -- yes --> J[create client & register]
    I -- no --> K[ensureAccountDaemon]
    K --> L{authDir exists?}
    L -- no --> M[warn & skip]
    L -- yes --> N[ensureDaemonRunning]
    N -- ok --> J
    N -- error --> O[error & skip]

    subgraph reactConnectorMessage
      P[resolveReactionTarget] --> Q{messageId set AND timestamp or author missing?}
      Q -- yes --> R[lookupReactionTargetFromMemory]
      Q -- no --> S[use params directly]
      R --> S
      S --> T{emoji set?}
      T -- no --> U[throw error]
      T -- yes --> V{params.remove?}
      V -- yes --> W[removeReaction]
      V -- no --> X[sendReaction]
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(signal): remove stray conflict marke..."](https://github.com/elizaos/eliza/commit/d01c8b400c48c51af6b3018539f1a0276e03f237) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32245292)</sub>

<!-- /greptile_comment -->