### PR TITLE
[codex] fix(shared): export default app config

### DIFF
--- a/packages/shared/src/config/app-config.ts
+++ b/packages/shared/src/config/app-config.ts
@@ -292,6 +292,34 @@ export interface AppConfig {
 }
 
 /**
+ * Framework default app configuration used by apps that do not provide a
+ * white-label `app.config.ts`. Forks can still override any field by shipping
+ * their own config through the app-core config loader.
+ */
+export const DEFAULT_APP_CONFIG: AppConfig = {
+  appName: "Eliza",
+  appId: "app.eliza",
+  orgName: "elizaos",
+  repoName: "eliza",
+  cliName: "eliza",
+  description: "Open-source AI agents for everyone",
+  branding: {},
+  envPrefix: "ELIZA",
+  namespace: "eliza",
+  defaultApps: ["@elizaos/plugin-lifeops"],
+  desktop: {
+    bundleId: "app.eliza",
+    urlScheme: "elizaos",
+  },
+  web: {
+    shortName: "Eliza",
+    themeColor: "#08080a",
+    backgroundColor: "#0a0a0a",
+    shareImagePath: "/og-image.png",
+  },
+};
+
+/**
  * Resolve a full BrandingConfig from an AppConfig.
  * Merges app-specific overrides with the framework defaults.
  */


### PR DESCRIPTION
## What

Exports a `DEFAULT_APP_CONFIG` from `@elizaos/shared` so app/runtime config consumers have a framework default when a white-label app does not provide its own `app.config.ts`.

## Why

The current Android local-source APK build imports `DEFAULT_APP_CONFIG` through the app config path. After syncing to the latest tree, `@elizaos/shared` exported the app config types/helpers but not the default object, so the production bundle failed at build time instead of falling back to the base Eliza branding/config.

## Impact

This is a package-boundary fix only. White-label apps can still override fields through their own app config; this just restores the default Eliza config for consumers that need a concrete fallback.

## Validation

- `bun run --cwd packages/shared build`
- Also validated in the Android APK integration workspace where the missing export was the blocker before the full debug APK build could proceed.
