### PR TITLE
fix(orchestrator): harden gpt-oss opencode follow-up routing

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -396,9 +396,12 @@ describe("runV5MessageRuntimeStage1", () => {
 
 	it("executes an umbrella action directly when the planner supplies its dispatcher enum", async () => {
 		const runtime = makeRuntime([
-			"",
-			"",
-			"",
+			stage1Response({
+				thought: "A coding task should be delegated.",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS"],
+				extra: { requiresTool: true },
+			}),
 			{
 				thought: "A coding task should be delegated.",
 				toolCalls: [
@@ -489,8 +492,6 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(parentHandler).toHaveBeenCalledTimes(1);
 		expect(childHandler).not.toHaveBeenCalled();
 		expect(useModelCalls(runtime).map((call) => call[0])).toEqual([
-			ModelType.RESPONSE_HANDLER,
-			ModelType.RESPONSE_HANDLER,
 			ModelType.RESPONSE_HANDLER,
 			ModelType.ACTION_PLANNER,
 		]);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -799,6 +799,7 @@ const CORE_RESPONSE_STATE_PROVIDERS = [
 	"ATTACHMENTS",
 	"PLATFORM_CHAT_CONTEXT",
 	"PLATFORM_USER_CONTEXT",
+	"RUNTIME_MODEL_CONTEXT",
 	// CURRENT_TIME is dynamic and would otherwise be filtered out before
 	// reaching the response handler. The wall-clock time is a baseline
 	// signal for nearly every routing decision (scheduling, freshness of
@@ -1583,11 +1584,15 @@ function appendPriorDialogueEvents(
 			if (!memory || typeof memory !== "object") return false;
 			const m = memory as Memory;
 			if (m.id && currentMessage.id && m.id === currentMessage.id) return false;
+			if (m.entityId === runtime.agentId || m.agentId === runtime.agentId) {
+				return false;
+			}
 			const contentType =
 				m.content && typeof m.content === "object"
 					? (m.content as { type?: string }).type
 					: undefined;
 			if (contentType === "action_result") return false;
+			if (isSubAgentCompletionArtifact(m)) return false;
 			const text =
 				typeof m.content?.text === "string" ? m.content.text.trim() : "";
 			return text.length > 0;
@@ -1611,6 +1616,20 @@ function appendPriorDialogueEvents(
 			},
 		});
 	}
+}
+
+function isSubAgentCompletionArtifact(memory: Memory): boolean {
+	const content = memory.content;
+	if (!content || typeof content !== "object") return false;
+	const metadata =
+		content.metadata && typeof content.metadata === "object"
+			? (content.metadata as Record<string, unknown>)
+			: {};
+	if (metadata.subAgent === true) return true;
+	const source = typeof content.source === "string" ? content.source : "";
+	if (source.startsWith("acpx:sub-agent-router")) return true;
+	const text = typeof content.text === "string" ? content.text.trim() : "";
+	return text.startsWith("[sub-agent:");
 }
 
 function hasStructuredRecentMessagesProvider(state: State): boolean {
@@ -1656,6 +1675,7 @@ function getRecentConversationSearchText(
 			if (memory.id && currentMessage.id && memory.id === currentMessage.id) {
 				return false;
 			}
+			if (isSubAgentCompletionArtifact(memory)) return false;
 			return typeof memory.content?.text === "string";
 		})
 		.sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
@@ -2120,6 +2140,21 @@ async function createV5MessageContextObject(args: {
 			: []),
 	];
 	appendStateProviderEvents(events, args.state, renderExclusions);
+
+	if (hasStructuredRecentMessagesProvider(args.state)) {
+		events.push({
+			id: "prior-dialogue-policy",
+			type: "segment",
+			source: "message-service",
+			segment: {
+				id: "prior-dialogue-policy",
+				label: "system",
+				content:
+					"prior_dialogue_policy: Prior chat is context only. For current, latest, live, filesystem, runtime, build, deploy, or verification requests, use the current turn's tools/context instead of answering from prior tool results or stale sub-agent transcripts.",
+				stable: true,
+			},
+		});
+	}
 
 	appendPriorDialogueEvents(events, args.runtime, args.state, args.message);
 
@@ -2706,8 +2741,12 @@ export function messageHandlerFromFieldResult(
 	const replyTextRaw =
 		typeof result.replyText === "string" ? result.replyText : "";
 	const currentMessageText = runtimeContext?.messageText ?? "";
+	const hasRunnableCandidateAction = candidateActionsContainRunnableAction(
+		candidateActions,
+		runtimeContext,
+	);
 	const inferredAckCandidateActions =
-		candidateActions.length === 0 &&
+		!hasRunnableCandidateAction &&
 		hasAckOnlyActionableIntent(result, replyTextRaw, currentMessageText)
 			? inferAckIntentCandidateActions(
 					result,
@@ -2716,7 +2755,7 @@ export function messageHandlerFromFieldResult(
 				)
 			: [];
 	const inferredDirectCandidateActions =
-		candidateActions.length === 0 &&
+		!hasRunnableCandidateAction &&
 		inferredAckCandidateActions.length === 0 &&
 		currentMessageText.trim().length > 0
 			? inferDirectCurrentRequestCandidateActions(
@@ -2834,6 +2873,25 @@ export function messageHandlerFromFieldResult(
 	};
 }
 
+function candidateActionsContainRunnableAction(
+	candidateActions: readonly string[],
+	runtimeContext:
+		| {
+				actions: ReadonlyArray<Pick<Action, "name">>;
+		  }
+		| undefined,
+): boolean {
+	if (candidateActions.length === 0) return false;
+	if (!runtimeContext) return true;
+	return candidateActions.some((name) => {
+		const normalized = normalizeActionIdentifier(name);
+		if (canonicalPlannerControlActionName(normalized) !== null) return true;
+		return runtimeContext.actions.some(
+			(action) => normalizeActionIdentifier(action.name) === normalized,
+		);
+	});
+}
+
 const PLANNING_ACK_REPLIES = new Set([
 	"got it.",
 	"looking into it.",
@@ -2869,7 +2927,7 @@ function hasAckOnlyActionableIntent(
 	return (
 		looksLikeLocalShellRequest(actionText) ||
 		looksLikeWebSearchRequest(actionText) ||
-		looksLikeCodingDelegationRequest(actionText)
+		looksLikeCodingWorkRequest(actionText)
 	);
 }
 
@@ -2901,9 +2959,10 @@ function inferAckIntentCandidateActions(
 		const lookupAction = findWebLookupActionName(actions);
 		if (lookupAction) return [lookupAction];
 	}
-	if (looksLikeCodingDelegationRequest(actionText)) {
+	if (looksLikeCodingWorkRequest(actionText)) {
 		const codingAction = findAvailableActionName(actions, [
 			"TASKS",
+			"TASKS_SPAWN_AGENT",
 			"SPAWN_AGENT",
 			"START_CODING_TASK",
 			"CODE_TASK",
@@ -2934,9 +2993,10 @@ function inferDirectCurrentRequestCandidateActions(
 		const lookupAction = findWebLookupActionName(actions);
 		if (lookupAction) return [lookupAction];
 	}
-	if (looksLikeCodingDelegationRequest(messageText)) {
+	if (looksLikeCodingWorkRequest(messageText)) {
 		const codingAction = findAvailableActionName(actions, [
 			"TASKS",
+			"TASKS_SPAWN_AGENT",
 			"SPAWN_AGENT",
 			"START_CODING_TASK",
 			"CODE_TASK",
@@ -3543,7 +3603,11 @@ async function executeV5PlannedToolCall(
 		(candidate) => candidate.name === toolCall.name,
 	);
 
-	if (action && actionHasSubActions(action)) {
+	if (
+		action &&
+		actionHasSubActions(action) &&
+		!hasDispatcherActionParam(toolCall)
+	) {
 		const subResult = await runSubPlanner({
 			runtime: args.runtime as IAgentRuntime & PlannerRuntime,
 			action,
@@ -3567,6 +3631,11 @@ async function executeV5PlannedToolCall(
 		{ ...(args.executorOptions ?? {}), actions: executionActions },
 	);
 	return actionResultToPlannerToolResult(actionResult);
+}
+
+function hasDispatcherActionParam(toolCall: PlannerToolCall): boolean {
+	const action = toolCall.params?.action;
+	return typeof action === "string" && action.trim().length > 0;
 }
 
 export function subPlannerResultToPlannerToolResult(
@@ -5517,7 +5586,7 @@ function looksLikeWebSearchRequest(text: string): boolean {
 	return explicitlyAsksSearch || (asksCurrentInfo && mentionsMarketOrNews);
 }
 
-function looksLikeCodingDelegationRequest(text: string): boolean {
+function looksLikeCodingWorkRequest(text: string): boolean {
 	const normalized = text.toLowerCase();
 	if (!normalized.trim()) {
 		return false;
@@ -5535,23 +5604,14 @@ function looksLikeCodingDelegationRequest(text: string): boolean {
 		return false;
 	}
 
-	const asksDelegation =
-		/\b(?:spawn|delegate|use|start|ask|have)\b[\s\S]{0,80}\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b/iu.test(
-			normalized,
-		) ||
-		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
-			normalized,
-		);
-	if (!asksDelegation) return false;
-
-	const asksCodingWork =
+	return (
 		/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b[\s\S]{0,160}\b(?:app|site|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/iu.test(
 			normalized,
 		) ||
 		/\b(?:app|site|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b[\s\S]{0,160}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
 			normalized,
-		);
-	return asksCodingWork;
+		)
+	);
 }
 
 function quoteShellArg(value: string): string {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -403,7 +403,7 @@ describe("AcpService", () => {
     expect(result.response).toContain("[tool output: Read home usage]");
     expect(result.response).toContain("/home            387G");
     expect(result.response).not.toContain('"metadata"');
-    expect(taskCompletePayloads[0]?.response).toBe("done");
+    expect(taskCompletePayloads[0]?.response).toBe(result.response);
     expect(result.stopReason).toBe("end_turn");
     expect(events).toEqual(
       expect.arrayContaining([

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/resolve-spawn-workdir.test.ts
@@ -1,4 +1,5 @@
 import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveSpawnWorkdir } from "../../src/services/task-agent-routing.js";
 
@@ -16,13 +17,15 @@ describe("resolveSpawnWorkdir — explicit workdir fallback", () => {
   });
 
   it("ignores a typo'd explicit workdir that does not exist, falling back to cwd", () => {
-    // gpt-oss routinely emits paths like `/home/milody/...` — non-existent and
-    // un-creatable (mkdir under `/home` needs root). The guess must be dropped.
+    const missing = path.join(
+      os.tmpdir(),
+      "planner-workdir-typo-does-not-exist",
+    );
     const result = resolveSpawnWorkdir(
       undefined,
       NO_ROUTE_TASK,
       NO_ROUTE_TASK,
-      "/home/milody/projects/agent-home",
+      missing,
     );
     expect(result).toEqual({ workdir: process.cwd() });
   });
@@ -33,15 +36,18 @@ describe("resolveSpawnWorkdir — explicit workdir fallback", () => {
     ).toEqual({ workdir: process.cwd() });
   });
 
-  it("honours lockWorkdir even when the locked path does not exist", () => {
-    // `lockWorkdir` is the scaffold-aware opt-out (e.g. APP_CREATE dispatching
-    // into a freshly-scaffolded dir the caller is about to create) — it must
-    // bypass the existence check.
-    const locked = "/home/milody/projects/agent-home";
+  it("ignores a locked workdir that does not exist", () => {
+    // `lockWorkdir` is only trusted after a scaffold-aware caller has created
+    // the exact target directory. Planner-guessed typo paths must still fall
+    // through to route/default resolution.
+    const locked = path.join(
+      os.tmpdir(),
+      "planner-workdir-typo-does-not-exist",
+    );
     expect(
       resolveSpawnWorkdir(undefined, NO_ROUTE_TASK, NO_ROUTE_TASK, locked, {
         lockWorkdir: true,
       }),
-    ).toEqual({ workdir: locked });
+    ).toEqual({ workdir: process.cwd() });
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -12,6 +12,12 @@ import {
 const spawnOptions = { parameters: { action: "spawn_agent" } };
 
 describe("TASKS:spawn_agent", () => {
+  it("does not expose lockWorkdir to planner-generated tool calls", () => {
+    expect(
+      spawnAgentAction.parameters?.map((param) => param.name),
+    ).not.toContain("lockWorkdir");
+  });
+
   it("validates with explicit payload and a service available", async () => {
     expect(
       await spawnAgentAction.validate(

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -384,12 +384,32 @@ describe("subAgentCompletionResponseEvaluator", () => {
     });
   });
 
-  it("does not suppress incomplete build reports", async () => {
+  it("surfaces incomplete build reports without spawning another agent", async () => {
     const context = makeContext({
-      text: "[sub-agent: demo (opencode) — task_complete]\nDone: https://example.test/apps/demo/\n\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]",
+      text: "[sub-agent: demo (opencode) — task_complete]\nDone: https://example.test/apps/demo/\n\n[verification: the following URL(s) the sub-agent referenced are NOT reachable — do NOT tell the user the app is live]\n  - https://example.test/apps/demo/ → HTTP 404",
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "On it — spawning opencode sub-agent to handle your request.",
+          requiresTool: true,
+          candidateActions: ["TASKS_SPAWN_AGENT"],
+          parentActionHints: ["TASKS"],
+        },
+      },
     });
 
-    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(false);
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply:
+        "The sub-agent reported completion, but verification failed, so I am not treating the app as live yet.\nUnreachable URL(s):\n- https://example.test/apps/demo/ → HTTP 404",
+      debug: [
+        "sub-agent completion failed verification; surfacing failure without re-dispatch",
+      ],
+    });
   });
 
   it("does not handle non-completion sub-agent events", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -662,6 +662,76 @@ describe("SubAgentRouter", () => {
       expect(posted?.content?.text).not.toContain("[verification:");
     });
 
+    it("adds verified public route aliases when a completion only mentions loopback", async () => {
+      const tmpRoot = fs.mkdtempSync(
+        path.join(os.tmpdir(), "sub-agent-router-"),
+      );
+      try {
+        const localUrl = "http://127.0.0.1:6900/apps/tea-fortune/";
+        const publicUrl = "https://example.test/apps/tea-fortune/";
+        const appDir = path.join(tmpRoot, "data/apps/tea-fortune");
+        fs.mkdirSync(appDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(appDir, "index.html"),
+          "<html><body>tea fortunes</body></html>",
+        );
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+          const url = String(input);
+          if (url === localUrl || url === publicUrl) {
+            return new Response("<html><body>tea fortunes</body></html>", {
+              status: 200,
+              headers: { "content-type": "text/html" },
+            });
+          }
+          return new Response("not found", { status: 404 });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+        session = {
+          ...sessionWithTask(`build and verify ${publicUrl}`, undefined, {
+            workdirRoute: {
+              id: "static-apps",
+              workdir: tmpRoot,
+              urlMappings: [
+                {
+                  urlPrefix: "http://127.0.0.1:6900/apps/",
+                  localPath: "data/apps/",
+                },
+                {
+                  urlPrefix: "https://example.test/apps/",
+                  localPath: "data/apps/",
+                },
+              ],
+            },
+          }),
+          workdir: tmpRoot,
+        };
+        acp = makeAcpService(session);
+        const { runtime, handleMessage, spawnSession } = makeRuntime({
+          acp: acp.service,
+        });
+        await SubAgentRouter.start(runtime);
+
+        acp.emit(SESSION_ID, "task_complete", {
+          response: localUrl,
+        });
+        await new Promise((r) => setTimeout(r, 200));
+
+        const fetched = fetchMock.mock.calls.map(([url]) => String(url));
+        expect(fetched).toContain(localUrl);
+        expect(fetched).toContain(publicUrl);
+        expect(spawnSession).not.toHaveBeenCalled();
+        expect(handleMessage).toHaveBeenCalledTimes(1);
+        const posted = handleMessage.mock.calls[0]?.[1];
+        expect(posted?.content?.metadata?.subAgentVerifiedUrls).toEqual([
+          localUrl,
+          publicUrl,
+        ]);
+        expect(posted?.content?.text).not.toContain("[verification:");
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
     it("focuses verification on the referenced app route instead of header telemetry", async () => {
       const appBase = "https://nubilio.org/apps/cache-safe/";
       const styleUrl = `${appBase}style-v2.css`;

--- a/plugins/plugin-agent-orchestrator/src/__tests__/workdir-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/workdir-routes.test.ts
@@ -195,6 +195,23 @@ describe("resolveSpawnWorkdir", () => {
     expect(result.route).toBeUndefined();
   });
 
+  it("uses the route when lockWorkdir points at a missing planner-guessed path", () => {
+    process.env[ENV_KEY] = JSON.stringify([
+      { id: "static-apps", workdir: appsDir, matchAny: ["build"] },
+    ]);
+
+    const result = resolveSpawnWorkdir(
+      undefined,
+      "build me an app",
+      "build me an app",
+      path.join(tmpRoot, "planner-workdir-typo-does-not-exist"),
+      { lockWorkdir: true },
+    );
+
+    expect(result.workdir).toBe(appsDir);
+    expect(result.route?.id).toBe("static-apps");
+  });
+
   it("keeps the explicit workdir when it exists on disk and no route matches", () => {
     delete process.env[ENV_KEY];
     const fresh = path.join(tmpRoot, "fresh-scratch");

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2238,17 +2238,6 @@ export const tasksAction: Action & {
       schema: { type: "string" as const },
     },
     {
-      name: "lockWorkdir",
-      description:
-        "When true, the supplied `workdir` is used verbatim and operator " +
-        "workdir routes (TASK_AGENT_WORKDIR_ROUTES) are NOT consulted. Set " +
-        "this only from scaffold-aware callers that have already created " +
-        "the exact target directory (e.g. APP_CREATE). Leave unset for " +
-        "normal planner spawns so routes can correct guessed paths.",
-      required: false,
-      schema: { type: "boolean" as const },
-    },
-    {
       name: "memoryContent",
       description:
         "Additional memory/context for action=create / action=spawn_agent.",

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -195,7 +195,7 @@ function verifiedUrlsFromMetadata(message: Memory): string[] {
   return stringArrayOf(metadataRecord(message)?.subAgentVerifiedUrls);
 }
 
-function isSuccessfulSubAgentCompletion(message: Memory): boolean {
+function isSubAgentTaskComplete(message: Memory): boolean {
   const content = contentRecord(message);
   const metadata = metadataRecord(message);
   if (!content || !metadata) return false;
@@ -203,7 +203,33 @@ function isSuccessfulSubAgentCompletion(message: Memory): boolean {
   if (source !== SUB_AGENT_SOURCE && metadata.subAgent !== true) return false;
   if (textOf(metadata.subAgentEvent) !== "task_complete") return false;
   if (metadata.subAgentCapExceeded === true) return false;
-  return !completionHasVerificationFailure(textOf(content.text));
+  return true;
+}
+
+function isSuccessfulSubAgentCompletion(message: Memory): boolean {
+  if (!isSubAgentTaskComplete(message)) return false;
+  return !completionHasVerificationFailure(
+    textOf(contentRecord(message)?.text),
+  );
+}
+
+function verificationFailureReply(text: string): string {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const verificationIndex = lines.findIndex((line) =>
+    line.startsWith("[verification:"),
+  );
+  const detailLines =
+    verificationIndex >= 0
+      ? lines
+          .slice(verificationIndex + 1)
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .slice(0, 8)
+      : [];
+  return [
+    "The sub-agent reported completion, but verification failed, so I am not treating the app as live yet.",
+    ...(detailLines.length > 0 ? ["Unreachable URL(s):", ...detailLines] : []),
+  ].join("\n");
 }
 
 function replyPatchFromCompletion(
@@ -257,10 +283,12 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     "Routes verified sub-agent task_complete messages to direct replies unless Stage 1 requested a concrete follow-up action.",
   priority: 10,
   shouldRun: ({ message, messageHandler }) => {
-    if (!isSuccessfulSubAgentCompletion(message)) return false;
+    if (!isSubAgentTaskComplete(message)) return false;
     if (messageHandler.processMessage === "STOP") return false;
-    const currentReply = textOf(messageHandler.plan.reply);
     const completionText = textOf(contentRecord(message)?.text);
+    if (completionHasVerificationFailure(completionText)) return true;
+    if (!isSuccessfulSubAgentCompletion(message)) return false;
+    const currentReply = textOf(messageHandler.plan.reply);
     const verifiedUrls = verifiedUrlsFromMetadata(message);
     if (hasVerifiedCompletionReply(currentReply, completionText, verifiedUrls))
       return true;
@@ -277,6 +305,19 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     const currentReply = textOf(messageHandler.plan.reply);
     const completionText = textOf(contentRecord(message)?.text);
     const verifiedUrls = verifiedUrlsFromMetadata(message);
+    if (completionHasVerificationFailure(completionText)) {
+      return {
+        ...respondIfNeeded(messageHandler),
+        requiresTool: false,
+        setContexts: [SIMPLE_CONTEXT_ID],
+        clearCandidateActions: true,
+        clearParentActionHints: true,
+        reply: verificationFailureReply(completionText),
+        debug: [
+          "sub-agent completion failed verification; surfacing failure without re-dispatch",
+        ],
+      };
+    }
     const reply = replyPatchFromCompletion(
       currentReply,
       completionText,

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -855,6 +855,64 @@ function routeVerificationForSession(
   };
 }
 
+function expandRouteUrlAliases(
+  urls: readonly string[],
+  routeVerification: RouteUrlVerification | undefined,
+): string[] {
+  if (!routeVerification) return [...urls];
+  const expanded = new Set(urls);
+  for (const url of urls) {
+    const relativePath = routeRelativePathForUrl(
+      url,
+      routeVerification.mappings,
+    );
+    if (!relativePath) continue;
+    for (const mapping of routeVerification.mappings) {
+      const alias = urlForRouteMapping(mapping, relativePath);
+      if (alias) expanded.add(alias);
+    }
+  }
+  return [...expanded];
+}
+
+function routeRelativePathForUrl(
+  url: string,
+  mappings: readonly RouteUrlMapping[],
+): string | undefined {
+  for (const mapping of mappings) {
+    let parsed: URL;
+    let prefix: URL;
+    try {
+      parsed = new URL(url);
+      prefix = new URL(mapping.urlPrefix);
+    } catch {
+      continue;
+    }
+    if (parsed.origin !== prefix.origin) continue;
+    const prefixPath = prefix.pathname.endsWith("/")
+      ? prefix.pathname
+      : `${prefix.pathname}/`;
+    if (!parsed.pathname.startsWith(prefixPath)) continue;
+    const relativePath = parsed.pathname.slice(prefixPath.length);
+    if (relativePath) return relativePath;
+  }
+  return undefined;
+}
+
+function urlForRouteMapping(
+  mapping: RouteUrlMapping,
+  relativePath: string,
+): string | undefined {
+  try {
+    const prefix = mapping.urlPrefix.endsWith("/")
+      ? mapping.urlPrefix
+      : `${mapping.urlPrefix}/`;
+    return new URL(relativePath, prefix).toString();
+  } catch {
+    return undefined;
+  }
+}
+
 function mergeCachedStaleMissUrls(
   prior: Set<string>,
   dead: DeadUrl[],
@@ -937,7 +995,10 @@ async function annotateUnverifiedUrls(
   runtime?: IAgentRuntime,
   routeVerification?: RouteUrlVerification,
 ): Promise<{ text: string; dead: DeadUrl[]; verifiedUrls: string[] }> {
-  const urls = extractVerifiableUrls(text, 5, referenceText, ignoredUrls);
+  const urls = expandRouteUrlAliases(
+    extractVerifiableUrls(text, 5, referenceText, ignoredUrls),
+    routeVerification,
+  );
   if (urls.length === 0) return { text, dead: [], verifiedUrls: [] };
   log?.(
     `[verify] start @ ${new Date().toISOString()} — ${urls.length} url(s): ${urls.join(", ")}`,

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts
@@ -68,7 +68,7 @@ export function resolveSpawnWorkdir(
   const expandedExplicit = explicitWorkdir
     ? expandHomePath(explicitWorkdir)
     : undefined;
-  if (opts.lockWorkdir && expandedExplicit) {
+  if (opts.lockWorkdir && expandedExplicit && fs.existsSync(expandedExplicit)) {
     return { workdir: expandedExplicit };
   }
   const route = resolveWorkdirRoute(runtime, task, userRequest);


### PR DESCRIPTION
## Summary

This is the focused follow-up from the live GPT-OSS/OpenCode battletest after #7716/#7718 landed.

- keep current-turn routing grounded when the response handler emits only synthetic/unregistered action hints
- include runtime model context in the response state path so self-model questions answer from runtime facts instead of old chat/training priors
- prevent stale sub-agent completion artifacts from being reintroduced as prior dialogue context/search context
- execute dispatcher-style `TASKS { action: "spawn_agent" }` calls directly instead of forcing a redundant sub-planner pass
- harden OpenCode app-build routing:
  - planner-generated TASKS calls can no longer set `lockWorkdir`
  - missing locked workdirs fall through to configured route/default resolution
  - verification failures are surfaced honestly instead of causing repeated respawn loops
  - verified route aliases include the public URL when loopback/public map to the same app

## Validation

Focused checks on a clean worktree created from latest `origin/develop` (`01cc2c423d`):

- `packages/core`: `bun vitest run src/__tests__/message-runtime-stage1.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts src/runtime/__tests__/planner-loop.test.ts src/features/basic-capabilities/providers/runtimeModelContext.test.ts` -> 77/77 passing
- `packages/core`: `bun run build` -> passing
- `packages/core`: `bun run typecheck` -> passing after generating the standard shared/core i18n keyword files in the fresh worktree
- `plugins/plugin-agent-orchestrator`: `bunx vitest run __tests__/unit/acp-service.test.ts __tests__/unit/opencode-spawn-config-auto-detect.test.ts __tests__/unit/task-agent-frameworks.test.ts __tests__/unit/sub-agent-completion-evaluator.test.ts __tests__/unit/spawn-agent.test.ts __tests__/unit/resolve-spawn-workdir.test.ts src/__tests__/workdir-routes.test.ts __tests__/unit/sub-agent-router.test.ts` -> 111/111 passing
- `plugins/plugin-agent-orchestrator`: `bun run typecheck && bun run build` -> passing
- `bunx @biomejs/biome check` on all changed files -> passing
- `git diff --check origin/develop...HEAD` -> passing
- added-line hygiene scan for local/personal strings, stale `PARALLAX_`, `vault://`, debug logs, and hack markers -> clean

Live verification from the VPS runtime used real Discord API responses, `bot.log`, and trajectory JSON:

- model identity prompt replied with `gpt-oss-120b`; trajectory `tj-2addd391baef7a` used `gpt-oss-120b` and included runtime model context
- disk-space prompt used `SHELL`; trajectory `tj-2b25df79cdd10d` had `toolCallsExecuted: 1`, `toolCallFailures: 0`
- BTC price prompt used `SHELL`; trajectory `tj-2b82be22dea8e9` had `toolCallFailures: 0`
- final OpenCode app-build prompt `1504869100696899674` produced final Discord response `1504869245064843368` with both:
  - `http://127.0.0.1:6900/apps/comet-name-app/`
  - `https://nubilio.org/apps/comet-name-app/`
- parent trajectory `tj-449a3cfd892944`: `plannerIterations: 1`, `toolCallsExecuted: 1`, `toolCallFailures: 0`, model `gpt-oss-120b`, OpenCode route selected, no `lockWorkdir`, no `/home/milody`
- final trajectory `tj-44e8d058347fb0`: direct final response, no tool failures
- both app URLs returned HTTP 200 with the generated app content

## Notes

The vendored OpenCode Cerebras reasoning replay fix is separate and already open as elizaOS/opencode#2. This Eliza PR intentionally does not move the `vendor/opencode` pointer.

Broad monorepo CI work is intentionally out of scope here; this PR is the runtime routing/completion follow-up for GPT-OSS + OpenCode behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens GPT-OSS/OpenCode follow-up routing across the orchestrator stack: it prevents synthetic action hints from suppressing current-turn inference, adds runtime model context to the response state path, filters stale sub-agent completion artifacts from prior-dialogue and search context, short-circuits sub-planner passes for dispatcher-style TASKS calls, and fixes several OpenCode app-build routing edge cases (lockWorkdir bypass, verification failure surfacing, and loopback/public URL alias expansion).

- `message.ts`: adds `RUNTIME_MODEL_CONTEXT` to the core state providers, introduces `candidateActionsContainRunnableAction` to guard inference-suppression against unregistered action hints, adds `hasDispatcherActionParam` to skip the sub-planner for explicit dispatcher calls, filters sub-agent artifacts from prior dialogue/search, and injects a dialogue-policy system segment.
- `task-agent-routing.ts` / `tasks.ts`: removes `lockWorkdir` from the TASKS public schema and adds an `existsSync` guard so planner-guessed paths can no longer bypass route resolution.
- `sub-agent-completion.ts` / `sub-agent-router.ts`: verification failures now produce a structured user-facing reply instead of suppressing the evaluator, and URL alias expansion ensures loopback + public variants of an app are both verified.

<h3>Confidence Score: 3/5</h3>

The orchestrator routing and evaluator changes are well-targeted and test-backed, but a filter condition in message.ts could silently drop all user messages from prior-dialogue context in production.

The appendPriorDialogueEvents filter at line 1587-1589 adds || m.agentId === runtime.agentId alongside the entityId check. In elizaOS V5, platform adapters routinely persist user messages with agentId = runtime.agentId to associate them with the agent room context. If that field is set in production, every user message in the conversation would be excluded from prior dialogue, making multi-turn context invisible to the LLM. The unit tests pass because mock memories generally do not set agentId, so the regression would surface only at runtime.

packages/core/src/services/message.ts — specifically the agentId OR condition in the appendPriorDialogueEvents filter and the now-unreachable isAgent branch that follows it.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Core routing hardening: adds RUNTIME_MODEL_CONTEXT provider, filters sub-agent completion artifacts from prior-dialogue, injects a dialogue-policy segment, hardens candidate-action inference with a runnable-action check, and bypasses the sub-planner for dispatcher-style TASKS calls. The agentId filter in appendPriorDialogueEvents is potentially overly broad and could strip all user messages from dialogue context. |
| plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts | Sub-agent completion evaluator now surfaces verification failures as direct user-facing replies instead of suppressing the evaluator, preventing repeated respawn loops. Logic is well-structured and tests cover the new path. |
| plugins/plugin-agent-orchestrator/src/services/task-agent-routing.ts | lockWorkdir now requires the path to exist before honouring it; missing planner-guessed paths fall through to route/default resolution. Clean, minimal change with matching test coverage. |
| plugins/plugin-agent-orchestrator/src/actions/tasks.ts | Removes the lockWorkdir parameter from the TASKS action schema so planner-generated calls can no longer pin an arbitrary workdir, closing a path for hallucinated paths bypassing route resolution. |
| plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts | Adds expandRouteUrlAliases to automatically verify loopback and public URL variants when they map to the same app. URL alias logic is correct, but the 5-URL cap is applied before expansion so the effective fetch count can exceed the documented limit. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/services/message.ts`, line 1601-1610 ([link](https://github.com/elizaos/eliza/blob/8df446986383f391492ff7b6d8bd8bd6a038ec59/packages/core/src/services/message.ts#L1601-L1610)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead `isAgent` variable after filter removes all agent messages**

   The filter on lines 1587-1589 already excludes every memory where `entityId === runtime.agentId`, so after filtering, `memory.entityId` can never equal `runtime.agentId` in the loop body. `isAgent` will always be `false`, the `"agent"` / `"assistant"` branches are unreachable, and the variable is dead code.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): harden opencode app-b..."](https://github.com/elizaos/eliza/commit/8df446986383f391492ff7b6d8bd8bd6a038ec59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32339453)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->