### PR TITLE
perf(agent/role-gating): cache + in-flight dedup for sender-role checks

### DIFF
--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -73,6 +73,121 @@ const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGate>> = {
 };
 
 // ---------------------------------------------------------------------------
+// Sender-role lookup cache
+// ---------------------------------------------------------------------------
+// `checkSenderRole` does two DB queries (resolveWorldForMessage +
+// resolveEntityRole). When state composition runs, every gated provider's
+// wrapped `get()` calls it in parallel via `Promise.all`. With even a
+// modest set of gated providers (ACTIVE_WORKSPACE_CONTEXT,
+// CODING_AGENT_EXAMPLES, SECRETS_STATUS, walletPortfolio, etc. —
+// 10+ providers gated to admin or owner), that's 20+ DB queries per
+// turn before the planner is prompted. On a busy host the per-validator
+// stats compound and the provider provider-loop hits its overall
+// timeout cap, dropping providers from the prompt's context.
+//
+// Cache key: `${agentId}|${entityId}|${roomId}`. Roles are scoped per
+// world, and a room's world is stable for a single conversation. TTL is
+// short so admin promotions/demotions become visible within the cache
+// window.
+//
+// In-flight dedup ensures parallel callers for the same key share one DB
+// roundtrip instead of N.
+type CachedRoleCheck = {
+  value: { role: string; isOwner: boolean; isAdmin: boolean } | null;
+  expiresAt: number;
+};
+
+const ROLE_CHECK_CACHE_TTL_MS = 30_000;
+const ROLE_CHECK_CACHE_MAX_SIZE = 512;
+const roleCheckCache = new Map<string, CachedRoleCheck>();
+const roleCheckInflight = new Map<string, Promise<CachedRoleCheck["value"]>>();
+let roleCheckLoader:
+  | Promise<typeof import("./roles.ts").checkSenderRole>
+  | undefined;
+
+function loadCheckSenderRole() {
+  if (!roleCheckLoader) {
+    // Clear the cached promise if the dynamic import rejects so the next
+    // call can retry. Without this, a single transient module-registry
+    // failure (e.g. evaluation error during startup) would permanently
+    // wedge every gated provider for the runtime's lifetime by handing
+    // back the same rejected promise on every call.
+    roleCheckLoader = import("./roles.ts").then((mod) => mod.checkSenderRole);
+    roleCheckLoader.catch(() => {
+      roleCheckLoader = undefined;
+    });
+  }
+  return roleCheckLoader;
+}
+
+async function fetchAndCacheSenderRole(
+  runtime: IAgentRuntime,
+  message: Memory,
+  cacheKey: string,
+): Promise<CachedRoleCheck["value"]> {
+  const checkSenderRole = await loadCheckSenderRole();
+  const fresh = await checkSenderRole(runtime, message);
+  const value = fresh
+    ? { role: fresh.role, isOwner: fresh.isOwner, isAdmin: fresh.isAdmin }
+    : null;
+  roleCheckCache.set(cacheKey, {
+    value,
+    expiresAt: Date.now() + ROLE_CHECK_CACHE_TTL_MS,
+  });
+
+  // Bound the cache. Drop the oldest-inserted 25% (FIFO via Map iteration
+  // order) when we cross the threshold so a long-running agent never
+  // accumulates unbounded entries. FIFO is intentional — true LRU would
+  // require tracking last-access timestamps on every cache hit, and the
+  // 30s TTL is short enough that the eviction policy difference doesn't
+  // meaningfully affect hit rate for the parallel-Promise.all workload
+  // this cache is sized for.
+  if (roleCheckCache.size > ROLE_CHECK_CACHE_MAX_SIZE) {
+    const toDrop = Math.ceil(roleCheckCache.size / 4);
+    let dropped = 0;
+    for (const k of roleCheckCache.keys()) {
+      roleCheckCache.delete(k);
+      if (++dropped >= toDrop) break;
+    }
+  }
+
+  return value;
+}
+
+async function getCachedSenderRole(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<CachedRoleCheck["value"]> {
+  const entityId = message.entityId;
+  const roomId = message.roomId;
+  if (!entityId || !roomId) {
+    const checkSenderRole = await loadCheckSenderRole();
+    const fresh = await checkSenderRole(runtime, message);
+    return fresh
+      ? { role: fresh.role, isOwner: fresh.isOwner, isAdmin: fresh.isAdmin }
+      : null;
+  }
+
+  const key = `${runtime.agentId}|${entityId}|${roomId}`;
+  const cached = roleCheckCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  // Dedup: if a fetch for this key is already in flight (another gated
+  // provider's wrapper running in the same Promise.all batch), await the
+  // shared promise instead of starting a duplicate DB query.
+  const inflight = roleCheckInflight.get(key);
+  if (inflight) return inflight;
+
+  const promise = fetchAndCacheSenderRole(runtime, message, key).finally(() => {
+    roleCheckInflight.delete(key);
+  });
+  roleCheckInflight.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
 // Gating implementation
 // ---------------------------------------------------------------------------
 
@@ -110,9 +225,7 @@ function gateProvider(provider: Provider, gate: RoleGate): void {
     message: Memory,
     state: State,
   ): Promise<ProviderResult> => {
-    const { checkSenderRole } = await import("./roles.ts");
-
-    const check = await checkSenderRole(runtime, message);
+    const check = await getCachedSenderRole(runtime, message);
     if (!check || !roleCheckPasses(check, gate)) {
       return { text: "" };
     }


### PR DESCRIPTION
The provider role-gating wrapper at gateProvider() calls
`await import('./roles.ts')` then `await checkSenderRole(...)` on every
gated provider's get(). When state composition runs the
`Promise.all([...providers].map(p => p.get(...)))` batch, each gated
provider triggers an independent `checkSenderRole` round-trip, which
itself does two DB queries (resolveWorldForMessage + resolveEntityRole).

With ~10 admin/owner-gated providers (ACTIVE_WORKSPACE_CONTEXT,
CODING_AGENT_EXAMPLES, SECRETS_STATUS, walletPortfolio, terminalUsage
etc.) that's 20 simultaneous DB roundtrips per inbound message before
the planner is prompted. On a load-constrained host the per-provider
timeout cap fires and gated providers drop out of the prompt's context,
which then surfaces upstream as an under-informed planner pick.

This adds a per-runtime in-memory cache:

- Key: `${agentId}|${entityId}|${roomId}`. Roles are world-scoped and a
  room's world is stable for the conversation, so this is the natural
  key. Per-message turns within the same conversation reuse the value.
- TTL: 30s. Long enough to catch the parallel-Promise.all fan-out and a
  burst of subsequent turns; short enough that admin promotions/
  demotions take effect within a window the operator can tolerate.
- In-flight dedup: when N parallel callers all miss the cache for the
  same key, only the first one calls `checkSenderRole`; the remaining
  N-1 await its Promise. Without this, the cache helps subsequent calls
  but the cold parallel batch still fans out.
- Bounded LRU drop (oldest 25%) when entries cross 512 — protects
  long-running agents from unbounded growth.

The dynamic `import('./roles.ts')` is also memoized so the resolver
isn't re-evaluated on every cache miss (Node already caches module
graphs after the first load, but holding the resolved Promise avoids
re-entering the module evaluator at all).

No behavior change: cache hit returns the same shape `checkSenderRole`
would have computed; cache miss is a transparent pass-through. Action
gating (which uses `action.roleGate` enforced in the core execution
path, not this module) is unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a per-runtime in-memory cache with in-flight deduplication for `checkSenderRole` lookups in the provider role-gating layer. Previously, every gated provider's `get()` call performed two DB round-trips in parallel via `Promise.all`, causing 20+ simultaneous queries per message on a busy host and hitting provider-loop timeout caps.

- Introduces a module-level `roleCheckCache` (TTL 30 s, max 512 entries with FIFO eviction) keyed by `agentId|entityId|roomId`, plus a `roleCheckInflight` map to deduplicate the first cold-miss batch so N parallel providers share one DB call instead of N.
- Memoizes the `import('./roles.ts')` dynamic import with a safe rejection-clear fallback (the `.catch` resets `roleCheckLoader` so transient module failures are retryable), replacing the per-call `await import(...)` in `gateProvider`.
- Adds a bypass path (no caching) when `entityId` or `roomId` is absent from the message, since no stable key can be derived.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, scoped to an in-memory cache layer, and leaves the DB-level role check logic untouched.

The cache, dedup, eviction, and module-loader logic are all correctly implemented. Both issues from the previous review round (rejected-promise retention in roleCheckLoader and FIFO/LRU label mismatch) are explicitly addressed in this revision. JavaScript's single-threaded event loop eliminates the cache-write race concerns, and the .finally cleanup correctly ensures in-flight entries are removed whether the fetch succeeds or fails.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/plugin-role-gating.ts | Adds sender-role lookup cache with TTL, FIFO eviction, in-flight deduplication, and memoized module import; both previously flagged issues (rejected-promise retention, FIFO/LRU naming mismatch) are fully addressed in this revision. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as Provider A (gated)
    participant PB as Provider B (gated)
    participant GC as getCachedSenderRole
    participant CI as roleCheckInflight Map
    participant CC as roleCheckCache Map
    participant DB as checkSenderRole (DB)

    note over PA,PB: Promise.all([A.get(), B.get(), ...]) fires

    PA->>GC: getCachedSenderRole(runtime, msg)
    GC->>CC: get(key) → miss (cold)
    GC->>CI: get(key) → undefined
    GC->>CI: set(key, promise P1)
    GC-->>PA: return P1

    PB->>GC: getCachedSenderRole(runtime, msg)
    GC->>CC: get(key) → miss (cold)
    GC->>CI: get(key) → P1 (in-flight!)
    GC-->>PB: return P1 (shared!)

    PA->>DB: checkSenderRole(runtime, msg)
    DB-->>PA: "{ role, isOwner, isAdmin }"
    PA->>CC: "set(key, value, TTL=30s)"
    PA->>CI: delete(key) [finally]
    P1-->>PA: resolved value
    P1-->>PB: same resolved value (deduped)

    note over PA,PB: Subsequent turn within 30 s
    PA->>GC: getCachedSenderRole(runtime, msg)
    GC->>CC: get(key) → HIT ✓
    GC-->>PA: cached value (no DB call)
```

<sub>Reviews (2): Last reviewed commit: ["perf(agent/role-gating): cache + in-flig..."](https://github.com/elizaos/eliza/commit/f9db613774c00b5ad56dfc6bc540fcaf8bbf6bc4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32420192)</sub>

<!-- /greptile_comment -->