### PR TITLE
Keep OpenVINO out of text recommendations

### DIFF
--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -482,6 +482,7 @@ function runtimeForTier(
       parallel: 4,
       flashAttention: true,
       requiresKernel,
+      unsupportedKernels: ["openvino"],
       ctxCheckpoints: 4,
       ctxCheckpointInterval: 4096,
     },

--- a/packages/shared/src/local-inference/types.ts
+++ b/packages/shared/src/local-inference/types.ts
@@ -252,6 +252,11 @@ export interface LocalRuntimeOptimizations {
    * provide these kernels.
    */
   requiresKernel?: LocalRuntimeKernel[];
+  /**
+   * Runtime kernels this model must not be routed through. OpenVINO is ASR-only
+   * for current Eliza-1 bundles; text tiers keep using the DFlash/W4-B path.
+   */
+  unsupportedKernels?: LocalRuntimeKernel[];
 }
 
 export interface LocalRuntimeAcceleration {

--- a/packages/ui/src/services/local-inference/recommendation.ts
+++ b/packages/ui/src/services/local-inference/recommendation.ts
@@ -179,6 +179,11 @@ function kernelRequirementsSatisfied(
   model: CatalogModel,
   binaryKernels: Partial<Record<string, boolean>> | null,
 ): boolean {
+  const unsupported = model.runtime?.optimizations?.unsupportedKernels ?? [];
+  if (unsupported.includes("openvino") && binaryKernels?.openvino === true) {
+    return false;
+  }
+
   const required = model.runtime?.optimizations?.requiresKernel ?? [];
   if (required.length === 0) return true;
   if (!binaryKernels) return true;


### PR DESCRIPTION
This narrows the OpenVINO catalog handling to the ASR use case discussed in #7633. Eliza-1 text tiers now declare OpenVINO as an unsupported runtime kernel, and the recommender filters those tiers when the probed binary only advertises OpenVINO, so Intel hosts keep chat generation on the existing DFlash/W4-B path instead of accidentally routing autoregressive text through the slower OpenVINO backend.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR narrows OpenVINO to the ASR use-case by declaring it as an `unsupportedKernels` entry on every Eliza-1 text tier and filtering those tiers in the recommender when the probed binary advertises OpenVINO. It also lands the Eliza-1 model series (2B/9B/27B/27B-256k) as the Vast.ai native catalog, ships the OpenVINO Whisper ASR Python worker and its TS bridge, and refactors the cloud model catalog to add `recommended`/`free` annotation helpers.

- **OpenVINO exclusion** is correctly wired in `packages/ui` and `packages/shared` — the `unsupportedKernels: [\"openvino\"]` field is set on every text tier in the shared catalog and the UI recommender enforces it — but the parallel `kernelRequirementsSatisfied` in `plugins/plugin-local-inference/src/services/recommendation.ts` omits the same guard, leaving the server-side path unprotected on a binary that advertises both OpenVINO and the DFlash kernel set.
- **Eliza-1 Vast catalog** replaces the previous Qwen3.6-27B-NEO-CODE entry with a full 2B/9B/27B/27B-256k tier family; `isVastNativeModel` is updated to consult the `VAST_NATIVE_MODELS` array directly.
- **OpenVINO Whisper worker** (`openvino-whisper-asr-worker.py` + `openvino-whisper-asr.ts`) is scoped purely to ASR/transcription with a persistent-worker architecture that pays the `WhisperPipeline.compile()` cost once.

<h3>Confidence Score: 3/5</h3>

The OpenVINO text exclusion is fully enforced in the UI recommender but not in the plugin server-side recommender, which runs during actual model selection on the host.

The unsupportedKernels guard is set in the shared catalog and respected by the UI code, but the parallel kernelRequirementsSatisfied in plugins/plugin-local-inference/src/services/recommendation.ts was added without it. On a binary that advertises both openvino: true and the full DFlash kernel set, the plugin recommender would still surface Eliza-1 text tiers. In practice most OpenVINO-only binaries do not carry DFlash kernels so the requiresKernel gate coincidentally blocks this today, but the defense disappears the moment a mixed binary ships.

plugins/plugin-local-inference/src/services/recommendation.ts needs the unsupportedKernels guard from the UI copy; recommendation.test.ts needs a matching test case for binaryKernels with openvino: true alongside all required DFlash kernels.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/src/services/recommendation.ts | New server-side recommender: missing the `unsupportedKernels` guard that blocks OpenVINO for text tiers — present in the UI copy but absent here. |
| packages/ui/src/services/local-inference/recommendation.ts | New UI-side recommender: correctly implements the `unsupportedKernels` check that filters OpenVINO from text generation tiers. |
| packages/shared/src/local-inference/types.ts | Adds `unsupportedKernels` to `LocalRuntimeOptimizations` and `openvino` to `LocalRuntimeKernel`; well-documented with clear separation from the manifest kernel layer. |
| packages/shared/src/local-inference/catalog.ts | New shared catalog: sets `unsupportedKernels: ["openvino"]` on every Eliza-1 text tier. |
| plugins/plugin-local-inference/src/services/manifest/schema.ts | New manifest schema: `openvino` is explicitly excluded from the kernel bridge with a clear doc comment. |
| plugins/plugin-local-inference/src/services/recommendation.test.ts | New tests cover hardware-fit and kernel-gate scenarios but omit the `openvino: true + all required kernels` case. |
| cloud/packages/lib/models/catalog.ts | Cloud catalog: adds `annotateCatalogModel`, switches to Eliza-1 Vast models, removes Qwen/Meta, adds `recommended`/`free` priority sort. |
| cloud/packages/lib/providers/vast.ts | Extends VastProvider to forward `eliza_*` fields and support per-model `apiModelId` override. |
| plugins/plugin-local-inference/src/services/voice/openvino-whisper-asr.ts | New OpenVINO Whisper ASR integration scoped to transcription only. |
| packages/app-core/scripts/openvino-whisper-asr-worker.py | Persistent Python OpenVINO Whisper worker with clean protocol and safe device-chain fallback. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HardwareProbe binaryKernels] --> B{UI or Plugin recommender?}
    B -->|packages/ui| C[kernelRequirementsSatisfied UI]
    B -->|plugins/plugin-local-inference| D[kernelRequirementsSatisfied Plugin]
    C --> E{unsupportedKernels includes openvino AND binaryKernels.openvino?}
    E -->|YES| F[Reject tier - OpenVINO text blocked]
    E -->|NO| G{requiresKernel all satisfied?}
    G -->|YES| H[Recommend DFlash/W4-B path]
    G -->|NO| I[Reject tier]
    D --> J{requiresKernel all satisfied?}
    J -->|YES even if openvino=true| K[Recommend - OpenVINO guard MISSING]
    J -->|NO| L[Reject tier]
```

<sub>Reviews (1): Last reviewed commit: ["Keep OpenVINO out of text recommendation..."](https://github.com/elizaos/eliza/commit/c5478dbd4f6ef6fc7ef6822487cfb646fda0add1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32269274)</sub>

<!-- /greptile_comment -->