### PR TITLE
fix(cloud): pricing unavailable for unsuffixed model ids (gemini-2.0-flash etc)

### DIFF
--- a/cloud/packages/lib/services/ai-pricing.ts
+++ b/cloud/packages/lib/services/ai-pricing.ts
@@ -372,7 +372,7 @@ function inferOpenRouterProductFamily(model: OpenRouterCatalogModel): PricingPro
 export function stripVersionedSnapshotSuffix(modelId: string): string | null {
   const datedOrLabelledPatterns = [
     /-\d{4}-\d{2}-\d{2}$/, // ISO date: -2024-06-05
-    /-\d{8}$/, // compact date: -20240605
+    /-(?:19|20)\d{6}$/, // compact date: -20240605 (year-anchored so unrelated 8-digit run-ids aren't stripped)
     /-latest$/,
     /-preview$/,
     /-beta$/,
@@ -1123,7 +1123,7 @@ function providerPersistRank(provider: string, logicalProvider: string): number 
   return idx === -1 ? keys.length : idx;
 }
 
-function chooseBestCandidatePricingEntry(
+export function chooseBestCandidatePricingEntry(
   candidates: CandidatePreparedPricingEntry[],
   requestedDimensions: PricingDimensions,
   canonicalModel: string,
@@ -1154,6 +1154,14 @@ function chooseBestCandidatePricingEntry(
       providerPersistRank(left.entry.provider, left.logicalProvider) -
       providerPersistRank(right.entry.provider, right.logicalProvider);
     if (providerDiff !== 0) return providerDiff;
+
+    // When two stripped snapshot variants reduce to the same canonical id
+    // (e.g. `gemini-2.0-flash-001` and `gemini-2.0-flash-002` both stripping
+    // to `gemini-2.0-flash`), every preceding tie-break is a no-op. Prefer
+    // the higher unitPrice as a conservative fallback: never under-bill the
+    // platform when snapshot prices diverge.
+    const priceDiff = right.entry.unitPrice - left.entry.unitPrice;
+    if (priceDiff !== 0) return priceDiff;
 
     return right.modelId.localeCompare(left.modelId);
   });

--- a/cloud/packages/lib/services/ai-pricing.ts
+++ b/cloud/packages/lib/services/ai-pricing.ts
@@ -34,10 +34,14 @@ import {
   type SupportedVideoModelDefinition,
 } from "./ai-pricing-definitions";
 
-const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models?output_modalities=all";
+const OPENROUTER_MODELS_URL =
+  "https://openrouter.ai/api/v1/models?output_modalities=all";
 const EXTERNAL_CACHE_TTL_MS = 15 * 60 * 1000;
 const DEFAULT_OPENROUTER_IMAGE_OUTPUT_TOKENS = 1300;
-const VAST_DEFAULT_PRICING_PER_1M: Record<string, { input: number; output: number }> = {
+const VAST_DEFAULT_PRICING_PER_1M: Record<
+  string,
+  { input: number; output: number }
+> = {
   "vast/eliza-1-2b": { input: 0.2, output: 0.4 },
   "vast/eliza-1-9b": { input: 1, output: 2 },
   "vast/eliza-1-27b": { input: 4, output: 8 },
@@ -46,7 +50,13 @@ const VAST_DEFAULT_PRICING_PER_1M: Record<string, { input: number; output: numbe
 
 type PriceLookupSource = PricingBillingSource | "seed";
 
-type PricingRefreshSource = "gateway" | "openrouter" | "fal" | "elevenlabs" | "suno" | "vast";
+type PricingRefreshSource =
+  | "gateway"
+  | "openrouter"
+  | "fal"
+  | "elevenlabs"
+  | "suno"
+  | "vast";
 
 type PreparedPricingEntry = {
   billingSource: PriceLookupSource;
@@ -141,7 +151,9 @@ function applyPlatformMarkup(baseCost: Decimal): {
   };
 }
 
-function normalizeDimensionValue(value: unknown): string | number | boolean | null {
+function normalizeDimensionValue(
+  value: unknown,
+): string | number | boolean | null {
   if (
     value === null ||
     typeof value === "string" ||
@@ -169,13 +181,22 @@ export function normalizePricingDimensions(
   );
 }
 
-export function buildDimensionKey(dimensions?: Record<string, unknown>): string {
+export function buildDimensionKey(
+  dimensions?: Record<string, unknown>,
+): string {
   const normalized = normalizePricingDimensions(dimensions);
-  return Object.keys(normalized).length === 0 ? "*" : JSON.stringify(normalized);
+  return Object.keys(normalized).length === 0
+    ? "*"
+    : JSON.stringify(normalized);
 }
 
-function dimensionsAreSubset(candidate: PricingDimensions, requested: PricingDimensions): boolean {
-  return Object.entries(candidate).every(([key, value]) => requested[key] === value);
+function dimensionsAreSubset(
+  candidate: PricingDimensions,
+  requested: PricingDimensions,
+): boolean {
+  return Object.entries(candidate).every(
+    ([key, value]) => requested[key] === value,
+  );
 }
 
 function sourcePriorityForKind(sourceKind: string): number {
@@ -214,7 +235,10 @@ function inferProviderFromCanonicalModel(model: string): string {
 }
 
 /** Provider column for a catalog `model` row; cross-provider aliases use the target id prefix, not the request gateway. */
-export function providerForPricingCandidate(modelId: string, requestProvider: string): string {
+export function providerForPricingCandidate(
+  modelId: string,
+  requestProvider: string,
+): string {
   const inferred = inferProviderFromCanonicalModel(modelId);
   return inferred !== "unknown" ? inferred : requestProvider;
 }
@@ -262,7 +286,10 @@ function hashPreparedEntry(entry: PreparedPricingEntry): string {
     .digest("hex");
 }
 
-function toDbEntry(entry: PreparedPricingEntry, timestamp: Date): NewAiPricingEntry {
+function toDbEntry(
+  entry: PreparedPricingEntry,
+  timestamp: Date,
+): NewAiPricingEntry {
   const dimensions = normalizePricingDimensions(entry.dimensions);
 
   return {
@@ -280,7 +307,8 @@ function toDbEntry(entry: PreparedPricingEntry, timestamp: Date): NewAiPricingEn
     source_url: entry.sourceUrl,
     source_hash: hashPreparedEntry(entry),
     fetched_at: entry.fetchedAt ?? timestamp,
-    stale_after: entry.staleAfter ?? new Date(timestamp.getTime() + EXTERNAL_CACHE_TTL_MS),
+    stale_after:
+      entry.staleAfter ?? new Date(timestamp.getTime() + EXTERNAL_CACHE_TTL_MS),
     effective_from: timestamp,
     priority: entry.priority ?? sourcePriorityForKind(entry.sourceKind),
     is_active: true,
@@ -323,7 +351,9 @@ function parseNumericPrice(value: unknown): number | null {
   return null;
 }
 
-function inferOpenRouterProductFamily(model: OpenRouterCatalogModel): PricingProductFamily {
+function inferOpenRouterProductFamily(
+  model: OpenRouterCatalogModel,
+): PricingProductFamily {
   if (model.id.includes("embedding")) {
     return "embedding";
   }
@@ -335,7 +365,10 @@ function inferOpenRouterProductFamily(model: OpenRouterCatalogModel): PricingPro
   // explicit array is missing.
   const outputModalities = model.architecture?.output_modalities;
   if (Array.isArray(outputModalities) && outputModalities.length > 0) {
-    if (outputModalities.includes("image") && !outputModalities.includes("text")) {
+    if (
+      outputModalities.includes("image") &&
+      !outputModalities.includes("text")
+    ) {
       return "image";
     }
     return "language";
@@ -390,7 +423,8 @@ export function stripVersionedSnapshotSuffix(modelId: string): string | null {
     const stripped = modelId.replace(numericPattern, "");
     if (stripped.length === 0 || stripped.endsWith("/")) return null;
     const slashIdx = stripped.indexOf("/");
-    const afterSlash = slashIdx === -1 ? stripped : stripped.slice(slashIdx + 1);
+    const afterSlash =
+      slashIdx === -1 ? stripped : stripped.slice(slashIdx + 1);
     if (afterSlash.split("-").length < 2) return null;
     return stripped;
   }
@@ -441,7 +475,7 @@ export function buildOpenRouterPreparedEntries(
   const promptPrice = parseNumericPrice(pricing.prompt);
   if (promptPrice != null) {
     entries.push(buildEntry(model.id, "input", promptPrice));
-    if (baseId !== null && baseId !== model.id) {
+    if (baseId !== null) {
       entries.push(buildEntry(baseId, "input", promptPrice, -1));
     }
   }
@@ -449,7 +483,7 @@ export function buildOpenRouterPreparedEntries(
   const completionPrice = parseNumericPrice(pricing.completion);
   if (completionPrice != null) {
     entries.push(buildEntry(model.id, "output", completionPrice));
-    if (baseId !== null && baseId !== model.id) {
+    if (baseId !== null) {
       entries.push(buildEntry(baseId, "output", completionPrice, -1));
     }
   }
@@ -510,13 +544,19 @@ function parseFalPricingEntries(
 
   switch (model.pricingParser) {
     case "veo": {
-      const match = paragraph.match(/\$([\d.]+)\s+\(audio off\)\s+or\s+\$([\d.]+)\s+\(audio on\)/i);
+      const match = paragraph.match(
+        /\$([\d.]+)\s+\(audio off\)\s+or\s+\$([\d.]+)\s+\(audio on\)/i,
+      );
       if (!match) {
         throw new Error(`Unable to parse Veo pricing paragraph: ${paragraph}`);
       }
 
-      entries.push(buildFalEntry(model, "second", Number(match[1]), { audio: false }));
-      entries.push(buildFalEntry(model, "second", Number(match[2]), { audio: true }));
+      entries.push(
+        buildFalEntry(model, "second", Number(match[1]), { audio: false }),
+      );
+      entries.push(
+        buildFalEntry(model, "second", Number(match[2]), { audio: true }),
+      );
       break;
     }
     case "veo31": {
@@ -524,7 +564,9 @@ function parseFalPricingEntries(
         /\$([\d.]+)\s+without audio\s+or\s+\$([\d.]+)\s+with audio\s+for 720p or 1080p.*?\$([\d.]+)\s+per second without audio,\s+or\s+\$([\d.]+)\s+with/i,
       );
       if (!match) {
-        throw new Error(`Unable to parse Veo 3.1 pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Veo 3.1 pricing paragraph: ${paragraph}`,
+        );
       }
 
       for (const resolution of ["720p", "1080p"]) {
@@ -560,7 +602,9 @@ function parseFalPricingEntries(
         /\$([\d.]+)\s+for 720p with audio,\s+\$([\d.]+)\s+for 720p without audio,\s+\$([\d.]+)\s+for 1080p with audio\s+or\s+\$([\d.]+)\s+for 1080p without audio/i,
       );
       if (!match) {
-        throw new Error(`Unable to parse Veo 3.1 Lite pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Veo 3.1 Lite pricing paragraph: ${paragraph}`,
+        );
       }
 
       entries.push(
@@ -594,7 +638,9 @@ function parseFalPricingEntries(
         /\$([\d.]+)\s+\(audio off\)\s+or\s+\$([\d.]+)\s+\(audio on\)(?:,\s+if voice control is used while generating audio you will be charged\s+\$([\d.]+))?/i,
       );
       if (!match) {
-        throw new Error(`Unable to parse Kling pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Kling pricing paragraph: ${paragraph}`,
+        );
       }
 
       entries.push(
@@ -620,9 +666,13 @@ function parseFalPricingEntries(
       break;
     }
     case "hailuo_standard": {
-      const match = paragraph.match(/\$([\d.]+)\s+per\s+6 second.*?\$([\d.]+)\s+per\s+10 second/i);
+      const match = paragraph.match(
+        /\$([\d.]+)\s+per\s+6 second.*?\$([\d.]+)\s+per\s+10 second/i,
+      );
       if (!match) {
-        throw new Error(`Unable to parse Hailuo standard pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Hailuo standard pricing paragraph: ${paragraph}`,
+        );
       }
 
       entries.push(
@@ -640,7 +690,9 @@ function parseFalPricingEntries(
     case "hailuo_pro": {
       const match = paragraph.match(/\$([\d.]+)\s+per video generation/i);
       if (!match) {
-        throw new Error(`Unable to parse Hailuo pro pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Hailuo pro pricing paragraph: ${paragraph}`,
+        );
       }
 
       entries.push(buildFalEntry(model, "request", Number(match[1]), {}));
@@ -671,7 +723,9 @@ function parseFalPricingEntries(
         /\$([\d.]+)\s+for 360p and 540p,\s+\$([\d.]+)\s+for 720p,\s+and\s+\$([\d.]+)\s+for 1080p\.\s+Enabling audio adds\s+\$([\d.]+)\s+for 360p\/540p\/720p,\s+and\s+\$([\d.]+)\s+for 1080p\.\s+For 8-second videos, costs are 2x the 5-second base;\s+for 10-second videos, costs are 2.2x the 5-second base/i,
       );
       if (!match) {
-        throw new Error(`Unable to parse PixVerse pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse PixVerse pricing paragraph: ${paragraph}`,
+        );
       }
 
       const baseByResolution: Record<string, number> = {
@@ -690,7 +744,9 @@ function parseFalPricingEntries(
 
       for (const [duration, multiplier] of Object.entries(multipliers)) {
         const numericDuration = Number(duration);
-        for (const [resolution, basePrice] of Object.entries(baseByResolution)) {
+        for (const [resolution, basePrice] of Object.entries(
+          baseByResolution,
+        )) {
           if (numericDuration === 10 && resolution === "1080p") {
             continue;
           }
@@ -704,7 +760,8 @@ function parseFalPricingEntries(
             }),
           );
 
-          const audioPrice = (basePrice + audioAddByResolution[resolution]) * multiplier;
+          const audioPrice =
+            (basePrice + audioAddByResolution[resolution]) * multiplier;
           entries.push(
             buildFalEntry(model, "request", audioPrice, {
               durationSeconds: numericDuration,
@@ -719,7 +776,9 @@ function parseFalPricingEntries(
     case "seedance": {
       const match = paragraph.match(/\$([\d.]+)\/second/);
       if (!match) {
-        throw new Error(`Unable to parse Seedance pricing paragraph: ${paragraph}`);
+        throw new Error(
+          `Unable to parse Seedance pricing paragraph: ${paragraph}`,
+        );
       }
 
       entries.push(
@@ -808,115 +867,135 @@ const OPENROUTER_EMBEDDING_MODEL_IDS = [
   "openai/text-embedding-ada-002",
 ] as const;
 
-async function fetchOpenRouterEmbeddingEndpointEntries(): Promise<PreparedPricingEntry[]> {
+async function fetchOpenRouterEmbeddingEndpointEntries(): Promise<
+  PreparedPricingEntry[]
+> {
   const fetchedAt = new Date();
   const staleAfter = new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS);
 
   const results = await Promise.all(
-    OPENROUTER_EMBEDDING_MODEL_IDS.map(async (modelId): Promise<PreparedPricingEntry[]> => {
-      const url = `https://openrouter.ai/api/v1/models/${modelId}/endpoints`;
-      try {
-        const payload = await fetchJson<{
-          data?: {
-            endpoints?: Array<{
-              pricing?: { prompt?: string | number };
-            }>;
-          };
-        }>(url);
-        const endpoint = payload.data?.endpoints?.[0];
-        const unitPrice = parseNumericPrice(endpoint?.pricing?.prompt);
-        if (unitPrice == null) {
-          return [];
-        }
-        return [
-          {
-            billingSource: "openrouter",
-            provider: inferProviderFromCanonicalModel(modelId),
-            model: modelId,
-            productFamily: "embedding",
-            chargeType: "input",
-            unit: "token",
-            unitPrice,
-            sourceKind: "openrouter_endpoints",
-            sourceUrl: url,
-            fetchedAt,
-            staleAfter,
-          },
-        ];
-      } catch (error) {
-        logger.warn("[AI Pricing] OpenRouter embedding endpoint fetch failed", {
-          modelId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return [];
-      }
-    }),
-  );
-
-  return results.flat();
-}
-
-async function fetchOpenRouterImageEndpointEntries(): Promise<PreparedPricingEntry[]> {
-  const fetchedAt = new Date();
-  const staleAfter = new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS);
-
-  const results = await Promise.all(
-    SUPPORTED_IMAGE_MODELS.map(async (model): Promise<PreparedPricingEntry[]> => {
-      const url = `https://openrouter.ai/api/v1/models/${model.modelId}/endpoints`;
-      try {
-        const payload = await fetchJson<{
-          data?: {
-            endpoints?: Array<{
-              pricing?: { image_output?: string | number };
-            }>;
-          };
-        }>(url);
-        const endpoint = payload.data?.endpoints?.[0];
-        const outputTokenPrice = parseNumericPrice(endpoint?.pricing?.image_output);
-        if (outputTokenPrice == null) {
-          return [];
-        }
-        const estimatedOutputTokens =
-          model.estimatedOutputTokens ?? DEFAULT_OPENROUTER_IMAGE_OUTPUT_TOKENS;
-
-        return [
-          {
-            billingSource: "openrouter",
-            provider: inferProviderFromCanonicalModel(model.modelId),
-            model: model.modelId,
-            productFamily: "image",
-            chargeType: "generation",
-            unit: "image",
-            unitPrice: outputTokenPrice * estimatedOutputTokens,
-            dimensions: model.defaultDimensions,
-            sourceKind: "openrouter_endpoints",
-            sourceUrl: url,
-            fetchedAt,
-            staleAfter,
-            metadata: {
-              estimated_output_tokens: estimatedOutputTokens,
-              image_output_token_price: outputTokenPrice,
+    OPENROUTER_EMBEDDING_MODEL_IDS.map(
+      async (modelId): Promise<PreparedPricingEntry[]> => {
+        const url = `https://openrouter.ai/api/v1/models/${modelId}/endpoints`;
+        try {
+          const payload = await fetchJson<{
+            data?: {
+              endpoints?: Array<{
+                pricing?: { prompt?: string | number };
+              }>;
+            };
+          }>(url);
+          const endpoint = payload.data?.endpoints?.[0];
+          const unitPrice = parseNumericPrice(endpoint?.pricing?.prompt);
+          if (unitPrice == null) {
+            return [];
+          }
+          return [
+            {
+              billingSource: "openrouter",
+              provider: inferProviderFromCanonicalModel(modelId),
+              model: modelId,
+              productFamily: "embedding",
+              chargeType: "input",
+              unit: "token",
+              unitPrice,
+              sourceKind: "openrouter_endpoints",
+              sourceUrl: url,
+              fetchedAt,
+              staleAfter,
             },
-          },
-        ];
-      } catch (error) {
-        logger.warn("[AI Pricing] OpenRouter image endpoint fetch failed", {
-          modelId: model.modelId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return [];
-      }
-    }),
+          ];
+        } catch (error) {
+          logger.warn(
+            "[AI Pricing] OpenRouter embedding endpoint fetch failed",
+            {
+              modelId,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+          return [];
+        }
+      },
+    ),
   );
 
   return results.flat();
 }
 
-async function fetchOpenRouterCatalogEntries(): Promise<PreparedPricingEntry[]> {
+async function fetchOpenRouterImageEndpointEntries(): Promise<
+  PreparedPricingEntry[]
+> {
+  const fetchedAt = new Date();
+  const staleAfter = new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS);
+
+  const results = await Promise.all(
+    SUPPORTED_IMAGE_MODELS.map(
+      async (model): Promise<PreparedPricingEntry[]> => {
+        const url = `https://openrouter.ai/api/v1/models/${model.modelId}/endpoints`;
+        try {
+          const payload = await fetchJson<{
+            data?: {
+              endpoints?: Array<{
+                pricing?: { image_output?: string | number };
+              }>;
+            };
+          }>(url);
+          const endpoint = payload.data?.endpoints?.[0];
+          const outputTokenPrice = parseNumericPrice(
+            endpoint?.pricing?.image_output,
+          );
+          if (outputTokenPrice == null) {
+            return [];
+          }
+          const estimatedOutputTokens =
+            model.estimatedOutputTokens ??
+            DEFAULT_OPENROUTER_IMAGE_OUTPUT_TOKENS;
+
+          return [
+            {
+              billingSource: "openrouter",
+              provider: inferProviderFromCanonicalModel(model.modelId),
+              model: model.modelId,
+              productFamily: "image",
+              chargeType: "generation",
+              unit: "image",
+              unitPrice: outputTokenPrice * estimatedOutputTokens,
+              dimensions: model.defaultDimensions,
+              sourceKind: "openrouter_endpoints",
+              sourceUrl: url,
+              fetchedAt,
+              staleAfter,
+              metadata: {
+                estimated_output_tokens: estimatedOutputTokens,
+                image_output_token_price: outputTokenPrice,
+              },
+            },
+          ];
+        } catch (error) {
+          logger.warn("[AI Pricing] OpenRouter image endpoint fetch failed", {
+            modelId: model.modelId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return [];
+        }
+      },
+    ),
+  );
+
+  return results.flat();
+}
+
+async function fetchOpenRouterCatalogEntries(): Promise<
+  PreparedPricingEntry[]
+> {
   return await getCachedExternalEntries("openrouter", async () => {
-    const payload = await fetchJson<{ data?: OpenRouterCatalogModel[] }>(OPENROUTER_MODELS_URL);
+    const payload = await fetchJson<{ data?: OpenRouterCatalogModel[] }>(
+      OPENROUTER_MODELS_URL,
+    );
     const models = Array.isArray(payload.data) ? payload.data : [];
-    const bulkEntries = models.flatMap((model) => buildOpenRouterPreparedEntries(model));
+    const bulkEntries = models.flatMap((model) =>
+      buildOpenRouterPreparedEntries(model),
+    );
     const embeddingEntries = await fetchOpenRouterEmbeddingEndpointEntries();
     const imageEntries = await fetchOpenRouterImageEndpointEntries();
     return [...bulkEntries, ...embeddingEntries, ...imageEntries];
@@ -932,7 +1011,8 @@ async function fetchFalCatalogEntries(): Promise<PreparedPricingEntry[]> {
           const paragraph = extractFalPricingParagraph(html);
           return parseFalPricingEntries(model, paragraph);
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
+          const message =
+            error instanceof Error ? error.message : String(error);
           logger.warn("[AI Pricing] fal parse failed, falling back to DB", {
             model: model.modelId,
             error: message,
@@ -959,7 +1039,10 @@ async function fetchFalCatalogEntries(): Promise<PreparedPricingEntry[]> {
       }),
     );
 
-    return [...entryArrays.flat(), ...buildMusicSnapshotEntries("fal", "fal_model_page")];
+    return [
+      ...entryArrays.flat(),
+      ...buildMusicSnapshotEntries("fal", "fal_model_page"),
+    ];
   });
 }
 
@@ -1026,16 +1109,27 @@ async function fetchSunoEntries(): Promise<PreparedPricingEntry[]> {
   );
 }
 
-function parseVastPricingOverrides(): Record<string, { input: number; output: number }> {
+function parseVastPricingOverrides(): Record<
+  string,
+  { input: number; output: number }
+> {
   const raw = process.env.VAST_PRICING_PER_1M_JSON?.trim();
   if (!raw) return {};
   try {
-    const parsed = JSON.parse(raw) as Record<string, { input?: unknown; output?: unknown }>;
+    const parsed = JSON.parse(raw) as Record<
+      string,
+      { input?: unknown; output?: unknown }
+    >;
     return Object.fromEntries(
       Object.entries(parsed).flatMap(([model, value]) => {
         const input = Number(value?.input);
         const output = Number(value?.output);
-        if (!Number.isFinite(input) || !Number.isFinite(output) || input < 0 || output < 0) {
+        if (
+          !Number.isFinite(input) ||
+          !Number.isFinite(output) ||
+          input < 0 ||
+          output < 0
+        ) {
           logger.warn("ai-pricing: ignoring invalid Vast pricing override", {
             model,
           });
@@ -1088,7 +1182,9 @@ async function fetchVastSnapshotEntries(): Promise<PreparedPricingEntry[]> {
   });
 }
 
-async function fetchEntriesForSource(source: PriceLookupSource): Promise<PreparedPricingEntry[]> {
+async function fetchEntriesForSource(
+  source: PriceLookupSource,
+): Promise<PreparedPricingEntry[]> {
   switch (source) {
     case "gateway":
     case "openrouter":
@@ -1117,7 +1213,10 @@ async function fetchEntriesForSource(source: PriceLookupSource): Promise<Prepare
  * logical key first keeps charges aligned with app-level provider labels and
  * avoids non-deterministic `localeCompare` on `model` deciding billing.
  */
-function providerPersistRank(provider: string, logicalProvider: string): number {
+function providerPersistRank(
+  provider: string,
+  logicalProvider: string,
+): number {
   const keys = expandPersistedPricingProviderKeys(logicalProvider);
   const idx = keys.indexOf(provider);
   return idx === -1 ? keys.length : idx;
@@ -1129,7 +1228,10 @@ export function chooseBestCandidatePricingEntry(
   canonicalModel: string,
 ): CandidatePreparedPricingEntry | null {
   const matching = candidates.filter(({ entry }) =>
-    dimensionsAreSubset(normalizePricingDimensions(entry.dimensions), requestedDimensions),
+    dimensionsAreSubset(
+      normalizePricingDimensions(entry.dimensions),
+      requestedDimensions,
+    ),
   );
 
   if (matching.length === 0) {
@@ -1137,7 +1239,8 @@ export function chooseBestCandidatePricingEntry(
   }
 
   const sorted = [...matching].sort((left, right) => {
-    const priorityDiff = (right.entry.priority ?? 0) - (left.entry.priority ?? 0);
+    const priorityDiff =
+      (right.entry.priority ?? 0) - (left.entry.priority ?? 0);
     if (priorityDiff !== 0) return priorityDiff;
 
     const specificityDiff =
@@ -1196,7 +1299,9 @@ function stripOpenRouterModelVariant(model: string): string | null {
 }
 
 /** Manual gateway rename map + inverse (new id → legacy ids still in DB). */
-function collectGatewayPricingManualAliasCandidates(canonicalModel: string): string[] {
+function collectGatewayPricingManualAliasCandidates(
+  canonicalModel: string,
+): string[] {
   const extras: string[] = [];
   const seen = new Set<string>();
   const push = (m: string) => {
@@ -1228,7 +1333,9 @@ function collectGatewayPricingManualAliasCandidates(canonicalModel: string): str
  * still key off either spelling; expanding both avoids “pricing unavailable” for
  * valid models during migration.
  */
-export function expandPricingCatalogModelCandidates(canonicalModel: string): string[] {
+export function expandPricingCatalogModelCandidates(
+  canonicalModel: string,
+): string[] {
   const out: string[] = [];
   const seen = new Set<string>();
   const push = (m: string) => {
@@ -1287,7 +1394,10 @@ async function resolvePreparedPricingEntry(params: {
   const canonicalModel = canonicalModelId(params.model, params.provider);
   const modelCandidates = expandPricingCatalogModelCandidates(canonicalModel);
   const requestedDimensions = normalizePricingDimensions(params.dimensions);
-  const sources = normalizeBillingSourceCandidates(params.billingSource, params.provider);
+  const sources = normalizeBillingSourceCandidates(
+    params.billingSource,
+    params.provider,
+  );
 
   for (const source of sources) {
     const providerModelPairs = modelCandidates.flatMap((modelId) => {
@@ -1298,19 +1408,27 @@ async function resolvePreparedPricingEntry(params: {
       }));
     });
 
-    const allPersisted = await aiPricingRepository.listActiveEntriesForProviderModelPairs({
-      billingSource: source,
-      productFamily: params.productFamily,
-      chargeType: params.chargeType,
-      pairs: providerModelPairs,
-    });
+    const allPersisted =
+      await aiPricingRepository.listActiveEntriesForProviderModelPairs({
+        billingSource: source,
+        productFamily: params.productFamily,
+        chargeType: params.chargeType,
+        pairs: providerModelPairs,
+      });
 
     const persistedCandidates = modelCandidates.flatMap(
       (modelId): CandidatePreparedPricingEntry[] => {
-        const logicalProvider = providerForPricingCandidate(modelId, params.provider);
-        const providerKeys = expandPersistedPricingProviderKeys(logicalProvider);
+        const logicalProvider = providerForPricingCandidate(
+          modelId,
+          params.provider,
+        );
+        const providerKeys =
+          expandPersistedPricingProviderKeys(logicalProvider);
         return allPersisted
-          .filter((row) => row.model === modelId && providerKeys.includes(row.provider))
+          .filter(
+            (row) =>
+              row.model === modelId && providerKeys.includes(row.provider),
+          )
           .map((entry) => ({
             entry: aiEntryToPrepared(entry),
             modelId,
@@ -1338,23 +1456,29 @@ async function resolvePreparedPricingEntry(params: {
     }
 
     const liveAll = await fetchEntriesForSource(source);
-    const liveCandidates = modelCandidates.flatMap((modelId): CandidatePreparedPricingEntry[] => {
-      const logicalProvider = providerForPricingCandidate(modelId, params.provider);
-      const providerKeys = expandPersistedPricingProviderKeys(logicalProvider);
-      return liveAll
-        .filter(
-          (entry) =>
-            entry.model === modelId &&
-            providerKeys.includes(entry.provider) &&
-            entry.productFamily === params.productFamily &&
-            entry.chargeType === params.chargeType,
-        )
-        .map((entry) => ({
-          entry,
+    const liveCandidates = modelCandidates.flatMap(
+      (modelId): CandidatePreparedPricingEntry[] => {
+        const logicalProvider = providerForPricingCandidate(
           modelId,
-          logicalProvider,
-        }));
-    });
+          params.provider,
+        );
+        const providerKeys =
+          expandPersistedPricingProviderKeys(logicalProvider);
+        return liveAll
+          .filter(
+            (entry) =>
+              entry.model === modelId &&
+              providerKeys.includes(entry.provider) &&
+              entry.productFamily === params.productFamily &&
+              entry.chargeType === params.chargeType,
+          )
+          .map((entry) => ({
+            entry,
+            modelId,
+            logicalProvider,
+          }));
+      },
+    );
 
     const bestLive = chooseBestCandidatePricingEntry(
       liveCandidates,
@@ -1380,7 +1504,10 @@ async function resolvePreparedPricingEntry(params: {
   );
 }
 
-function computeCostFromEntry(entry: PreparedPricingEntry, quantity: number): FlatOperationCost {
+function computeCostFromEntry(
+  entry: PreparedPricingEntry,
+  quantity: number,
+): FlatOperationCost {
   const baseCost = asDecimal(entry.unitPrice).mul(quantity);
   const markedUp = applyPlatformMarkup(baseCost);
 
@@ -1447,14 +1574,18 @@ export async function calculateTextCostFromCatalog(params: {
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily: params.model.includes("embedding")
+      ? "embedding"
+      : "language",
     chargeType: "input",
   });
   const outputEntry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider: params.provider,
     model: canonicalModel,
-    productFamily: params.model.includes("embedding") ? "embedding" : "language",
+    productFamily: params.model.includes("embedding")
+      ? "embedding"
+      : "language",
     chargeType: "output",
   }).catch(() => null);
 
@@ -1469,7 +1600,9 @@ export async function calculateTextCostFromCatalog(params: {
   return {
     inputCost: inputTotals.totalCost,
     outputCost: outputTotals.totalCost,
-    totalCost: decimalToMoney(asDecimal(inputTotals.totalCost).plus(outputTotals.totalCost)),
+    totalCost: decimalToMoney(
+      asDecimal(inputTotals.totalCost).plus(outputTotals.totalCost),
+    ),
     baseInputCost: inputTotals.baseTotalCost,
     baseOutputCost: outputTotals.baseTotalCost,
     baseTotalCost: decimalToMoney(baseInputCost.plus(baseOutputCost)),
@@ -1534,7 +1667,9 @@ export async function calculateMusicGenerationCostFromCatalog(params: {
 }): Promise<FlatOperationCost> {
   const definition = getSupportedMusicModelDefinition(params.model);
   const provider =
-    params.provider ?? definition?.provider ?? inferProviderFromCanonicalModel(params.model);
+    params.provider ??
+    definition?.provider ??
+    inferProviderFromCanonicalModel(params.model);
   const entry = await resolvePreparedPricingEntry({
     billingSource: params.billingSource,
     provider,
@@ -1547,7 +1682,8 @@ export async function calculateMusicGenerationCostFromCatalog(params: {
   return computeCostFromEntry(
     entry,
     quantityForEntryUnit(entry.unit, {
-      durationSeconds: params.durationSeconds ?? definition?.defaultParameters.durationSeconds,
+      durationSeconds:
+        params.durationSeconds ?? definition?.defaultParameters.durationSeconds,
       requests: 1,
     }),
   );
@@ -1746,9 +1882,13 @@ export async function refreshPricingCatalog(
 
   if (sources.includes("openrouter")) {
     results.push(
-      await refreshSourceEntries("openrouter", OPENROUTER_MODELS_URL, async () => {
-        return await fetchOpenRouterCatalogEntries();
-      }),
+      await refreshSourceEntries(
+        "openrouter",
+        OPENROUTER_MODELS_URL,
+        async () => {
+          return await fetchOpenRouterCatalogEntries();
+        },
+      ),
     );
   }
 
@@ -1762,25 +1902,37 @@ export async function refreshPricingCatalog(
 
   if (sources.includes("elevenlabs")) {
     results.push(
-      await refreshSourceEntries("elevenlabs", "https://elevenlabs.io/pricing/api", async () => {
-        return await fetchElevenLabsEntries();
-      }),
+      await refreshSourceEntries(
+        "elevenlabs",
+        "https://elevenlabs.io/pricing/api",
+        async () => {
+          return await fetchElevenLabsEntries();
+        },
+      ),
     );
   }
 
   if (sources.includes("suno")) {
     results.push(
-      await refreshSourceEntries("suno", "https://docs.sunoapi.org/suno-api/", async () => {
-        return await fetchSunoEntries();
-      }),
+      await refreshSourceEntries(
+        "suno",
+        "https://docs.sunoapi.org/suno-api/",
+        async () => {
+          return await fetchSunoEntries();
+        },
+      ),
     );
   }
 
   if (sources.includes("vast")) {
     results.push(
-      await refreshSourceEntries("vast", "internal://vast/pricing", async () => {
-        return await fetchVastSnapshotEntries();
-      }),
+      await refreshSourceEntries(
+        "vast",
+        "internal://vast/pricing",
+        async () => {
+          return await fetchVastSnapshotEntries();
+        },
+      ),
     );
   }
 
@@ -1801,7 +1953,9 @@ export async function listPersistedPricingEntries(filters?: {
   const entries = await aiPricingRepository.listActiveEntries({
     billingSource: filters?.billingSource,
     provider: filters?.provider,
-    model: filters?.model ? canonicalModelId(filters.model, filters.provider) : undefined,
+    model: filters?.model
+      ? canonicalModelId(filters.model, filters.provider)
+      : undefined,
     productFamily: filters?.productFamily,
     chargeType: filters?.chargeType,
   });

--- a/cloud/packages/lib/services/ai-pricing.ts
+++ b/cloud/packages/lib/services/ai-pricing.ts
@@ -349,46 +349,109 @@ function inferOpenRouterProductFamily(model: OpenRouterCatalogModel): PricingPro
   return "language";
 }
 
-function buildOpenRouterPreparedEntries(model: OpenRouterCatalogModel): PreparedPricingEntry[] {
+/**
+ * Strips a versioned snapshot suffix from a model id when the suffix looks
+ * unambiguous: dated (`-20240605`, `-2024-06-05`), labeled (`-latest`,
+ * `-preview`, `-beta`), or numeric (`-001`, `-1234`).
+ *
+ * **Why:** OpenRouter's catalog lists models under their snapshot ids
+ * (`google/gemini-2.0-flash-001`, `openai/gpt-4o-2024-11-20`) while clients
+ * routinely send the unsuffixed canonical id (`google/gemini-2.0-flash`,
+ * `openai/gpt-4o`). Without a second index entry under the base id, pricing
+ * lookup throws "Pricing unavailable" even though the inference call itself
+ * succeeds at OpenRouter (which performs its own alias resolution).
+ *
+ * **Numeric-suffix safety rail:** for `-NNN` patterns we require at least two
+ * dash-separated segments to remain after the slash so `openai/gpt-4` does not
+ * collapse to `openai/gpt`. Date and labelled suffixes are unambiguous so
+ * `openai/o1-2024-12-17` still strips to `openai/o1`.
+ *
+ * Returns the stripped id, or `null` if no rule applies or the result would be
+ * degenerate (empty, or just a `provider/` prefix).
+ */
+export function stripVersionedSnapshotSuffix(modelId: string): string | null {
+  const datedOrLabelledPatterns = [
+    /-\d{4}-\d{2}-\d{2}$/, // ISO date: -2024-06-05
+    /-\d{8}$/, // compact date: -20240605
+    /-latest$/,
+    /-preview$/,
+    /-beta$/,
+  ];
+
+  for (const pattern of datedOrLabelledPatterns) {
+    if (!pattern.test(modelId)) continue;
+    const stripped = modelId.replace(pattern, "");
+    if (stripped.length === 0 || stripped.endsWith("/")) return null;
+    return stripped;
+  }
+
+  const numericPattern = /-\d{1,4}$/;
+  if (numericPattern.test(modelId)) {
+    const stripped = modelId.replace(numericPattern, "");
+    if (stripped.length === 0 || stripped.endsWith("/")) return null;
+    const slashIdx = stripped.indexOf("/");
+    const afterSlash = slashIdx === -1 ? stripped : stripped.slice(slashIdx + 1);
+    if (afterSlash.split("-").length < 2) return null;
+    return stripped;
+  }
+
+  return null;
+}
+
+/**
+ * Builds pricing entries from a single OpenRouter catalog row.
+ *
+ * For each (input/output) price we emit the exact-id row at default priority
+ * and — when `stripVersionedSnapshotSuffix` produces a base id — a duplicate
+ * row at `priority: -1` so lookups for the unsuffixed canonical id resolve.
+ * The exact match still wins via `chooseBestCandidatePricingEntry`'s priority
+ * tie-break when both forms are requested.
+ */
+export function buildOpenRouterPreparedEntries(
+  model: OpenRouterCatalogModel,
+): PreparedPricingEntry[] {
   const pricing = model.pricing ?? {};
   const provider = inferProviderFromCanonicalModel(model.id);
   const productFamily = inferOpenRouterProductFamily(model);
   const fetchedAt = new Date();
   const staleAfter = new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS);
-  const entries: PreparedPricingEntry[] = [];
+  const baseId = stripVersionedSnapshotSuffix(model.id);
 
+  const buildEntry = (
+    modelId: string,
+    chargeType: "input" | "output",
+    unitPrice: number,
+    priority?: number,
+  ): PreparedPricingEntry => ({
+    billingSource: "openrouter",
+    provider,
+    model: modelId,
+    productFamily,
+    chargeType,
+    unit: "token",
+    unitPrice,
+    sourceKind: "openrouter_catalog",
+    sourceUrl: OPENROUTER_MODELS_URL,
+    fetchedAt,
+    staleAfter,
+    ...(priority !== undefined ? { priority } : {}),
+  });
+
+  const entries: PreparedPricingEntry[] = [];
   const promptPrice = parseNumericPrice(pricing.prompt);
   if (promptPrice != null) {
-    entries.push({
-      billingSource: "openrouter",
-      provider,
-      model: model.id,
-      productFamily,
-      chargeType: "input",
-      unit: "token",
-      unitPrice: promptPrice,
-      sourceKind: "openrouter_catalog",
-      sourceUrl: OPENROUTER_MODELS_URL,
-      fetchedAt,
-      staleAfter,
-    });
+    entries.push(buildEntry(model.id, "input", promptPrice));
+    if (baseId !== null && baseId !== model.id) {
+      entries.push(buildEntry(baseId, "input", promptPrice, -1));
+    }
   }
 
   const completionPrice = parseNumericPrice(pricing.completion);
   if (completionPrice != null) {
-    entries.push({
-      billingSource: "openrouter",
-      provider,
-      model: model.id,
-      productFamily,
-      chargeType: "output",
-      unit: "token",
-      unitPrice: completionPrice,
-      sourceKind: "openrouter_catalog",
-      sourceUrl: OPENROUTER_MODELS_URL,
-      fetchedAt,
-      staleAfter,
-    });
+    entries.push(buildEntry(model.id, "output", completionPrice));
+    if (baseId !== null && baseId !== model.id) {
+      entries.push(buildEntry(baseId, "output", completionPrice, -1));
+    }
   }
 
   return entries;
@@ -973,7 +1036,9 @@ function parseVastPricingOverrides(): Record<string, { input: number; output: nu
         const input = Number(value?.input);
         const output = Number(value?.output);
         if (!Number.isFinite(input) || !Number.isFinite(output) || input < 0 || output < 0) {
-          logger.warn("ai-pricing: ignoring invalid Vast pricing override", { model });
+          logger.warn("ai-pricing: ignoring invalid Vast pricing override", {
+            model,
+          });
           return [];
         }
         return [[model, { input, output }]];

--- a/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
+++ b/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Catalog-time variant indexing: OpenRouter lists models under snapshot ids
+ * (e.g. `google/gemini-2.0-flash-001`) but clients send the unsuffixed
+ * canonical id. The ingest now emits a low-priority duplicate row under the
+ * stripped base id so lookups for the canonical id resolve without
+ * maintaining a hand-curated alias map.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildOpenRouterPreparedEntries,
+  stripVersionedSnapshotSuffix,
+} from "@/lib/services/ai-pricing";
+
+describe("stripVersionedSnapshotSuffix — dated and labelled suffixes", () => {
+  test("strips compact 8-digit date suffix", () => {
+    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku-20241022")).toBe(
+      "anthropic/claude-3-5-haiku",
+    );
+  });
+
+  test("strips ISO date suffix", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe("openai/gpt-4o");
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-08-06")).toBe("openai/gpt-4o");
+  });
+
+  test("strips -latest label", () => {
+    expect(stripVersionedSnapshotSuffix("anthropic/claude-haiku-latest")).toBe(
+      "anthropic/claude-haiku",
+    );
+  });
+
+  test("strips -preview label", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-search-preview")).toBe(
+      "openai/gpt-4o-search",
+    );
+  });
+
+  test("strips -beta label", () => {
+    expect(stripVersionedSnapshotSuffix("openai/o1-beta")).toBe("openai/o1");
+  });
+
+  test("dated suffix bypasses the 2-segment safety check for short bases", () => {
+    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe("openai/o1");
+  });
+});
+
+describe("stripVersionedSnapshotSuffix — numeric snapshot suffixes", () => {
+  test("strips -001 numeric snapshot", () => {
+    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-001")).toBe(
+      "google/gemini-2.0-flash",
+    );
+    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-lite-001")).toBe(
+      "google/gemini-2.0-flash-lite",
+    );
+  });
+
+  test("strips multi-digit numeric snapshot when two+ segments remain", () => {
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-1234")).toBe("vendor/family-name");
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-99")).toBe("vendor/family-name");
+  });
+
+  test("does NOT strip when result would collapse to one segment after slash", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("vendor/model-1234")).toBeNull();
+  });
+});
+
+describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
+  test("returns null when no suffix pattern matches", () => {
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-mini")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("google/gemini-2.5-flash")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o")).toBeNull();
+  });
+
+  test("returns null when stripping would empty the id", () => {
+    expect(stripVersionedSnapshotSuffix("001")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("latest")).toBeNull();
+  });
+
+  test("returns null when stripping would leave just a provider prefix", () => {
+    expect(stripVersionedSnapshotSuffix("openai/123")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("anthropic/latest")).toBeNull();
+  });
+
+  test("returns null for ids without dash-version markers", () => {
+    expect(stripVersionedSnapshotSuffix("openai")).toBeNull();
+    expect(stripVersionedSnapshotSuffix("anthropic/")).toBeNull();
+  });
+});
+
+describe("buildOpenRouterPreparedEntries — exact + stripped variants", () => {
+  test("emits both exact and stripped rows for prompt and completion", () => {
+    const entries = buildOpenRouterPreparedEntries({
+      id: "google/gemini-2.0-flash-001",
+      architecture: {
+        modality: "text->text",
+        input_modalities: ["text"],
+        output_modalities: ["text"],
+      },
+      pricing: { prompt: "0.0000001", completion: "0.0000004" },
+    });
+
+    const inputEntries = entries.filter((e) => e.chargeType === "input");
+    const outputEntries = entries.filter((e) => e.chargeType === "output");
+
+    expect(inputEntries).toHaveLength(2);
+    expect(outputEntries).toHaveLength(2);
+
+    const exactInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
+    const strippedInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    expect(exactInput?.priority).toBeUndefined();
+    expect(strippedInput?.priority).toBe(-1);
+    expect(exactInput?.unitPrice).toBe(strippedInput?.unitPrice);
+
+    const exactOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
+    const strippedOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    expect(exactOutput?.priority).toBeUndefined();
+    expect(strippedOutput?.priority).toBe(-1);
+    expect(exactOutput?.unitPrice).toBe(strippedOutput?.unitPrice);
+  });
+
+  test("emits only exact rows when no suffix can be stripped", () => {
+    const entries = buildOpenRouterPreparedEntries({
+      id: "openai/gpt-4o-mini",
+      architecture: { modality: "text->text" },
+      pricing: { prompt: "0.00000015", completion: "0.0000006" },
+    });
+
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.model === "openai/gpt-4o-mini")).toBe(true);
+    expect(entries.every((e) => e.priority === undefined)).toBe(true);
+  });
+
+  test("propagates provider, productFamily, billingSource on stripped row", () => {
+    const entries = buildOpenRouterPreparedEntries({
+      id: "anthropic/claude-3-5-haiku-20241022",
+      architecture: { modality: "text->text" },
+      pricing: { prompt: "0.0000008" },
+    });
+
+    const stripped = entries.find((e) => e.model === "anthropic/claude-3-5-haiku");
+    expect(stripped).toBeDefined();
+    expect(stripped?.provider).toBe("anthropic");
+    expect(stripped?.productFamily).toBe("language");
+    expect(stripped?.billingSource).toBe("openrouter");
+    expect(stripped?.sourceKind).toBe("openrouter_catalog");
+  });
+
+  test("does not emit stripped row when prices are missing", () => {
+    const entries = buildOpenRouterPreparedEntries({
+      id: "google/gemini-2.0-flash-001",
+      architecture: { modality: "text->text" },
+      pricing: {},
+    });
+
+    expect(entries).toHaveLength(0);
+  });
+
+  test("emits stripped row only for the priced direction (input-only)", () => {
+    const entries = buildOpenRouterPreparedEntries({
+      id: "google/gemini-2.0-flash-001",
+      architecture: { modality: "text->text" },
+      pricing: { prompt: "0.0000001" },
+    });
+
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.chargeType === "input")).toBe(true);
+    expect(entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority).toBe(-1);
+  });
+});

--- a/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
+++ b/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
@@ -15,14 +15,18 @@ import {
 
 describe("stripVersionedSnapshotSuffix — dated and labelled suffixes", () => {
   test("strips compact 8-digit date suffix", () => {
-    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku-20241022")).toBe(
-      "anthropic/claude-3-5-haiku",
-    );
+    expect(
+      stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku-20241022"),
+    ).toBe("anthropic/claude-3-5-haiku");
   });
 
   test("strips ISO date suffix", () => {
-    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe("openai/gpt-4o");
-    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-08-06")).toBe("openai/gpt-4o");
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe(
+      "openai/gpt-4o",
+    );
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-08-06")).toBe(
+      "openai/gpt-4o",
+    );
   });
 
   test("strips -latest label", () => {
@@ -42,7 +46,9 @@ describe("stripVersionedSnapshotSuffix — dated and labelled suffixes", () => {
   });
 
   test("dated suffix bypasses the 2-segment safety check for short bases", () => {
-    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe("openai/o1");
+    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe(
+      "openai/o1",
+    );
   });
 });
 
@@ -51,14 +57,18 @@ describe("stripVersionedSnapshotSuffix — numeric snapshot suffixes", () => {
     expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-001")).toBe(
       "google/gemini-2.0-flash",
     );
-    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-lite-001")).toBe(
-      "google/gemini-2.0-flash-lite",
-    );
+    expect(
+      stripVersionedSnapshotSuffix("google/gemini-2.0-flash-lite-001"),
+    ).toBe("google/gemini-2.0-flash-lite");
   });
 
   test("strips multi-digit numeric snapshot when two+ segments remain", () => {
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-1234")).toBe("vendor/family-name");
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-99")).toBe("vendor/family-name");
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-1234")).toBe(
+      "vendor/family-name",
+    );
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-99")).toBe(
+      "vendor/family-name",
+    );
   });
 
   test("does NOT strip when result would collapse to one segment after slash", () => {
@@ -70,7 +80,9 @@ describe("stripVersionedSnapshotSuffix — numeric snapshot suffixes", () => {
 describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
   test("returns null when no suffix pattern matches", () => {
     expect(stripVersionedSnapshotSuffix("openai/gpt-4o-mini")).toBeNull();
-    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku")).toBeNull();
+    expect(
+      stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku"),
+    ).toBeNull();
     expect(stripVersionedSnapshotSuffix("google/gemini-2.5-flash")).toBeNull();
     expect(stripVersionedSnapshotSuffix("openai/gpt-4o")).toBeNull();
   });
@@ -94,7 +106,9 @@ describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
     // A vendor suffix like -99000001 must not be silently stripped as a
     // compact date. Year-anchoring the compact-date pattern is what blocks
     // this: only -19YYMMDD / -20YYMMDD shapes are accepted as dates.
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-99000001")).toBeNull();
+    expect(
+      stripVersionedSnapshotSuffix("vendor/family-name-99000001"),
+    ).toBeNull();
   });
 
   test("accepts realistic compact-date suffixes for both 19xx and 20xx years", () => {
@@ -125,14 +139,22 @@ describe("buildOpenRouterPreparedEntries — exact + stripped variants", () => {
     expect(inputEntries).toHaveLength(2);
     expect(outputEntries).toHaveLength(2);
 
-    const exactInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
-    const strippedInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    const exactInput = inputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash-001",
+    );
+    const strippedInput = inputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash",
+    );
     expect(exactInput?.priority).toBeUndefined();
     expect(strippedInput?.priority).toBe(-1);
     expect(exactInput?.unitPrice).toBe(strippedInput?.unitPrice);
 
-    const exactOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
-    const strippedOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    const exactOutput = outputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash-001",
+    );
+    const strippedOutput = outputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash",
+    );
     expect(exactOutput?.priority).toBeUndefined();
     expect(strippedOutput?.priority).toBe(-1);
     expect(exactOutput?.unitPrice).toBe(strippedOutput?.unitPrice);
@@ -157,8 +179,11 @@ describe("buildOpenRouterPreparedEntries — exact + stripped variants", () => {
       pricing: { prompt: "0.0000008" },
     });
 
-    const stripped = entries.find((e) => e.model === "anthropic/claude-3-5-haiku");
-    expect(stripped).toBeDefined();
+    const stripped = entries.find(
+      (e) => e.model === "anthropic/claude-3-5-haiku",
+    );
+    expect(stripped?.model).toBe("anthropic/claude-3-5-haiku");
+    expect(stripped?.priority).toBe(-1);
     expect(stripped?.provider).toBe("anthropic");
     expect(stripped?.productFamily).toBe("language");
     expect(stripped?.billingSource).toBe("openrouter");
@@ -184,7 +209,9 @@ describe("buildOpenRouterPreparedEntries — exact + stripped variants", () => {
 
     expect(entries).toHaveLength(2);
     expect(entries.every((e) => e.chargeType === "input")).toBe(true);
-    expect(entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority).toBe(-1);
+    expect(
+      entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority,
+    ).toBe(-1);
   });
 });
 
@@ -239,8 +266,12 @@ describe("chooseBestCandidatePricingEntry — tie-break when stripped variants c
     const a = buildCandidate("google/gemini-2.0-flash-001", 0.0000001);
     const b = buildCandidate("google/gemini-2.0-flash-002", 0.0000001);
 
-    const winner = chooseBestCandidatePricingEntry([a, b], {}, "google/gemini-2.0-flash");
-    expect(winner).not.toBeNull();
+    const winner = chooseBestCandidatePricingEntry(
+      [a, b],
+      {},
+      "google/gemini-2.0-flash",
+    );
+    expect(winner?.entry.model).toBe("google/gemini-2.0-flash");
     expect(winner?.entry.unitPrice).toBe(0.0000001);
   });
 });

--- a/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
+++ b/cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildOpenRouterPreparedEntries,
+  chooseBestCandidatePricingEntry,
   stripVersionedSnapshotSuffix,
 } from "@/lib/services/ai-pricing";
 
@@ -87,6 +88,22 @@ describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
   test("returns null for ids without dash-version markers", () => {
     expect(stripVersionedSnapshotSuffix("openai")).toBeNull();
     expect(stripVersionedSnapshotSuffix("anthropic/")).toBeNull();
+  });
+
+  test("does NOT treat a non-date 8-digit run id as a date suffix", () => {
+    // A vendor suffix like -99000001 must not be silently stripped as a
+    // compact date. Year-anchoring the compact-date pattern is what blocks
+    // this: only -19YYMMDD / -20YYMMDD shapes are accepted as dates.
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-99000001")).toBeNull();
+  });
+
+  test("accepts realistic compact-date suffixes for both 19xx and 20xx years", () => {
+    expect(stripVersionedSnapshotSuffix("vendor/model-family-19991231")).toBe(
+      "vendor/model-family",
+    );
+    expect(stripVersionedSnapshotSuffix("vendor/model-family-20240605")).toBe(
+      "vendor/model-family",
+    );
   });
 });
 
@@ -168,5 +185,62 @@ describe("buildOpenRouterPreparedEntries — exact + stripped variants", () => {
     expect(entries).toHaveLength(2);
     expect(entries.every((e) => e.chargeType === "input")).toBe(true);
     expect(entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority).toBe(-1);
+  });
+});
+
+describe("chooseBestCandidatePricingEntry — tie-break when stripped variants conflict", () => {
+  function buildCandidate(snapshotId: string, unitPrice: number) {
+    return {
+      entry: {
+        billingSource: "openrouter" as const,
+        provider: "google",
+        model: "google/gemini-2.0-flash",
+        productFamily: "language" as const,
+        chargeType: "input",
+        unit: "token" as const,
+        unitPrice,
+        sourceKind: "openrouter_catalog",
+        sourceUrl: "https://openrouter.ai/api/v1/models",
+        priority: -1,
+        metadata: { snapshotId },
+      },
+      modelId: "google/gemini-2.0-flash",
+      logicalProvider: "google",
+    };
+  }
+
+  test("picks the higher unitPrice when two stripped snapshots collide", () => {
+    // Two snapshots strip to the same canonical id but list different
+    // prices. Without the unitPrice tie-break the winner is decided by input
+    // ordering, which is non-deterministic across catalog fetches and DB
+    // result orderings. Conservative billing: the higher price wins.
+    const cheap = buildCandidate("google/gemini-2.0-flash-001", 0.0000001);
+    const expensive = buildCandidate("google/gemini-2.0-flash-002", 0.00000015);
+
+    const cheapFirst = chooseBestCandidatePricingEntry(
+      [cheap, expensive],
+      {},
+      "google/gemini-2.0-flash",
+    );
+    expect(cheapFirst?.entry.unitPrice).toBe(0.00000015);
+
+    const expensiveFirst = chooseBestCandidatePricingEntry(
+      [expensive, cheap],
+      {},
+      "google/gemini-2.0-flash",
+    );
+    expect(expensiveFirst?.entry.unitPrice).toBe(0.00000015);
+  });
+
+  test("returns deterministic winner when both prices are equal", () => {
+    // Equal prices: localeCompare on modelId is the final tie-break, but
+    // since both rows share the same stripped modelId we still need a
+    // stable answer. The function must return a non-null match either way.
+    const a = buildCandidate("google/gemini-2.0-flash-001", 0.0000001);
+    const b = buildCandidate("google/gemini-2.0-flash-002", 0.0000001);
+
+    const winner = chooseBestCandidatePricingEntry([a, b], {}, "google/gemini-2.0-flash");
+    expect(winner).not.toBeNull();
+    expect(winner?.entry.unitPrice).toBe(0.0000001);
   });
 });


### PR DESCRIPTION
## Summary

`POST /api/v1/chat/completions` was returning 500 for several common model
ids (e.g. `google/gemini-2.0-flash`, `anthropic/claude-3-5-haiku-latest`,
`openai/gpt-4o-2024-11-20`) with the message:

> Pricing unavailable for language:input google/gemini-2.0-flash

The inference call to OpenRouter succeeded — the user was charged upstream
— but our local billing lookup threw and we returned 500 with no body.
Reported in #eliza-cloud channel today.

## Root cause

OpenRouter's `/api/v1/models` catalog lists models under their snapshot
ids:

- `google/gemini-2.0-flash-001` (not `google/gemini-2.0-flash`)
- `google/gemini-2.0-flash-lite-001`
- `openai/gpt-4o-2024-11-20`
- `anthropic/claude-3-5-haiku-20241022`

OpenRouter itself resolves the unsuffixed canonical id on its routing
layer so inference works. Our local pricing lookup, however, does an
exact-id match against the cached catalog and misses these aliases. The
existing `PRICING_MODEL_ALIASES` map covers a few hand-curated cases but
direction is sometimes wrong (e.g. `vertex/gemini-2.0-flash-001` →
`google/gemini-2.0-flash`, which doesn't help because the catalog only
has `-001`).

## Fix

Catalog-time variant indexing: when ingesting the OpenRouter catalog, for
each model whose id has a strippable versioned suffix, also emit a
duplicate priced row under the stripped base id at `priority: -1`.

`chooseBestCandidatePricingEntry` already sorts by `priority` desc so
exact matches always win when both forms exist; the stripped row only
matters when the client sends the canonical unsuffixed id.

Stripping rules (in `stripVersionedSnapshotSuffix`):
- Trailing 8-digit date `-YYYYMMDD`
- Trailing ISO date `-YYYY-MM-DD`
- Trailing `-latest`, `-preview`, `-beta`
- Trailing numeric snapshot `-NNN` (1-4 digits) **only when** the
  resulting basename has at least two dash-separated segments after the
  slash (so `openai/gpt-4` is NOT stripped to `openai/gpt`)

Date and labelled suffixes are unambiguous so they bypass the
2-segment safety rail (e.g. `openai/o1-2024-12-17` → `openai/o1`).

## Why dynamic > manual map

`PRICING_MODEL_ALIASES` requires a code change every time OpenRouter
adds a model variant or a provider rotates a date suffix. One ingest-time
helper covers Google, OpenAI, Anthropic, and any future provider following
the same convention.

`PRICING_MODEL_ALIASES` is **not** touched in this PR (cleanup of entries
now made redundant is left as a follow-up).

## Test plan

- Unit tests for `stripVersionedSnapshotSuffix`: dated, ISO-dated,
  labelled, numeric, all must-not-strip cases (gpt-4o-mini,
  claude-3-5-haiku without date, gpt-4 single-segment collapse).
- Unit tests for `buildOpenRouterPreparedEntries`: both exact and
  stripped rows emitted with correct priority; one-direction pricing
  (input-only) honoured; missing pricing → no rows; metadata
  propagation (provider, productFamily, billingSource, sourceKind).

```
SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test --preload \
  ./packages/tests/load-env.ts \
  packages/tests/unit/ai-pricing-variant-indexing.test.ts
# 18 pass, 0 fail, 43 expect() calls

bun run typecheck 2>&1 | grep -E "ai-pricing(\.ts|-variant-indexing\.test\.ts)"
# (empty — clean on touched files)

bun run lint:check
# Found 1 warning (pre-existing, unrelated)
```

## Post-deploy smoke

After merge to develop → CF Worker prod auto-deploy:

```
curl -X POST https://api.elizacloud.ai/api/v1/chat/completions \
  -H "Authorization: Bearer eliza_<your-key>" \
  -H "Content-Type: application/json" \
  -d '{"model":"google/gemini-2.0-flash","messages":[{"role":"user","content":"ping"}]}'
# expected: 200 with assistant reply, no "Pricing unavailable"
```

## Rollback

`git revert` of this commit. The change is purely additive at ingest;
exact-id rows are unchanged so nothing prior to this PR breaks.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 500 error on `POST /api/v1/chat/completions` for common unsuffixed model IDs (e.g. `google/gemini-2.0-flash`, `anthropic/claude-3-5-haiku-latest`) by adding catalog-time variant indexing: during OpenRouter catalog ingest, each snapshotted model ID (e.g. `-001`, `-20241022`) now also emits a duplicate low-priority (`-1`) row under its stripped base ID, so pricing lookup succeeds without a hand-curated alias map.

- **`stripVersionedSnapshotSuffix`** — new exported helper that strips dated (`-YYYYMMDD`, `-YYYY-MM-DD`), labelled (`-latest`, `-preview`, `-beta`), and numeric (`-NNN`) suffixes with a 2-segment safety rail to prevent `openai/gpt-4` collapsing to `openai/gpt`.
- **`buildOpenRouterPreparedEntries`** — refactored to emit both exact (default priority ≈ 175) and stripped (priority -1) rows per pricing direction; exact matches always win via `chooseBestCandidatePricingEntry`'s priority sort.
- **`chooseBestCandidatePricingEntry`** — now exported and gains a `unitPrice` descending tie-break after the provider-rank step, resolving the previously non-deterministic winner when two snapshots strip to the same canonical ID with different prices (conservative billing: higher price wins).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive at ingest time; existing exact-ID rows are unaffected and the new stripped rows only activate as fallbacks at priority -1.

Both new functions have clear, well-tested logic. The numeric-suffix safety rail correctly prevents degenerate collapses. The unitPrice tie-break makes previously non-deterministic same-canonical collisions deterministic. The two issues flagged in the prior review thread are both addressed. No regressions are expected on existing pricing paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/ai-pricing.ts | Adds stripVersionedSnapshotSuffix and catalog-time variant indexing in buildOpenRouterPreparedEntries; exports chooseBestCandidatePricingEntry with a deterministic unitPrice tie-break; all formatting changes are pure style (line-length). |
| cloud/packages/tests/unit/ai-pricing-variant-indexing.test.ts | New test file with 18 cases covering stripVersionedSnapshotSuffix (dated, compact, labelled, numeric, must-not-strip), buildOpenRouterPreparedEntries entry emission, and chooseBestCandidatePricingEntry price tie-break; coverage is thorough and well-structured. |

</details>

<sub>Reviews (3): Last reviewed commit: ["chore(cloud/ai-pricing): /clean pass — s..."](https://github.com/elizaos/eliza/commit/2f55db622243c658c95e66f23dcb5204cba0086b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32302220)</sub>

<!-- /greptile_comment -->