### PR TITLE
fix(agent): allow long Android direct local generations

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-streaming.test.ts
@@ -220,6 +220,9 @@ describe("generateChatResponse token streaming", () => {
     const directParams = useModel.mock.calls[0]?.[1] as { prompt?: string };
     expect(directParams.prompt).not.toContain("/no_think");
     expect(directParams.prompt).toContain("can you hear me locally?");
+    expect(directParams.prompt).toContain(
+      "One natural sentence under 10 words. Stop after it.",
+    );
 
     expect(useModel).toHaveBeenCalledWith(
       expect.anything(),
@@ -247,6 +250,147 @@ describe("generateChatResponse token streaming", () => {
       expect.objectContaining({
         provider: "mobile-local-direct-reply",
         streamedChunks: 2,
+      }),
+    );
+  });
+
+  it("allows benchmark harnesses to request long Android local direct generations", async () => {
+    const chunks: string[] = [];
+    const useModel = createUseModelMock(async (_modelType, params) => {
+      const textParams = params as {
+        onStreamChunk?: (chunk: string) => Promise<void> | void;
+      };
+      await textParams.onStreamChunk?.("First sentence.");
+      await textParams.onStreamChunk?.(" Second sentence.");
+      await textParams.onStreamChunk?.(" Third sentence.");
+      return "First sentence. Second sentence. Third sentence.";
+    });
+    const runtime = createRuntime({
+      getSetting: (key: string) => {
+        const values: Record<string, string> = {
+          ELIZA_MOBILE_PLATFORM: "android",
+          ELIZA_LOCAL_LLAMA: "1",
+          ELIZA_MOBILE_LOCAL_DIRECT_REPLY: "1",
+        };
+        return values[key] ?? null;
+      },
+      useModel,
+    });
+
+    const message = createChatMessage("write three local benchmark sentences");
+    message.content = {
+      ...message.content,
+      metadata: {
+        benchmarkHarness: {
+          maxTokens: 96,
+        },
+      },
+    } as typeof message.content;
+
+    const result = await generateChatResponse(
+      runtime,
+      message,
+      "Streaming Agent",
+      {
+        timeoutDuration: 5_000,
+        onChunk: (chunk) => {
+          chunks.push(chunk);
+        },
+      },
+    );
+
+    const directParams = useModel.mock.calls[0]?.[1] as { prompt?: string };
+    expect(directParams.prompt).not.toContain(
+      "One natural sentence under 10 words. Stop after it.",
+    );
+    expect(directParams.prompt).toContain(
+      "Answer directly in concise natural language.",
+    );
+
+    expect(useModel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        stream: true,
+        maxTokens: 96,
+        providerOptions: expect.objectContaining({
+          androidLocal: expect.objectContaining({
+            stopOnFirstSentence: false,
+          }),
+        }),
+      }),
+    );
+    expect(chunks.join("")).toBe(
+      "First sentence. Second sentence. Third sentence.",
+    );
+    expect(result.text).toBe(
+      "First sentence. Second sentence. Third sentence.",
+    );
+    expect(result.localInference).toEqual(
+      expect.objectContaining({
+        generationMode: "long",
+        maxTokens: 96,
+        provider: "mobile-local-direct-reply",
+        stopOnFirstSentence: false,
+      }),
+    );
+  });
+
+  it("uses the long Android local direct cap when longGeneration is explicit", async () => {
+    const useModel = createUseModelMock(async (_modelType, params) => {
+      const textParams = params as {
+        onStreamChunk?: (chunk: string) => Promise<void> | void;
+      };
+      await textParams.onStreamChunk?.("Long direct generation.");
+      return "Long direct generation.";
+    });
+    const runtime = createRuntime({
+      getSetting: (key: string) => {
+        const values: Record<string, string> = {
+          ELIZA_MOBILE_LOCAL_DIRECT_REPLY_LONG_MAX_TOKENS: "64",
+          ELIZA_MOBILE_PLATFORM: "android",
+          ELIZA_LOCAL_LLAMA: "1",
+          ELIZA_MOBILE_LOCAL_DIRECT_REPLY: "1",
+        };
+        return values[key] ?? null;
+      },
+      useModel,
+    });
+
+    const message = createChatMessage("write a longer local direct benchmark");
+    message.content = {
+      ...message.content,
+      metadata: {
+        androidLocalDirect: {
+          longGeneration: true,
+        },
+      },
+    } as typeof message.content;
+
+    const result = await generateChatResponse(
+      runtime,
+      message,
+      "Streaming Agent",
+      {
+        timeoutDuration: 5_000,
+      },
+    );
+
+    expect(useModel).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        maxTokens: 64,
+        providerOptions: expect.objectContaining({
+          androidLocal: expect.objectContaining({
+            stopOnFirstSentence: false,
+          }),
+        }),
+      }),
+    );
+    expect(result.localInference).toEqual(
+      expect.objectContaining({
+        generationMode: "long",
+        maxTokens: 64,
+        stopOnFirstSentence: false,
       }),
     );
   });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -134,6 +134,8 @@ const ANDROID_LOCAL_CURRENT_DATA_PATTERN =
 const ANDROID_LOCAL_CONTEXTUAL_MEMORY_PATTERN =
   /\b(what\s+did\s+i\s+just\s+say|what\s+(?:is|'s)\s+my\s+name|who\s+am\s+i|do\s+you\s+remember|remember\s+(?:me|my|that)|what\s+was\s+my|what\s+did\s+we|previous(?:ly)?|earlier|last\s+(?:message|thing|question|conversation)|recent\s+(?:message|conversation)|my\s+(?:name|email|address|phone|preference|preferences))\b/i;
 
+type AndroidLocalDirectChatMode = "short" | "long";
+
 function readRuntimeStringSetting(
   runtime: AgentRuntime,
   key: string,
@@ -158,6 +160,82 @@ function readPositiveIntegerSetting(
   const raw = readRuntimeStringSetting(runtime, key);
   const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function readPositiveIntegerValue(value: unknown): number | null {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+function readBooleanValue(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return null;
+  if (/^(1|true|yes|on)$/i.test(value.trim())) return true;
+  if (/^(0|false|no|off)$/i.test(value.trim())) return false;
+  return null;
+}
+
+function readAndroidLocalDirectChatSettings(args: {
+  runtime: AgentRuntime;
+  message: ReturnType<typeof createMessageMemory>;
+}): {
+  maxTokens: number;
+  stopOnFirstSentence: boolean;
+  mode: AndroidLocalDirectChatMode;
+} {
+  const defaultMaxTokens = readPositiveIntegerSetting(
+    args.runtime,
+    "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
+    20,
+  );
+  const longMaxTokens = Math.max(
+    defaultMaxTokens,
+    readPositiveIntegerSetting(
+      args.runtime,
+      "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_LONG_MAX_TOKENS",
+      256,
+    ),
+  );
+  const metadata = asRecord(args.message.content.metadata) ?? {};
+  const directOptions =
+    asRecord(metadata.androidLocalDirect) ??
+    asRecord(metadata.mobileLocalDirect) ??
+    {};
+  const benchmarkOptions = asRecord(metadata.benchmarkHarness) ?? {};
+  const requestedMaxTokens =
+    readPositiveIntegerValue(directOptions.maxTokens) ??
+    readPositiveIntegerValue(directOptions.max_tokens) ??
+    readPositiveIntegerValue(benchmarkOptions.maxTokens) ??
+    readPositiveIntegerValue(benchmarkOptions.max_tokens);
+  const explicitLong =
+    readBooleanValue(directOptions.longGeneration) ??
+    readBooleanValue(benchmarkOptions.longGeneration) ??
+    false;
+  const explicitStopOnFirstSentence =
+    readBooleanValue(directOptions.stopOnFirstSentence) ??
+    readBooleanValue(directOptions.stop_on_first_sentence) ??
+    readBooleanValue(benchmarkOptions.stopOnFirstSentence) ??
+    readBooleanValue(benchmarkOptions.stop_on_first_sentence);
+  const longMode =
+    explicitLong ||
+    (requestedMaxTokens != null && requestedMaxTokens > defaultMaxTokens);
+  const cappedRequestedMaxTokens =
+    requestedMaxTokens != null
+      ? Math.min(requestedMaxTokens, longMaxTokens)
+      : null;
+  const maxTokens = longMode
+    ? (cappedRequestedMaxTokens ?? longMaxTokens)
+    : (cappedRequestedMaxTokens ?? defaultMaxTokens);
+  return {
+    maxTokens,
+    stopOnFirstSentence: explicitStopOnFirstSentence ?? !longMode,
+    mode: longMode ? "long" : "short",
+  };
 }
 
 function isAndroidLocalDirectChatRuntime(runtime: AgentRuntime): boolean {
@@ -267,10 +345,15 @@ function normalizeAndroidLocalDirectUserText(text: string): string {
 function buildAndroidLocalDirectChatPrompt(args: {
   runtime: AgentRuntime;
   userText: string;
+  mode: AndroidLocalDirectChatMode;
 }): string {
+  const responseInstruction =
+    args.mode === "long"
+      ? "Answer directly in concise natural language. Include the requested detail, but stay within the token budget."
+      : "One natural sentence under 10 words. Stop after it.";
   const systemText = [
     "Eliza-1 on Android.",
-    "One natural sentence under 10 words. Stop after it.",
+    responseInstruction,
     "If asked local/on-device: yes, local Eliza-1 with DFlash.",
     "No markdown, labels, tools, logs, or hidden reasoning.",
   ].join("\n");
@@ -342,7 +425,10 @@ function stripAndroidLocalReasoning(text: string): string {
   return next;
 }
 
-function cleanAndroidLocalDirectChatReply(raw: unknown): string {
+function cleanAndroidLocalDirectChatReply(
+  raw: unknown,
+  options: { stopOnFirstSentence?: boolean } = {},
+): string {
   let text = stripAndroidLocalReasoning(extractAndroidLocalModelText(raw));
   text = text
     .split("<|im_end|>")[0]
@@ -350,11 +436,14 @@ function cleanAndroidLocalDirectChatReply(raw: unknown): string {
     .replace(/^\s*(assistant|eliza)\s*:\s*/i, "")
     .replace(/\bMilady-1\b/gi, "Eliza-1")
     .trim();
-  text = truncateAndroidLocalReplyToFirstSentence(text);
-  if (text.length <= 700) {
+  if (options.stopOnFirstSentence !== false) {
+    text = truncateAndroidLocalReplyToFirstSentence(text);
+  }
+  const maxReplyChars = options.stopOnFirstSentence === false ? 2_000 : 700;
+  if (text.length <= maxReplyChars) {
     return text;
   }
-  const truncated = text.slice(0, 700);
+  const truncated = text.slice(0, maxReplyChars);
   const sentenceEnd = Math.max(
     truncated.lastIndexOf("."),
     truncated.lastIndexOf("!"),
@@ -379,21 +468,21 @@ async function maybeGenerateAndroidLocalDirectChatResponse(args: {
     extractCompatTextContent(args.message.content),
   );
   if (!userText) return null;
+  const directSettings = readAndroidLocalDirectChatSettings(args);
+  const { maxTokens, stopOnFirstSentence } = directSettings;
   const prompt = buildAndroidLocalDirectChatPrompt({
     runtime: args.runtime,
     userText,
+    mode: directSettings.mode,
   });
-  const maxTokens = readPositiveIntegerSetting(
-    args.runtime,
-    "ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS",
-    20,
-  );
   const startedAt = Date.now();
   args.runtime.logger.info(
     {
       src: "eliza-api",
       promptChars: prompt.length,
       maxTokens,
+      mode: directSettings.mode,
+      stopOnFirstSentence,
       messageId: args.message.id,
     },
     "[eliza-api] Android local direct chat fast path start",
@@ -434,7 +523,7 @@ async function maybeGenerateAndroidLocalDirectChatResponse(args: {
         thinking: "off",
       },
       androidLocal: {
-        stopOnFirstSentence: true,
+        stopOnFirstSentence,
         minFirstSentenceChars: 12,
       },
     },
@@ -443,11 +532,15 @@ async function maybeGenerateAndroidLocalDirectChatResponse(args: {
     onStreamChunk: (chunk: string) => {
       streamedRaw += chunk;
       streamedChunks += 1;
-      const snapshot = cleanAndroidLocalDirectChatReply(streamedRaw);
+      const snapshot = cleanAndroidLocalDirectChatReply(streamedRaw, {
+        stopOnFirstSentence,
+      });
       emitCleanStreamingSnapshot(snapshot);
     },
   });
-  const text = cleanAndroidLocalDirectChatReply(raw);
+  const text = cleanAndroidLocalDirectChatReply(raw, {
+    stopOnFirstSentence,
+  });
   if (!text) {
     args.runtime.logger.warn(
       { src: "eliza-api", messageId: args.message.id },
@@ -463,6 +556,8 @@ async function maybeGenerateAndroidLocalDirectChatResponse(args: {
     latencyMs,
     promptChars: prompt.length,
     maxTokens,
+    generationMode: directSettings.mode,
+    stopOnFirstSentence,
     streamedChunks,
   } satisfies LocalInferenceChatMetadata;
   const responseContent = {


### PR DESCRIPTION
## Summary

Adds an explicit long-generation mode to the Android local direct chat fast path while preserving the default short voice/chat behavior.

Default Android direct replies still use the existing short path:

- 20-token default cap via `ELIZA_MOBILE_LOCAL_DIRECT_REPLY_MAX_TOKENS`
- first-sentence stopping enabled
- short prompt: one natural sentence, under 10 words

Benchmark/dev callers can now request a long direct local generation through message metadata:

- `metadata.androidLocalDirect.maxTokens` / `max_tokens`
- `metadata.androidLocalDirect.longGeneration`
- `metadata.androidLocalDirect.stopOnFirstSentence`
- `metadata.benchmarkHarness.maxTokens` / `max_tokens`
- `metadata.benchmarkHarness.longGeneration`
- `metadata.benchmarkHarness.stopOnFirstSentence`

Long mode is capped by `ELIZA_MOBILE_LOCAL_DIRECT_REPLY_LONG_MAX_TOKENS` (default 256) and switches the prompt away from the short one-sentence instruction. This gives Pixel/mobile validation a clean way to exercise DFlash/speculative decoding on meaningful longer generations without forcing DFlash onto short voice turns, where current Pixel evidence showed it can hurt latency.

## Why

The stock Android APK local voice path needs two different behaviors:

1. User-facing voice/chat should stay short and low-latency.
2. Benchmarks and DFlash validation need a longer direct local generation path so the speculative pipeline can be measured without routing through unrelated agent/tool code.

Previously the direct path only exposed the short behavior. Forcing DFlash globally was not production-safe for short turns, and it made short voice latency worse in Pixel validation.

## Validation

- `bunx @biomejs/biome check packages/agent/src/api/chat-routes.ts packages/agent/src/api/__tests__/conversation-streaming.test.ts`
- `git diff --check`
- `bun run --cwd packages/agent test -- src/api/__tests__/conversation-streaming.test.ts`
  - 13 tests passed

## Pixel context

This PR is based on the Pixel APK validation work where:

- `eliza-1-0_8b` was active on a Pixel 9a stock Android debug APK.
- Shaw/elizaOS llama.cpp fork libs and QJL/Polar/TBQ/fused-attn kernels were packaged.
- Forced DFlash did execute, but was slower for short voice turns.

This PR does not claim NNAPI/Tensor/TPU support and does not change AOSP flashing behavior.
