### PR TITLE
fix(android): polish stock APK local-agent startup

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBootReceiver.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBootReceiver.java
@@ -26,12 +26,16 @@ public class ElizaBootReceiver extends BroadcastReceiver {
             return;
         }
         // PACKAGE_USAGE_STATS has both a manifest permission (granted via
-        // privapp-permissions whitelist) and an appop. The privapp grant
-        // covers the permission; the appop must be flipped to ALLOWED
-        // separately. AppOpsManager#setMode(String, int, String, int)
-        // is hidden API, so we invoke via reflection — visible to system
-        // apps at runtime, no-ops cleanly otherwise.
-        allowUsageStatsAppOp(context);
+        // privapp-permissions whitelist) and an appop. Only the privileged
+        // AOSP/system image is allowed to flip the appop itself; stock APK
+        // installs must not try hidden AppOpsManager#setMode because Android
+        // will reject it with MANAGE_APP_OPS_MODES and log a scary startup
+        // warning even though local chat/voice still work.
+        if (BuildConfig.AOSP_BUILD && isBrandedDevice()) {
+            allowUsageStatsAppOp(context);
+        } else {
+            Log.i(TAG, "Skipping GET_USAGE_STATS appop auto-grant on non-privileged APK install.");
+        }
         GatewayConnectionService.start(context);
         // Only auto-start the on-device agent on branded devices (AOSP /
         // ElizaOS) or when the user has opted into Local runtime mode.
@@ -94,6 +98,22 @@ public class ElizaBootReceiver extends BroadcastReceiver {
         } catch (SecurityException error) {
             // Non-priv installs cannot setMode on themselves.
             Log.w(TAG, "GET_USAGE_STATS appop grant denied; user grant required.", error);
+        }
+    }
+
+    private static boolean isBrandedDevice() {
+        return !readSystemProperty("ro.elizaos.product").isEmpty();
+    }
+
+    private static String readSystemProperty(String key) {
+        try {
+            Class<?> systemProperties = Class.forName("android.os.SystemProperties");
+            Method get = systemProperties.getMethod("get", String.class, String.class);
+            Object value = get.invoke(null, key, "");
+            return value instanceof String ? (String) value : "";
+        } catch (Exception error) {
+            Log.w(TAG, "Unable to read system property " + key, error);
+            return "";
         }
     }
 }

--- a/packages/elizaos/templates/project/apps/app/index.html
+++ b/packages/elizaos/templates/project/apps/app/index.html
@@ -41,7 +41,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' electrobun://* https://* http://localhost:* http://127.0.0.1:*;
                script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' http://localhost:* http://127.0.0.1:* https://*;
                style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* https://*;
-               connect-src 'self' blob: data: http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:* https://* wss://*;
+               connect-src 'self' blob: data: eliza-local-agent: http://localhost:* ws://localhost:* wss://localhost:* http://127.0.0.1:* ws://127.0.0.1:* wss://127.0.0.1:* https://* wss://*;
                img-src 'self' data: blob: http://localhost:* http://127.0.0.1:* https://*;
                media-src 'self' blob: http://localhost:* http://127.0.0.1:* https://*;
                frame-src 'self' http://localhost:* http://127.0.0.1:* https://*;


### PR DESCRIPTION
## Summary

- allow `eliza-local-agent:` in the generated app template CSP `connect-src` so mobile local-agent IPC/EventSource streams are not blocked by WebView CSP
- gate `ElizaBootReceiver`'s `GET_USAGE_STATS` AppOps self-grant to privileged branded AOSP builds only
- leave stock/sideload APK installs on the normal user-granted permission path instead of logging `MANAGE_APP_OPS_MODES` SecurityException during package replacement/startup

## Pixel validation

Validated on a stock Android APK install on Pixel 9a, Android 16 / SDK 36, package `ai.milady.milady`.

Evidence from the local validation run:

- Rebuilt APK contains `connect-src ... eliza-local-agent:` in `assets/public/index.html`.
- Installed the rebuilt APK with `adb install -r`.
- Logcat after package replacement/startup now reports:
  - `Skipping GET_USAGE_STATS appop auto-grant on non-privileged APK install.`
  - no `MANAGE_APP_OPS_MODES` `SecurityException` from `ElizaBootReceiver`.
