### PR TITLE
fix(streaming): forward local TTS voice hints

### DIFF
--- a/plugins/plugin-streaming/src/api/tts-routes.test.ts
+++ b/plugins/plugin-streaming/src/api/tts-routes.test.ts
@@ -71,6 +71,39 @@ describe("handleTtsRoutes local-inference", () => {
     expect(res.body.subarray(0, 4).toString("ascii")).toBe("RIFF");
   });
 
+  it("forwards local voice, model, speed, sample rate, and format hints", async () => {
+    const useModel = vi.fn(async (_modelType, params, provider) => {
+      expect(_modelType).toBe(ModelType.TEXT_TO_SPEECH);
+      expect(provider).toBe("eliza-local-inference");
+      expect(params).toEqual({
+        text: "hello",
+        voice: "af_bella",
+        modelId: "kokoro-q4",
+        speed: 1.1,
+        sampleRate: 24000,
+        format: "wav",
+      });
+      return riffWav();
+    });
+    const ctx = makeContext({
+      state: { config: {}, runtime: { useModel } as never },
+      readJsonBody: vi.fn(async () => ({
+        text: "hello",
+        voice: "ignored",
+        voiceId: "af_bella",
+        modelId: "kokoro-q4",
+        speed: 1.1,
+        sampleRate: 24000,
+        format: "wav",
+      })),
+    });
+
+    await expect(handleTtsRoutes(ctx)).resolves.toBe(true);
+
+    const res = ctx.res as unknown as ReturnType<typeof makeRes>;
+    expect(res.status).toBe(200);
+  });
+
   it("fails closed when no local provider is registered", async () => {
     const useModel = vi.fn(async () => {
       throw new Error("No handler found for delegate type: TEXT_TO_SPEECH");

--- a/plugins/plugin-streaming/src/api/tts-routes.ts
+++ b/plugins/plugin-streaming/src/api/tts-routes.ts
@@ -145,7 +145,7 @@ export async function handleTtsRoutes(ctx: TtsRouteContext): Promise<boolean> {
 
   // ── POST /api/tts/local-inference ──────────────────────────────────────
   if (method === "POST" && pathname === "/api/tts/local-inference") {
-    const body = await readJsonBody<{ text?: string }>(req, res);
+    const body = await readJsonBody<LocalInferenceTtsRequestBody>(req, res);
     if (!body) return true;
 
     const text =
@@ -164,7 +164,30 @@ export async function handleTtsRoutes(ctx: TtsRouteContext): Promise<boolean> {
     }
 
     try {
-      const audio = await useLocalInferenceTts(runtime, text);
+      const audio = await useLocalInferenceTts(runtime, {
+        text,
+        ...(optionalString(body.voice)
+          ? { voice: optionalString(body.voice) }
+          : {}),
+        ...(optionalString(body.voiceId)
+          ? { voice: optionalString(body.voiceId) }
+          : {}),
+        ...(optionalString(body.model)
+          ? { model: optionalString(body.model) }
+          : {}),
+        ...(optionalString(body.modelId)
+          ? { modelId: optionalString(body.modelId) }
+          : {}),
+        ...(optionalPositiveNumber(body.speed)
+          ? { speed: optionalPositiveNumber(body.speed) }
+          : {}),
+        ...(optionalPositiveNumber(body.sampleRate)
+          ? { sampleRate: optionalPositiveNumber(body.sampleRate) }
+          : {}),
+        ...(optionalString(body.format)
+          ? { format: optionalString(body.format) }
+          : {}),
+      });
       const bytes = normalizeAudioBytes(audio);
       if (bytes.length === 0) {
         error(res, "Local inference TEXT_TO_SPEECH returned empty audio", 502);
@@ -393,16 +416,37 @@ const LOCAL_TTS_PROVIDER_IDS = [
   "eliza-aosp-llama",
 ] as const;
 
+interface LocalInferenceTtsRequestBody {
+  text?: string;
+  voice?: string;
+  voiceId?: string;
+  model?: string;
+  modelId?: string;
+  speed?: number;
+  sampleRate?: number;
+  format?: string;
+}
+
+interface LocalInferenceTtsRequest {
+  text: string;
+  voice?: string;
+  model?: string;
+  modelId?: string;
+  speed?: number;
+  sampleRate?: number;
+  format?: string;
+}
+
 async function useLocalInferenceTts(
   runtime: IAgentRuntime,
-  text: string,
+  request: LocalInferenceTtsRequest,
 ): Promise<Buffer | Uint8Array | ArrayBuffer> {
   let lastError: unknown;
   for (const provider of LOCAL_TTS_PROVIDER_IDS) {
     try {
       return await runtime.useModel(
         ModelType.TEXT_TO_SPEECH,
-        { text },
+        request,
         provider,
       );
     } catch (err) {
@@ -416,6 +460,16 @@ async function useLocalInferenceTts(
     throw lastError;
   }
   throw new Error("No local-inference TEXT_TO_SPEECH provider is registered");
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function optionalPositiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
 }
 
 function isMissingProviderError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

Forwards local TTS request hints through the streaming plugin's `/api/tts/local-inference` route instead of reducing the request to `{ text }`.

The route now preserves:

- `voice` / `voiceId`
- `model` / `modelId`
- `speed`
- `sampleRate`
- `format`

This lets Android/TalkMode and other streaming clients select the same Kokoro or OmniVoice voice/model options that the local-inference provider already understands.

## Why

Pixel stock-APK validation showed local TTS was being called through the route layer while the native/backend code needed explicit voice/model hints for repeatable tests. Without forwarding those fields, callers could request `af_bella` or a specific local backend model and still get whichever default the provider chose.

## Pixel context

This is one small piece of the Pixel APK voice work. Latest packaged APK evidence from the validation harness:

- Device: Pixel 9a, Android 16, package `ai.milady.milady`
- Active model: `eliza-1-0_8b`
- Text route: `mobile-local-direct-reply` / `aosp-local-llama`
- TTFT: `2483.1 ms`
- Local TTS: `audio/wav`, `100844 bytes`, `2.1 s` audio, `7757.8 ms` total
- Kokoro log: `voice=af_bella`, `phonemizer=phonemizer`, `Kokoro ORT wasm numThreads=1`
- DFlash was not claimed as active: speculative shim loaded, but `dflash=false` with the current `.8B` self-drafter.

Benchmark artifacts:

- `/tmp/pixel-local-voice-packaged-20260517T084529Z.json`
- `/tmp/pixel-local-voice-packaged-20260517T084529Z.wav`
- `/tmp/milady-packaged-apk-20260517T084510Z.png`

## Validation

- `bunx @biomejs/biome check plugins/plugin-streaming/src/api/tts-routes.ts plugins/plugin-streaming/src/api/tts-routes.test.ts`
- `git diff --check`
- `BUN_CONFIG_COVERAGE=false bun test plugins/plugin-streaming/src/api/tts-routes.test.ts --timeout 60000`
  - All 3 route assertions passed.
  - Note: the repo-level `bunfig.toml` still forces coverage output, so the process was manually killed after the pass lines when Bun stalled rendering the coverage table.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `/api/tts/local-inference` route to forward caller-supplied voice/model hints (`voice`/`voiceId`, `model`/`modelId`, `speed`, `sampleRate`, `format`) to the local TTS provider instead of stripping them down to just `{ text }`. A matching test validates the `voiceId`-over-`voice` precedence and the end-to-end hint forwarding.

- Adds `LocalInferenceTtsRequestBody` and `LocalInferenceTtsRequest` interfaces to type the incoming HTTP body and the internal provider call respectively, with `voiceId` collapsed into `voice` before dispatch.
- Introduces two pure helper functions (`optionalString`, `optionalPositiveNumber`) to safely coerce untrusted JSON fields; each helper is currently invoked twice per field due to the ternary-spread pattern (see inline suggestion).
- The new test covers the happy-path and the `voiceId`-wins precedence, but the `model` field forwarding branch goes untested.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrow and the core forwarding logic is well-tested.

The forwarding logic is correct and the voiceId-over-voice precedence is explicitly validated by the new test. The remaining gaps — redundant helper calls, an untested model forwarding branch, and the unvalidated format field — are quality issues rather than functional defects.

tts-routes.ts deserves a second look at the format field and the double-call pattern; tts-routes.test.ts is missing coverage for the model field.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-streaming/src/api/tts-routes.ts | Adds LocalInferenceTtsRequestBody/LocalInferenceTtsRequest interfaces and forwards voice/voiceId, model/modelId, speed, sampleRate, and format through to the provider. Two minor issues: each helper is called twice per field (redundant), and format is accepted as an unrestricted string with no allowlist. |
| plugins/plugin-streaming/src/api/tts-routes.test.ts | Adds a focused test verifying that voiceId takes priority over voice and that numeric/string hints reach the provider. The model forwarding path is not exercised by any test case. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Android/TalkMode Client
    participant Route as /api/tts/local-inference
    participant Handler as handleTtsRoutes
    participant Util as optionalString / optionalPositiveNumber
    participant Provider as useLocalInferenceTts
    participant Runtime as runtime.useModel (TEXT_TO_SPEECH)

    Client->>Route: "POST { text, voice, voiceId, model, modelId, speed, sampleRate, format }"
    Route->>Handler: "readJsonBody<LocalInferenceTtsRequestBody>"
    Handler->>Util: coerce each field (trim strings, positive-number guard)
    Note over Handler,Util: voiceId overrides voice (last-spread wins)
    Handler->>Provider: "useLocalInferenceTts(runtime, { text, voice?, model?, modelId?, speed?, sampleRate?, format? })"
    loop Try each LOCAL_TTS_PROVIDER_IDS in order
        Provider->>Runtime: runtime.useModel(TEXT_TO_SPEECH, request, providerId)
        alt Provider registered
            Runtime-->>Provider: "Buffer | Uint8Array | ArrayBuffer"
        else Missing provider error
            Runtime-->>Provider: throws No handler found
        end
    end
    Provider-->>Handler: audio bytes
    Handler-->>Client: 200 audio/wav (or audio/mpeg)
```

<sub>Reviews (1): Last reviewed commit: ["fix(streaming): forward local TTS voice ..."](https://github.com/elizaos/eliza/commit/66dd8754b6346fbfb69abcc54411d483cb9fb9ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32495534)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->