### PR TITLE
fix(agent): harden Discord timeout and dedup caches

### DIFF
--- a/packages/agent/src/runtime/plugin-role-gating.test.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.test.ts
@@ -1,0 +1,125 @@
+import type {
+  IAgentRuntime,
+  Memory,
+  Plugin,
+  Provider,
+  State,
+} from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rolesMock = vi.hoisted(() => ({
+  checkSenderRole: vi.fn(),
+}));
+
+vi.mock("./roles.ts", () => rolesMock);
+
+import { applyPluginRoleGating } from "./plugin-role-gating.ts";
+
+const runtime = {
+  agentId: "11111111-1111-1111-1111-111111111111",
+} as IAgentRuntime;
+
+function message(metadata: Record<string, unknown> = {}): Memory {
+  return {
+    id: "22222222-2222-2222-2222-222222222222",
+    entityId: "33333333-3333-3333-3333-333333333333",
+    roomId: "44444444-4444-4444-4444-444444444444",
+    content: { text: "hi", source: "discord" },
+    metadata,
+  } as Memory;
+}
+
+function provider(name: string): Provider {
+  return {
+    name,
+    get: vi.fn(async () => ({ text: `${name}: visible` })),
+  } as unknown as Provider;
+}
+
+function pluginWithProviders(providers: Provider[]): Plugin {
+  return {
+    name: "test-plugin",
+    providers,
+  } as Plugin;
+}
+
+describe("applyPluginRoleGating", () => {
+  beforeEach(() => {
+    rolesMock.checkSenderRole.mockReset();
+  });
+
+  it("deduplicates concurrent provider role checks for the same message", async () => {
+    rolesMock.checkSenderRole.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({ role: "ADMIN", isOwner: false, isAdmin: true });
+          }, 10);
+        }),
+    );
+    const providers = [provider("SECRETS_STATUS"), provider("MISSING_SECRETS")];
+    applyPluginRoleGating([pluginWithProviders(providers)]);
+
+    const results = await Promise.all(
+      providers.map((item) =>
+        item.get?.(runtime, message({ fromId: "discord-user-1" }), {} as State),
+      ),
+    );
+
+    expect(rolesMock.checkSenderRole).toHaveBeenCalledTimes(1);
+    expect(results.map((item) => item?.text)).toEqual([
+      "SECRETS_STATUS: visible",
+      "MISSING_SECRETS: visible",
+    ]);
+  });
+
+  it("does not reuse a resolved role decision across later turns", async () => {
+    rolesMock.checkSenderRole
+      .mockResolvedValueOnce({ role: "ADMIN", isOwner: false, isAdmin: true })
+      .mockResolvedValueOnce({ role: "GUEST", isOwner: false, isAdmin: false });
+    const gatedProvider = provider("SECRETS_STATUS");
+    applyPluginRoleGating([pluginWithProviders([gatedProvider])]);
+
+    await expect(
+      gatedProvider.get?.(
+        runtime,
+        message({ fromId: "discord-user-1" }),
+        {} as State,
+      ),
+    ).resolves.toMatchObject({ text: "SECRETS_STATUS: visible" });
+    await expect(
+      gatedProvider.get?.(
+        runtime,
+        message({ fromId: "discord-user-1" }),
+        {} as State,
+      ),
+    ).resolves.toMatchObject({ text: "" });
+
+    expect(rolesMock.checkSenderRole).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps concurrent role checks separate when live connector metadata differs", async () => {
+    rolesMock.checkSenderRole.mockResolvedValue({
+      role: "ADMIN",
+      isOwner: false,
+      isAdmin: true,
+    });
+    const gatedProvider = provider("SECRETS_STATUS");
+    applyPluginRoleGating([pluginWithProviders([gatedProvider])]);
+
+    await Promise.all([
+      gatedProvider.get?.(
+        runtime,
+        message({ fromId: "discord-user-1" }),
+        {} as State,
+      ),
+      gatedProvider.get?.(
+        runtime,
+        message({ fromId: "discord-user-2" }),
+        {} as State,
+      ),
+    ]);
+
+    expect(rolesMock.checkSenderRole).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -73,6 +73,121 @@ const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGate>> = {
 };
 
 // ---------------------------------------------------------------------------
+// Sender-role lookup cache
+// ---------------------------------------------------------------------------
+// `checkSenderRole` does two DB queries (resolveWorldForMessage +
+// resolveEntityRole). When state composition runs, every gated provider's
+// wrapped `get()` calls it in parallel via `Promise.all`. With even a
+// modest set of gated providers (ACTIVE_WORKSPACE_CONTEXT,
+// CODING_AGENT_EXAMPLES, SECRETS_STATUS, walletPortfolio, etc. —
+// 10+ providers gated to admin or owner), that's 20+ DB queries per
+// turn before the planner is prompted. On a busy host the per-validator
+// stats compound and the provider provider-loop hits its overall
+// timeout cap, dropping providers from the prompt's context.
+//
+// Cache key: `${agentId}|${entityId}|${roomId}`. Roles are scoped per
+// world, and a room's world is stable for a single conversation. TTL is
+// short so admin promotions/demotions become visible within the cache
+// window.
+//
+// In-flight dedup ensures parallel callers for the same key share one DB
+// roundtrip instead of N.
+type CachedRoleCheck = {
+  value: { role: string; isOwner: boolean; isAdmin: boolean } | null;
+  expiresAt: number;
+};
+
+const ROLE_CHECK_CACHE_TTL_MS = 30_000;
+const ROLE_CHECK_CACHE_MAX_SIZE = 512;
+const roleCheckCache = new Map<string, CachedRoleCheck>();
+const roleCheckInflight = new Map<string, Promise<CachedRoleCheck["value"]>>();
+let roleCheckLoader:
+  | Promise<typeof import("./roles.ts").checkSenderRole>
+  | undefined;
+
+function loadCheckSenderRole() {
+  if (!roleCheckLoader) {
+    // Clear the cached promise if the dynamic import rejects so the next
+    // call can retry. Without this, a single transient module-registry
+    // failure (e.g. evaluation error during startup) would permanently
+    // wedge every gated provider for the runtime's lifetime by handing
+    // back the same rejected promise on every call.
+    roleCheckLoader = import("./roles.ts").then((mod) => mod.checkSenderRole);
+    roleCheckLoader.catch(() => {
+      roleCheckLoader = undefined;
+    });
+  }
+  return roleCheckLoader;
+}
+
+async function fetchAndCacheSenderRole(
+  runtime: IAgentRuntime,
+  message: Memory,
+  cacheKey: string,
+): Promise<CachedRoleCheck["value"]> {
+  const checkSenderRole = await loadCheckSenderRole();
+  const fresh = await checkSenderRole(runtime, message);
+  const value = fresh
+    ? { role: fresh.role, isOwner: fresh.isOwner, isAdmin: fresh.isAdmin }
+    : null;
+  roleCheckCache.set(cacheKey, {
+    value,
+    expiresAt: Date.now() + ROLE_CHECK_CACHE_TTL_MS,
+  });
+
+  // Bound the cache. Drop the oldest-inserted 25% (FIFO via Map iteration
+  // order) when we cross the threshold so a long-running agent never
+  // accumulates unbounded entries. FIFO is intentional — true LRU would
+  // require tracking last-access timestamps on every cache hit, and the
+  // 30s TTL is short enough that the eviction policy difference doesn't
+  // meaningfully affect hit rate for the parallel-Promise.all workload
+  // this cache is sized for.
+  if (roleCheckCache.size > ROLE_CHECK_CACHE_MAX_SIZE) {
+    const toDrop = Math.ceil(roleCheckCache.size / 4);
+    let dropped = 0;
+    for (const k of roleCheckCache.keys()) {
+      roleCheckCache.delete(k);
+      if (++dropped >= toDrop) break;
+    }
+  }
+
+  return value;
+}
+
+async function getCachedSenderRole(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<CachedRoleCheck["value"]> {
+  const entityId = message.entityId;
+  const roomId = message.roomId;
+  if (!entityId || !roomId) {
+    const checkSenderRole = await loadCheckSenderRole();
+    const fresh = await checkSenderRole(runtime, message);
+    return fresh
+      ? { role: fresh.role, isOwner: fresh.isOwner, isAdmin: fresh.isAdmin }
+      : null;
+  }
+
+  const key = `${runtime.agentId}|${entityId}|${roomId}`;
+  const cached = roleCheckCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value;
+  }
+
+  // Dedup: if a fetch for this key is already in flight (another gated
+  // provider's wrapper running in the same Promise.all batch), await the
+  // shared promise instead of starting a duplicate DB query.
+  const inflight = roleCheckInflight.get(key);
+  if (inflight) return inflight;
+
+  const promise = fetchAndCacheSenderRole(runtime, message, key).finally(() => {
+    roleCheckInflight.delete(key);
+  });
+  roleCheckInflight.set(key, promise);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
 // Gating implementation
 // ---------------------------------------------------------------------------
 
@@ -110,9 +225,7 @@ function gateProvider(provider: Provider, gate: RoleGate): void {
     message: Memory,
     state: State,
   ): Promise<ProviderResult> => {
-    const { checkSenderRole } = await import("./roles.ts");
-
-    const check = await checkSenderRole(runtime, message);
+    const check = await getCachedSenderRole(runtime, message);
     if (!check || !roleCheckPasses(check, gate)) {
       return { text: "" };
     }

--- a/packages/agent/src/runtime/plugin-role-gating.ts
+++ b/packages/agent/src/runtime/plugin-role-gating.ts
@@ -73,7 +73,7 @@ const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGate>> = {
 };
 
 // ---------------------------------------------------------------------------
-// Sender-role lookup cache
+// Sender-role lookup dedup
 // ---------------------------------------------------------------------------
 // `checkSenderRole` does two DB queries (resolveWorldForMessage +
 // resolveEntityRole). When state composition runs, every gated provider's
@@ -85,22 +85,20 @@ const PROVIDER_ROLE_OVERRIDES: Readonly<Record<string, RoleGate>> = {
 // stats compound and the provider provider-loop hits its overall
 // timeout cap, dropping providers from the prompt's context.
 //
-// Cache key: `${agentId}|${entityId}|${roomId}`. Roles are scoped per
-// world, and a room's world is stable for a single conversation. TTL is
-// short so admin promotions/demotions become visible within the cache
-// window.
-//
-// In-flight dedup ensures parallel callers for the same key share one DB
-// roundtrip instead of N.
-type CachedRoleCheck = {
-  value: { role: string; isOwner: boolean; isAdmin: boolean } | null;
-  expiresAt: number;
-};
+// This intentionally dedups only live in-flight checks. Provider redaction is
+// security-sensitive, and `checkSenderRole` also depends on live connector
+// metadata stamped onto the current message, so resolved role decisions are not
+// cached across turns.
+type RoleCheckValue = {
+  role: string;
+  isOwner: boolean;
+  isAdmin: boolean;
+} | null;
 
-const ROLE_CHECK_CACHE_TTL_MS = 30_000;
-const ROLE_CHECK_CACHE_MAX_SIZE = 512;
-const roleCheckCache = new Map<string, CachedRoleCheck>();
-const roleCheckInflight = new Map<string, Promise<CachedRoleCheck["value"]>>();
+const roleCheckInflightByRuntime = new WeakMap<
+  IAgentRuntime,
+  Map<string, Promise<RoleCheckValue>>
+>();
 let roleCheckLoader:
   | Promise<typeof import("./roles.ts").checkSenderRole>
   | undefined;
@@ -120,44 +118,45 @@ function loadCheckSenderRole() {
   return roleCheckLoader;
 }
 
-async function fetchAndCacheSenderRole(
+function stableStringify(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+    .join(",")}}`;
+}
+
+function liveRoleMetadataKey(message: Memory): string {
+  const source =
+    typeof message.content.source === "string" ? message.content.source : "";
+  const metadata = (message as Memory & { metadata?: unknown }).metadata;
+  return stableStringify({ metadata, source });
+}
+
+async function fetchSenderRole(
   runtime: IAgentRuntime,
   message: Memory,
-  cacheKey: string,
-): Promise<CachedRoleCheck["value"]> {
+): Promise<RoleCheckValue> {
   const checkSenderRole = await loadCheckSenderRole();
   const fresh = await checkSenderRole(runtime, message);
-  const value = fresh
+  return fresh
     ? { role: fresh.role, isOwner: fresh.isOwner, isAdmin: fresh.isAdmin }
     : null;
-  roleCheckCache.set(cacheKey, {
-    value,
-    expiresAt: Date.now() + ROLE_CHECK_CACHE_TTL_MS,
-  });
-
-  // Bound the cache. Drop the oldest-inserted 25% (FIFO via Map iteration
-  // order) when we cross the threshold so a long-running agent never
-  // accumulates unbounded entries. FIFO is intentional — true LRU would
-  // require tracking last-access timestamps on every cache hit, and the
-  // 30s TTL is short enough that the eviction policy difference doesn't
-  // meaningfully affect hit rate for the parallel-Promise.all workload
-  // this cache is sized for.
-  if (roleCheckCache.size > ROLE_CHECK_CACHE_MAX_SIZE) {
-    const toDrop = Math.ceil(roleCheckCache.size / 4);
-    let dropped = 0;
-    for (const k of roleCheckCache.keys()) {
-      roleCheckCache.delete(k);
-      if (++dropped >= toDrop) break;
-    }
-  }
-
-  return value;
 }
 
 async function getCachedSenderRole(
   runtime: IAgentRuntime,
   message: Memory,
-): Promise<CachedRoleCheck["value"]> {
+): Promise<RoleCheckValue> {
   const entityId = message.entityId;
   const roomId = message.roomId;
   if (!entityId || !roomId) {
@@ -168,19 +167,16 @@ async function getCachedSenderRole(
       : null;
   }
 
-  const key = `${runtime.agentId}|${entityId}|${roomId}`;
-  const cached = roleCheckCache.get(key);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.value;
+  const key = `${runtime.agentId}|${entityId}|${roomId}|${liveRoleMetadataKey(message)}`;
+  let roleCheckInflight = roleCheckInflightByRuntime.get(runtime);
+  if (!roleCheckInflight) {
+    roleCheckInflight = new Map();
+    roleCheckInflightByRuntime.set(runtime, roleCheckInflight);
   }
-
-  // Dedup: if a fetch for this key is already in flight (another gated
-  // provider's wrapper running in the same Promise.all batch), await the
-  // shared promise instead of starting a duplicate DB query.
   const inflight = roleCheckInflight.get(key);
   if (inflight) return inflight;
 
-  const promise = fetchAndCacheSenderRole(runtime, message, key).finally(() => {
+  const promise = fetchSenderRole(runtime, message).finally(() => {
     roleCheckInflight.delete(key);
   });
   roleCheckInflight.set(key, promise);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts
@@ -25,6 +25,7 @@ const ENV_KEYS = [
   "HOME",
   "OPENAI_API_KEY",
   "OPENAI_BASE_URL",
+  "PATH",
 ] as const;
 
 const savedEnv = new Map<string, string | undefined>();
@@ -43,6 +44,23 @@ function installedProbe(): TaskAgentFrameworkProbe {
       { adapter: "OpenAI Codex", installed: true },
       { adapter: "OpenCode", installed: true },
     ]),
+  };
+}
+
+function delayedInstalledProbe(): TaskAgentFrameworkProbe {
+  return {
+    checkAvailableAgents: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve([
+              { adapter: "Claude Code", installed: true },
+              { adapter: "OpenAI Codex", installed: true },
+              { adapter: "OpenCode", installed: true },
+            ]);
+          }, 10);
+        }),
+    ),
   };
 }
 
@@ -65,6 +83,7 @@ describe("getTaskAgentFrameworkState", () => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-frameworks-"));
     process.env.HOME = tempHome;
     process.env.ELIZA_CONFIG_PATH = path.join(tempHome, "missing-eliza.json");
+    process.env.PATH = tempHome;
     clearTaskAgentFrameworkStateCache();
   });
 
@@ -135,5 +154,47 @@ describe("getTaskAgentFrameworkState", () => {
     expect(
       state.frameworks.find((item) => item.id === "claude")?.authReady,
     ).toBe(true);
+  });
+
+  it("deduplicates concurrent preflight-backed cold fills", async () => {
+    const probe = delayedInstalledProbe();
+
+    const [first, second] = await Promise.all([
+      getTaskAgentFrameworkState(runtime(), probe),
+      getTaskAgentFrameworkState(runtime(), probe),
+    ]);
+
+    expect(probe.checkAvailableAgents).toHaveBeenCalledTimes(1);
+    expect(
+      first.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(true);
+    expect(
+      second.frameworks.find((item) => item.id === "codex")?.installed,
+    ).toBe(true);
+  });
+
+  it("keeps static and preflight discovery caches separate", async () => {
+    const probe: TaskAgentFrameworkProbe = {
+      checkAvailableAgents: vi.fn(async () => [
+        {
+          adapter: "OpenAI Codex",
+          installed: true,
+          installCommand: "preflight-codex-install",
+        },
+      ]),
+    };
+
+    const staticState = await getTaskAgentFrameworkState(runtime());
+    const preflightState = await getTaskAgentFrameworkState(runtime(), probe);
+
+    expect(probe.checkAvailableAgents).toHaveBeenCalledTimes(1);
+    expect(
+      staticState.frameworks.find((item) => item.id === "codex")
+        ?.installCommand,
+    ).toBeUndefined();
+    expect(
+      preflightState.frameworks.find((item) => item.id === "codex")
+        ?.installCommand,
+    ).toBe("preflight-codex-install");
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -249,15 +249,20 @@ export const TASK_AGENT_DEFAULT_MODEL_PREFS: Record<
 const TASK_AGENT_COMPLEXITY_RE =
   /\b(repo|repository|code|coding|debug|fix|implement|investigate|research|analyze|analysis|summarize|summary|write|draft|document|plan|workflow|automation|parallel|delegate|subtask|agent|orchestrate|coordinate|compare|test|tests|pull request|pr\b|branch|commit)\b/i;
 
-let frameworkStateCache:
-  | {
-      expiresAt: number;
-      value: {
-        configuredSubscriptionProvider?: string;
-        frameworks: TaskAgentFrameworkAvailability[];
-      };
-    }
-  | undefined;
+type FrameworkInventory = {
+  configuredSubscriptionProvider?: string;
+  frameworks: TaskAgentFrameworkAvailability[];
+};
+type FrameworkDiscoveryCacheKey = "static" | "preflight";
+type FrameworkStateCacheEntry = {
+  expiresAt: number;
+  value: FrameworkInventory;
+};
+
+const frameworkStateCache = new Map<
+  FrameworkDiscoveryCacheKey,
+  FrameworkStateCacheEntry
+>();
 
 // In-flight dedup for the slow `computeTaskAgentFrameworkState` path.
 // Multiple providers (CODING_AGENT_EXAMPLES, ACTIVE_WORKSPACE_CONTEXT)
@@ -267,18 +272,22 @@ let frameworkStateCache:
 // installed CLI binaries and adapter availability — the dominant
 // per-turn cost when the cache is cold. With this dedup, the first
 // caller starts the probe and the rest await its promise.
-let frameworkStateInflight:
-  | Promise<{
-      configuredSubscriptionProvider?: string;
-      frameworks: TaskAgentFrameworkAvailability[];
-    }>
-  | undefined;
+const frameworkStateInflight = new Map<
+  FrameworkDiscoveryCacheKey,
+  Promise<FrameworkInventory>
+>();
 const frameworkCooldowns = new Map<
   SupportedTaskAgentAdapter,
   { until: number; reason: string }
 >();
 const TASK_AGENT_USAGE_EXHAUSTED_RE =
   /\b(insufficient(?:[_\s]+(?:credits?|quota))|insufficient_quota|out of credits|credit balance|usage (?:has )?(?:reached|exceeded)|(?:you(?:'ve| have)? hit your usage limits?)|usage[-\s]?limits?|quota exceeded|payment required|status(?:code)?[:\s]*402)\b/i;
+
+function frameworkDiscoveryCacheKey(
+  probe?: TaskAgentFrameworkProbe,
+): FrameworkDiscoveryCacheKey {
+  return probe?.checkAvailableAgents ? "preflight" : "static";
+}
 
 function normalizePreflightAdapterId(
   value: string | undefined,
@@ -835,10 +844,12 @@ export async function getTaskAgentFrameworkState(
   probe?: TaskAgentFrameworkProbe,
   profileInput?: TaskAgentTaskProfileInput,
 ): Promise<TaskAgentFrameworkState> {
-  if (frameworkStateCache && frameworkStateCache.expiresAt > Date.now()) {
+  const cacheKey = frameworkDiscoveryCacheKey(probe);
+  const cached = frameworkStateCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
     return computeTaskAgentFrameworkStateFromInventory(
       runtime,
-      frameworkStateCache.value,
+      cached.value,
       probe,
       profileInput,
     );
@@ -850,17 +861,21 @@ export async function getTaskAgentFrameworkState(
   // in the same state-composition cycle share one probe instead of
   // racing N independent filesystem walks.
   if (!profileInput) {
-    if (!frameworkStateInflight) {
+    let inflight = frameworkStateInflight.get(cacheKey);
+    if (!inflight) {
       // Forward `probe` to the cold compute so the first caller's ACP
       // preflight data (auth/install/docs status) is reflected in the
       // cached inventory. Without this, the dedup path would silently
       // strip the probe and bake stale availability into the 15s cache
       // for all parallel and subsequent callers in the window.
+      // The in-flight and cache entries are keyed by discovery source:
+      // probe-backed ACP preflight and static filesystem/env discovery
+      // must not share a cold-fill promise or cached inventory.
       // The cached value still strips probe-dependent enrichment fields
       // (`recommended`, `selectionScore`, `selectionSignals`) so they
       // can be recomputed per-call from `computeTaskAgentFrameworkStateFromInventory`.
       const inflightProbe = probe;
-      frameworkStateInflight = (async () => {
+      inflight = (async () => {
         try {
           const fresh = await computeTaskAgentFrameworkState(
             runtime,
@@ -876,17 +891,18 @@ export async function getTaskAgentFrameworkState(
               selectionSignals: undefined,
             })),
           };
-          frameworkStateCache = {
+          frameworkStateCache.set(cacheKey, {
             expiresAt: Date.now() + 15_000,
             value: inventory,
-          };
+          });
           return inventory;
         } finally {
-          frameworkStateInflight = undefined;
+          frameworkStateInflight.delete(cacheKey);
         }
       })();
+      frameworkStateInflight.set(cacheKey, inflight);
     }
-    const inventory = await frameworkStateInflight;
+    const inventory = await inflight;
     return computeTaskAgentFrameworkStateFromInventory(
       runtime,
       inventory,
@@ -905,20 +921,13 @@ export async function getTaskAgentFrameworkState(
 
 function computeTaskAgentFrameworkStateFromInventory(
   runtime: IAgentRuntime,
-  inventory: {
-    configuredSubscriptionProvider?: string;
-    frameworks: TaskAgentFrameworkAvailability[];
-  },
+  inventory: FrameworkInventory,
   probe?: TaskAgentFrameworkProbe,
   profileInput?: TaskAgentTaskProfileInput,
 ): TaskAgentFrameworkState {
   const clonedProbe = {
     ...probe,
     checkAvailableAgents: undefined,
-  };
-  frameworkStateCache = {
-    expiresAt: Date.now() + 15_000,
-    value: inventory,
   };
   return {
     ...computeTaskAgentFrameworkStateFromCachedInventory(
@@ -1049,10 +1058,6 @@ function computeTaskAgentFrameworkStateFromCachedInventory(
       framework.selectionSignals = scored.selectionSignals;
     }
   }
-  frameworkStateCache = {
-    expiresAt: Date.now() + 15_000,
-    value: inventory,
-  };
   return {
     configuredSubscriptionProvider,
     frameworks,
@@ -1220,7 +1225,8 @@ function buildPreferredReason(
 }
 
 export function clearTaskAgentFrameworkStateCache(): void {
-  frameworkStateCache = undefined;
+  frameworkStateCache.clear();
+  frameworkStateInflight.clear();
 }
 
 export function isUsageExhaustedTaskAgentError(text: string): boolean {

--- a/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts
@@ -258,6 +258,21 @@ let frameworkStateCache:
       };
     }
   | undefined;
+
+// In-flight dedup for the slow `computeTaskAgentFrameworkState` path.
+// Multiple providers (CODING_AGENT_EXAMPLES, ACTIVE_WORKSPACE_CONTEXT)
+// call `getTaskAgentFrameworkState` in parallel during a single state
+// composition. On a cold cache miss, every caller would race into
+// `computeTaskAgentFrameworkState`, which probes the filesystem for
+// installed CLI binaries and adapter availability — the dominant
+// per-turn cost when the cache is cold. With this dedup, the first
+// caller starts the probe and the rest await its promise.
+let frameworkStateInflight:
+  | Promise<{
+      configuredSubscriptionProvider?: string;
+      frameworks: TaskAgentFrameworkAvailability[];
+    }>
+  | undefined;
 const frameworkCooldowns = new Map<
   SupportedTaskAgentAdapter,
   { until: number; reason: string }
@@ -828,25 +843,63 @@ export async function getTaskAgentFrameworkState(
       profileInput,
     );
   }
+
+  // When `profileInput` is supplied the result is request-shaped (not
+  // cacheable), so we still pay the full compute. The common case
+  // (no profileInput) goes through the dedup path so parallel callers
+  // in the same state-composition cycle share one probe instead of
+  // racing N independent filesystem walks.
+  if (!profileInput) {
+    if (!frameworkStateInflight) {
+      // Forward `probe` to the cold compute so the first caller's ACP
+      // preflight data (auth/install/docs status) is reflected in the
+      // cached inventory. Without this, the dedup path would silently
+      // strip the probe and bake stale availability into the 15s cache
+      // for all parallel and subsequent callers in the window.
+      // The cached value still strips probe-dependent enrichment fields
+      // (`recommended`, `selectionScore`, `selectionSignals`) so they
+      // can be recomputed per-call from `computeTaskAgentFrameworkStateFromInventory`.
+      const inflightProbe = probe;
+      frameworkStateInflight = (async () => {
+        try {
+          const fresh = await computeTaskAgentFrameworkState(
+            runtime,
+            inflightProbe,
+          );
+          const inventory = {
+            configuredSubscriptionProvider:
+              fresh.configuredSubscriptionProvider,
+            frameworks: fresh.frameworks.map((framework) => ({
+              ...framework,
+              recommended: false,
+              selectionScore: undefined,
+              selectionSignals: undefined,
+            })),
+          };
+          frameworkStateCache = {
+            expiresAt: Date.now() + 15_000,
+            value: inventory,
+          };
+          return inventory;
+        } finally {
+          frameworkStateInflight = undefined;
+        }
+      })();
+    }
+    const inventory = await frameworkStateInflight;
+    return computeTaskAgentFrameworkStateFromInventory(
+      runtime,
+      inventory,
+      probe,
+      profileInput,
+    );
+  }
+
   const value = await computeTaskAgentFrameworkState(
     runtime,
     probe,
     profileInput,
   );
-  if (!profileInput) {
-    frameworkStateCache = {
-      expiresAt: Date.now() + 15_000,
-      value: {
-        configuredSubscriptionProvider: value.configuredSubscriptionProvider,
-        frameworks: value.frameworks.map((framework) => ({
-          ...framework,
-          recommended: false,
-          selectionScore: undefined,
-          selectionSignals: undefined,
-        })),
-      },
-    };
-  }
   return value;
 }
 

--- a/plugins/plugin-discord/__tests__/messages-url.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-url.test.ts
@@ -6,7 +6,11 @@ import {
 } from "@elizaos/core";
 import type { Message as DiscordMessage } from "discord.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { hasActiveTaskAgentWorkForMessage, MessageManager } from "../messages";
+import {
+	hasActiveTaskAgentWorkForMessage,
+	MessageManager,
+	shouldSuppressTimeoutForInFlightDispatchForTests,
+} from "../messages";
 
 function runtime(): IAgentRuntime {
 	return {
@@ -197,5 +201,30 @@ describe("hasActiveTaskAgentWorkForMessage", () => {
 		expect(hasActiveTaskAgentWorkForMessage(runtime, "message-memory-id")).toBe(
 			false,
 		);
+	});
+});
+
+describe("shouldSuppressTimeoutForInFlightDispatchForTests", () => {
+	it("suppresses only timeout handling that loses to an in-flight response dispatch", () => {
+		expect(
+			shouldSuppressTimeoutForInFlightDispatchForTests({
+				generationTimedOut: true,
+				responseDispatchInFlight: true,
+			}),
+		).toBe(true);
+
+		expect(
+			shouldSuppressTimeoutForInFlightDispatchForTests({
+				generationTimedOut: false,
+				responseDispatchInFlight: true,
+			}),
+		).toBe(false);
+
+		expect(
+			shouldSuppressTimeoutForInFlightDispatchForTests({
+				generationTimedOut: true,
+				responseDispatchInFlight: false,
+			}),
+		).toBe(false);
 	});
 });

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -203,6 +203,16 @@ export function hasActiveTaskAgentWorkForMessage(
 	return false;
 }
 
+export function shouldSuppressTimeoutForInFlightDispatchForTests({
+	generationTimedOut,
+	responseDispatchInFlight,
+}: {
+	generationTimedOut: boolean;
+	responseDispatchInFlight: boolean;
+}): boolean {
+	return generationTimedOut && responseDispatchInFlight;
+}
+
 /**
  * Class representing a Message Manager for handling Discord messages.
  */
@@ -780,6 +790,7 @@ export class MessageManager {
 				: null;
 			let typingStarted = false;
 			let responseEmitted = false;
+			let responseDispatchInFlight = false;
 			let generationTimedOut = false;
 			const generationTimeoutMs = resolveGenerationTimeoutMs(
 				this.runtime.getSetting("DISCORD_GENERATION_TIMEOUT_MS") ??
@@ -827,6 +838,17 @@ export class MessageManager {
 						},
 						"Failed to send Discord failure reply",
 					);
+				}
+			};
+
+			const runResponseDispatch = async <T>(
+				dispatch: () => Promise<T>,
+			): Promise<T> => {
+				responseDispatchInFlight = true;
+				try {
+					return await dispatch();
+				} finally {
+					responseDispatchInFlight = false;
 				}
 			};
 
@@ -947,39 +969,31 @@ export class MessageManager {
 						}
 					}
 
-					// Commit-to-send flag: mark `responseEmitted` true now, before any
-					// `channel.send` / `user.send` / `sendMessageInChunks` awaits. If
-					// the discord-generation timer races against an in-flight Discord
-					// HTTP call, the catch handler now sees the commit and skips the
-					// "before I could send a Discord reply" failure note (the message
-					// is almost certainly already delivered, since the HTTP request
-					// is in flight by the time the await suspends). If the send
-					// genuinely fails, the underlying error still surfaces through
-					// the catch chain — the only behavior change is suppressing the
-					// duplicate user-facing failure note for the race case.
-					responseEmitted = true;
-
 					let messages: DiscordMessage[] = [];
 					if (draftStream?.isStarted() && !draftStream.isDone()) {
 						if (hasText || files.length === 0) {
-							messages = await draftStream.finalize(textContent);
+							messages = await runResponseDispatch(() =>
+								draftStream.finalize(textContent),
+							);
 						} else {
 							await finalizePendingDraft();
 						}
 
 						if (files.length > 0) {
 							try {
-								const attachmentMessage = await channel.send({
-									files,
-									...(outboundReplyToMessageId &&
-									(replyToMode === "all" || !hasText)
-										? {
-												reply: {
-													messageReference: outboundReplyToMessageId,
-												},
-											}
-										: {}),
-								});
+								const attachmentMessage = await runResponseDispatch(() =>
+									channel.send({
+										files,
+										...(outboundReplyToMessageId &&
+										(replyToMode === "all" || !hasText)
+											? {
+													reply: {
+														messageReference: outboundReplyToMessageId,
+													},
+												}
+											: {}),
+									}),
+								);
 								messages.push(attachmentMessage);
 							} catch (error) {
 								this.runtime.logger.warn(
@@ -1007,10 +1021,12 @@ export class MessageManager {
 							return [];
 						}
 
-						const dmMessage = await user.send({
-							content: textContent,
-							files: files.length > 0 ? files : undefined,
-						});
+						const dmMessage = await runResponseDispatch(() =>
+							user.send({
+								content: textContent,
+								files: files.length > 0 ? files : undefined,
+							}),
+						);
 						messages = [dmMessage];
 					} else {
 						if (!message.id) {
@@ -1020,14 +1036,16 @@ export class MessageManager {
 							);
 							return [];
 						}
-						messages = await sendMessageInChunks(
-							channel,
-							textContent,
-							outboundReplyToMessageId ?? "",
-							files,
-							undefined,
-							this.runtime,
-							replyToMode,
+						messages = await runResponseDispatch(() =>
+							sendMessageInChunks(
+								channel,
+								textContent,
+								outboundReplyToMessageId ?? "",
+								files,
+								undefined,
+								this.runtime,
+								replyToMode,
+							),
 						);
 					}
 
@@ -1206,6 +1224,26 @@ export class MessageManager {
 							timeoutMs: generationTimeoutMs,
 						},
 						"Suppressing Discord timeout reply while task-agent work is still active",
+					);
+					return;
+				}
+
+				if (
+					shouldSuppressTimeoutForInFlightDispatchForTests({
+						generationTimedOut,
+						responseDispatchInFlight,
+					})
+				) {
+					this.runtime.logger.warn(
+						{
+							src: "plugin:discord",
+							agentId: this.runtime.agentId,
+							messageId: message.id,
+							memoryId: messageId,
+							roomId,
+							timeoutMs: generationTimeoutMs,
+						},
+						"Suppressing Discord timeout handling while response dispatch is in flight",
 					);
 					return;
 				}

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -947,6 +947,18 @@ export class MessageManager {
 						}
 					}
 
+					// Commit-to-send flag: mark `responseEmitted` true now, before any
+					// `channel.send` / `user.send` / `sendMessageInChunks` awaits. If
+					// the discord-generation timer races against an in-flight Discord
+					// HTTP call, the catch handler now sees the commit and skips the
+					// "before I could send a Discord reply" failure note (the message
+					// is almost certainly already delivered, since the HTTP request
+					// is in flight by the time the await suspends). If the send
+					// genuinely fails, the underlying error still surfaces through
+					// the catch chain — the only behavior change is suppressing the
+					// duplicate user-facing failure note for the race case.
+					responseEmitted = true;
+
 					let messages: DiscordMessage[] = [];
 					if (draftStream?.isStarted() && !draftStream.isDone()) {
 						if (hasText || files.length === 0) {


### PR DESCRIPTION
## Summary

Cherry-picks and hardens PRs #7741, #7740, and #7739 for production readiness.

- Discord: keeps `responseEmitted` tied to actual emitted memories and adds a separate in-flight dispatch gate so timeout handling is suppressed only while Discord send/finalize is still resolving.
- Agent orchestrator: keys framework-state cache/in-flight dedup by discovery source so static discovery and ACP preflight do not poison each other.
- Role gating: replaces the 30s authorization cache with per-runtime in-flight dedup keyed by live connector metadata, avoiding stale admin/owner decisions after role or identity changes.

## Validation

- `bunx vitest run --config vitest.config.ts __tests__/messages-url.test.ts` in `plugins/plugin-discord`
- `bunx vitest run --config vitest.config.ts __tests__/unit/task-agent-frameworks.test.ts` in `plugins/plugin-agent-orchestrator`
- `bunx vitest run --config vitest.config.ts src/runtime/plugin-role-gating.test.ts` in `packages/agent`
- `bunx @biomejs/biome check` on the six changed files
- `git diff --check`

## Notes

Package typechecks were attempted but are currently blocked by existing workspace dependency/type-resolution issues unrelated to these files: missing `@elizaos/contracts`, missing declarations for `fast-redact`/`markdown-it`, and missing package type libs for `bun`/`node`/`react`/`react-dom` in the affected package configs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens three production pain points around concurrent in-flight deduplication: Discord response dispatch, agent-orchestrator framework discovery, and provider role-gating. Each fix replaces either a time-based cache or a missing gate with a per-key in-flight promise that is cleaned up immediately after resolution.

- **Discord (`messages.ts`)**: Introduces `runResponseDispatch` to track when a send/finalize call is actively resolving and suppresses the generation-timeout error handler while that window is open, keeping `responseEmitted` tied to actual memory creation.
- **Agent orchestrator (`task-agent-frameworks.ts`)**: Promotes the single `frameworkStateCache` variable to a keyed `Map` with separate `\"static\"` and `\"preflight\"` entries and adds a parallel `frameworkStateInflight` map so concurrent callers share one filesystem probe instead of racing N independent walks.
- **Role gating (`plugin-role-gating.ts`)**: Replaces the 30 s TTL authorization cache with a WeakMap-backed per-runtime in-flight dedup keyed on live connector metadata (`entityId | roomId | metadata | source`), ensuring resolved role decisions are never reused across turns.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are well-tested and address real concurrency issues without altering external contracts.

The core logic across all three files is sound and thoroughly exercised by the new tests. The two comments identify a misleading export name that doubles as production logic and a boolean flag that could momentarily read false during concurrent multi-dispatch scenarios — neither represents broken behaviour in the common single-dispatch path that Discord uses today.

messages.ts — the `shouldSuppressTimeoutForInFlightDispatchForTests` naming and the single-boolean `responseDispatchInFlight` flag are worth a second look before this pattern is copied to other message adapters.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/messages.ts | Adds `responseDispatchInFlight` boolean flag and `runResponseDispatch` helper to gate the timeout suppression to a narrower window; also exports the suppression predicate with a misleading `ForTests` suffix while using it in production code. |
| packages/agent/src/runtime/plugin-role-gating.ts | Replaces the 30s TTL authorization cache with per-runtime in-flight dedup keyed on live connector metadata; correctly clears entries via `.finally()` and resets the module loader promise on rejection. |
| plugins/plugin-agent-orchestrator/src/services/task-agent-frameworks.ts | Splits the single `frameworkStateCache` variable into per-discovery-source `Map` entries and adds a parallel in-flight dedup Map; removes stale cache re-writes from `computeTaskAgentFrameworkStateFromInventory` and `computeTaskAgentFrameworkStateFromCachedInventory`. |
| plugins/plugin-discord/__tests__/messages-url.test.ts | Adds a test suite for `shouldSuppressTimeoutForInFlightDispatchForTests` covering all boolean-input combinations; straightforward and correct. |
| packages/agent/src/runtime/plugin-role-gating.test.ts | New test file covering dedup, no-cache-across-turns, and per-metadata isolation for the role-gating in-flight dedup; tests are well-structured with good mock resets. |
| plugins/plugin-agent-orchestrator/__tests__/unit/task-agent-frameworks.test.ts | Adds `PATH` to the saved env keys and two new tests for preflight dedup and cache-key isolation; correctly validates the new per-discovery-source behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden PR 7739 7740 7741 changes"](https://github.com/elizaos/eliza/commit/56eb30ccc2bc0998b0c9f76d2a588570dd35e5a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32431418)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->