### PR TITLE
[codex] Stabilize desktop startup surfaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2153,6 +2153,22 @@
         "react-dom": "^19.0.0",
       },
     },
+    "packages/ui-stories": {
+      "name": "@elizaos/ui-stories",
+      "version": "0.0.0",
+      "dependencies": {
+        "@elizaos/ui": "workspace:*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.0.0",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.8",
+      },
+    },
     "packages/vault": {
       "name": "@elizaos/vault",
       "version": "2.0.0-beta.2",
@@ -4468,6 +4484,8 @@
 
     "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
 
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.5", "", {}, "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg=="],
@@ -4477,6 +4495,10 @@
     "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
 
     "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
@@ -5117,6 +5139,8 @@
     "@elizaos/tui": ["@elizaos/tui@2.0.0-alpha.77", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-x/6C7bxfPfZuAOtV8ExH0n2x1VNAQiE6oer/AbHyOrqUXjiXxQYWmK7Mw8M1z3uAk2OCYut8FxullxWKe4IEmg=="],
 
     "@elizaos/ui": ["@elizaos/ui@workspace:packages/ui"],
+
+    "@elizaos/ui-stories": ["@elizaos/ui-stories@workspace:packages/ui-stories"],
 
     "@elizaos/vault": ["@elizaos/vault@workspace:packages/vault"],
 
@@ -10372,7 +10396,7 @@
 
     "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
 
-    "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
@@ -11515,6 +11539,8 @@
     "@elizaos/three-agent-dialogue/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@elizaos/tui/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "@elizaos/ui-stories/@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
     "@elizaos/vitest-vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -13066,6 +13092,8 @@
 
     "react-native/pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ=="],
 
+    "react-native/react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
+
     "react-native/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
     "react-native/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
@@ -13491,6 +13519,8 @@
     "@elizaos/plugin-social-alpha/vite/esbuild": ["esbuild@0.25.10", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.10", "@esbuild/android-arm": "0.25.10", "@esbuild/android-arm64": "0.25.10", "@esbuild/android-x64": "0.25.10", "@esbuild/darwin-arm64": "0.25.10", "@esbuild/darwin-x64": "0.25.10", "@esbuild/freebsd-arm64": "0.25.10", "@esbuild/freebsd-x64": "0.25.10", "@esbuild/linux-arm": "0.25.10", "@esbuild/linux-arm64": "0.25.10", "@esbuild/linux-ia32": "0.25.10", "@esbuild/linux-loong64": "0.25.10", "@esbuild/linux-mips64el": "0.25.10", "@esbuild/linux-ppc64": "0.25.10", "@esbuild/linux-riscv64": "0.25.10", "@esbuild/linux-s390x": "0.25.10", "@esbuild/linux-x64": "0.25.10", "@esbuild/netbsd-arm64": "0.25.10", "@esbuild/netbsd-x64": "0.25.10", "@esbuild/openbsd-arm64": "0.25.10", "@esbuild/openbsd-x64": "0.25.10", "@esbuild/openharmony-arm64": "0.25.10", "@esbuild/sunos-x64": "0.25.10", "@esbuild/win32-arm64": "0.25.10", "@esbuild/win32-ia32": "0.25.10", "@esbuild/win32-x64": "0.25.10" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ=="],
 
     "@elizaos/plugin-starter/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "@elizaos/ui-stories/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@elizaos/vitest-vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -25,6 +25,36 @@ function isTruthyEnv(value: string | undefined): boolean {
 	);
 }
 
