### PR TITLE
perf(plugin-agent-orchestrator): in-flight dedup for getTaskAgentFrameworkState

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -258,6 +258,21 @@ let frameworkStateCache:
       };
     }
   | undefined;
+
+// In-flight dedup for the slow `computeTaskAgentFrameworkState` path.
+// Multiple providers (CODING_AGENT_EXAMPLES, ACTIVE_WORKSPACE_CONTEXT)
+// call `getTaskAgentFrameworkState` in parallel during a single state
+// composition. On a cold cache miss, every caller would race into
+// `computeTaskAgentFrameworkState`, which probes the filesystem for
+// installed CLI binaries and adapter availability — the dominant
+// per-turn cost when the cache is cold. With this dedup, the first
+// caller starts the probe and the rest await its promise.
+let frameworkStateInflight:
+  | Promise<{
+      configuredSubscriptionProvider?: string;
+      frameworks: TaskAgentFrameworkAvailability[];
+    }>
+  | undefined;
 const frameworkCooldowns = new Map<
   SupportedTaskAgentAdapter,
   { until: number; reason: string }
@@ -828,25 +843,63 @@ export async function getTaskAgentFrameworkState(
       profileInput,
     );
   }
+
+  // When `profileInput` is supplied the result is request-shaped (not
+  // cacheable), so we still pay the full compute. The common case
+  // (no profileInput) goes through the dedup path so parallel callers
+  // in the same state-composition cycle share one probe instead of
+  // racing N independent filesystem walks.
+  if (!profileInput) {
+    if (!frameworkStateInflight) {
+      // Forward `probe` to the cold compute so the first caller's ACP
+      // preflight data (auth/install/docs status) is reflected in the
+      // cached inventory. Without this, the dedup path would silently
+      // strip the probe and bake stale availability into the 15s cache
+      // for all parallel and subsequent callers in the window.
+      // The cached value still strips probe-dependent enrichment fields
+      // (`recommended`, `selectionScore`, `selectionSignals`) so they
+      // can be recomputed per-call from `computeTaskAgentFrameworkStateFromInventory`.
+      const inflightProbe = probe;
+      frameworkStateInflight = (async () => {
+        try {
+          const fresh = await computeTaskAgentFrameworkState(
+            runtime,
+            inflightProbe,
+          );
+          const inventory = {
+            configuredSubscriptionProvider:
+              fresh.configuredSubscriptionProvider,
+            frameworks: fresh.frameworks.map((framework) => ({
+              ...framework,
+              recommended: false,
+              selectionScore: undefined,
+              selectionSignals: undefined,
+            })),
+          };
+          frameworkStateCache = {
+            expiresAt: Date.now() + 15_000,
+            value: inventory,
+          };
+          return inventory;
+        } finally {
+          frameworkStateInflight = undefined;
+        }
+      })();
+    }
+    const inventory = await frameworkStateInflight;
+    return computeTaskAgentFrameworkStateFromInventory(
+      runtime,
+      inventory,
+      probe,
+      profileInput,
+    );
+  }
+
   const value = await computeTaskAgentFrameworkState(
     runtime,
     probe,
     profileInput,
   );
-  if (!profileInput) {
-    frameworkStateCache = {
-      expiresAt: Date.now() + 15_000,
-      value: {
-        configuredSubscriptionProvider: value.configuredSubscriptionProvider,
-        frameworks: value.frameworks.map((framework) => ({
-          ...framework,
-          recommended: false,
-          selectionScore: undefined,
-          selectionSignals: undefined,
-        })),
-      },
-    };
-  }
   return value;
 }
 


### PR DESCRIPTION
`getTaskAgentFrameworkState` already has a 15s TTL cache, but the cache
miss path (`computeTaskAgentFrameworkState`) probes the filesystem for
installed CLI binaries (codex, claude, gemini, opencode, pi, copilot)
and inspects adapter availability — the dominant per-turn cost when
the cache is cold.

Multiple providers call this function in parallel during a single
state-composition cycle:

