### PR TITLE
[codex] fix(android): read TalkMode mic permission from package manager

### DIFF
--- a/packages/native-plugins/talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
+++ b/packages/native-plugins/talkmode/android/src/main/java/ai/eliza/plugins/talkmode/TalkModePlugin.kt
@@ -2,6 +2,7 @@ package ai.eliza.plugins.talkmode
 
 import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioManager
@@ -1162,6 +1163,9 @@ class TalkModePlugin : Plugin() {
     }
 
     private fun isPermissionGranted(permission: String): Boolean {
+        if (permission == Manifest.permission.RECORD_AUDIO) {
+            return context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+        }
         return getPermissionState(permission) == com.getcapacitor.PermissionState.GRANTED
     }
 


### PR DESCRIPTION
## Summary

- Read Android `RECORD_AUDIO` permission directly from `PackageManager` inside TalkMode.
- Keep Capacitor's permission state path for any non-microphone permissions.

## Why

On the Pixel APK validation path, the app-level runtime permission can be granted while Capacitor's cached alias state is stale. TalkMode then reports microphone permission incorrectly and can show an auth/permission-style failure even though Android has granted `RECORD_AUDIO`.

Using `context.checkSelfPermission(Manifest.permission.RECORD_AUDIO)` makes the plugin's permission readback match the platform source of truth before starting speech recognition.

## Validation

- `git diff --check`
- Built into the current Pixel Android debug APK during local validation.
- On Pixel, `TalkMode.checkPermissions()` reports `{"microphone":"granted","speechRecognition":"granted"}` after `adb shell pm grant ai.milady.milady android.permission.RECORD_AUDIO`.
- Logcat shows TalkMode starts recognition, opens the Pixel bottom microphone on the `VOICE_RECOGNITION` route, and Android SODA begins on-device recognition. The remaining no-speech result is a capture/proof issue, not a permission denial.

## Notes

This is intentionally narrow. It does not include the larger local llama.cpp, Eliza-1 routing, TTS timeout, or voice-conversation proof work from the Pixel validation branch.