- `/api/health` after reinstall:
  - `ready: true`
  - `runtime: ok`
  - `database: ok`
  - `plugins.loaded: 10`
  - `plugins.failed: 0`
- `/api/local-inference/active` stayed on `eliza-1-0_8b`, `status: ready`.

Additional same-session stock APK proof before this split PR:

- local Eliza-1 text turn: HTTP 200, ~5.03s total after the CSP rebuild smoke, `mobile-local-direct-reply`, 11 streamed chunks
- Kokoro local TTS route: HTTP 200, returned `audio/wav`
- local ASR route: HTTP 200 against generated WAV
- scripted ASR -> Eliza-1 -> Kokoro voice loop completed locally on Pixel

## Notes

This PR does not claim NNAPI/Tensor or DFlash speculative decoding is active. Those remain separate hardware/runtime follow-ups. This is only the stock APK polish that is already proven on Pixel and should be safe for the AOSP path because the privileged app-op self-grant is still preserved under `BuildConfig.AOSP_BUILD && isBrandedDevice()`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two Android stock-APK startup issues: it gates the hidden `AppOpsManager#setMode` call behind a `BuildConfig.AOSP_BUILD && isBrandedDevice()` runtime check so non-privileged installs no longer log a `SecurityException` on boot, and it adds the `eliza-local-agent:` custom URI scheme to the WebView CSP `connect-src` directive so mobile IPC/EventSource streams are not blocked.

- **ElizaBootReceiver.java**: adds `isBrandedDevice()` (reads `ro.elizaos.product` via reflection) and wraps `allowUsageStatsAppOp` behind the double gate; the existing `SecurityException` catch inside `allowUsageStatsAppOp` is left intact as a further safety net for privileged AOSP builds.
- **index.html (template)**: appends `eliza-local-agent:` to `connect-src`; this template is shared across all generated projects so the scheme entry will appear in desktop and web builds where it is a no-op.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both changes are narrow, well-contained, and the fallback path for stock installs is correct in every failure mode.

The Java change correctly guards the privileged appop call and degrades gracefully when reflection fails or the branded-device check returns false. The CSP addition is benign on non-Android platforms. The two observations left as comments are non-blocking quality notes with no impact on runtime correctness.

No files require special attention, though reviewers may want to confirm that the template CSP change is intentionally cross-platform rather than Android-only.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaBootReceiver.java | Gates the hidden AppOpsManager#setMode call behind BuildConfig.AOSP_BUILD && isBrandedDevice(); adds isBrandedDevice() and readSystemProperty() helpers using reflection on android.os.SystemProperties. |
| packages/elizaos/templates/project/apps/app/index.html | Adds eliza-local-agent: to the connect-src CSP directive; the template is shared across all generated projects (not just Android), so the scheme entry will appear in desktop and web builds where it is unused but harmless. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ElizaBootReceiver.onReceive] --> B{Valid action?}
    B -- No --> Z[return early]
    B -- Yes --> C{BuildConfig.AOSP_BUILD?}
    C -- No --> E[Log: Skipping appop auto-grant]
    C -- Yes --> D{isBrandedDevice?\nro.elizaos.product non-empty?}
    D -- No --> E
    D -- Yes --> F[allowUsageStatsAppOp via reflection]
    F --> G{Reflection result}
    G -- ReflectiveOperationException --> H[Log warning: hidden API blocked]
    G -- SecurityException --> I[Log warning: user grant required]
    G -- Success --> J[AppOp set to ALLOWED]
    E --> K[GatewayConnectionService.start]
    H --> K
    I --> K
    J --> K
    K --> L{ElizaAgentService.shouldAutoStart?}
    L -- Yes --> M[ElizaAgentService.start]
    L -- No --> N{background enabled in prefs?}
    M --> N
    N -- Yes --> O[ElizaWorkScheduler.enqueuePeriodic]
    N -- No --> P[Log: background disabled]
```

<sub>Reviews (1): Last reviewed commit: ["fix(android): polish stock apk local-age..."](https://github.com/elizaos/eliza/commit/e912e5a1826ed643db8eee9377adb23ef8a2ca33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32418623)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->