### PR TITLE
fix(cloud): shield agent-sandbox API keys from user dashboard

### DIFF
--- a/cloud/apps/api/v1/api-keys/[id]/regenerate/route.ts
+++ b/cloud/apps/api/v1/api-keys/[id]/regenerate/route.ts
@@ -5,8 +5,11 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { RateLimitPresets, rateLimit } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { apiKeysService } from "@/lib/services/api-keys";
+import {
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { ApiKeysService, apiKeysService } from "@/lib/services/api-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -25,8 +28,21 @@ app.post("/", async (c) => {
     if (existingKey.organization_id !== user.organization_id) {
       return c.json({ error: "Forbidden" }, 403);
     }
+    if (ApiKeysService.isAgentSandboxKey(existingKey)) {
+      return c.json(
+        {
+          error:
+            "This API key is managed by an agent sandbox and cannot be regenerated from the dashboard. Restart the agent to rotate its key.",
+        },
+        403,
+      );
+    }
 
-    const { key: newKey, hash: newHash, prefix: newPrefix } = apiKeysService.generateApiKey();
+    const {
+      key: newKey,
+      hash: newHash,
+      prefix: newPrefix,
+    } = apiKeysService.generateApiKey();
 
     const updatedKey = await apiKeysService.update(id, {
       key: newKey,
@@ -34,7 +50,8 @@ app.post("/", async (c) => {
       key_prefix: newPrefix,
       updated_at: new Date(),
     });
-    if (!updatedKey) return c.json({ error: "Failed to regenerate API key" }, 500);
+    if (!updatedKey)
+      return c.json({ error: "Failed to regenerate API key" }, 500);
 
     return c.json({
       apiKey: {

--- a/cloud/apps/api/v1/api-keys/[id]/route.ts
+++ b/cloud/apps/api/v1/api-keys/[id]/route.ts
@@ -7,8 +7,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { RateLimitPresets, rateLimit } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { apiKeysService } from "@/lib/services/api-keys";
+import {
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { ApiKeysService, apiKeysService } from "@/lib/services/api-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -17,6 +20,9 @@ import { updateApiKeySchema } from "../schemas";
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
+
+const AGENT_KEY_SHIELDED_MESSAGE =
+  "This API key is managed by an agent sandbox. Delete the agent to revoke this key.";
 
 app.delete("/", async (c) => {
   try {
@@ -28,6 +34,9 @@ app.delete("/", async (c) => {
     if (!existingKey) return c.json({ error: "API key not found" }, 404);
     if (existingKey.organization_id !== user.organization_id) {
       return c.json({ error: "Forbidden" }, 403);
+    }
+    if (ApiKeysService.isAgentSandboxKey(existingKey)) {
+      return c.json({ error: AGENT_KEY_SHIELDED_MESSAGE }, 403);
     }
 
     await apiKeysService.delete(id);
@@ -49,10 +58,19 @@ app.patch("/", async (c) => {
     if (existingKey.organization_id !== user.organization_id) {
       return c.json({ error: "Forbidden" }, 403);
     }
+    if (ApiKeysService.isAgentSandboxKey(existingKey)) {
+      return c.json({ error: AGENT_KEY_SHIELDED_MESSAGE }, 403);
+    }
 
     const body = await c.req.json();
-    const { name, description, permissions, rate_limit, is_active, expires_at } =
-      updateApiKeySchema.parse(body);
+    const {
+      name,
+      description,
+      permissions,
+      rate_limit,
+      is_active,
+      expires_at,
+    } = updateApiKeySchema.parse(body);
 
     const updatedKey = await apiKeysService.update(id, {
       ...(name !== undefined && { name }),

--- a/cloud/apps/api/v1/api-keys/route.ts
+++ b/cloud/apps/api/v1/api-keys/route.ts
@@ -9,8 +9,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
-import { RateLimitPresets, rateLimit } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { apiKeysService } from "@/lib/services/api-keys";
+import {
+  RateLimitPresets,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { ApiKeysService, apiKeysService } from "@/lib/services/api-keys";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -42,7 +45,13 @@ app.get("/", async (c) => {
   try {
     const user = await requireUserWithOrg(c);
     const keys = await apiKeysService.listByOrganization(user.organization_id);
-    return c.json({ keys: keys.map(toClientApiKey) });
+    // Sandbox-managed keys (name prefix `agent-sandbox:`) are lifecycle-owned
+    // by the provisioner and must not surface in the user dashboard — see
+    // ApiKeysService.isAgentSandboxKey for the rationale.
+    const visibleKeys = keys.filter(
+      (key) => !ApiKeysService.isAgentSandboxKey(key),
+    );
+    return c.json({ keys: visibleKeys.map(toClientApiKey) });
   } catch (error) {
     logger.error("Error fetching API keys:", error);
     return failureResponse(c, error);

--- a/cloud/packages/lib/services/api-keys.ts
+++ b/cloud/packages/lib/services/api-keys.ts
@@ -5,13 +5,18 @@
  */
 
 import crypto from "crypto";
-import { type ApiKey, apiKeysRepository, type NewApiKey } from "@/db/repositories";
+import {
+  type ApiKey,
+  apiKeysRepository,
+  type NewApiKey,
+} from "@/db/repositories";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
 import { API_KEY_PREFIX_LENGTH } from "@/lib/pricing";
 import { logger } from "@/lib/utils/logger";
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function isUuid(value: unknown): value is string {
   return typeof value === "string" && UUID_RE.test(value);
@@ -46,7 +51,10 @@ const API_KEY_NEGATIVE_TTL_SECONDS = 60;
 function isNegativeApiKeySentinel(value: unknown): boolean {
   if (!value || typeof value !== "object") return false;
   const marker = Object.getOwnPropertyDescriptor(value, "__none");
-  return marker !== undefined && Object.is(marker.value, API_KEY_NEGATIVE_SENTINEL.__none);
+  return (
+    marker !== undefined &&
+    Object.is(marker.value, API_KEY_NEGATIVE_SENTINEL.__none)
+  );
 }
 
 /**
@@ -122,7 +130,11 @@ export class ApiKeysService {
     // Negative cache: prevent a flood of bad keys from hammering the DB.
     // Short TTL so a freshly-created key isn't blocked by a stale negative entry
     // from a recent typo'd attempt.
-    await cache.set(cacheKey, API_KEY_NEGATIVE_SENTINEL, API_KEY_NEGATIVE_TTL_SECONDS);
+    await cache.set(
+      cacheKey,
+      API_KEY_NEGATIVE_SENTINEL,
+      API_KEY_NEGATIVE_TTL_SECONDS,
+    );
     return null;
   }
 
@@ -169,7 +181,9 @@ export class ApiKeysService {
     return await apiKeysRepository.listByOrganization(organizationId);
   }
 
-  async create(data: Omit<NewApiKey, "key" | "key_hash" | "key_prefix">): Promise<{
+  async create(
+    data: Omit<NewApiKey, "key" | "key_hash" | "key_prefix">,
+  ): Promise<{
     apiKey: ApiKey;
     plainKey: string;
   }> {
@@ -188,7 +202,10 @@ export class ApiKeysService {
     };
   }
 
-  async update(id: string, data: Partial<NewApiKey>): Promise<ApiKey | undefined> {
+  async update(
+    id: string,
+    data: Partial<NewApiKey>,
+  ): Promise<ApiKey | undefined> {
     // Get the key first to invalidate cache
     const existing = await apiKeysRepository.findById(id);
     if (existing) {
@@ -213,7 +230,10 @@ export class ApiKeysService {
   }
 
   async deactivateUserKeysByName(userId: string, name: string): Promise<void> {
-    const existingKeys = await apiKeysRepository.findByUserAndName(userId, name);
+    const existingKeys = await apiKeysRepository.findByUserAndName(
+      userId,
+      name,
+    );
 
     for (const key of existingKeys) {
       await this.invalidateCache(key.key_hash);
@@ -224,8 +244,22 @@ export class ApiKeysService {
 
   // Sandbox-scoped keys are named "agent-sandbox:<id>". Listing/revoking by that
   // canonical name is enough — no need for a separate metadata column today.
+  static readonly AGENT_KEY_NAME_PREFIX = "agent-sandbox:";
+
   private static agentApiKeyName(agentSandboxId: string): string {
-    return `agent-sandbox:${agentSandboxId}`;
+    return `${ApiKeysService.AGENT_KEY_NAME_PREFIX}${agentSandboxId}`;
+  }
+
+  /**
+   * Returns true when `name` identifies a sandbox-scoped key. These keys are
+   * lifecycle-managed by the provisioner (`createForAgent` /
+   * `revokeForAgent`) and must never appear in the user-facing API key list
+   * nor be mutable from the user dashboard — otherwise a user could delete a
+   * key their own running agent depends on and break inference until the
+   * sandbox is re-provisioned.
+   */
+  static isAgentSandboxKey(key: Pick<ApiKey, "name">): boolean {
+    return key.name.startsWith(ApiKeysService.AGENT_KEY_NAME_PREFIX);
   }
 
   async createForAgent(params: {

--- a/cloud/packages/tests/unit/agent-sandbox-keys-shielded.test.ts
+++ b/cloud/packages/tests/unit/agent-sandbox-keys-shielded.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Sandbox-scoped API keys (name prefix `agent-sandbox:`) are lifecycle-owned
+ * by the provisioner (`createForAgent` / `revokeForAgent`). They must never
+ * appear in the user-facing API key list, and the dashboard delete /
+ * regenerate / patch endpoints must refuse to act on them. Otherwise a user
+ * could revoke a key their own running agent depends on, breaking inference
+ * until the sandbox is re-provisioned.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { ApiKey } from "@/db/repositories";
+import { ApiKeysService } from "@/lib/services/api-keys";
+
+function buildKey(name: string): ApiKey {
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    name,
+    description: null,
+    key: "eliza_secret",
+    key_hash: "hash",
+    key_prefix: "eliza_se",
+    organization_id: "11111111-1111-4111-8111-111111111111",
+    user_id: "22222222-2222-4222-8222-222222222222",
+    permissions: [],
+    rate_limit: 1000,
+    is_active: true,
+    usage_count: 0,
+    expires_at: null,
+    last_used_at: null,
+    created_at: new Date("2026-01-01T00:00:00Z"),
+    updated_at: new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+describe("ApiKeysService.isAgentSandboxKey", () => {
+  test("returns true for the canonical sandbox name shape", () => {
+    expect(
+      ApiKeysService.isAgentSandboxKey(
+        buildKey("agent-sandbox:c7088b34-2b4b-41de-91a8-e69a1a4b8622"),
+      ),
+    ).toBe(true);
+  });
+
+  test("returns false for user-created keys with descriptive names", () => {
+    expect(
+      ApiKeysService.isAgentSandboxKey(buildKey("My Production Key")),
+    ).toBe(false);
+    expect(ApiKeysService.isAgentSandboxKey(buildKey("CI"))).toBe(false);
+    expect(ApiKeysService.isAgentSandboxKey(buildKey("explorer"))).toBe(false);
+  });
+
+  test("does not match when the prefix appears mid-string", () => {
+    expect(
+      ApiKeysService.isAgentSandboxKey(buildKey("my-agent-sandbox:foo")),
+    ).toBe(false);
+  });
+
+  test("matches the bare prefix (defensive — provisioner always appends an id)", () => {
+    // Prefix-only is a malformed name we should still treat as sandbox-owned
+    // so a corrupted row cannot be deleted from the dashboard.
+    expect(ApiKeysService.isAgentSandboxKey(buildKey("agent-sandbox:"))).toBe(
+      true,
+    );
+  });
+
+  test("AGENT_KEY_NAME_PREFIX constant is the static source of truth", () => {
+    expect(ApiKeysService.AGENT_KEY_NAME_PREFIX).toBe("agent-sandbox:");
+  });
+});
+
+describe("Agent sandbox keys excluded from dashboard listing", () => {
+  test("filter drops every key whose name starts with the sandbox prefix", () => {
+    const userKeyA = buildKey("My Production Key");
+    const userKeyB = buildKey("CI");
+    const sandboxKeyA = buildKey(
+      "agent-sandbox:c7088b34-2b4b-41de-91a8-e69a1a4b8622",
+    );
+    const sandboxKeyB = buildKey(
+      "agent-sandbox:5710d11d-aaaa-bbbb-cccc-dddddddddddd",
+    );
+
+    const stored = [userKeyA, sandboxKeyA, userKeyB, sandboxKeyB];
+    const visible = stored.filter(
+      (key) => !ApiKeysService.isAgentSandboxKey(key),
+    );
+
+    expect(visible).toEqual([userKeyA, userKeyB]);
+  });
+
+  test("filter is a no-op when no sandbox keys exist", () => {
+    const stored = [buildKey("My Production Key"), buildKey("CI")];
+    const visible = stored.filter(
+      (key) => !ApiKeysService.isAgentSandboxKey(key),
+    );
+    expect(visible).toEqual(stored);
+  });
+
+  test("filter returns empty array when every key is sandbox-managed", () => {
+    const stored = [
+      buildKey("agent-sandbox:c7088b34-2b4b-41de-91a8-e69a1a4b8622"),
+      buildKey("agent-sandbox:5710d11d-aaaa-bbbb-cccc-dddddddddddd"),
+    ];
+    const visible = stored.filter(
+      (key) => !ApiKeysService.isAgentSandboxKey(key),
+    );
+    expect(visible).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Per-agent API keys (name prefix \`agent-sandbox:<sandbox-id>\`) minted by the provisioner share the same \`api_keys\` table, \`organization_id\`, and \`user_id\` as user-created keys. Before this PR, the dashboard surfaced them with no marker and no protection: a user clicking "delete" on what looked like an unknown key would silently revoke their own agent's \`ELIZAOS_CLOUD_API_KEY\`, breaking inference until the next provisioning cycle.

## Why

These keys are lifecycle-owned by the provisioner (\`createForAgent\` mints, \`revokeForAgent\` revokes at sandbox delete time). The dashboard must treat them as read-only — invisible in the list, refused on delete/regenerate/patch.

## Changes

| Surface | Behaviour before | Behaviour after |
|---|---|---|
| \`GET /api/v1/api-keys\` | Returns all keys including \`agent-sandbox:*\` | Filters out sandbox-managed keys |
| \`DELETE /api/v1/api-keys/:id\` | Deletes any org-owned key | 403 with message *"This API key is managed by an agent sandbox. Delete the agent to revoke this key."* for sandbox keys |
| \`PATCH /api/v1/api-keys/:id\` | Patches any org-owned key | Same 403 guard |
| \`POST /api/v1/api-keys/:id/regenerate\` | Regenerates any org-owned key | 403 with *"This API key is managed by an agent sandbox and cannot be regenerated from the dashboard. Restart the agent to rotate its key."* |

The provisioner path (\`createForAgent\`, \`revokeForAgent\`) is unchanged — sandbox key creation and cleanup work as before.

## Source of truth

\`ApiKeysService.AGENT_KEY_NAME_PREFIX\` is now a static (\`"agent-sandbox:"\`) and \`ApiKeysService.isAgentSandboxKey(key)\` is the single check used by every shielded endpoint.

## Test plan

\`cloud/packages/tests/unit/agent-sandbox-keys-shielded.test.ts\` covers:

- \`isAgentSandboxKey\` returns true for \`agent-sandbox:<uuid>\` and the bare prefix.
- Returns false for user names, including names where the prefix appears mid-string (\`my-agent-sandbox:foo\` → false).
- \`AGENT_KEY_NAME_PREFIX\` constant is asserted.
- Filter excludes every prefixed key; is a no-op when there are none; returns empty when every key is sandbox-managed.

\`\`\`
SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test --preload \\
  ./packages/tests/load-env.ts \\
  packages/tests/unit/agent-sandbox-keys-shielded.test.ts
# 8 pass, 0 fail, 10 expect() calls

bun run typecheck 2>&1 | grep -E "(api-keys|agent-sandbox-keys-shielded)"
# (empty)
\`\`\`

## Rollback

\`git revert\` of this commit. The provisioner path is untouched, so sandbox keys will continue to work; reverting only restores the prior dashboard exposure of those keys.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR shields agent-provisioned API keys (name prefix `agent-sandbox:`) from the user dashboard: the `GET` list filters them out, and `DELETE`, `PATCH`, and `POST .../regenerate` return 403 when a sandbox key is targeted. The central abstraction (`ApiKeysService.isAgentSandboxKey` / `AGENT_KEY_NAME_PREFIX`) is clean and the provisioner path is untouched.

- `ApiKeysService` gains a `static readonly AGENT_KEY_NAME_PREFIX` and `static isAgentSandboxKey(key)` used by all three route files as the single guard.
- `GET /api/v1/api-keys` filters sandbox keys before serialisation; `DELETE`, `PATCH`, and `POST .../regenerate` return 403 with descriptive messages when the target is a sandbox key.
- The unit tests cover the helper and the filter, but the `POST /api/v1/api-keys` creation path and the `PATCH` rename path do not yet block users from adopting the reserved `agent-sandbox:` name prefix, which would make those keys invisible and unrevocable from the dashboard.

<h3>Confidence Score: 3/5</h3>

The shielding logic for existing sandbox keys is correct, but two write paths — key creation and key rename — can introduce user-owned keys into the sandbox namespace, making them immediately invisible in the dashboard and blocking all dashboard-side revocation.

The POST /api/v1/api-keys and PATCH /api/v1/api-keys/:id handlers both allow a user to adopt the agent-sandbox: name prefix. Once a key carries that prefix it drops off the dashboard list and every mutation endpoint rejects it with 403, leaving no in-product path to revoke an active key.

cloud/apps/api/v1/api-keys/route.ts (POST handler) and cloud/apps/api/v1/api-keys/[id]/route.ts (PATCH handler) both need a guard rejecting names that start with ApiKeysService.AGENT_KEY_NAME_PREFIX.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cloud/packages/lib/services/api-keys.ts | Adds AGENT_KEY_NAME_PREFIX static constant and isAgentSandboxKey helper as the canonical single check; agentApiKeyName now delegates to the constant. Logic is correct and well-documented. |
| cloud/apps/api/v1/api-keys/route.ts | GET correctly filters sandbox keys; POST is missing a guard that rejects names with the reserved prefix, allowing users to create permanently hidden, undeletable keys. |
| cloud/apps/api/v1/api-keys/[id]/route.ts | DELETE and PATCH correctly block sandbox keys, but PATCH does not prevent renaming a user key into the agent-sandbox: namespace, which causes the key to vanish from the dashboard and become unrevocable. |
| cloud/apps/api/v1/api-keys/[id]/regenerate/route.ts | Adds correct isAgentSandboxKey guard before the regeneration path; no issues. |
| cloud/packages/tests/unit/agent-sandbox-keys-shielded.test.ts | Good unit coverage for isAgentSandboxKey and the filter logic, including edge cases. Does not cover the POST/PATCH reservation-bypass scenarios identified above. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `cloud/apps/api/v1/api-keys/route.ts`, line 68-77 ([link](https://github.com/elizaos/eliza/blob/52fbcb19cc47f2b223c8d51c37d7a92a9e8d917d/cloud/apps/api/v1/api-keys/route.ts#L68-L77)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **User can mint a permanently hidden, undeletable API key**

   The `POST /api/v1/api-keys` handler does not reject names that start with `ApiKeysService.AGENT_KEY_NAME_PREFIX`. A user who creates a key named `agent-sandbox:anything` will have that key immediately filtered out of `GET /api/v1/api-keys` and refused at every dashboard mutation endpoint with a 403. The key remains active in the database and valid for authentication, but the owner has no dashboard path to revoke it. In a multi-member org this also provides a way to leave an active key off the visible audit list.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(cloud/api-keys): shield agent-sandbo..."](https://github.com/elizaos/eliza/commit/52fbcb19cc47f2b223c8d51c37d7a92a9e8d917d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32311222)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->