+const EXTERNAL_API_BASE_ENV_KEYS = [
+	"ELIZA_DESKTOP_TEST_API_BASE",
+	"ELIZA_DESKTOP_API_BASE",
+	"ELIZA_API_BASE_URL",
+	"ELIZA_API_BASE",
+] as const;
+
+function normalizeApiBase(raw: string | undefined): string | null {
+	if (!raw?.trim()) return null;
+	try {
+		const parsed = new URL(raw.trim());
+		return parsed.protocol === "http:" || parsed.protocol === "https:"
+			? parsed.origin
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function shouldEmbedRuntimeBundle(
+	env: Record<string, string | undefined> = process.env,
+): boolean {
+	for (const key of EXTERNAL_API_BASE_ENV_KEYS) {
+		if (normalizeApiBase(env[key])) {
+			return false;
+		}
+	}
+	return !isTruthyEnv(env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT);
+}
+
 function linuxCefChromiumFlags(): Record<string, string | true> {
 	// Linux CEF WebGPU/Vulkan is still experimental in Electrobun. Keep the
 	// default renderer path stable and let hardware debugging opt in explicitly.
@@ -277,9 +307,11 @@ function trimEnv(name: string): string {
 export function resolveElectrobunCopyMap({
 	buildVariant,
 	runtimeDistDir,
+	embedRuntime = buildVariant !== "store",
 }: {
 	buildVariant: "store" | "direct";
 	runtimeDistDir: string;
+	embedRuntime?: boolean;
 }): Record<string, string> {
 	const copy: Record<string, string> = {
 		[rendererDistDir]: "renderer",
@@ -288,7 +320,7 @@ export function resolveElectrobunCopyMap({
 		"assets/appIcon.ico": "assets/appIcon.ico",
 	};
 
-	if (buildVariant !== "store") {
+	if (buildVariant !== "store" && embedRuntime) {
 		copy[runtimeBundleDistDir] = runtimeDistDir;
 		if (fs.existsSync(runtimeBundleNodeModulesPath)) {
 			copy[runtimeBundleNodeModulesDir] = `${runtimeDistDir}/node_modules`;
@@ -373,6 +405,7 @@ export function createElectrobunConfig(): ElectrobunConfig {
 		(process.env.ELIZA_RUNTIME_DIST_DIR ?? "").trim() || "eliza-dist";
 	const buildVariant: "store" | "direct" =
 		process.env.ELIZA_BUILD_VARIANT === "store" ? "store" : "direct";
+	const embedRuntime = shouldEmbedRuntimeBundle(process.env);
 	const brandConfigCopySource = resolveBrandConfigCopySource({
 		appName,
 		appId,
@@ -454,7 +487,11 @@ export function createElectrobunConfig(): ElectrobunConfig {
 			// 2. Electrobun-native Dawn for Bun-side GpuWindow / <electrobun-wgpu>
 			//    surfaces and future native compute workloads.
 			copy: {
-				...resolveElectrobunCopyMap({ buildVariant, runtimeDistDir }),
+				...resolveElectrobunCopyMap({
+					buildVariant,
+					runtimeDistDir,
+					embedRuntime,
+				}),
 				[brandConfigCopySource]: "brand-config.json",
 				...(process.platform === "darwin" &&
 				fs.existsSync(libMacWindowEffectsDylib)

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveElectrobunCopyMap } from "../electrobun.config";
+import {
+	resolveElectrobunCopyMap,
+	shouldEmbedRuntimeBundle,
+} from "../electrobun.config";
 
 describe("Electrobun Store packaging", () => {
 	it("omits the embedded local agent runtime tree for Mac App Store builds", () => {
@@ -18,6 +21,32 @@ describe("Electrobun Store packaging", () => {
 		const copy = resolveElectrobunCopyMap({
 			buildVariant: "direct",
 			runtimeDistDir: "eliza-dist",
+		});
+
+		expect(Object.values(copy)).toContain("eliza-dist");
+		expect(Object.values(copy)).toContain("eliza-dist/package.json");
+	});
+
+	it("omits the embedded runtime tree for external API desktop builds", () => {
+		const copy = resolveElectrobunCopyMap({
+			buildVariant: "direct",
+			runtimeDistDir: "eliza-dist",
+			embedRuntime: shouldEmbedRuntimeBundle({
+				ELIZA_DESKTOP_API_BASE: "http://127.0.0.1:31337",
+			}),
+		});
+
+		expect(Object.values(copy)).not.toContain("eliza-dist");
+		expect(Object.values(copy)).not.toContain("eliza-dist/package.json");
+	});
+
+	it("keeps the embedded runtime tree when external API env is invalid", () => {
+		const copy = resolveElectrobunCopyMap({
+			buildVariant: "direct",
+			runtimeDistDir: "eliza-dist",
+			embedRuntime: shouldEmbedRuntimeBundle({
+				ELIZA_DESKTOP_API_BASE: "not-a-url",
+			}),
 		});
 
 		expect(Object.values(copy)).toContain("eliza-dist");

--- a/packages/ui/src/backgrounds/BackgroundHost.tsx
+++ b/packages/ui/src/backgrounds/BackgroundHost.tsx
@@ -1,5 +1,6 @@
 import { logger } from "@elizaos/core";
 import { useEffect, useRef, useState } from "react";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
 import {
   getActiveBackground,
   getBackground,
@@ -29,6 +30,35 @@ function prefersReducedMotion(): boolean {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
+export interface BackgroundFallbackContext {
+  moduleKind?: string;
+  electrobunRuntime: boolean;
+  reducedMotion: boolean;
+}
+
+export function shouldUseSolidBackgroundFallback({
+  moduleKind,
+  electrobunRuntime,
+  reducedMotion,
+}: BackgroundFallbackContext): boolean {
+  if (moduleKind !== "svg-filtered-clouds") {
+    return false;
+  }
+  return electrobunRuntime || reducedMotion;
+}
+
+function mountSolidBackground(target: HTMLElement): BackgroundHandle {
+  target.dataset.elizaBg = "solid";
+  target.style.backgroundColor = SKY_BACKGROUND_COLOR;
+  return {
+    update(): void {},
+    unmount(): void {
+      delete target.dataset.elizaBg;
+      target.style.backgroundColor = "";
+    },
+  };
+}
+
 export interface BackgroundHostProps {
   moduleId?: string;
   className?: string;
@@ -50,10 +80,27 @@ export function BackgroundHost(props: BackgroundHostProps): React.JSX.Element {
     }
 
     let handle: BackgroundHandle | null = null;
+    const reducedMotion = prefersReducedMotion();
+    if (
+      shouldUseSolidBackgroundFallback({
+        moduleKind: mod.kind,
+        electrobunRuntime: isElectrobunRuntime(),
+        reducedMotion,
+      })
+    ) {
+      handle = mountSolidBackground(target);
+      handleRef.current = handle;
+      return () => {
+        const current = handleRef.current;
+        handleRef.current = null;
+        current?.unmount();
+      };
+    }
+
     try {
       handle = mod.mount(target);
       handleRef.current = handle;
-      handle.update({ reducedMotion: prefersReducedMotion() });
+      handle.update({ reducedMotion });
     } catch (error) {
       logger.warn(
         `[BackgroundHost] Failed to mount background module; falling back to solid sky: ${

--- a/packages/ui/src/backgrounds/__tests__/BackgroundHost.test.ts
+++ b/packages/ui/src/backgrounds/__tests__/BackgroundHost.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseSolidBackgroundFallback } from "../BackgroundHost";
+
+describe("BackgroundHost", () => {
+  it("uses a solid fallback for SVG-filtered backgrounds in Electrobun", () => {
+    expect(
+      shouldUseSolidBackgroundFallback({
+        moduleKind: "svg-filtered-clouds",
+        electrobunRuntime: true,
+        reducedMotion: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses a solid fallback for SVG-filtered backgrounds when motion is reduced", () => {
+    expect(
+      shouldUseSolidBackgroundFallback({
+        moduleKind: "svg-filtered-clouds",
+        electrobunRuntime: false,
+        reducedMotion: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps non-SVG backgrounds on their own renderer", () => {
+    expect(
+      shouldUseSolidBackgroundFallback({
+        moduleKind: "solid",
+        electrobunRuntime: true,
+        reducedMotion: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/components/shell/RuntimeGate.tsx
+++ b/packages/ui/src/components/shell/RuntimeGate.tsx
@@ -70,7 +70,6 @@ import {
 import {
   getElizaApiBase,
   preOpenWindow,
-  resolveAppAssetUrl,
 } from "../../utils";
 import { LanguageDropdown } from "../shared/LanguageDropdown";
 import { ThemeToggle } from "../shared/ThemeToggle";
@@ -2011,22 +2010,6 @@ function GateShell({
       style={{ height: "100dvh" }}
     >
       <div
-        aria-hidden="true"
-        className="pointer-events-none fixed inset-0 overflow-hidden"
-      >
-        {/* Splash background. Dark-mode is letterboxed against the wrapper
-            bg below, which provides a complementary brand tone. */}
-        <img
-          src={resolveAppAssetUrl("splash-bg.png")}
-          alt=""
-          className="absolute inset-0 h-full w-full object-contain object-center"
-        />
-        {/* Subtle vignette to keep panel content readable when window is large
-            and the image sits centered with letterbox. */}
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_30%,rgba(0,0,0,0.55)_100%)]" />
-      </div>
-
-      <div
         className="flex items-center gap-2"
         style={{
           position: "absolute",
@@ -2349,12 +2332,6 @@ function ElizaOSLocalSplash({ message }: { message: string }) {
       data-testid="runtime-gate-elizaos-local-splash"
       className="relative flex h-full w-full items-center justify-center overflow-hidden bg-[#ffe600] text-black"
     >
-      <img
-        src={resolveAppAssetUrl("splash-bg.png")}
-        alt=""
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-      />
       <div
         className="relative z-10 flex w-full flex-col items-center gap-5 px-6 text-center"
         style={{ maxWidth: 360 }}

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -347,15 +347,7 @@ export function StartupShell() {
  */
 function BootstrapGateShell({ children }: { children: ReactNode }) {
   return (
-    <div className="relative flex min-h-full w-full flex-col bg-black text-white">
-      <div
-        aria-hidden="true"
-        className="absolute inset-0 overflow-hidden pointer-events-none"
-      >
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.14),transparent_36%),linear-gradient(180deg,rgba(11,14,20,0.18),rgba(6,7,8,0.56))]" />
-        <div className="absolute left-[-10%] top-[8%] h-[24rem] w-[24rem] rounded-full bg-[rgba(240,185,11,0.1)] blur-[110px]" />
-        <div className="absolute bottom-[-12%] right-[-8%] h-[20rem] w-[20rem] rounded-full bg-[rgba(255,255,255,0.08)] blur-[120px]" />
-      </div>
+    <div className="relative flex min-h-full w-full flex-col bg-[#ffe600] text-black">
       <div className="relative z-10 flex flex-1 items-center justify-center px-4 pb-[max(1.5rem,var(--safe-area-bottom,0px))] pt-[calc(var(--safe-area-top,0px)_+_3.75rem)] sm:px-6 md:px-8">
         <div className="flex w-full max-w-[32rem] flex-col items-center gap-4">
           {children}

--- a/packages/ui/src/components/shell/StartupShell.tsx
+++ b/packages/ui/src/components/shell/StartupShell.tsx
@@ -27,7 +27,6 @@ import {
   saveVoicePrefixDone,
 } from "../../state/persistence";
 import type { StartupErrorReason, StartupErrorState } from "../../state/types";
-import { resolveAppAssetUrl } from "../../utils";
 import { BootstrapStep } from "../onboarding/BootstrapStep";
 import { OnboardingRoot } from "../onboarding/states";
 import { VoicePrefixGate } from "../onboarding/VoicePrefixGate";
@@ -310,12 +309,6 @@ export function StartupShell() {
       data-startup-phase={phase}
       className="flex items-center justify-center h-full w-full bg-[#ffe600] text-black overflow-hidden"
     >
-      <img
-        src={resolveAppAssetUrl("splash-bg.png")}
-        alt=""
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 h-full w-full object-cover"
-      />
       <div
         className="relative z-10 flex flex-col items-center gap-5 px-6 text-center w-full"
         style={{ maxWidth: 360 }}

--- a/packages/ui/src/components/shell/startup-shell-assets.test.ts
+++ b/packages/ui/src/components/shell/startup-shell-assets.test.ts
@@ -21,4 +21,18 @@ describe("startup shell assets", () => {
       expect(source).not.toContain("splash-bg.png");
     }
   });
+
+  it("keeps the bootstrap shell on the plain yellow startup surface", () => {
+    const source = readFileSync(
+      resolve(repoRoot, "packages/ui/src/components/shell/StartupShell.tsx"),
+      "utf8",
+    );
+
+    const bootstrapShell = source.slice(
+      source.indexOf("function BootstrapGateShell"),
+    );
+    expect(bootstrapShell).toContain("bg-[#ffe600]");
+    expect(bootstrapShell).not.toContain("radial-gradient");
+    expect(bootstrapShell).not.toContain("blur-[");
+  });
 });

--- a/packages/ui/src/components/shell/startup-shell-assets.test.ts
+++ b/packages/ui/src/components/shell/startup-shell-assets.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../../",
+);
+
+const shellSourcePaths = [
+  "packages/ui/src/components/shell/StartupShell.tsx",
+  "packages/ui/src/components/shell/RuntimeGate.tsx",
+];
+
+describe("startup shell assets", () => {
+  it("does not reference missing splash background images", () => {
+    for (const sourcePath of shellSourcePaths) {
+      const source = readFileSync(resolve(repoRoot, sourcePath), "utf8");
+      expect(source).not.toContain("splash-bg.svg");
+      expect(source).not.toContain("splash-bg.png");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This draft PR keeps the desktop startup surface boring and predictable while we continue the deeper GUI/voice work.

- Removes the missing splash background path from the startup shell path and keeps the bootstrap screen on a plain yellow surface instead of decorative generated/gradient artwork.
- Adds a solid fallback for the SVG-filtered clouds background in Electrobun and reduced-motion contexts, avoiding expensive/fragile filtered SVG rendering in the desktop shell.
- Makes Electrobun direct builds skip embedding the local runtime bundle when an explicit external API base is configured. That keeps external-backend desktop dev/test launches from trying to copy/use stale embedded runtime assets.
- Adds focused tests for the Electrobun copy map, background fallback, and startup shell surface.

## Validation

```bash
bunx vitest run --config vitest.config.ts \
  packages/ui/src/backgrounds/__tests__/BackgroundHost.test.ts \
  packages/ui/src/backgrounds/__tests__/registry.test.ts \
  packages/app-core/platforms/electrobun/src/electrobun-config.test.ts \
  packages/ui/src/components/shell/startup-shell-assets.test.ts
```

Result: 4 files passed, 16 tests passed.

```bash
bun run --cwd packages/ui build
```

Result: passed.

```bash
git diff --check
```

Result: passed.

## Notes

I intentionally backed out an unproven renderer startup experiment before pushing this commit. The branch now contains only the small validated surface/runtime-packaging fixes above. The deeper WebKit startup/memory issue still needs a separate focused fix and should not be conflated with this PR.
