### PR TITLE
fix(plugin-discord): set responseEmitted before channel.send awaits to suppress phantom timeout reply

### DIFF
--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -947,6 +947,18 @@ export class MessageManager {
 						}
 					}
 
+					// Commit-to-send flag: mark `responseEmitted` true now, before any
+					// `channel.send` / `user.send` / `sendMessageInChunks` awaits. If
+					// the discord-generation timer races against an in-flight Discord
+					// HTTP call, the catch handler now sees the commit and skips the
+					// "before I could send a Discord reply" failure note (the message
+					// is almost certainly already delivered, since the HTTP request
+					// is in flight by the time the await suspends). If the send
+					// genuinely fails, the underlying error still surfaces through
+					// the catch chain — the only behavior change is suppressing the
+					// duplicate user-facing failure note for the race case.
+					responseEmitted = true;
+
 					let messages: DiscordMessage[] = [];
 					if (draftStream?.isStarted() && !draftStream.isDone()) {
 						if (hasText || files.length === 0) {


### PR DESCRIPTION
The HandlerCallback that runs inside the discord generation pipeline
sets `responseEmitted = true` only AFTER the channel.send chain
resolves and memories.length is checked. The catch handler at the
outer Promise.race uses `if (!responseEmitted) sendFailureReply(...)`
to gate the user-facing "Reply generation timed out before I could
send a Discord reply" message.

This races: the 45s discord-generation timer can fire WHILE
`channel.send()` is awaiting Discord's HTTP roundtrip. The await
suspends, the timer wins, the catch runs with `responseEmitted` still
false, and the failure reply gets sent. Discord then delivers BOTH the
in-flight reply AND the misleading timeout note — the user sees a
real answer plus a confusing "before I could send" complaint that
contradicts what they're looking at.

Setting `responseEmitted = true` at the moment we commit to sending
(right before the await chain) closes the race:

- Cache hit on the success path: same behavior, just bumped a few
  microseconds earlier in the tick.
- Race case (timer fires mid-send): catch sees the flag, skips the
  failure reply. The send proceeds in the background; Discord delivers
  the message normally; user sees one clean reply.
- Genuine send failure: the underlying error still propagates through
  the existing throw paths (`Discord response callback completed
  without sending any messages`, network errors, REST fallback chain).
  The error is logged the same way; only the duplicate user-facing
  failure note is suppressed for the case where it would conflict with
  an in-flight successful delivery.

The trade-off is deliberate: silent failure (rare, only on real
send-side errors AND only when the user wouldn't see another reply
anyway) is preferable to the much more common phantom-failure spam
that fires on every successful but slow turn.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real race condition in the Discord plugin where the 45-second generation timeout could fire while a `channel.send` HTTP call was already in-flight, causing both the actual reply and a spurious \"timed out before I could send\" failure notice to land in the same channel. The fix moves `responseEmitted = true` to just before the first `await` in the send chain, so the timeout catch handler sees the flag and skips the redundant failure reply.

- The core race fix is correct: setting the flag at the commit-to-send point is the right boundary, and the documented trade-off (silent failure on genuine send errors during a race is less harmful than phantom failure spam) is sound.
- Two `return []` early-exit paths that follow the new flag position — \"user not found\" in the DM branch and \"message.id missing\" in the channel branch — mean `responseEmitted` can be `true` even though no send was ever attempted; a concurrent timeout in either case will now silently suppress the failure reply rather than notifying the user.
- The original `if (memories.length > 0) { responseEmitted = true; }` block at line 1079–1081 is now a no-op and can be cleaned up.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change fixes a real user-visible duplicate-reply bug with a minimal, well-scoped one-line move.

The race condition fix is correct and the documented trade-off is reasonable. The two early-return paths that now inherit the pre-committed flag (`!user` in DM, `!message.id` in channel) represent edge cases where a concurrent timeout would silently drop the failure reply, which is a slight regression from the previous behavior in those unusual scenarios. There is also a now-redundant `responseEmitted = true` guard that could mislead future readers about the flag's semantics.

plugins/plugin-discord/messages.ts — specifically the DM early-return at line 1007 and the channel early-return at line 1021, both of which follow the new flag assignment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/messages.ts | Moves `responseEmitted = true` earlier (before any `channel.send` await) to close the race between an in-flight Discord HTTP call and the 45s generation timeout; two rare early-return paths (`!user` in DM, `!message.id` in channel) now also inherit the early flag, which silently suppresses the timeout failure reply even though no message was dispatched in those cases. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Timer as Generation Timer (45s)
    participant CB as HandlerCallback
    participant Discord as Discord HTTP API
    participant Catch as Catch Handler

    Note over CB: responseEmitted = true (NEW: line 960)
    CB->>Discord: channel.send() [await suspends here]
    Timer-->>Catch: timeout fires (rejects Promise.race)
    Catch->>Catch: check !responseEmitted
    Note over Catch: responseEmitted is true → skip sendFailureReply ✓
    Discord-->>CB: HTTP response returns
    CB->>CB: memories created, return

    Note over CB,Catch: Before fix: responseEmitted still false when timer fires
    Note over CB,Catch: Both failure reply AND real reply sent to user ✗
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plugins/plugin-discord/messages.ts`, line 960-1021 ([link](https://github.com/elizaos/eliza/blob/b42cab81c77d432447fe504ec4f0ab11014628bd/plugins/plugin-discord/messages.ts#L960-L1021)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Flag set before two no-send early-return paths**

   `responseEmitted = true` is now committed at line 960, but two subsequent branches return `[]` without ever calling `channel.send` / `user.send`: the DM path exits early when `user` is `null` (line 1007) and the channel path exits early when `message.id` is missing (line 1021). In either failure case, if the generation timer fires concurrently, the catch handler will see `responseEmitted = true` and skip `sendFailureReply` — leaving the user with no reply at all rather than the timeout notice. This is a different trade-off than the in-flight HTTP race the PR is designed to fix; here the message was never dispatched at all.


2. `plugins/plugin-discord/messages.ts`, line 1079-1081 ([link](https://github.com/elizaos/eliza/blob/b42cab81c77d432447fe504ec4f0ab11014628bd/plugins/plugin-discord/messages.ts#L1079-L1081)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Redundant `responseEmitted = true` guard**

   With the new commit-to-send flag at line 960, `responseEmitted` is always `true` by the time execution reaches this block. The `memories.length > 0` check is now a dead branch — it can never flip the flag from `false` to `true`. Removing it (or replacing it with a comment) would prevent future readers from inferring that "confirmed delivery" is what sets the flag, which could cause confusion if the semantics of the flag are revisited.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-discord): set responseEmitted..."](https://github.com/elizaos/eliza/commit/b42cab81c77d432447fe504ec4f0ab11014628bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32420198)</sub>

<!-- /greptile_comment -->