### PR TITLE
Disable DFlash for M-RoPE catalog tiers

### DIFF
--- a/packages/shared/src/local-inference/catalog.test.ts
+++ b/packages/shared/src/local-inference/catalog.test.ts
@@ -111,6 +111,7 @@ describe("Eliza-1 runtime quant metadata", () => {
       expect(entry?.runtime?.optimizations?.requiresKernel).toContain(
         "polarquant",
       );
+      expect(entry?.runtime?.dflash?.disabledReason).toContain("#7631");
     }
   });
 });

--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -514,6 +514,8 @@ function runtimeForTier(
     dflash: {
       drafterModelId: drafterId(id),
       specType: "dflash",
+      disabledReason:
+        "Pending hardware validation for M-RoPE speculative decoding; see elizaOS/eliza#7631.",
       contextSize: contextLength,
       draftContextSize: Math.min(contextLength, 65536),
       draftMin: 2,

--- a/packages/shared/src/local-inference/types.ts
+++ b/packages/shared/src/local-inference/types.ts
@@ -275,6 +275,12 @@ export interface LocalRuntimeAcceleration {
     /** Catalog id of the hidden drafter GGUF companion. */
     drafterModelId: string;
     specType: "dflash";
+    /**
+     * Optional catalog-level disable reason. When set, the runtime keeps the
+     * drafter metadata bundled but launches target-only until the backend
+     * path is validated again.
+     */
+    disabledReason?: string;
     /** llama-server context for the target model. */
     contextSize: number;
     /** llama-server context for the drafter. */

--- a/plugins/plugin-local-inference/src/services/dflash-catalog-disable.test.ts
+++ b/plugins/plugin-local-inference/src/services/dflash-catalog-disable.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { DflashLlamaServer } from "./dflash-server";
+
+vi.mock("./backend", () => ({
+	gpuLayersForKvOffload: () => null,
+}));
+
+vi.mock("./catalog", () => ({
+	ELIZA_1_PLACEHOLDER_IDS: new Set<string>(),
+	ELIZA_1_TIER_IDS: [],
+	MODEL_CATALOG: [],
+	findCatalogModel: vi.fn(() => undefined),
+}));
+
+vi.mock("./cache-bridge", () => ({
+	DEFAULT_CACHE_TTLS: { short: 1, long: 1, extended: 1 },
+	buildModelHash: () => "hash",
+	deriveSlotId: () => 0,
+	evictExpired: vi.fn(() => Promise.resolve()),
+	readCacheStats: vi.fn(() => []),
+	slotCacheFileName: () => "slot.json",
+	slotSavePath: () => "/tmp/dflash-slots",
+}));
+
+vi.mock("./dflash-event-schema", () => ({
+	parseDflashFieldFromSseChunk: vi.fn(() => null),
+}));
+
+vi.mock("./dflash-metrics-collector", () => ({
+	DflashMetricsCollector: class {},
+	dflashTurnHistory: [],
+}));
+
+vi.mock("./dflash-verify-event", () => ({
+	parseDflashVerifyEventsFromSseChunk: vi.fn(() => []),
+}));
+
+vi.mock("./hardware", () => ({
+	probeHardware: vi.fn(() => ({ totalRamMb: 0, appleSilicon: false })),
+}));
+
+vi.mock("./inference-telemetry", () => ({
+	inferenceTelemetry: {
+		record: vi.fn(),
+	},
+}));
+
+vi.mock("./kv-spill", () => ({
+	estimateQuantizedKvBytesPerToken: () => 0,
+	KV_SPILL_MIN_CONTEXT: 0,
+	planKvSpill: vi.fn(() => null),
+	residentKvBudgetFromRamBudget: () => 0,
+	restoreClassForHardware: () => null,
+}));
+
+vi.mock("./llama-server-metrics", () => ({
+	diffSnapshots: vi.fn(() => null),
+	fetchMetricsSnapshot: vi.fn(() => null),
+}));
+
+vi.mock("./manifest", () => ({
+	parseManifestOrThrow: vi.fn(() => null),
+	validateManifest: vi.fn(() => null),
+}));
+
+vi.mock("./ram-budget", () => ({
+	ramHeadroomReserveMb: () => 0,
+	resolveRamBudget: () => ({ minMb: 0, recommendedMb: 0 }),
+}));
+
+vi.mock("./registry", () => ({
+	listInstalledModels: vi.fn(),
+}));
+
+vi.mock("./structured-output", () => ({
+	grammarRequestFields: [],
+	prefillPlanRequestFields: [],
+	repairStructuredOutput: vi.fn(),
+	resolveGuidedDecodeForParams: vi.fn(() => null),
+	StructuredOutputRepairStream: class {},
+	spanSamplerPlanRequestFields: [],
+}));
+
+describe("DflashLlamaServer catalog disable reason", () => {
+	it("launches target-only when the catalog disables DFlash", async () => {
+		const registry = await import("./registry");
+		vi.mocked(registry.listInstalledModels).mockResolvedValue([
+			{
+				id: "target-model",
+				displayName: "Target model",
+				path: "/models/target.gguf",
+				sizeBytes: 1,
+				installedAt: "2026-05-16T00:00:00.000Z",
+				lastUsedAt: null,
+				source: "eliza-download",
+			},
+			{
+				id: "drafter-model",
+				displayName: "Drafter model",
+				path: "/models/drafter.gguf",
+				sizeBytes: 1,
+				installedAt: "2026-05-16T00:00:00.000Z",
+				lastUsedAt: null,
+				source: "eliza-download",
+				runtimeRole: "dflash-drafter",
+				companionFor: "target-model",
+			},
+		] as never);
+
+		const startSpy = vi
+			.spyOn(DflashLlamaServer.prototype, "start")
+			.mockResolvedValue(undefined);
+
+		try {
+			const server = new DflashLlamaServer();
+			await server.load({
+				modelId: "target-model",
+				modelPath: "/models/target.gguf",
+				catalog: {
+					id: "target-model",
+					displayName: "Target model",
+					hfRepo: "example/repo",
+					ggufFile: "/models/target.gguf",
+					params: "2B",
+					quant: "q4",
+					sizeGb: 1,
+					minRamGb: 1,
+					category: "chat",
+					bucket: "small",
+					blurb: "Target model",
+					runtime: {
+						dflash: {
+							drafterModelId: "drafter-model",
+							specType: "dflash",
+							disabledReason:
+								"Pending hardware validation for M-RoPE speculative decoding; see elizaOS/eliza#7631.",
+							contextSize: 128,
+							draftContextSize: 64,
+							draftMin: 2,
+							draftMax: 4,
+							gpuLayers: "auto",
+							draftGpuLayers: "auto",
+							disableThinking: false,
+						},
+					},
+				} as never,
+			} as never);
+
+			expect(startSpy).toHaveBeenCalledTimes(1);
+			expect(startSpy.mock.calls[0]?.[0]).toMatchObject({
+				targetModelPath: "/models/target.gguf",
+				drafterModelPath: "/models/drafter.gguf",
+				disableDrafter: true,
+				disabledDrafterReason:
+					"Pending hardware validation for M-RoPE speculative decoding; see elizaOS/eliza#7631.",
+			});
+		} finally {
+			startSpy.mockRestore();
+		}
+	});
+});

--- a/plugins/plugin-local-inference/src/services/dflash-server.ts
+++ b/plugins/plugin-local-inference/src/services/dflash-server.ts
@@ -3088,6 +3088,10 @@ export class DflashLlamaServer implements LocalInferenceBackend {
 			);
 		}
 		const drafter = installed.find((m) => m.id === dflash.drafterModelId);
+		const disabledReason =
+			typeof dflash.disabledReason === "string"
+				? dflash.disabledReason.trim()
+				: "";
 		// DFlash is normally always-on (AGENTS.md §4), but staged bundles
 		// ("weights-staged.*") ship a drafter that is a byte-copy of the target
 		// — not a usable draft model — and some bundles ship no drafter at all.
@@ -3096,13 +3100,21 @@ export class DflashLlamaServer implements LocalInferenceBackend {
 		// `restartWithoutDrafter()` uses for memory eviction): the server runs
 		// target-only, no `-md`. Loud warning because this departs from the
 		// always-on DFlash contract.
-		const drafterUnavailable = !drafter;
+		const drafterUnavailable = !drafter || disabledReason.length > 0;
+		const disabledDrafterReason =
+			disabledReason ||
+			(drafterUnavailable
+				? `companion drafter '${dflash.drafterModelId}' is not installed`
+				: undefined);
 		if (drafterUnavailable) {
 			console.warn(
-				`[dflash] ⚠️  ${target.displayName}: companion drafter ` +
-					`'${dflash.drafterModelId}' is not installed — loading target-only ` +
-					`(speculative decoding OFF). Install a valid drafter to restore the ` +
-					`always-on DFlash path.`,
+				disabledReason.length > 0
+					? `[dflash] ⚠️  ${target.displayName}: catalog disables DFlash ` +
+						`(${disabledReason}) — loading target-only (speculative decoding OFF).`
+					: `[dflash] ⚠️  ${target.displayName}: companion drafter ` +
+						`'${dflash.drafterModelId}' is not installed — loading target-only ` +
+						`(speculative decoding OFF). Install a valid drafter to restore the ` +
+						`always-on DFlash path.`,
 			);
 		}
 
@@ -3169,9 +3181,7 @@ export class DflashLlamaServer implements LocalInferenceBackend {
 				// passed to llama-server (`-md`) while `disableDrafter` is true.
 				drafterModelPath: drafter?.path ?? target.path,
 				disableDrafter: drafterUnavailable,
-				disabledDrafterReason: drafterUnavailable
-					? `companion drafter '${dflash.drafterModelId}' is not installed`
-					: undefined,
+				disabledDrafterReason,
 				contextSize,
 				draftContextSize: dflash.draftContextSize,
 				draftMin: dflash.draftMin,


### PR DESCRIPTION
## Summary
This PR applies the repo-side mitigation for #7631 by disabling DFlash for Eliza-1 M-RoPE catalog tiers until the current speculative-decoding path is hardware-validated.

Today, these tiers can enter a speculative-decoding path that is not yet validated for M-RoPE behavior. Rather than allowing an unreliable or misleading runtime path, this change makes the fallback explicit: the runtime launches target-only and records a clear disable reason.

## What Changed
- Added a catalog-level `disabledReason` field to the DFlash runtime metadata.
- Marked the Eliza-1 M-RoPE catalog tiers with a DFlash disable reason tied to #7631.
- Updated the DFlash launcher to honor that catalog flag during startup.
- Preserved the existing target-only fallback path, but made the reason explicit and user-visible instead of silent.
- Added focused test coverage for both the catalog metadata and the startup behavior.

## Runtime Behavior
With this change, when a catalog tier declares a DFlash disable reason:
- the runtime does not attempt to start speculative decoding for that tier
- the launcher falls back to target-only startup
- the disable reason is carried through as part of the runtime diagnostic path

This keeps the current mitigation narrow in scope. Tiers without a DFlash disable reason continue to use the existing behavior.

## Why This Change
Issue #7631 tracks the M-RoPE speculative-decoding problem. The goal of this PR is not to solve the underlying model/runtime compatibility issue inside llama.cpp, but to prevent Eliza from selecting a path that is known to be unvalidated for these tiers.

That makes the system behavior more honest and more predictable:
- no silent speculative-decoding attempt on affected tiers
- no ambiguous startup path when DFlash should be suppressed
- a clear catalog-driven control point for re-enabling the feature later

## Verification
Added coverage for:
- `packages/shared/src/local-inference/catalog.test.ts`
- `plugins/plugin-local-inference/src/services/dflash-catalog-disable.test.ts`

These checks validate:
- the catalog metadata carries the expected DFlash disable reason
- the launcher switches to target-only startup when the catalog disables DFlash
- the disable reason is preserved in the startup flow

## Related
Mitigates #7631.
