### PR TITLE
[codex] fix(ui): allow local TTS longer on mobile

### DIFF
--- a/packages/ui/src/api/request-timeout.test.ts
+++ b/packages/ui/src/api/request-timeout.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { defaultFetchTimeoutMs } from "./request-timeout";
+
+describe("defaultFetchTimeoutMs", () => {
+  it("allows local neural TTS enough time for mobile CPU generation", () => {
+    expect(
+      defaultFetchTimeoutMs("http://127.0.0.1:31337/api/tts/local-inference", {
+        method: "POST",
+      }),
+    ).toBe(180_000);
+  });
+
+  it("keeps ordinary API calls on the short default timeout", () => {
+    expect(
+      defaultFetchTimeoutMs("http://127.0.0.1:31337/api/health", {
+        method: "GET",
+      }),
+    ).toBe(10_000);
+  });
+});

--- a/packages/ui/src/api/request-timeout.ts
+++ b/packages/ui/src/api/request-timeout.ts
@@ -1,4 +1,9 @@
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+// Local neural TTS on mobile CPU is slower than ordinary JSON API calls. Pixel
+// APK validation with the bundled Kokoro path produced normal chat clips in the
+// 15-30 s range, so the generic 10 s bridge timeout aborts valid responses
+// before the WAV is ready.
+const LOCAL_INFERENCE_TTS_FETCH_TIMEOUT_MS = 3 * 60_000;
 // First-turn inference on Capacitor mobile (Moto G Play 2024, Snapdragon
 // 4 Gen 1, CPU-only) lands at ~240 s for a 256-token Llama-3.2-1B reply.
 // The bun-side `ELIZA_CHAT_GENERATION_TIMEOUT_MS` is 600 s on that build
@@ -31,6 +36,9 @@ export function defaultFetchTimeoutMs(
     /^\/api\/conversations\/[^/]+\/messages(?:\/stream)?$/.test(pathname)
   ) {
     return CHAT_MESSAGE_FETCH_TIMEOUT_MS;
+  }
+  if (pathname === "/api/tts/local-inference") {
+    return LOCAL_INFERENCE_TTS_FETCH_TIMEOUT_MS;
   }
   return DEFAULT_FETCH_TIMEOUT_MS;
 }


### PR DESCRIPTION
## Summary

Local neural TTS on mobile can legitimately take longer than the generic 10s API timeout. The Pixel APK validation path produced normal local Kokoro/Eliza TTS clips in the 15-30s range, so the Android native Agent bridge was aborting valid `/api/tts/local-inference` responses before the WAV was ready.

This PR gives only the local inference TTS route a 3 minute fetch timeout and keeps ordinary API calls on the short 10s default.

## Why

The stock Android local-runtime APK uses the WebView UI to call the embedded agent through the Capacitor Agent bridge. Text responses were working locally, but local TTS was slow enough on mobile CPU to hit the generic timeout. A longer timeout is scoped to `/api/tts/local-inference` so it does not mask hangs for health/status/ordinary JSON routes.

## Validation

- `bun test packages/ui/src/api/request-timeout.test.ts --runInBand`
- Pixel APK evidence from local validation:
  - `POST /api/tts/local-inference` used `timeoutMs: 180000`
  - returned HTTP 200 `audio/wav`
  - returned a 459,644 byte WAV
  - WebAudio started playback at 28.808s and played 9.575s of audio

## Notes

This PR is intentionally narrow. It does not include the larger Android native llama, TalkMode, AOSP, or local model-routing work from the Pixel validation branch.
