### PR TITLE
fix(app-core): harden browser fallback stubs

### DIFF
--- a/packages/app-core/src/platform/elizaos-agent-browser-stub.ts
+++ b/packages/app-core/src/platform/elizaos-agent-browser-stub.ts
@@ -4,6 +4,18 @@
 // Node-only code.
 
 const noop = () => undefined;
+const noopProxyHandler: ProxyHandler<typeof noop> = {
+  get: (_target, key) => (key === "prototype" ? noop.prototype : noop),
+  apply: () => undefined,
+  ownKeys: (target) => Reflect.ownKeys(target),
+  getOwnPropertyDescriptor: (target, key) =>
+    Reflect.getOwnPropertyDescriptor(target, key) ?? {
+      configurable: true,
+      enumerable: false,
+      value: noop,
+      writable: true,
+    },
+};
 export const ACCOUNT_CREDENTIAL_PROVIDER_IDS = [];
 export const AccountCredentialRecord = noop;
 export const AGENT_EVENT_ALLOWED_STREAMS = [];
@@ -145,4 +157,4 @@ export const typeWalletCapabilityStatus = noop;
 export const UninstallResult = noop;
 export const validatePluginConfig = noop;
 export const validateMcpServerConfig = noop;
-export default new Proxy(noop, { get: () => noop, apply: () => undefined });
+export default new Proxy(noop, noopProxyHandler);

--- a/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
+++ b/packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts
@@ -4,6 +4,18 @@
 // imports to statically resolve. Every export here is an inert stub.
 
 const noop = () => undefined;
+const noopProxyHandler: ProxyHandler<typeof noop> = {
+  get: (_target, key) => (key === "prototype" ? noop.prototype : noop),
+  apply: () => undefined,
+  ownKeys: (target) => Reflect.ownKeys(target),
+  getOwnPropertyDescriptor: (target, key) =>
+    Reflect.getOwnPropertyDescriptor(target, key) ?? {
+      configurable: true,
+      enumerable: false,
+      value: noop,
+      writable: true,
+    },
+};
 
 // Sync void / secret / URL resolvers — server-only, nothing to resolve or
 // mutate in a renderer.
@@ -49,4 +61,4 @@ export const isCloudProvisionedContainer = (): boolean => false;
 // Cloud client — server-only; the renderer never opens a cloud connection.
 export class ElizaCloudClient {}
 
-export default new Proxy(noop, { get: () => noop, apply: () => undefined });
+export default new Proxy(noop, noopProxyHandler);

--- a/packages/app-core/src/platform/empty-node-module.ts
+++ b/packages/app-core/src/platform/empty-node-module.ts
@@ -1,6 +1,18 @@
 const noop = () => undefined;
 const asyncNoop = async () => undefined;
 const falseNoop = () => false;
+const noopProxyHandler: ProxyHandler<typeof noop> = {
+  get: (_target, key) => (key === "prototype" ? noop.prototype : noop),
+  apply: () => undefined,
+  ownKeys: (target) => Reflect.ownKeys(target),
+  getOwnPropertyDescriptor: (target, key) =>
+    Reflect.getOwnPropertyDescriptor(target, key) ?? {
+      configurable: true,
+      enumerable: false,
+      value: noop,
+      writable: true,
+    },
+};
 
 export const pipeline = asyncNoop;
 export const finished = asyncNoop;
@@ -19,10 +31,7 @@ export const isRegExp = falseNoop;
 export const isSet = falseNoop;
 export const isTypedArray = falseNoop;
 
-export default new Proxy(noop, {
-  get: () => noop,
-  apply: () => undefined,
-});
+export default new Proxy(noop, noopProxyHandler);
 
 // elizaOS server-only stubs (browser bundle reach-through)
 export const ACCOUNT_CREDENTIAL_PROVIDER_IDS = [];


### PR DESCRIPTION
## Summary

Hardens the browser fallback stubs used when renderer/browser bundles statically reach server-only modules.

The prior fallback proxy returned the same noop for all property reads but did not behave like a normal function/object under introspection. Browser bundles can hit `prototype`, `ownKeys`, property descriptors, destructuring, or class-ish access while walking imported server-only modules, and the fallback should remain inert instead of throwing.

## What Changed

- Add a shared proxy handler shape to the app-core browser stubs.
- Return the real function `prototype` when code asks for `prototype`.
- Preserve `ownKeys`/`getOwnPropertyDescriptor` behavior so object introspection does not fail.
- Keep calls inert with `apply: () => undefined`.

## Validation

```sh
git diff --check
bun build packages/app-core/src/platform/elizaos-agent-browser-stub.ts \
  packages/app-core/src/platform/elizaos-plugin-elizacloud-browser-stub.ts \
  packages/app-core/src/platform/empty-node-module.ts \
  --target=browser --outdir=/tmp/eliza-stub-bundle-check
```

Result: all three stub entrypoints bundled for browser successfully.

This was also exercised indirectly by the Pixel stock Android APK validation in milady-ai/milady#2153, where keeping server-only agent/app-core code out of the WebView was required for the renderer to mount cleanly.

## Notes

`packages/app-core` typecheck is not included as validation here because a clean sibling worktree without a full local workspace install fails on missing repo dependency declarations before reaching this patch. This PR is intentionally limited to self-contained browser stub behavior.
