### PR TITLE
feat(cloud): sandbox self-registration in Redis enables gateway routing to Hetzner containers

### DIFF
--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -152,6 +152,7 @@
     "@elizaos/ui": "workspace:*",
     "@elizaos/vault": "workspace:*",
     "@node-rs/argon2": "^2.0.2",
+    "@upstash/redis": "^1.37.0",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "dotenv": "^17.2.3",

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -1234,6 +1234,21 @@ export async function startEliza(
       console.log(`[eliza] Control UI: http://localhost:${actualApiPort}`);
       console.log("[eliza] Server running. Press Ctrl+C to stop.");
 
+      const { buildSandboxRegistryFromEnv } = await import(
+        "../services/sandbox-registry.js"
+      );
+      const sandboxRegistry = buildSandboxRegistryFromEnv();
+      if (sandboxRegistry) {
+        try {
+          await sandboxRegistry.register();
+          sandboxRegistry.startHeartbeat(30_000);
+        } catch (err) {
+          logger.error(
+            `[eliza] Failed to register sandbox in Redis (gateways will not route inbound platform messages here until the next heartbeat succeeds): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
       const keepAlive = setInterval(() => {}, 1 << 30);
       let isCleaningUp = false;
       const cleanup = async () => {
@@ -1249,6 +1264,16 @@ export async function startEliza(
         }, 10_000);
         forceExitTimer.unref();
         stopTelegramBotPolling("SIGINT");
+        if (sandboxRegistry) {
+          sandboxRegistry.stopHeartbeat();
+          try {
+            await sandboxRegistry.unregister();
+          } catch (err) {
+            logger.warn(
+              `[eliza] Sandbox unregister failed (keys will expire via TTL): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
         if (currentRuntime) {
           await upstreamShutdownRuntime(currentRuntime, "server-only shutdown");
         }

--- a/packages/app-core/src/services/__tests__/sandbox-registry.test.ts
+++ b/packages/app-core/src/services/__tests__/sandbox-registry.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for SandboxRegistry. The Upstash REST client is mocked at the
+ * module boundary (`@upstash/redis`) so we can record the exact key/value/TTL
+ * triples that would be sent to Redis. Everything else runs the real
+ * production code path.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface PipelineCall {
+  type: "set";
+  key: string;
+  value: string;
+  opts?: { ex?: number };
+}
+
+interface DelCall {
+  type: "del";
+  keys: string[];
+}
+
+type RedisCall = PipelineCall | DelCall;
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as RedisCall[],
+  nextPipelineFails: false,
+}));
+
+vi.mock("@upstash/redis", () => {
+  class FakePipeline {
+    private willThrow: boolean;
+    constructor(willThrow: boolean) {
+      this.willThrow = willThrow;
+    }
+    set(key: string, value: string, opts?: { ex?: number }): this {
+      if (!this.willThrow) {
+        mocks.calls.push({ type: "set", key, value, opts });
+      }
+      return this;
+    }
+    async exec(): Promise<unknown[]> {
+      if (this.willThrow) {
+        throw new Error("simulated upstash failure");
+      }
+      return [];
+    }
+  }
+
+  class FakeRedis {
+    constructor(_config: { url: string; token: string }) {}
+    pipeline(): FakePipeline {
+      const willThrow = mocks.nextPipelineFails;
+      mocks.nextPipelineFails = false;
+      return new FakePipeline(willThrow);
+    }
+    async del(...keys: string[]): Promise<number> {
+      mocks.calls.push({ type: "del", keys });
+      return keys.length;
+    }
+  }
+
+  return { Redis: FakeRedis };
+});
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  buildSandboxRegistryFromEnv,
+  SandboxRegistry,
+} from "../sandbox-registry";
+
+const CONFIG = {
+  redisUrl: "https://example.upstash.io",
+  redisToken: "tok",
+  agentId: "agent-42",
+  serverName: "sandbox-agent-42",
+  serverUrl: "http://10.0.0.7:18791",
+  ttlSeconds: 60,
+};
+
+describe("SandboxRegistry", () => {
+  beforeEach(() => {
+    mocks.calls.length = 0;
+    mocks.nextPipelineFails = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("register() writes both routing keys with the configured TTL", async () => {
+    const registry = new SandboxRegistry(CONFIG);
+    await registry.register();
+
+    const sets = mocks.calls.filter((c) => c.type === "set") as PipelineCall[];
+    expect(sets).toHaveLength(2);
+    expect(sets[0]).toEqual({
+      type: "set",
+      key: "server:sandbox-agent-42:url",
+      value: "http://10.0.0.7:18791",
+      opts: { ex: 60 },
+    });
+    expect(sets[1]).toEqual({
+      type: "set",
+      key: "agent:agent-42:server",
+      value: "sandbox-agent-42",
+      opts: { ex: 60 },
+    });
+  });
+
+  it("refresh() reissues the same two writes (idempotent)", async () => {
+    const registry = new SandboxRegistry(CONFIG);
+    await registry.register();
+    mocks.calls.length = 0;
+
+    await registry.refresh();
+
+    const sets = mocks.calls.filter((c) => c.type === "set") as PipelineCall[];
+    expect(sets).toHaveLength(2);
+    expect(sets.map((s) => s.key)).toEqual([
+      "server:sandbox-agent-42:url",
+      "agent:agent-42:server",
+    ]);
+    expect(sets.every((s) => s.opts?.ex === 60)).toBe(true);
+  });
+
+  it("unregister() deletes both routing keys", async () => {
+    const registry = new SandboxRegistry(CONFIG);
+    await registry.register();
+    mocks.calls.length = 0;
+
+    await registry.unregister();
+
+    const dels = mocks.calls.filter((c) => c.type === "del") as DelCall[];
+    expect(dels).toHaveLength(1);
+    expect(dels[0]?.keys).toEqual([
+      "server:sandbox-agent-42:url",
+      "agent:agent-42:server",
+    ]);
+  });
+
+  it("startHeartbeat() refreshes on the interval; errors do not kill the timer", async () => {
+    vi.useFakeTimers();
+    const registry = new SandboxRegistry(CONFIG);
+    await registry.register();
+    mocks.calls.length = 0;
+
+    registry.startHeartbeat(30_000);
+
+    mocks.nextPipelineFails = true;
+    await vi.advanceTimersByTimeAsync(30_000);
+    // Failing tick: the FakePipeline.set short-circuits without recording when
+    // willThrow is set, and exec() then rejects. The handler in
+    // startHeartbeat caught the error so the next tick still runs.
+    expect(mocks.calls.filter((c) => c.type === "set")).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(mocks.calls.filter((c) => c.type === "set")).toHaveLength(2);
+
+    registry.stopHeartbeat();
+  });
+
+  it("stopHeartbeat() halts the timer", async () => {
+    vi.useFakeTimers();
+    const registry = new SandboxRegistry(CONFIG);
+    await registry.register();
+    mocks.calls.length = 0;
+
+    registry.startHeartbeat(30_000);
+    registry.stopHeartbeat();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mocks.calls).toHaveLength(0);
+  });
+
+  it("buildSandboxRegistryFromEnv() returns null when any required var is missing", () => {
+    const complete = {
+      SANDBOX_REGISTRY_REDIS_URL: "https://x.upstash.io",
+      SANDBOX_REGISTRY_REDIS_TOKEN: "t",
+      SANDBOX_AGENT_ID: "a",
+      SANDBOX_SERVER_NAME: "s",
+      SANDBOX_PUBLIC_URL: "http://1.2.3.4:1",
+    };
+    expect(buildSandboxRegistryFromEnv(complete)).not.toBeNull();
+
+    for (const key of Object.keys(complete) as Array<keyof typeof complete>) {
+      const partial = { ...complete, [key]: "" };
+      expect(buildSandboxRegistryFromEnv(partial)).toBeNull();
+    }
+  });
+
+  it("buildSandboxRegistryFromEnv() trims whitespace and rejects whitespace-only values", () => {
+    expect(
+      buildSandboxRegistryFromEnv({
+        SANDBOX_REGISTRY_REDIS_URL: "https://x.upstash.io",
+        SANDBOX_REGISTRY_REDIS_TOKEN: "t",
+        SANDBOX_AGENT_ID: "a",
+        SANDBOX_SERVER_NAME: "s",
+        SANDBOX_PUBLIC_URL: "   ", // whitespace only
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/app-core/src/services/sandbox-registry.ts
+++ b/packages/app-core/src/services/sandbox-registry.ts
@@ -1,0 +1,130 @@
+/**
+ * SandboxRegistry — self-registers the sandbox container in the shared
+ * Upstash Redis so the multi-tenant gateways (`gateway-discord`,
+ * `gateway-webhook`) can resolve `agent_id → server URL` and forward inbound
+ * platform messages here.
+ *
+ * Two Redis keys are written with a short TTL; a periodic heartbeat refreshes
+ * the TTL while the sandbox is alive, and `unregister()` deletes them on
+ * graceful shutdown. If the container crashes, the keys expire naturally and
+ * the gateways stop routing to a dead address.
+ *
+ *   server:<serverName>:url = <serverUrl>   (resolver address)
+ *   agent:<agentId>:server  = <serverName>  (agent → server pointer)
+ *
+ * The write pattern mirrors `packages/cloud-services/agent-server/src/agent-manager.ts:refreshRedisState`
+ * but is stripped to a single-tenant sandbox: one agent, one server, no
+ * capacity bookkeeping.
+ */
+
+import { logger } from "@elizaos/core";
+import { Redis } from "@upstash/redis";
+
+export interface SandboxRegistryConfig {
+  redisUrl: string;
+  redisToken: string;
+  agentId: string;
+  serverName: string;
+  serverUrl: string;
+  /** TTL for both Redis keys in seconds. The heartbeat must refresh at half this interval (or sooner) to avoid windows where the keys expire while the sandbox is healthy. */
+  ttlSeconds: number;
+}
+
+export class SandboxRegistry {
+  private readonly redis: Redis;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly config: SandboxRegistryConfig) {
+    this.redis = new Redis({ url: config.redisUrl, token: config.redisToken });
+  }
+
+  async register(): Promise<void> {
+    await this.writeKeys();
+    logger.info(
+      `[sandbox-registry] Registered ${this.config.serverName} → ${this.config.serverUrl} (agent ${this.config.agentId}, ttl ${this.config.ttlSeconds}s)`,
+    );
+  }
+
+  async refresh(): Promise<void> {
+    await this.writeKeys();
+  }
+
+  async unregister(): Promise<void> {
+    const { serverName, agentId } = this.config;
+    await this.redis.del(`server:${serverName}:url`, `agent:${agentId}:server`);
+    logger.info(
+      `[sandbox-registry] Unregistered ${serverName} (agent ${agentId})`,
+    );
+  }
+
+  startHeartbeat(intervalMs: number): void {
+    if (this.heartbeatTimer) return;
+
+    this.heartbeatTimer = setInterval(() => {
+      void this.refresh().catch((err) => {
+        logger.warn(
+          `[sandbox-registry] Heartbeat refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    }, intervalMs);
+
+    if (
+      typeof this.heartbeatTimer === "object" &&
+      "unref" in this.heartbeatTimer
+    ) {
+      this.heartbeatTimer.unref();
+    }
+  }
+
+  stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Atomic two-key write via Upstash pipeline. Both keys must succeed
+   * together — partial state would let gateways resolve `agent:X:server` to
+   * a stale `server:Y:url` value or miss a routing entry whose other half
+   * was just renewed.
+   */
+  private async writeKeys(): Promise<void> {
+    const { serverName, serverUrl, agentId, ttlSeconds } = this.config;
+    await this.redis
+      .pipeline()
+      .set(`server:${serverName}:url`, serverUrl, { ex: ttlSeconds })
+      .set(`agent:${agentId}:server`, serverName, { ex: ttlSeconds })
+      .exec();
+  }
+}
+
+/**
+ * Reads the SANDBOX_REGISTRY_* and SANDBOX_* env vars and returns a fully
+ * wired `SandboxRegistry`, or `null` if the sandbox context is not
+ * configured (e.g. local dev, non-Hetzner deployment). Caller must call
+ * `register()` and `startHeartbeat(...)` after a successful boot.
+ */
+export function buildSandboxRegistryFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  ttlSeconds = 60,
+): SandboxRegistry | null {
+  const redisUrl = env.SANDBOX_REGISTRY_REDIS_URL?.trim();
+  const redisToken = env.SANDBOX_REGISTRY_REDIS_TOKEN?.trim();
+  const agentId = env.SANDBOX_AGENT_ID?.trim();
+  const serverName = env.SANDBOX_SERVER_NAME?.trim();
+  const serverUrl = env.SANDBOX_PUBLIC_URL?.trim();
+
+  if (!redisUrl || !redisToken || !agentId || !serverName || !serverUrl) {
+    return null;
+  }
+
+  return new SandboxRegistry({
+    redisUrl,
+    redisToken,
+    agentId,
+    serverName,
+    serverUrl,
+    ttlSeconds,
+  });
+}

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -513,6 +513,20 @@ export class DockerSandboxProvider implements SandboxProvider {
         stewardTenant.apiKey,
       );
 
+      // Pass the shared Upstash credentials through to the sandbox so it can
+      // self-register `agent:<id>:server` + `server:<name>:url` keys that
+      // gateway-discord / gateway-webhook resolve for inbound platform
+      // messages. Omit when the orchestrator env doesn't carry them — the
+      // sandbox will skip registration silently in that case.
+      const registryRedisUrl = process.env.KV_REST_API_URL?.trim() ?? "";
+      const registryRedisToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
+      const canSelfRegister = registryRedisUrl !== "" && registryRedisToken !== "";
+      if (!canSelfRegister) {
+        logger.warn(
+          "[docker-sandbox] KV_REST_API_URL / KV_REST_API_TOKEN missing from orchestrator env — sandbox will not register in Redis and gateways will not route inbound platform messages to it",
+        );
+      }
+
       const allEnv: Record<string, string> = {
         ...baseEnv,
         STEWARD_AGENT_TOKEN: stewardAgentToken,
@@ -536,6 +550,19 @@ export class DockerSandboxProvider implements SandboxProvider {
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
         ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        // Gateway service discovery — see SandboxRegistry in app-core.
+        // SANDBOX_PUBLIC_URL targets the public Docker host (not the headscale
+        // VPN IP set later at line ~653) because the gateways on Railway can't
+        // route through Hetzner's private VPN.
+        ...(canSelfRegister
+          ? {
+              SANDBOX_REGISTRY_REDIS_URL: registryRedisUrl,
+              SANDBOX_REGISTRY_REDIS_TOKEN: registryRedisToken,
+              SANDBOX_AGENT_ID: agentId,
+              SANDBOX_SERVER_NAME: `sandbox-${agentId}`,
+              SANDBOX_PUBLIC_URL: `http://${hostname}:${bridgePort}`,
+            }
+          : {}),
       };
 
       // Validate env keys/values before they are interpolated into remote shell commands.


### PR DESCRIPTION
## Why

The shared gateways (`gateway-discord`, `gateway-webhook`) decide where to forward an inbound platform message — Discord DM, WhatsApp webhook, Telegram update, SMS — by looking up two keys in the shared Upstash Redis:

```
agent:<agent_id>:server   →  <server_name>
server:<server_name>:url  →  <http url of the agent server>
```

Hetzner-provisioned sandboxes (running `@elizaos/app-core` from `ghcr.io/elizaos/eliza:stable`) **never wrote those keys**, so any inbound platform message addressed to one of those agents was dropped. The only writer today is the (failing) Railway `agent-server` service, which we want to retire.

This PR closes that gap by making the sandbox container responsible for its own registration — same pattern Eureka / Consul use, no orchestrator-side write path that can drift.

## How

New `SandboxRegistry` in `@elizaos/app-core`:

- Atomic Upstash pipeline writes both routing keys with a 60s TTL.
- 30s heartbeat re-issues the writes (idempotent) — Redis auto-expires the keys if the sandbox crashes, so gateways naturally stop routing to a dead address.
- SIGTERM / SIGINT cleanup calls `DEL` on both keys for graceful shutdown.
- Configured via env vars (`SANDBOX_REGISTRY_REDIS_URL`, `SANDBOX_REGISTRY_REDIS_TOKEN`, `SANDBOX_AGENT_ID`, `SANDBOX_SERVER_NAME`, `SANDBOX_PUBLIC_URL`). Missing any → registration silently skipped, runtime continues normally (covers local dev and non-Hetzner deployments).

Bootstrap wires into the existing app-core entry point right after the API server starts listening. Cleanup is integrated with the existing SIGTERM/SIGINT path.

`docker-sandbox-provider` injects the five env vars at `docker create` time, reusing the same Upstash creds (`KV_REST_API_URL` / `KV_REST_API_TOKEN`) the rest of the cloud already uses. If those aren't present on the orchestrator env, provisioning still succeeds — only the registration env vars are omitted, with a warn log.

Pattern mirrors `packages/cloud-services/agent-server/src/agent-manager.ts:refreshRedisState` but stripped to single-tenant (one agent, one server, no capacity bookkeeping).

## What's intentionally not in this PR

- No data migration. New sandboxes register new keys; existing rows untouched.
- No change to gateway code — they already read these keys; this fixes the *write* side.
- Decommissioning the Railway `agent-server` is a separate follow-up.

## Operator note

The provisioning worker env (where `docker-sandbox-provider` runs) needs `KV_REST_API_URL` and `KV_REST_API_TOKEN`. If those are missing on a given orchestrator, sandboxes provisioned by it will boot fine but won't be reachable by gateways.

## Test plan

- [x] 7 unit tests cover register, refresh, unregister, heartbeat-survives-error, stopHeartbeat, env-var validation (missing + whitespace-only). All passing.
- [x] Typecheck clean on touched files.
- [x] Biome clean.
- [ ] Manual e2e on staging: provision a sandbox, observe `agent:<id>:server` and `server:<name>:url` appear in Upstash, kill the sandbox, observe keys expire within 60s.
- [ ] Manual e2e: send a Discord DM to an agent on a self-registered sandbox, verify it routes and the agent replies.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces self-registration of Hetzner sandbox containers in Upstash Redis, closing the gap where inbound platform messages (Discord, webhook, etc.) were dropped because only the now-retiring Railway `agent-server` wrote the gateway routing keys. The new `SandboxRegistry` in `app-core` handles both the write path and graceful cleanup, while `docker-sandbox-provider` injects the required credentials at container creation.

- `SandboxRegistry` writes `agent:<id>:server` and `server:<name>:url` with a 60s TTL, refreshes them every 30s, and deletes them on SIGTERM/SIGINT; missing env vars cause it to silently skip (safe for local dev).
- `docker-sandbox-provider` reads `KV_REST_API_URL`/`KV_REST_API_TOKEN` from the orchestrator and forwards them plus the four sandbox identity vars to the container at `docker create` time; omits all five if the KV creds are absent and logs a warning.
- The startup wiring in `eliza.ts` has a bug: if the initial `register()` call throws, `startHeartbeat()` is never called and there is no automatic recovery \u2014 the sandbox stays dark until it is restarted.

<h3>Confidence Score: 3/5</h3>

Mostly safe to merge, but the startup wiring bug in eliza.ts means a transient Redis error at boot permanently disables gateway routing for that sandbox until it restarts.

The new SandboxRegistry class itself is solid and the test coverage is thorough. However, the integration in eliza.ts only arms the heartbeat when the initial register() call succeeds. A Redis blip at container boot silently leaves the sandbox dark with no recovery path, and the error message is actively misleading.

packages/app-core/src/runtime/eliza.ts — the try/catch block around register() needs the heartbeat call moved outside it so recovery is automatic.

<details open><summary><h3>Security Review</h3></summary>

- `SANDBOX_PUBLIC_URL` is set to `http://${hostname}:${bridgePort}` (plain HTTP). Railway gateways forward platform messages \u2014 including Discord DMs and webhook payloads \u2014 to this address over the public internet without TLS, exposing message content in transit.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/runtime/eliza.ts | Wires SandboxRegistry into startup and shutdown; heartbeat is not started when initial register() throws, leaving the sandbox permanently unregistered until restart |
| packages/app-core/src/services/sandbox-registry.ts | New SandboxRegistry class with heartbeat, TTL-based key expiry, and graceful unregister; TTL/heartbeat ratio leaves no margin for a single missed tick |
| packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts | Injects five registry env vars at docker create time; uses plain http:// for SANDBOX_PUBLIC_URL over the public Hetzner host |
| packages/app-core/src/services/__tests__/sandbox-registry.test.ts | Comprehensive unit tests covering register, refresh, unregister, heartbeat error recovery, stopHeartbeat, and env-var validation; all realistic scenarios covered |
| packages/app-core/package.json | Adds @upstash/redis ^1.37.0 dependency; straightforward addition with no conflicts |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DS as docker-sandbox-provider
    participant HC as Hetzner Container (app-core)
    participant RD as Upstash Redis
    participant GW as Gateway (Discord/Webhook)

    DS->>HC: docker create -e SANDBOX_REGISTRY_REDIS_URL ...
    DS->>HC: docker start

    HC->>RD: "pipeline SET server:<name>:url EX 60"
    HC->>RD: "pipeline SET agent:<id>:server EX 60"
    RD-->>HC: OK (registered)
    HC->>HC: startHeartbeat(30s)

    loop Every 30s
        HC->>RD: "pipeline SET server:<name>:url EX 60"
        HC->>RD: "pipeline SET agent:<id>:server EX 60"
    end

    GW->>RD: "GET agent:<id>:server"
    GW->>RD: "GET server:<name>:url"
    GW->>HC: Forward inbound platform message (HTTP)
    HC-->>GW: Response

    HC->>HC: SIGTERM received
    HC->>HC: stopHeartbeat()
    HC->>RD: "DEL server:<name>:url, agent:<id>:server"
    RD-->>HC: OK (unregistered)
```

<sub>Reviews (1): Last reviewed commit: ["test(app-core/sandbox-registry): cover r..."](https://github.com/elizaos/eliza/commit/33906b511e5703e70f5b7f32cfd659bf68c2c523) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32370730)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->