### PR TITLE
fix(ui): hide inactive continuous chat mic toggle

### DIFF
--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -592,6 +592,8 @@ export function ChatView({
       voice.isSpeaking ||
       Boolean(voiceSpeaker) ||
       Boolean(continuous.interimTranscript));
+  const continuousChatToggleVisible =
+    voice.supported && continuousChatMode !== "off";
 
   const auxiliaryNode = (
     <>
@@ -683,7 +685,7 @@ export function ChatView({
       before={
         <>
           <CodingAgentControlChip />
-          {voice.supported ? (
+          {continuousChatToggleVisible ? (
             <div className="flex justify-end px-1 pb-0.5">
               <ContinuousChatToggle
                 compact
@@ -745,7 +747,7 @@ export function ChatView({
       before={
         <>
           <CodingAgentControlChip />
-          {voice.supported ? (
+          {continuousChatToggleVisible ? (
             <div className="flex justify-end px-1 pb-0.5">
               <ContinuousChatToggle
                 compact

--- a/packages/ui/src/components/pages/PageScopedChatPane.tsx
+++ b/packages/ui/src/components/pages/PageScopedChatPane.tsx
@@ -1013,7 +1013,7 @@ export function PageScopedChatPane({
             data-testid={`page-scoped-chat-voice-status-bar-${scope}`}
           />
         ) : null}
-        {voice.supported ? (
+        {voice.supported && continuousChatMode !== "off" ? (
           <div className="mb-1 flex justify-end px-1">
             <ContinuousChatToggle
               compact


### PR DESCRIPTION
## Summary

- Hide the compact continuous-chat toggle when continuous chat is off.
- Keep the normal composer microphone button visible for one-shot voice input.
- Apply the same rule in the main chat view and page-scoped chat pane.

## Why

On the Android/Pixel chat screen, voice-capable devices rendered two microphone affordances at the composer: the normal input mic inside the composer and the compact continuous-chat toggle above/outside it. When continuous chat is disabled, that second mic is inactive and reads as a duplicate control.

The continuous-chat status bar already only appears when continuous chat is active or voice is in flight. This PR aligns the compact toggle with that behavior while preserving it for live/VAD mode.

## Validation

- `bun run --cwd packages/ui typecheck` passed in the main Pixel APK checkout with this exact diff applied.
- Built the Android debug APK from the local Eliza source during Pixel validation.
- Verified on Pixel screenshot: chat renders, no white screen, and the composer shows a single microphone when continuous chat is off.

## Notes

This is intentionally scoped to UI behavior only. The ongoing Pixel APK/native llama.cpp validation continues separately and is not bundled into this PR.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides the compact `ContinuousChatToggle` (the secondary mic affordance) in both `ChatView` and `PageScopedChatPane` when `continuousChatMode` is `"off"`, eliminating a confusing duplicate microphone control on voice-capable devices. The change is tightly scoped to render-condition logic and does not touch any underlying voice or state management.

- **`ChatView.tsx`**: Extracts the new condition into a named variable `continuousChatToggleVisible` (`voice.supported && continuousChatMode !== \"off\"`) and applies it to both composer variants (default and game-modal).
- **`PageScopedChatPane.tsx`**: Inlines the same guard (`voice.supported && continuousChatMode !== \"off\"`) directly on the toggle's render site, keeping parity with the `ChatView` behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to render-condition guards with no effect on voice state, audio logic, or data flow.

Both files apply the same `voice.supported && continuousChatMode !== "off"` guard, correctly mirroring how `voiceStatusBarVisible` already gated the companion status bar. The normal one-shot mic button in the composer is unaffected. No state mutations, hooks, or side-effect paths were modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/pages/ChatView.tsx | Introduces `continuousChatToggleVisible` variable (`voice.supported && continuousChatMode !== "off"`) and uses it in both composer variants (game-modal and default) to hide the compact `ContinuousChatToggle` when continuous chat is off. |
| packages/ui/src/components/pages/PageScopedChatPane.tsx | Applies the same `voice.supported && continuousChatMode !== "off"` guard directly inline (no extracted variable) to the compact `ContinuousChatToggle`, consistent with the ChatView change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Chat Composer renders] --> B{voice.supported?}
    B -- No --> C[No voice controls shown]
    B -- Yes --> D{continuousChatMode !== 'off'?}

    D -- Yes --> E[Show compact ContinuousChatToggle]
    D -- No --> F[Hide compact ContinuousChatToggle]

    F --> G[Normal composer mic button still visible]
    E --> G

    A --> H{voiceStatusBarVisible?}
    H -- "mode != off OR isListening OR isSpeaking OR interimTranscript" --> I[Show ChatVoiceStatusBar]
    H -- No --> J[Hide ChatVoiceStatusBar]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): hide inactive continuous chat m..."](https://github.com/elizaos/eliza/commit/c3e9cf034ee6cdcd4186e2f9a410cc1852f96755) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32285097)</sub>

<!-- /greptile_comment -->