- `CODING_AGENT_EXAMPLES` (action-examples provider)
- `ACTIVE_WORKSPACE_CONTEXT` (active-workspace-context provider)
- Any other consumer that comes online with cold cache

When all of these fire via `Promise.all` and none find a cached value,
each independently runs the full probe — N parallel filesystem walks
and adapter checks for one logical answer.

This adds an in-flight Promise dedup that mirrors the existing TTL
cache layer:

- First caller into the cold path holds the in-flight Promise.
- All other parallel callers await the same Promise instead of
  starting a duplicate probe.
- The `finally` cleanup ensures the in-flight slot is released
  whether the probe resolves or rejects, so a failed probe doesn't
  permanently lock out subsequent calls (they re-enter the cache miss
  path normally).
- The `profileInput` path is request-shaped and not cacheable, so it
  remains a passthrough — only the cacheable common case dedups.

No behavior change for cache hits or for the request-shaped
`profileInput` path; the dedup is transparent on the cold path.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an in-flight Promise deduplication layer on top of the existing 15-second TTL cache in `getTaskAgentFrameworkState`, preventing redundant parallel `computeTaskAgentFrameworkState` calls (which probe the filesystem for CLI binaries and query adapter availability) when multiple providers hit a cold cache simultaneously.

- **Dedup scope is appropriately limited**: the `profileInput` path (request-shaped, not cacheable) remains a direct passthrough; only the common `!profileInput` cold-cache path participates in deduplication.
- **Probe forwarding is correctly implemented**: the first caller's `probe` is captured as `inflightProbe` and forwarded to `computeTaskAgentFrameworkState`, so ACP preflight data (`checkAvailableAgents`) is included in the base inventory baked into the 15s cache.
- **Error handling is correct**: the `finally` block clears `frameworkStateInflight` whether the probe resolves or rejects, so a failed probe never permanently blocks subsequent callers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the dedup is additive over the existing TTL cache and introduces no behavioral change for cache hits or the profileInput path.

The in-flight Promise dedup is logically correct: the first caller holds the Promise, all parallel callers await the same reference, the finally block clears the slot whether the probe resolves or rejects, and the cache is set inside the try block so any caller arriving after the finally runs will hit the cache rather than starting a redundant probe. Probe forwarding is correctly implemented via inflightProbe.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts | Adds a module-level `frameworkStateInflight` Promise variable and restructures the cold-cache path in `getTaskAgentFrameworkState` to dedup parallel callers; probe forwarding, error handling, and finally-cleanup are all correctly implemented. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant A as Provider A (CODING_AGENT_EXAMPLES)
    participant B as Provider B (ACTIVE_WORKSPACE_CONTEXT)
    participant G as getTaskAgentFrameworkState
    participant I as frameworkStateInflight
    participant C as computeTaskAgentFrameworkState
    participant Cache as frameworkStateCache

    par Parallel state-composition cycle
        A->>G: call (probe, no profileInput)
        B->>G: call (probe, no profileInput)
    end

    G->>Cache: check TTL miss
    G->>I: frameworkStateInflight not set
    G->>I: "set frameworkStateInflight = Promise"
    G->>C: computeTaskAgentFrameworkState(runtime, inflightProbe)

    note over B,G: B arrives, sees frameworkStateInflight set
    B->>I: await existing Promise

    C-->>G: resolves with fresh frameworks
    G->>Cache: "frameworkStateCache = inventory with 15s TTL"
    G->>I: finally clears frameworkStateInflight

    par Both callers receive inventory
        G-->>A: inventory
        I-->>B: inventory
    end

    A->>G: computeTaskAgentFrameworkStateFromInventory(probe_A)
    B->>G: computeTaskAgentFrameworkStateFromInventory(probe_B)

    G-->>A: TaskAgentFrameworkState (scored for A)
    G-->>B: TaskAgentFrameworkState (scored for B)
```

<sub>Reviews (2): Last reviewed commit: ["perf(plugin-agent-orchestrator): in-flig..."](https://github.com/elizaos/eliza/commit/a9781182c7e83395edf50798c273b4ef902031ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32420195)</sub>

<!-- /greptile_comment -->