### PR TITLE
fix(bootstrap): warn loud when Upstash creds are missing on provisioning-worker host

### DIFF
--- a/packages/cloud-shared/.env.example
+++ b/packages/cloud-shared/.env.example
@@ -256,6 +256,13 @@ CACHE_BACKEND=wadis
 # REDIS_URL=redis://localhost:6379
 
 # Upstash REST credentials (cloud).
+# Required on the provisioning-worker host so the orchestrator can inject
+# the same creds into each Hetzner sandbox via docker-sandbox-provider.
+# Each sandbox boots a SandboxRegistry (packages/app-core) that publishes
+# its bridge URL to Upstash under server:<name>:url / agent:<id>:server so
+# gateway-discord / gateway-webhook can route inbound platform messages
+# (Discord, WhatsApp, Telegram, SMS) to it. Without these, sandboxes still
+# boot but the gateways will silently black-hole their traffic.
 # KV_REST_API_URL=https://your-redis.upstash.io
 # KV_REST_API_TOKEN=your_upstash_token_here
 # KV_REST_API_READ_ONLY_TOKEN=your_readonly_token_here

--- a/packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs
+++ b/packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs
@@ -169,13 +169,47 @@ function readFirstEnv(...keys) {
 function validateRuntimeEnv(env) {
   const required = ["DATABASE_URL", "NEON_API_KEY", "CONTAINERS_SSH_KEY"];
   const missing = required.filter((key) => !env[key]?.trim());
-  if (missing.length === 0 || values["allow-incomplete-env"]) return;
+  if (missing.length === 0 || values["allow-incomplete-env"]) {
+    warnMissingUpstash(env);
+    return;
+  }
 
   fail(
     [
       `Runtime env file is missing required key(s): ${missing.join(", ")}`,
       "The worker may start without these, but agent provisioning will fail.",
       "Pass --allow-incomplete-env only if you are intentionally bootstrapping in stages.",
+    ].join("\n"),
+  );
+}
+
+/**
+ * Sandbox containers boot a `SandboxRegistry` (packages/app-core) that
+ * publishes `agent:<id>:server` / `server:<name>:url` keys to the shared
+ * Upstash so gateway-discord and gateway-webhook can route inbound
+ * platform messages to them. The orchestrator reads `KV_REST_API_URL` and
+ * `KV_REST_API_TOKEN` from its own env and injects them into every new
+ * sandbox via docker-sandbox-provider. Without these on the orchestrator
+ * host the registration step silently no-ops, so Discord / WhatsApp /
+ * Telegram / SMS traffic to those sandboxes is black-holed. Warn loud —
+ * we deploy either way (some hosts intentionally skip platform routing)
+ * but the operator must opt-in to that silent path.
+ */
+function warnMissingUpstash(env) {
+  const missing = ["KV_REST_API_URL", "KV_REST_API_TOKEN"].filter(
+    (key) => !env[key]?.trim(),
+  );
+  if (missing.length === 0) return;
+  process.stderr.write(
+    [
+      "",
+      "[bootstrap-provisioning-worker-host] WARNING:",
+      `  Runtime env is missing ${missing.join(" + ")}.`,
+      "  Sandboxes provisioned by this worker will not self-register in Upstash,",
+      "  so the shared gateways cannot route inbound Discord / WhatsApp /",
+      "  Telegram / SMS messages to them.",
+      "  Add both keys to the env file and re-run if platform routing is needed.",
+      "",
     ].join("\n"),
   );
 }


### PR DESCRIPTION
## Why

The orchestrator host at \`89.167.63.246\` (and any other provisioning-worker box bootstrapped from the same script) is missing \`KV_REST_API_URL\` and \`KV_REST_API_TOKEN\` in \`/opt/eliza/cloud/.env.local\` today. Because of this:

- \`docker-sandbox-provider\` reads those vars to decide whether to inject the registry env vars into a new sandbox — they're empty, so injection is skipped silently
- The new sandbox boots, but the \`SandboxRegistry\` we shipped in PR #7731 detects no Upstash creds and silently no-ops
- The shared gateways (\`gateway-discord\`, \`gateway-webhook\`) can't find the sandbox in Upstash and **black-hole every inbound platform message** (Discord DMs, WhatsApp webhooks, Telegram updates, SMS)

Verified live during the prod e2e test on 2026-05-16: every sandbox provisioned from that host is unreachable from the shared bot. The bootstrap script ran fine, the worker is healthy, but the sandboxes are silently disconnected from the routing layer.

## What this PR changes

Two narrow changes:

1. **\`packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs\`** — adds \`warnMissingUpstash(env)\` called from \`validateRuntimeEnv\`. If either Upstash key is absent from the runtime env file the operator passed, the script writes a loud STDERR warning explaining the consequence (gateways won't route to sandboxes from this host) and still proceeds. Some orchestrator hosts intentionally skip platform routing (CI runners, local dev orchestrators) so a hard-fail would block them too; warn-loud is the right intermediate.

2. **\`packages/cloud-shared/.env.example\`** — expands the comment block around the existing \`KV_REST_API_URL\` / \`KV_REST_API_TOKEN\` lines so an operator copying the template understands these are load-bearing for sandbox platform routing, not just for the cache layer.

## Why not hard-fail

Some orchestrator hosts run on workspaces that don't need to route inbound platform messages (CI nodes, dev boxes provisioning only for warm pools). Those hosts will keep working without Upstash. Warning the operator loud each time is the strongest signal we can give without blocking them.

## Ops follow-up (not in this PR)

After this merges, fix the existing host directly:

\`\`\`bash
ssh -i ~/.ssh/id_ed25519_eliza root@89.167.63.246 << 'OPS'
  set -a
  # paste the Upstash creds from CF Workers \`eliza-cloud-api-prod\` secrets:
  #   KV_REST_API_URL=https://...
  #   KV_REST_API_TOKEN=...
  cat <<ENV >> /opt/eliza/cloud/.env.local
KV_REST_API_URL=\$KV_REST_API_URL
KV_REST_API_TOKEN=\$KV_REST_API_TOKEN
ENV
  systemctl restart eliza-provisioning-worker.service
OPS
\`\`\`

Then provision a fresh sandbox and confirm both Upstash keys (\`server:sandbox-<id>:url\`, \`agent:<id>:server\`) are written within 30s of the container coming healthy.

## Test plan

- [x] Bootstrap script still parses (no syntax error)
- [ ] Re-bootstrap the existing host with the updated runtime env file → warning is silent (creds now present)
- [ ] Bootstrap a fresh staging host with an env file missing the Upstash keys → warning appears in STDERR but bootstrap completes
- [ ] After op fix above, provision a new sandbox → \`KEYS \"agent:<id>:*\"\` returns 1 row in Upstash within ~30s

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a loud `WARN` to `bootstrap-provisioning-worker-host.mjs` when `KV_REST_API_URL` or `KV_REST_API_TOKEN` are absent from the operator-supplied env file, and expands the corresponding comment block in `packages/cloud-shared/.env.example` to explain the load-bearing role those keys play in sandbox-to-gateway routing.

- **`bootstrap-provisioning-worker-host.mjs`**: adds `warnMissingUpstash(env)` called from inside the early-return path of `validateRuntimeEnv`; the script still proceeds so CI/dev orchestrators without platform routing are not blocked.
- **`cloud-shared/.env.example`**: extends the comment above `KV_REST_API_URL` / `KV_REST_API_TOKEN` to explain that without them sandbox self-registration in Upstash silently no-ops and gateways black-hole inbound platform traffic.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both changes are additive and non-breaking — the warning path is the only new runtime behaviour.

The bootstrap script change is minimal and correct for the happy path. The one gap is that `warnMissingUpstash` is placed inside the early-return branch, so an operator missing both the required runtime keys and the Upstash keys will only see the required-key error on the first run; the Upstash warning surfaces only after those are fixed and the script is re-run.

packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs — specifically the placement of `warnMissingUpstash` relative to the `fail()` branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs | Adds `warnMissingUpstash(env)` called only inside the early-return branch of `validateRuntimeEnv`; when required keys are absent and `--allow-incomplete-env` is not set the script exits via `fail()` before `warnMissingUpstash` is reached, so the Upstash warning is silently skipped in that path. |
| packages/cloud-shared/.env.example | Pure documentation expansion — adds a comment block explaining the routing dependency on `KV_REST_API_URL` / `KV_REST_API_TOKEN`; no functional change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validateRuntimeEnv called] --> B{required keys present\nOR --allow-incomplete-env?}
    B -- YES --> C[warnMissingUpstash]
    C --> D{KV_REST_API_URL\nKV_REST_API_TOKEN present?}
    D -- YES --> E[return — script continues]
    D -- NO --> F[write STDERR warning]
    F --> E
    B -- NO --> G[fail — process.exit 1]
    G:::danger

    classDef danger fill:#f55,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["fix(bootstrap-provisioning-worker-host):..."](https://github.com/elizaos/eliza/commit/826bcbdf2700c76facdd72ed3a1b001d1e088cec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32435637)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->