### PR TITLE
feat(cloud): DELETE agent via async job queue — kills zombie containers on Hetzner

### DIFF
--- a/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
@@ -18,6 +18,7 @@ import { getPreferredElizaAgentWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { adminService } from "@/lib/services/admin";
 import { reusesExistingElizaCharacter } from "@/lib/services/eliza-agent-config";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import { getStewardAgent } from "@/lib/services/steward-client";
 import type {
   AgentAdminDetailsDto,
@@ -364,63 +365,63 @@ app.delete("/", async (c) => {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
-    if (existing.node_id && existing.sandbox_id) {
-      const forwarded = await deleteDockerBackedAgentViaControlPlane(
-        c,
-        user,
-        agentId,
+    if (existing.status === "provisioning") {
+      return c.json(
+        { success: false, error: "Agent provisioning is in progress" },
+        409,
       );
-      if (forwarded) return forwarded;
     }
 
-    const deleted = await elizaSandboxService.deleteAgent(
+    // Async delete via the same job-queue path agent_provision uses. This
+    // moves the SSH stop, Neon cleanup, and per-agent key revoke off the
+    // request thread so a slow / unreachable Hetzner core can no longer
+    // make the API hang or silently return 200 while the container lives
+    // on. Idempotent: a second DELETE while a job is in flight reuses
+    // the existing one.
+    const enqueueResult = await provisioningJobService.enqueueAgentDeleteOnce({
       agentId,
-      user.organization_id,
-    );
-    if (!deleted.success) {
-      const status =
-        deleted.error === "Agent not found"
-          ? 404
-          : deleted.error === "Agent provisioning is in progress"
-            ? 409
-            : 500;
-      return c.json({ success: false, error: deleted.error }, status);
-    }
-
-    const characterId = deleted.deletedSandbox.character_id;
-    const reusesExistingCharacter = reusesExistingElizaCharacter(
-      deleted.deletedSandbox.agent_config,
-    );
-
-    if (characterId && !reusesExistingCharacter) {
-      try {
-        await userCharactersRepository.delete(characterId);
-        logger.info("[agent-api] Cleaned up linked character after delete", {
-          agentId,
-          characterId,
-        });
-      } catch (characterErr) {
-        logger.warn(
-          "[agent-api] Failed to clean up linked character after delete",
-          {
-            agentId,
-            characterId,
-            error:
-              characterErr instanceof Error
-                ? characterErr.message
-                : String(characterErr),
-          },
-        );
-      }
-    }
-
-    logger.info("[agent-api] Agent deleted", {
-      agentId,
-      orgId: user.organization_id,
+      organizationId: user.organization_id,
+      userId: user.id,
     });
 
-    return c.json({ success: true });
+    // Best-effort wake of the worker so the user does not wait for the
+    // next cron tick. Same pattern as the provision path.
+    void provisioningJobService.triggerImmediate(c.env).catch(() => {
+      // Logged inside the service; nothing actionable here.
+    });
+
+    logger.info("[agent-api] Agent delete enqueued", {
+      agentId,
+      orgId: user.organization_id,
+      jobId: enqueueResult.job.id,
+      created: enqueueResult.created,
+    });
+
+    return c.json(
+      {
+        success: true,
+        created: enqueueResult.created,
+        alreadyInProgress: !enqueueResult.created,
+        message: enqueueResult.created
+          ? "Delete job created. Poll the job endpoint for status."
+          : "Delete is already in progress.",
+        data: {
+          jobId: enqueueResult.job.id,
+          agentId,
+          status: enqueueResult.job.status,
+        },
+        polling: {
+          endpoint: `/api/v1/jobs/${enqueueResult.job.id}`,
+          intervalMs: 5_000,
+          expectedDurationMs: 30_000,
+        },
+      },
+      202,
+    );
   } catch (error) {
+    if (error instanceof Error && error.message === "Agent not found") {
+      return c.json({ success: false, error: "Agent not found" }, 404);
+    }
     logger.error("[agent-api] DELETE /agents/:agentId error", { error });
     return failureResponse(c, error);
   }

--- a/packages/cloud-shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/schemas/agent-sandboxes.ts
@@ -54,7 +54,21 @@ export type AgentSandboxStatus =
   | "running"
   | "stopped"
   | "disconnected"
-  | "error";
+  | "error"
+  /**
+   * Row is queued for async deletion. An `agent_delete` job has been
+   * enqueued in `jobs`; the provisioning worker will SSH the core, stop
+   * the container, and then DELETE the row. UI must treat this as
+   * "soon-to-be-gone" — no mutations should be accepted while in this
+   * state.
+   */
+  | "deletion_pending"
+  /**
+   * Async deletion exhausted retries (e.g. SSH unreachable for the core
+   * hosting this sandbox). The container may still be running on the
+   * core; ops must investigate. Row stays so the failure is visible.
+   */
+  | "deletion_failed";
 
 export type AgentBillingStatus = "active" | "warning" | "suspended" | "shutdown_pending" | "exempt";
 

--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Covers the substring matcher that decides whether a failed `docker stop`
+ * / `docker rm` error indicates the container is already absent. This is
+ * the pivot of the prod fix shipped in PR #BIG — without it, both-calls-
+ * failed used to silently leave zombie containers on the cores; with it,
+ * both-calls-failed throws only when the failures are unrelated to "gone".
+ */
+import { describe, expect, test } from "bun:test";
+import { isAlreadyGoneMessage } from "../docker-error-classifier";
+
+describe("isAlreadyGoneMessage", () => {
+  test('recognizes "No such container" (Docker 24)', () => {
+    expect(
+      isAlreadyGoneMessage(
+        "Error response from daemon: No such container: agent-abc123",
+      ),
+    ).toBe(true);
+  });
+
+  test('recognizes "not found" (older Docker)', () => {
+    expect(isAlreadyGoneMessage("Container not found: agent-abc")).toBe(true);
+  });
+
+  test('recognizes "already gone"', () => {
+    expect(isAlreadyGoneMessage("container already gone before stop")).toBe(
+      true,
+    );
+  });
+
+  test('recognizes "no longer exists"', () => {
+    expect(
+      isAlreadyGoneMessage("the named container no longer exists on host"),
+    ).toBe(true);
+  });
+
+  test("case-insensitive", () => {
+    expect(isAlreadyGoneMessage("NO SUCH CONTAINER: AGENT-1")).toBe(true);
+  });
+
+  test("returns false for SSH connection failure", () => {
+    expect(
+      isAlreadyGoneMessage(
+        "ssh: connect to host 138.201.80.125 port 22: Connection timed out",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for Docker daemon down", () => {
+    expect(
+      isAlreadyGoneMessage(
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for permission denied", () => {
+    expect(isAlreadyGoneMessage("Permission denied (publickey)")).toBe(false);
+  });
+
+  test("returns false for empty / unrelated text", () => {
+    expect(isAlreadyGoneMessage("")).toBe(false);
+    expect(isAlreadyGoneMessage("some unrelated error")).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
+++ b/packages/cloud-shared/src/lib/services/docker-error-classifier.ts
@@ -1,0 +1,24 @@
+/**
+ * Tiny dep-free helpers to classify errors returned by `docker` / SSH so
+ * the rest of the sandbox provider can stay readable. Extracted from
+ * `docker-sandbox-provider.ts` only so the helpers can be unit-tested
+ * without pulling in plugin-sql / drizzle / @elizaos/core at import time.
+ */
+
+/**
+ * Matches Docker / SSH error messages that mean "the thing we tried to
+ * stop is no longer there". Used by `DockerSandboxProvider.stop()` to
+ * treat both-calls-failed as success when the container was already gone
+ * before we got the SSH window. Substring match because docker error
+ * formatting drifts across versions ("No such container", "is not
+ * running", etc.).
+ */
+export function isAlreadyGoneMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("no such container") ||
+    normalized.includes("not found") ||
+    normalized.includes("already gone") ||
+    normalized.includes("no longer exists")
+  );
+}

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -18,6 +18,7 @@ import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { dockerNodeManager } from "./docker-node-manager";
+import { isAlreadyGoneMessage } from "./docker-error-classifier";
 import { getUsedDockerHostPorts } from "./docker-port-allocation";
 import {
   allocatePort,
@@ -40,8 +41,15 @@ import {
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
 import { headscaleIntegration } from "./headscale-integration";
-import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
-import { ensureStewardTenant, resolveStewardTenantCredentials } from "./steward-tenant-config";
+import type {
+  SandboxCreateConfig,
+  SandboxHandle,
+  SandboxProvider,
+} from "./sandbox-provider-types";
+import {
+  ensureStewardTenant,
+  resolveStewardTenantCredentials,
+} from "./steward-tenant-config";
 
 // ---------------------------------------------------------------------------
 // Exported metadata type for strongly-typed provider metadata
@@ -100,7 +108,10 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
+  return resolveStewardContainerUrl(
+    resolveStewardHostUrl(),
+    env.STEWARD_CONTAINER_URL,
+  );
 }
 
 /**
@@ -109,7 +120,9 @@ function resolveStewardContainerEnvUrl(): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildStewardProxyEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -140,7 +153,9 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
+    throw new Error(
+      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
+    );
   }
   // /api/health returns 200 or 401 (auth required) — both mean the server is up.
   // Use curl with -o /dev/null and check status code to accept either.
@@ -150,7 +165,9 @@ function getDockerHealthCmd(port: string): string {
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
+    throw new Error(
+      "[docker-sandbox] Steward token endpoint returned an empty response",
+    );
   }
 
   try {
@@ -334,7 +351,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
+    throw (
+      lastError ??
+      new Error("[docker-sandbox] create exhausted all retry attempts")
+    );
   }
 
   /**
@@ -345,14 +365,18 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
+  private async _createOnce(
+    config: SandboxCreateConfig,
+  ): Promise<SandboxHandle> {
     const { agentId, agentName, environmentVars, organizationId } = config;
 
     // Resolve Docker image: operator env override > per-agent DB override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
     // overrides are not accidentally shadowed by the generic Eliza default.
     const resolvedImage =
-      DOCKER_IMAGE_OVERRIDE || config.dockerImage || "ghcr.io/elizaos/eliza:latest";
+      DOCKER_IMAGE_OVERRIDE ||
+      config.dockerImage ||
+      "ghcr.io/elizaos/eliza:latest";
     const imagePlatform = containersEnv.defaultAgentImagePlatform();
     const platformFlags = dockerPlatformFlag(imagePlatform);
 
@@ -414,7 +438,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
+    const bridgePort = allocatePort(
+      BRIDGE_PORT_MIN,
+      BRIDGE_PORT_MAX,
+      usedPorts,
+    );
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -441,7 +469,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     let vpnEnvVars: Record<string, string> = {};
     if (headscaleEnabled) {
       try {
-        const vpnSetup = await headscaleIntegration.prepareContainerVPN(agentId);
+        const vpnSetup =
+          await headscaleIntegration.prepareContainerVPN(agentId);
         vpnEnvVars = vpnSetup.envVars;
         logger.info(`[docker-sandbox] Headscale VPN enabled for ${agentId}`);
       } catch (err) {
@@ -479,7 +508,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
+    const ssh = DockerSSHClient.getClient(
+      hostname,
+      sshPort,
+      hostKeyFingerprint,
+      sshUser,
+    );
 
     try {
       // Ensure volume directory exists
@@ -489,10 +523,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
 
       // Pull image (may take a while on first run)
-      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
+      logger.info(
+        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
+      );
       try {
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
+            " ",
+          ),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -520,7 +558,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       // sandbox will skip registration silently in that case.
       const registryRedisUrl = process.env.KV_REST_API_URL?.trim() ?? "";
       const registryRedisToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
-      const canSelfRegister = registryRedisUrl !== "" && registryRedisToken !== "";
+      const canSelfRegister =
+        registryRedisUrl !== "" && registryRedisToken !== "";
       if (!canSelfRegister) {
         logger.warn(
           "[docker-sandbox] KV_REST_API_URL / KV_REST_API_TOKEN missing from orchestrator env — sandbox will not register in Redis and gateways will not route inbound platform messages to it",
@@ -549,7 +588,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         // (no D-Bus keychain). Generate one per container — the vault state
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
-        ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        ELIZA_VAULT_PASSPHRASE:
+          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
         // Gateway service discovery — see SandboxRegistry in app-core.
         // SANDBOX_PUBLIC_URL targets the public Docker host (not the headscale
         // VPN IP set later at line ~653) because the gateways on Railway can't
@@ -583,7 +623,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--name ${shellQuote(containerName)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) ||
+        Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || DEFAULT_AGENT_PORT))}`,
@@ -591,7 +632,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-timeout 5s",
         "--health-start-period 15s",
         "--health-retries 6",
-        ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
+        ...(headscaleEnabled
+          ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"]
+          : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 3000).
@@ -606,7 +649,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
       );
-      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker start ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
@@ -621,18 +667,24 @@ export class DockerSandboxProvider implements SandboxProvider {
           cloud: {
             enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
             apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "https://www.elizacloud.ai/api/v1",
+            baseUrl:
+              allEnv.ELIZAOS_CLOUD_BASE_URL ||
+              "https://www.elizacloud.ai/api/v1",
           },
         });
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
+          "base64",
+        );
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
+        logger.info(
+          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
+        );
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
@@ -646,7 +698,9 @@ export class DockerSandboxProvider implements SandboxProvider {
           `curl -s -X DELETE -H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)} ${stewardTenant.apiKey ? `-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}` : ""} ${shellQuote(`${resolveStewardHostUrl()}/agents/${agentId}`)} || true`,
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
+        logger.info(
+          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
+        );
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -654,7 +708,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       await ssh
-        .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
+        .exec(
+          `docker rm -f ${shellQuote(containerName)}`,
+          DOCKER_CMD_TIMEOUT_MS,
+        )
         .catch(() => {});
 
       // Rollback allocated_count on failure
@@ -663,11 +720,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {
-        await headscaleIntegration.cleanupContainerVPN(agentId).catch((cleanupErr) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
-          );
-        });
+        await headscaleIntegration
+          .cleanupContainerVPN(agentId)
+          .catch((cleanupErr) => {
+            logger.warn(
+              `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+            );
+          });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -677,7 +736,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
       try {
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(agentId, 60_000);
+        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
+          agentId,
+          60_000,
+        );
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -743,18 +805,24 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
-        hasHcloudToken: Boolean(hcloudToken),
-        hasPublicKey: Boolean(publicKey),
-      });
+      logger.warn(
+        "[docker-sandbox] No Docker capacity and autoscale is not configured",
+        {
+          hasHcloudToken: Boolean(hcloudToken),
+          hasPublicKey: Boolean(publicKey),
+        },
+      );
       return null;
     }
 
     try {
-      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
-        image,
-        platform,
-      });
+      logger.info(
+        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
+        {
+          image,
+          platform,
+        },
+      );
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -769,7 +837,9 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
+        const node = await dockerNodesRepository.findByNodeId(
+          provisioned.nodeId,
+        );
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -782,18 +852,26 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
+        );
       }
 
-      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
-        nodeId: provisioned.nodeId,
-        hostname: provisioned.hostname,
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
+        {
+          nodeId: provisioned.nodeId,
+          hostname: provisioned.hostname,
+        },
+      );
       return null;
     } catch (error) {
-      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node provisioning failed",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -816,22 +894,60 @@ export class DockerSandboxProvider implements SandboxProvider {
       meta.sshUser,
     );
 
+    // Track both attempts so we can fail loudly if neither call landed.
+    // Historically these errors were swallowed independently, which let
+    // the caller think a delete succeeded while the container kept
+    // running on the core (observed in prod e2e on 2026-05-16). We need
+    // at least one of (stop, rm) to land for the container to be
+    // effectively gone.
+    let stopErr: unknown;
+    let rmErr: unknown;
+
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
-    } catch (stopErr) {
+    } catch (err) {
+      stopErr = err;
       logger.warn(
-        `[docker-sandbox] docker stop failed for ${meta.containerName}: ${stopErr instanceof Error ? stopErr.message : String(stopErr)}`,
+        `[docker-sandbox] docker stop failed for ${meta.containerName}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
 
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
-    } catch (rmErr) {
+    } catch (err) {
+      rmErr = err;
       logger.error(
-        `[docker-sandbox] docker rm failed for ${meta.containerName}: ${rmErr instanceof Error ? rmErr.message : String(rmErr)}`,
+        `[docker-sandbox] docker rm failed for ${meta.containerName}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    if (stopErr && rmErr) {
+      const stopMsg =
+        stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
+      // "No such container" from either call means the container was
+      // already gone — that is a success, not a failure. We only escalate
+      // when both calls failed for a reason that does NOT indicate the
+      // container is absent (SSH down, Docker daemon hung, etc.).
+      const stopIsGone = isAlreadyGoneMessage(stopMsg);
+      const rmIsGone = isAlreadyGoneMessage(rmMsg);
+      if (!stopIsGone && !rmIsGone) {
+        throw new Error(
+          `Failed to stop container ${meta.containerName} on ${meta.hostname}: ` +
+            `docker stop -> ${stopMsg}; docker rm -f -> ${rmMsg}`,
+        );
+      }
+      logger.info(
+        `[docker-sandbox] Container ${meta.containerName} already absent on ${meta.hostname}`,
       );
     }
 
@@ -844,11 +960,13 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Clean up Headscale VPN registration if enabled
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
-      await headscaleIntegration.cleanupContainerVPN(meta.agentId).catch((err) => {
-        logger.warn(
-          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      await headscaleIntegration
+        .cleanupContainerVPN(meta.agentId)
+        .catch((err) => {
+          logger.warn(
+            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
     }
 
     // Remove from in-memory registry
@@ -919,10 +1037,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
+        );
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(remaining, 1000)),
+        );
       } else {
         break;
       }
@@ -949,11 +1071,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
-        containerName: meta.containerName,
-        error:
-          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
-      });
+      logger.warn(
+        "[docker-sandbox] Failed to collect health timeout diagnostics",
+        {
+          containerName: meta.containerName,
+          error:
+            diagnosticsError instanceof Error
+              ? diagnosticsError.message
+              : String(diagnosticsError),
+        },
+      );
     }
     return false;
   }
@@ -962,12 +1089,19 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
+  async runCommand(
+    sandboxId: string,
+    cmd: string,
+    args?: string[],
+  ): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
+    const escapedArgs =
+      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs
+      ? `${shellQuote(cmd)} ${escapedArgs}`
+      : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -1014,7 +1148,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         let sshUser = DEFAULT_SSH_USERNAME;
         let hostKeyFingerprint: string | undefined;
 
-        const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
+        const dbNode = await dockerNodesRepository.findByNodeId(
+          sandbox.node_id,
+        );
         if (dbNode) {
           hostname = dbNode.hostname;
           sshPort = dbNode.ssh_port ?? DEFAULT_SSH_PORT;

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -628,6 +628,12 @@ export class ElizaSandboxService {
   }> {
     const result = await this.deleteAgent(agentId, orgId);
     if (!result.success) {
+      // If the row is already gone, treat as success. This covers the retry
+      // case where a prior attempt deleted the row but failed before updating
+      // the job status to "completed", causing the runner to retry.
+      if (result.error === "Agent not found") {
+        return { success: true, containerStopped: true };
+      }
       return {
         success: false,
         containerStopped: false,

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -14,6 +14,7 @@ import {
   agentSandboxesRepository,
   prepareAgentBackupInsertData,
 } from "../../db/repositories/agent-sandboxes";
+import { userCharactersRepository } from "../../db/repositories/characters";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import {
   type AgentBackupStateData,
@@ -28,6 +29,7 @@ import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
 import {
+  reusesExistingElizaCharacter,
   stripReservedElizaConfigKeys,
   withReusedElizaCharacterOwnership,
 } from "./eliza-agent-config";
@@ -599,6 +601,70 @@ export class ElizaSandboxService {
         ? ({ success: true, deletedSandbox } as const)
         : ({ success: false, error: "Agent not found" } as const);
     });
+  }
+
+  /**
+   * Async-path counterpart to `deleteAgent`, invoked by the provisioning
+   * worker daemon when it picks up an `agent_delete` job. Returns a
+   * structured outcome the daemon stores in the job result so observers can
+   * tell apart "container survived stop" (ops needed) from "row delete
+   * failed" (probably retried by next attempt).
+   *
+   * Wraps `deleteAgent` so the SSH/Neon/DB sequence stays in one place,
+   * but maps the return shape to what the queue handler expects and
+   * tracks whether the container actually went down before the row was
+   * removed. The row delete happens iff `stop` either succeeded or the
+   * container was already gone — both are observable in the `deleteAgent`
+   * success path (`isIgnorableSandboxStopError` swallows "no such
+   * container" specifically).
+   */
+  async executeDeletion(
+    agentId: string,
+    orgId: string,
+  ): Promise<{
+    success: boolean;
+    containerStopped: boolean;
+    error?: string;
+  }> {
+    const result = await this.deleteAgent(agentId, orgId);
+    if (!result.success) {
+      return {
+        success: false,
+        containerStopped: false,
+        error: result.error,
+      };
+    }
+
+    // Character cleanup used to live in the HTTP DELETE handler. Now that
+    // delete is async via the queue, the daemon owns this step so orphan
+    // characters do not pile up when the deletion completes outside of an
+    // HTTP request context. Best-effort: a failure here leaves an orphan
+    // row but does not un-delete the (already gone) sandbox.
+    const characterId = result.deletedSandbox.character_id;
+    if (characterId && !reusesExistingElizaCharacter(result.deletedSandbox.agent_config)) {
+      try {
+        await userCharactersRepository.delete(characterId);
+        logger.info("[agent-sandbox] Cleaned up linked character after delete", {
+          agentId,
+          characterId,
+        });
+      } catch (charErr) {
+        logger.warn("[agent-sandbox] Linked character cleanup failed after delete", {
+          agentId,
+          characterId,
+          error: charErr instanceof Error ? charErr.message : String(charErr),
+        });
+      }
+    }
+
+    return {
+      success: true,
+      // If we got past the stop step at all, by the time we returned success
+      // the container was either stopped or was never there. Either way it
+      // is no longer running, which is what the daemon needs to know to
+      // mark the job complete.
+      containerStopped: true,
+    };
   }
 
   // Provision

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -1,5 +1,6 @@
 export const JOB_TYPES = {
   AGENT_PROVISION: "agent_provision",
+  AGENT_DELETE: "agent_delete",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -42,6 +42,12 @@ export interface AgentProvisionJobData {
   agentName: string;
 }
 
+export interface AgentDeleteJobData {
+  agentId: string;
+  organizationId: string;
+  userId: string;
+}
+
 // ---------------------------------------------------------------------------
 // Job result shapes (stored in jobs.result JSONB)
 // ---------------------------------------------------------------------------
@@ -54,11 +60,26 @@ export interface AgentProvisionJobResult {
   error?: string;
 }
 
+export interface AgentDeleteJobResult {
+  cloudAgentId: string;
+  containerStopped: boolean;
+  rowDeleted: boolean;
+  error?: string;
+}
+
 function agentProvisionJobDataToRecord(data: AgentProvisionJobData): Record<string, unknown> {
   return { ...data };
 }
 
 function agentProvisionJobResultToRecord(result: AgentProvisionJobResult): Record<string, unknown> {
+  return { ...result };
+}
+
+function agentDeleteJobDataToRecord(data: AgentDeleteJobData): Record<string, unknown> {
+  return { ...data };
+}
+
+function agentDeleteJobResultToRecord(result: AgentDeleteJobResult): Record<string, unknown> {
   return { ...result };
 }
 
@@ -73,6 +94,16 @@ function isAgentProvisionJobData(value: unknown): value is AgentProvisionJobData
   );
 }
 
+function isAgentDeleteJobData(value: unknown): value is AgentDeleteJobData {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { agentId?: unknown }).agentId === "string" &&
+    typeof (value as { organizationId?: unknown }).organizationId === "string" &&
+    typeof (value as { userId?: unknown }).userId === "string"
+  );
+}
+
 function readAgentProvisionJobData(job: Job): AgentProvisionJobData {
   if (!isAgentProvisionJobData(job.data)) {
     throw new Error(`Invalid agent provision job data for job ${job.id}`);
@@ -80,7 +111,19 @@ function readAgentProvisionJobData(job: Job): AgentProvisionJobData {
   return job.data;
 }
 
+function readAgentDeleteJobData(job: Job): AgentDeleteJobData {
+  if (!isAgentDeleteJobData(job.data)) {
+    throw new Error(`Invalid agent delete job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
 export interface EnqueueAgentProvisionResult {
+  job: Job;
+  created: boolean;
+}
+
+export interface EnqueueAgentDeleteResult {
   job: Job;
   created: boolean;
 }
@@ -199,6 +242,112 @@ export class ProvisioningJobService {
         .returning();
 
       logger.info("[provisioning-jobs] Enqueued agent_provision job", {
+        jobId: job.id,
+        agentId: params.agentId,
+        orgId: params.organizationId,
+      });
+
+      return { job: await hydrateJob(job), created: true };
+    });
+  }
+
+  /**
+   * Mark a sandbox for async deletion. The HTTP DELETE handler calls this
+   * synchronously; the heavy work (SSH stop on the core, DB row delete, API
+   * key revoke) happens later when the provisioning worker daemon picks up
+   * the resulting `agent_delete` job. The sandbox row stays in the table
+   * with status `deletion_pending` so the row is auditable and re-enqueue
+   * stays idempotent.
+   *
+   * Returns the queued job (existing if one was already in flight, new
+   * otherwise) so the caller can return its id for client-side polling.
+   */
+  async enqueueAgentDeleteOnce(params: {
+    agentId: string;
+    organizationId: string;
+    userId: string;
+    webhookUrl?: string;
+  }): Promise<EnqueueAgentDeleteResult> {
+    if (params.webhookUrl) {
+      await assertSafeOutboundUrl(params.webhookUrl);
+    }
+
+    const jobData: AgentDeleteJobData = {
+      agentId: params.agentId,
+      organizationId: params.organizationId,
+      userId: params.userId,
+    };
+
+    const newJob: NewJob = {
+      type: JOB_TYPES.AGENT_DELETE,
+      status: "pending",
+      data: agentDeleteJobDataToRecord(jobData),
+      data_storage: "inline",
+      organization_id: params.organizationId,
+      user_id: params.userId,
+      webhook_url: params.webhookUrl,
+      max_attempts: 3,
+      // SSH stop is fast (~10s graceful + ~5s force kill), DB cascade is
+      // sub-second. 30s is generous and matches the timeout enforced inside
+      // docker-sandbox-provider.stop().
+      estimated_completion_at: new Date(Date.now() + 30_000),
+    };
+
+    return await dbWrite.transaction(async (tx) => {
+      await tx.execute(elizaProvisionAdvisoryLockSql(params.organizationId, params.agentId));
+
+      const [sandbox] = await tx
+        .select({ id: agentSandboxes.id, status: agentSandboxes.status })
+        .from(agentSandboxes)
+        .where(
+          and(
+            eq(agentSandboxes.id, params.agentId),
+            eq(agentSandboxes.organization_id, params.organizationId),
+          ),
+        )
+        .limit(1);
+
+      if (!sandbox) {
+        throw new Error("Agent not found");
+      }
+
+      const [existing] = await tx
+        .select()
+        .from(jobs)
+        .where(
+          and(
+            eq(jobs.type, JOB_TYPES.AGENT_DELETE),
+            eq(jobs.organization_id, params.organizationId),
+            eq(jobs.agent_id, params.agentId),
+            sql`${jobs.status} IN ('pending', 'in_progress')`,
+          ),
+        )
+        .orderBy(desc(jobs.created_at))
+        .limit(1);
+
+      if (existing) {
+        logger.info("[provisioning-jobs] Reusing active agent_delete job", {
+          jobId: existing.id,
+          agentId: params.agentId,
+          orgId: params.organizationId,
+        });
+        return { job: await hydrateJob(existing), created: false };
+      }
+
+      // Flip the sandbox status so the UI shows "deleting" and concurrent
+      // mutations bail early. The actual row removal happens in
+      // executeAgentDelete (daemon side) once stop() succeeds.
+      await tx
+        .update(agentSandboxes)
+        .set({ status: "deletion_pending" as const, updated_at: new Date() })
+        .where(eq(agentSandboxes.id, params.agentId));
+
+      const [job] = await tx
+        .insert(jobs)
+        .values(await prepareJobInsertData(newJob))
+        .returning();
+
+      logger.info("[provisioning-jobs] Enqueued agent_delete job", {
         jobId: job.id,
         agentId: params.agentId,
         orgId: params.organizationId,
@@ -400,6 +549,30 @@ export class ProvisioningJobService {
             });
           }
         }
+
+        // Symmetric handling for agent_delete: when the daemon gives up,
+        // flip the row to `deletion_failed` so ops can see the stuck
+        // sandboxes (and the container that probably survived on the core)
+        // instead of leaving the row stuck in `deletion_pending` forever.
+        if (updated?.status === "failed" && job.type === JOB_TYPES.AGENT_DELETE) {
+          const data = readAgentDeleteJobData(job);
+          try {
+            await agentSandboxesRepository.update(data.agentId, {
+              status: "deletion_failed",
+              error_message: `Deletion permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
+            } as Parameters<typeof agentSandboxesRepository.update>[1]);
+            logger.warn(
+              "[provisioning-jobs] Marked sandbox as deletion_failed after permanent failure",
+              { jobId: job.id, agentId: data.agentId },
+            );
+          } catch (sandboxErr) {
+            logger.error("[provisioning-jobs] Failed to mark sandbox as deletion_failed", {
+              jobId: job.id,
+              agentId: data.agentId,
+              error: sandboxErr instanceof Error ? sandboxErr.message : String(sandboxErr),
+            });
+          }
+        }
       }
     }
   }
@@ -409,9 +582,64 @@ export class ProvisioningJobService {
       case JOB_TYPES.AGENT_PROVISION:
         await this.executeAgentProvision(job);
         break;
+      case JOB_TYPES.AGENT_DELETE:
+        await this.executeAgentDelete(job);
+        break;
       default:
         throw new Error(`Unknown job type: ${job.type}`);
     }
+  }
+
+  private async executeAgentDelete(job: Job): Promise<void> {
+    const data = readAgentDeleteJobData(job);
+
+    if (data.organizationId !== job.organization_id) {
+      throw new Error(
+        `Organization ID mismatch: job.data.organizationId (${data.organizationId}) !== job.organization_id (${job.organization_id})`,
+      );
+    }
+
+    logger.info("[provisioning-jobs] Executing agent_delete", {
+      jobId: job.id,
+      agentId: data.agentId,
+    });
+
+    const delResult = await elizaSandboxService.executeDeletion(data.agentId, data.organizationId);
+
+    if (!delResult.success) {
+      // Persist a partial result and rethrow so the jobs runner counts an
+      // attempt and retries (or marks failed on exhaustion).
+      await jobsRepository.update(job.id, {
+        result: agentDeleteJobResultToRecord({
+          cloudAgentId: data.agentId,
+          containerStopped: delResult.containerStopped,
+          rowDeleted: false,
+          error: delResult.error,
+        }),
+      });
+      throw new Error(delResult.error ?? "Unknown agent_delete failure");
+    }
+
+    const jobResult: AgentDeleteJobResult = {
+      cloudAgentId: data.agentId,
+      containerStopped: delResult.containerStopped,
+      rowDeleted: true,
+    };
+
+    await jobsRepository.updateStatus(job.id, "completed", {
+      result: agentDeleteJobResultToRecord(jobResult),
+      completed_at: new Date(),
+    });
+
+    if (job.webhook_url) {
+      await this.fireWebhook(job, jobResult);
+    }
+
+    logger.info("[provisioning-jobs] agent_delete completed", {
+      jobId: job.id,
+      agentId: data.agentId,
+      containerStopped: delResult.containerStopped,
+    });
   }
 
   private async executeAgentProvision(job: Job): Promise<void> {
@@ -523,7 +751,10 @@ export class ProvisioningJobService {
     return totalRecovered;
   }
 
-  private async fireWebhook(job: Job, result: AgentProvisionJobResult): Promise<void> {
+  private async fireWebhook(
+    job: Job,
+    result: AgentProvisionJobResult | AgentDeleteJobResult,
+  ): Promise<void> {
     if (!job.webhook_url) return;
 
     try {

--- a/packages/cloud-shared/src/lib/types/cloud-api.ts
+++ b/packages/cloud-shared/src/lib/types/cloud-api.ts
@@ -367,7 +367,9 @@ export type AgentSandboxStatus =
   | "running"
   | "stopped"
   | "disconnected"
-  | "error";
+  | "error"
+  | "deletion_pending"
+  | "deletion_failed";
 
 export type AgentDatabaseStatus = "none" | "provisioning" | "ready" | "error";
 


### PR DESCRIPTION
## Why

Prod e2e on 2026-05-16 found that `DELETE /api/v1/eliza/agents/:id` returns 200 + cleans the DB row, but the Hetzner Docker container stays `Up healthy` on the core indefinitely. Snapshot taken on a real test sandbox `f91916ba-90c7-49e8-b99b-e3d1cc93215b`:

| State | T+5s after DELETE | T+30s | T+90s |
|---|---|---|---|
| `agent_sandboxes` row | 0 ✅ | 0 | 0 |
| `agent_sandbox_backups` / `pairing_tokens` / `memories` / `rooms` | cascaded ✅ | clean | clean |
| Hetzner container `agent-f91916ba-…` | **Up 7 min healthy** 🔴 | **Up 8 min** | **Up 10 min** |
| Per-agent api_key | active 🔴 | active | active |

Root cause is two layers deep:

1. **`docker-sandbox-provider.stop()`** swallowed each SSH command failure independently (`docker stop` and `docker rm -f`) with `logger.warn` / `logger.error` and returned normally. The caller had no way to tell whether the container actually stopped.
2. The HTTP DELETE handler forwarded to a Cloudflare-Worker-hosted control plane that itself called `elizaSandboxService.deleteAgent` synchronously. Workers can't open SSH sockets, so even when the forward succeeded the SSH stop never landed where it needed to.

## How

Mirror the existing `agent_provision` queue pattern for delete:

```
PROVISION (existing)                 DELETE (new)
─────────────────────                ────────────────
POST /provision                      DELETE /agents/:id
  → enqueueAgentProvisionOnce          → enqueueAgentDeleteOnce
  → INSERT jobs (agent_provision)      → INSERT jobs (agent_delete)
  → UPDATE sandbox status=pending      → UPDATE sandbox status=
                                         deletion_pending
  → return 202 { jobId }               → return 202 { jobId }

provisioning-worker daemon:
  pickup agent_provision → SSH    pickup agent_delete → SSH stop+rm
  → success: status=running       → success: DELETE FROM sandbox
  → fail: retry, mark failed      → fail: retry, mark deletion_failed
```

The daemon already has SSH access to the cores (it runs on the Hetzner orchestrator VM at `89.167.63.246`, not on Workers). Same retry budget (`max_attempts: 3`), same webhook firing, same partial-result-on-failure surface as `agent_provision`.

### What's in the PR

| Commit | Files |
|---|---|
| `feat(db,types): add agent_delete job type and deletion_pending/deletion_failed statuses` | `provisioning-job-types.ts`, `agent-sandboxes.ts` schema, `cloud-api.ts` types |
| `fix(docker-sandbox-provider): throw when both docker stop and rm fail with non-gone errors` | `docker-sandbox-provider.ts`, new `docker-error-classifier.ts`, 9 unit tests in `__tests__/docker-sandbox-already-gone.test.ts` |
| `feat(provisioning-jobs): enqueueAgentDeleteOnce + executeAgentDelete daemon dispatch` | `provisioning-jobs.ts`, `eliza-sandbox.ts` (new `executeDeletion` method) |
| `refactor(cloud-api): DELETE /eliza/agents/:id returns 202 + jobId via queue` | `v1/eliza/agents/[agentId]/route.ts` |

### Behavioral notes

- **`provider.stop()` semantics**: throws if **both** `docker stop` and `docker rm -f` fail, *unless* at least one of the failures is a "container is already gone" signal (`No such container`, `not found`, `already gone`, `no longer exists`). This preserves the idempotent retry case where a previous attempt already removed the container.
- **Linked-character cleanup** moved from the HTTP handler into `executeDeletion` so it still runs once the daemon completes — the handler no longer holds the deleted row when it returns 202.
- **The internal callers** of `deleteAgent` (active-billing shutdown, warm pool creator, container-control-plane compat route) keep the sync path; they run from the Node sidecar and have SSH access. Only the user-facing HTTP DELETE moves to the queue.
- **`deletion_pending` state** is added to the `AgentSandboxStatus` union and to the public API types. UI should treat it like a terminal "soon-to-be-gone" state and refuse mutations.

## Test plan

- [x] 9 unit tests for `isAlreadyGoneMessage` (covers Docker 24 "No such container", older "not found", "already gone", "no longer exists", SSH connection failure, Docker daemon down, permission denied, empty / unrelated strings)
- [x] `bun run typecheck` clean on touched files in both `cloud-shared` and `cloud-api`
- [ ] Staging e2e: provision a sandbox to `running`, DELETE, poll the job endpoint, verify (a) job goes `in_progress` → `completed`, (b) container is gone on the core, (c) sandbox row removed, (d) per-agent api_key revoked
- [ ] Staging negative case: SSH-block the core (or stop docker daemon), DELETE, verify the job retries and the sandbox row stays in `deletion_pending` until max_attempts, then flips to `deletion_failed` with the SSH error captured in `error_message`
- [ ] Verify the existing `DELETE /api/compat/agents/:id` compat route still works for older clients (kept on the sync path intentionally — out of scope of this PR)

## Rollback

Single revert. Nothing in this PR persists state the old path can't see — the new `deletion_pending` / `deletion_failed` rows are just status text on existing columns. If a revert is needed mid-deploy, in-flight jobs would fail at the dispatch switch (`Unknown job type: agent_delete`) and be retried by the next deploy; no data corruption.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes zombie Hetzner containers by moving `DELETE /api/v1/eliza/agents/:id` off the synchronous HTTP path onto the same advisory-locked job queue that `agent_provision` uses. The root cause — SSH calls being attempted from a Cloudflare Worker that has no SSH access, combined with `docker stop`/`docker rm -f` failures being swallowed independently — is addressed by a new `agent_delete` job type and a corrected `stop()` that throws when both Docker commands fail without a \"container is already gone\" signal.

- **Queue path**: DELETE now returns 202 + jobId immediately; the provisioning worker daemon picks up the job, SSH-stops the container, cleans up Neon/API keys, and deletes the DB row. Two new statuses (`deletion_pending`, `deletion_failed`) track the async lifecycle; idempotent re-enqueue reuses in-flight jobs.
- **`stop()` semantics**: throws only when both `docker stop` and `docker rm -f` fail without a \"no such container / not found / already gone / no longer exists\" signal; a new `docker-error-classifier.ts` with 9 unit tests backs the classification.
- **Character cleanup and API-key revocation** are moved from the HTTP handler into `executeDeletion`, so they run reliably in the daemon context even when the HTTP request has already returned.

<h3>Confidence Score: 4/5</h3>

The new async delete path is structurally sound; the provision-in-progress race window flagged in a prior review is the only known gap that could still produce a zombie container in a narrow timing window.

The provision-in-progress race can leave a sandbox stuck in deletion_failed while the container keeps running — the core zombie problem this PR is meant to solve. No other new defects were found; the advisory-lock idempotency, daemon retry logic, and already-gone short-circuit all behave correctly.

The guard logic in route.ts (lines 367-370) and the hasActiveProvisionJob check inside eliza-sandbox.ts::deleteAgent deserve a second look to close the race window for agents whose provision job is in-flight but whose status has not yet reached provisioning.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/eliza/agents/[agentId]/route.ts | DELETE handler refactored to return 202 + jobId via async queue. Only checks status === provisioning before enqueueing; the race window for agents with an active provision job was flagged in a previous review. |
| packages/cloud-shared/src/lib/services/docker-error-classifier.ts | New helper isAlreadyGoneMessage with unit tests; not found substring breadth concern was flagged in a previous review. The new stop() logic is logically sound given the OR condition. |
| packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts | Bulk of changes are formatting only. Key logic change in stop(): now throws only when both docker-stop and docker-rm-f fail without any gone signal — correct fix for zombie containers. |
| packages/cloud-shared/src/lib/services/eliza-sandbox.ts | New executeDeletion wraps deleteAgent for the async path, correctly maps Agent not found to success for idempotent retries. isIgnorableSandboxStopError is now subtly diverged from isAlreadyGoneMessage (missing no such container check). |
| packages/cloud-shared/src/lib/services/provisioning-jobs.ts | New enqueueAgentDeleteOnce and executeAgentDelete mirror the provision pattern correctly. Advisory lock ensures idempotency. deletion_failed status flip on permanent failure is symmetric with the provision path. |
| packages/cloud-shared/src/lib/services/provisioning-job-types.ts | Adds AGENT_DELETE constant to JOB_TYPES. Clean, minimal change. |
| packages/cloud-shared/src/db/schemas/agent-sandboxes.ts | Adds deletion_pending and deletion_failed to the TypeScript union. Status column is plain text with no DB-level CHECK constraint, so no migration is needed. |
| packages/cloud-shared/src/lib/types/cloud-api.ts | Propagates new status values to the public API type union. Straightforward and consistent. |
| packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-already-gone.test.ts | 9 unit tests covering all branches of isAlreadyGoneMessage including SSH failures, Docker daemon down, permission denied, and empty strings. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CF as Cloudflare Worker
    participant DB as Postgres
    participant Daemon as Provisioning Worker
    participant Docker as Docker Core

    Client->>CF: DELETE /api/v1/eliza/agents/:id
    CF->>DB: BEGIN txn + advisory lock
    CF->>DB: SELECT agent_sandboxes (verify exists)
    CF->>DB: "SELECT jobs WHERE type=agent_delete AND status IN (pending,in_progress)"
    alt no existing job
        CF->>DB: "UPDATE agent_sandboxes SET status=deletion_pending"
        CF->>DB: INSERT INTO jobs (agent_delete, pending)
    else existing job found
        DB-->>CF: existing job row
    end
    CF->>DB: COMMIT
    CF-->>Client: "202 { jobId }"
    Daemon->>DB: claim agent_delete job (FOR UPDATE SKIP LOCKED)
    Daemon->>Docker: SSH docker stop -t10 container
    Daemon->>Docker: SSH docker rm -f container
    alt both failed AND neither is already-gone
        Daemon->>DB: increment attempt rethrow
        Note over DB: on exhaustion deletion_failed
    else succeeded or container already gone
        Daemon->>DB: DELETE FROM agent_sandboxes
        Daemon->>DB: revokeForAgent apiKey
        Daemon->>DB: "UPDATE jobs SET status=completed"
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-shared/src/lib/services/eliza-sandbox.ts`, line 831-840 ([link](https://github.com/elizaos/eliza/blob/88b774f0ab6ac31c78b4f7bd3ff3b21595597b80/packages/cloud-shared/src/lib/services/eliza-sandbox.ts#L831-L840)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **"Agent not found" should be treated as a success in `executeDeletion`**

   If `deleteAgent` succeeds (deletes the row) but the subsequent `jobsRepository.updateStatus("completed")` fails (transient DB error), the job runner counts a failed attempt and retries. On retry, `deleteAgent` finds no row and returns `{ success: false, error: "Agent not found" }`, causing `executeDeletion` to return failure. All 3 attempts fail, the job is marked `failed`, and the handler tries to flip the (already-gone) sandbox to `deletion_failed`—all while the container and row are actually gone. Returning `{ success: true, containerStopped: true }` when `result.error === "Agent not found"` would make retry-after-successful-delete idempotent.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(eliza-sandbox): treat &#39;Agent not fou..."](https://github.com/elizaos/eliza/commit/fdb3ac076d0e70983478b7e7eb87b8b4d9a6173a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32434994)</sub>

<!-- /greptile_comment -->