### PR TITLE
fix(app-core): bridge DATABASE_URL to POSTGRES_URL — sandboxes were silently on PGLite

### DIFF
--- a/packages/app-core/src/entry.ts
+++ b/packages/app-core/src/entry.ts
@@ -35,6 +35,16 @@ if (
   );
 }
 
+// Bridge DATABASE_URL → POSTGRES_URL. Cloud provisioners (docker-sandbox-provider,
+// k8s manifests, Railway env) inject DATABASE_URL, but plugin-sql reads
+// POSTGRES_URL via runtime.getSetting("POSTGRES_URL"). Without this bridge,
+// sandboxes silently fall back to PGLite at /root/.eliza/.elizadb instead of
+// connecting to the injected Neon database — losing all memories on container
+// restart and breaking memory transfer / centralized observability.
+if (process.env.DATABASE_URL && !process.env.POSTGRES_URL) {
+  process.env.POSTGRES_URL = process.env.DATABASE_URL;
+}
+
 // Keep `npx elizaai` startup readable by default.
 // This runs before CLI/runtime imports so @elizaos/core logger picks it up.
 if (!process.env.LOG_LEVEL) {


### PR DESCRIPTION
## What's broken today

Every Hetzner sandbox booted from \`ghcr.io/elizaos/eliza:stable\` (Dockerfile.cloud) is silently running on **PGLite local** under \`/root/.eliza/.elizadb\` — not the Neon database the provisioner thought it had wired up.

The mismatch: \`docker-sandbox-provider\` injects \`DATABASE_URL\` into the container env, but \`@elizaos/plugin-sql\` reads its connection string from \`runtime.getSetting(\"POSTGRES_URL\")\`. The two names never aligned, so the postgres adapter never kicks in and plugin-sql falls back to the in-container PGLite default.

A sibling bridge already exists for the **alternate** \`cloud-agent\` entry path ([cloud-agent-shared.ts:193](https://github.com/elizaOS/eliza/blob/develop/packages/app-core/deploy/cloud-agent-shared.ts#L193)) — but \`Dockerfile.cloud\` uses \`src/entry.ts\`, which never had it.

## Why it matters

- \`docker kill <sandbox>\` → all agent memories gone (PGLite lives on the container FS only)
- \`agent_sandboxes.neon_project_id\` is populated by the provisioner but the sandbox never connects to that project
- Workers can't observe agent state for cross-process flows (Stripe webhook → push event chain we're planning for the onboarding gateway)
- Memory transfer at claim time has nothing to transfer
- All the Neon multi-tenancy work in \`eliza-sandbox.ts\` is effectively dead code today

## The fix

10-line bridge at the very top of \`src/entry.ts\`, before the CLI imports run:

\`\`\`ts
if (process.env.DATABASE_URL && !process.env.POSTGRES_URL) {
  process.env.POSTGRES_URL = process.env.DATABASE_URL;
}
\`\`\`

Defensive:
- If \`POSTGRES_URL\` is already set (dev override), it wins
- If neither is set (purely local PGLite use case), nothing changes
- If only \`DATABASE_URL\` is set (the prod sandbox case), we alias it through

## Test plan

- [x] entry.ts compiles
- [ ] Build the agent image from this branch, run a sandbox with \`DATABASE_URL=<test-neon-url>\` (no \`POSTGRES_URL\`), confirm logs show postgres adapter selection instead of \`pglite: using local store\`
- [ ] Verify \`memories\` rows land in the Neon test database after a chat exchange
- [ ] Confirm a freshly-killed-and-restarted container retrieves prior memories from Neon (not lost to PGLite reset)

## Follow-ups, not in this PR

- Audit other env-var name mismatches the same way (DB_URL, etc.)
- Decide whether to deprecate \`POSTGRES_URL\` and standardize on \`DATABASE_URL\` everywhere (would be a plugin-sql change)
- Memory backfill from any existing PGLite files on running sandboxes — if any contain valuable state we don't want to lose at the next restart

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a 10-line `DATABASE_URL` → `POSTGRES_URL` environment variable bridge at the very top of `packages/app-core/src/entry.ts` (the entry point used by `Dockerfile.cloud`) to fix a silent fallback to PGLite in Hetzner cloud sandboxes.

- **Root cause fix**: Cloud provisioners inject `DATABASE_URL`, but `plugin-sql` reads `POSTGRES_URL` via `runtime.getSetting()`; the bridge aligns the two names before any CLI or runtime imports run, matching a sibling bridge that already existed in `cloud-agent-shared.ts` for the alternate agent entry path.
- **Guard logic is correct**: The bridge only fires when `DATABASE_URL` is set and `POSTGRES_URL` is not, so dev overrides and purely local PGLite setups are unaffected.
- **Potential follow-up needed**: This bridge produces no stderr log when it activates, and `applyDatabaseConfigToEnv` in the runtime could silently undo it if the loaded config defaults to PGLite.

<h3>Confidence Score: 4/5</h3>

Safe to merge for dev and local PGLite use cases; cloud sandbox postgres connectivity fix should be validated end-to-end before promoting to stable.

The bridge is minimal, defensive, and correctly placed before any CLI import. The two open questions — whether a diagnostic log should fire on activation, and whether applyDatabaseConfigToEnv in the X402 config startup path could delete POSTGRES_URL before plugin-sql reads it — are worth verifying but are unlikely to cause regressions beyond the pre-existing PGLite fallback that this PR is already fixing.

The one changed file packages/app-core/src/entry.ts is straightforward; the secondary concern is in packages/agent/src/runtime/eliza.ts (unchanged in this PR) and whether its applyDatabaseConfigToEnv function is exercised on the Dockerfile.cloud boot path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/entry.ts | Adds a DATABASE_URL to POSTGRES_URL bridge before CLI imports; logic is correct and defensive, but lacks the stderr diagnostic log present in the sibling bridge above it, and could be undone by applyDatabaseConfigToEnv if config.database.provider is not explicitly set to postgres. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Provisioner as docker-sandbox-provider
    participant Container as Container env
    participant Entry as entry.ts
    participant CLI as CLI / run-main
    participant PluginSQL as plugin-sql

    Provisioner->>Container: inject DATABASE_URL
    Note over Container: POSTGRES_URL not set
    Entry->>Entry: check DATABASE_URL and not POSTGRES_URL
    Entry->>Container: "set POSTGRES_URL = DATABASE_URL"
    Entry->>CLI: dynamic import run-main
    CLI->>PluginSQL: initialize
    PluginSQL->>Container: runtime.getSetting POSTGRES_URL
    Container-->>PluginSQL: neon-url
    PluginSQL->>PluginSQL: use Postgres adapter
    Note over CLI,PluginSQL: Risk - applyDatabaseConfigToEnv with pglite default deletes POSTGRES_URL
```

<sub>Reviews (1): Last reviewed commit: ["fix(app-core/entry): bridge DATABASE\_URL..."](https://github.com/elizaos/eliza/commit/148d2aced5e0baaeddc9242062ac332c76fc8bea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32399685)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->