### PR TITLE
fix(kokoro): use bundled phonemizer on mobile

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1803,6 +1803,7 @@
         "@elizaos/core": "workspace:*",
         "chalk": "^5.3.0",
         "drizzle-orm": "0.45.2",
+        "phonemizer": "^1.2.1",
         "react": "^19.0.0",
         "yaml": "^2.8.2",
         "zod": "^4.4.3",
@@ -2946,6 +2947,7 @@
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-capacitor-bridge": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "phonemizer": "^1.2.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
@@ -10269,6 +10271,8 @@
     "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
 
     "phin": ["phin@3.7.1", "", { "dependencies": { "centra": "^2.7.0" } }, "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ=="],
+
+    "phonemizer": ["phonemizer@1.2.1", "", {}, "sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1046,6 +1046,7 @@ public class ElizaAgentService extends Service {
             File abiLlamaShim = new File(abiDir, "libeliza-llama-shim.so");
             File abiSpeculativeShim = new File(abiDir, "libeliza-llama-speculative-shim.so");
             boolean nativeLlamaBundled = abiLibllama.isFile() && abiLlamaShim.isFile();
+            boolean brandedAospBuild = BuildConfig.AOSP_BUILD && isBrandedDevice();
             if (nativeLlamaBundled && !env.containsKey("ELIZA_LOCAL_LLAMA")) {
                 agentEnv.put("ELIZA_LOCAL_LLAMA", "1");
                 Log.i(TAG, "agent/" + abiDir.getName()
@@ -1057,6 +1058,13 @@ public class ElizaAgentService extends Service {
                 }
                 if (!env.containsKey("ELIZA_KOKORO_PREWARM")) {
                     agentEnv.put("ELIZA_KOKORO_PREWARM", "1");
+                }
+                if (!brandedAospBuild && !env.containsKey("ELIZA_KOKORO_DEFAULT_VOICE_ID")) {
+                    // The stock APK should default to a release-safe Kokoro
+                    // voice. AOSP/product builds can opt into a custom voice
+                    // through ELIZA_KOKORO_DEFAULT_VOICE_ID without changing
+                    // the Play Store APK behavior.
+                    agentEnv.put("ELIZA_KOKORO_DEFAULT_VOICE_ID", "af_bella");
                 }
                 if (!env.containsKey("ELIZA_KOKORO_PREWARM_DELAY_MS")) {
                     // Kokoro's first on-device ORT/WASM synthesis can be
@@ -1071,7 +1079,6 @@ public class ElizaAgentService extends Service {
                     Log.i(TAG, "agent/" + abiDir.getName()
                         + "/libeliza-llama-speculative-shim.so present; enabling in-process DFlash (ELIZA_DFLASH=1)");
                 }
-                boolean brandedAospBuild = BuildConfig.AOSP_BUILD && isBrandedDevice();
                 if (BuildConfig.DEBUG && !env.containsKey("ELIZA_AOSP_LLAMA_DEBUG_LOG")) {
                     File debugLog = new File(agentStateDir(), "aosp-llama-debug.log");
                     agentEnv.put("ELIZA_AOSP_LLAMA_DEBUG_LOG", debugLog.getAbsolutePath());

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -94,6 +94,7 @@
     "@elizaos/core": "workspace:*",
     "chalk": "^5.3.0",
     "drizzle-orm": "0.45.2",
+    "phonemizer": "^1.2.1",
     "react": "^19.0.0",
     "yaml": "^2.8.2",
     "zod": "^4.4.3"

--- a/packages/shared/src/local-inference/kokoro/kokoro-backend.ts
+++ b/packages/shared/src/local-inference/kokoro/kokoro-backend.ts
@@ -202,6 +202,7 @@ export class KokoroTtsBackend implements OmniVoiceBackend, StreamingTtsBackend {
   private async ensurePhonemizer(): Promise<KokoroPhonemizer> {
     if (this.phonemizer) return this.phonemizer;
     this.phonemizer = await resolvePhonemizer(this.phonemizerOverride);
+    console.info(`[kokoro] using phonemizer=${this.phonemizer.id}`);
     return this.phonemizer;
   }
 }

--- a/packages/shared/src/local-inference/kokoro/phonemizer.test.ts
+++ b/packages/shared/src/local-inference/kokoro/phonemizer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { FallbackG2PPhonemizer, KOKORO_PAD_ID } from "./phonemizer.js";
+import {
+  FallbackG2PPhonemizer,
+  KOKORO_PAD_ID,
+  kokoroLangToPhonemizerLanguage,
+  NpmPhonemizePhonemizer,
+} from "./phonemizer.js";
 
 describe("FallbackG2PPhonemizer", () => {
   it("uses Kokoro tokenizer boundary ids and IPA for common smoke phrases", async () => {
@@ -24,5 +29,25 @@ describe("FallbackG2PPhonemizer", () => {
       4,
       KOKORO_PAD_ID,
     ]);
+  });
+
+  it("maps Kokoro voice language ids to phonemizer locales", () => {
+    expect(kokoroLangToPhonemizerLanguage("a")).toBe("en-us");
+    expect(kokoroLangToPhonemizerLanguage("b")).toBe("en-gb");
+    expect(kokoroLangToPhonemizerLanguage("en-us")).toBe("en-us");
+  });
+
+  it("loads the bundled phonemizer package before falling back to pseudo phonemes", async () => {
+    const phonemizer = await NpmPhonemizePhonemizer.tryLoad();
+    expect(phonemizer?.id).toBe("phonemizer");
+    if (!phonemizer) {
+      throw new Error("phonemizer package did not load");
+    }
+
+    const seq = await phonemizer.phonemize("Hello there.", "a");
+
+    expect(seq.phonemes).not.toBe("hɛloʊ ðɛɹ.");
+    expect(seq.phonemes).toContain("h");
+    expect(Array.from(seq.ids)).toContain(156);
   });
 });

--- a/packages/shared/src/local-inference/kokoro/phonemizer.ts
+++ b/packages/shared/src/local-inference/kokoro/phonemizer.ts
@@ -3,14 +3,14 @@
  *
  * Kokoro is trained against espeak-ng IPA tokens with a small fixed vocab
  * (~178 entries: IPA symbols + stress/punct markers + special <s>/<pad>).
- * Production deployments should bring real espeak-ng (`phonemize` npm
- * package wraps the C library); the bundled fallback here is a
+ * Production deployments should bring real espeak-ng phonemization
+ * (`phonemizer` is the pure-JS eSpeak NG package); the bundled fallback here is a
  * deterministic letter-to-pseudo-phoneme adapter that produces audible
  * speech for ASCII English text but loses prosodic accuracy.
  *
  * Resolution order:
  *   1. Caller-provided `KokoroPhonemizer` (preferred — bring your own).
- *   2. Dynamically-imported `phonemize` npm package, if installed.
+ *   2. Dynamically-imported `phonemizer`/`phonemize` npm package, if installed.
  *   3. Bundled `FallbackG2PPhonemizer` (degrades gracefully, never throws on
  *      ASCII input).
  *
@@ -223,7 +223,7 @@ export class FallbackG2PPhonemizer implements KokoroPhonemizer {
       // surface non-English text rather than emit silence.
       if (cp > 127) {
         throw new KokoroPhonemizerError(
-          `[kokoro] fallback phonemizer cannot handle non-ASCII character '${ch}' (U+${cp.toString(16).padStart(4, "0")}). Install the 'phonemize' npm package or pass a custom KokoroPhonemizer for full Unicode coverage.`,
+          `[kokoro] fallback phonemizer cannot handle non-ASCII character '${ch}' (U+${cp.toString(16).padStart(4, "0")}). Install the 'phonemizer' npm package or pass a custom KokoroPhonemizer for full Unicode coverage.`,
         );
       }
     }
@@ -244,29 +244,48 @@ export class FallbackG2PPhonemizer implements KokoroPhonemizer {
 }
 
 interface PhonemizeMod {
-  // The `phonemize` npm package's typing varies between v1/v2; we treat it
-  // structurally so a minor version bump does not break our import.
-  phonemize?: (text: string, opts?: unknown) => string | Promise<string>;
+  // The `phonemizer` / legacy `phonemize` npm package typing varies between
+  // packages and versions; treat it structurally so minor updates do not break
+  // mobile TTS.
+  phonemize?: (
+    text: string,
+    langOrOpts?: unknown,
+  ) => string | string[] | Promise<string | string[]>;
   default?: { phonemize?: PhonemizeMod["phonemize"] };
 }
 
 /**
- * Wraps the npm `phonemize` package when present. It returns an IPA string
+ * Wraps the npm `phonemizer` package when present. It returns an IPA string
  * which we tokenise with the same VOCAB above. Real Kokoro inference should
  * use a proper espeak tokenizer — production deployments bring their own;
  * this is the "install npm and it works" middle ground.
  */
 export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
-  readonly id = "phonemize";
-  private constructor(private readonly mod: PhonemizeMod) {}
+  readonly id: string;
+  private constructor(
+    private readonly mod: PhonemizeMod,
+    id = "phonemizer",
+    private readonly callStyle: "language" | "options" = "language",
+  ) {
+    this.id = id;
+  }
 
   static async tryLoad(): Promise<NpmPhonemizePhonemizer | null> {
+    try {
+      const mod = (await import("phonemizer")) as PhonemizeMod;
+      const phon = mod.phonemize ?? mod.default?.phonemize;
+      if (typeof phon !== "function") return null;
+      return new NpmPhonemizePhonemizer(mod);
+    } catch {
+      // Older local installs used a package named `phonemize`. Keep it as a
+      // secondary, deliberately non-bundled fallback for developer machines.
+    }
     try {
       const spec = "phonemize";
       const mod = (await import(/* @vite-ignore */ spec)) as PhonemizeMod;
       const phon = mod.phonemize ?? mod.default?.phonemize;
       if (typeof phon !== "function") return null;
-      return new NpmPhonemizePhonemizer(mod);
+      return new NpmPhonemizePhonemizer(mod, "phonemize", "options");
     } catch {
       return null;
     }
@@ -279,8 +298,17 @@ export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
         "[kokoro] 'phonemize' module loaded but does not export a phonemize() function",
       );
     }
-    const out = await phon(text, { lang });
-    const phonemes = typeof out === "string" ? out : String(out);
+    const out = await phon(
+      text,
+      this.callStyle === "language"
+        ? kokoroLangToPhonemizerLanguage(lang)
+        : { lang },
+    );
+    const phonemes = Array.isArray(out)
+      ? out.join(" ")
+      : typeof out === "string"
+        ? out
+        : String(out);
     const ids: number[] = [BOS];
     for (const ch of phonemes.toLowerCase()) {
       const id = VOCAB[ch];
@@ -291,7 +319,18 @@ export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
   }
 }
 
-/** Lazy resolver: caller override → npm `phonemize` → bundled fallback. */
+export function kokoroLangToPhonemizerLanguage(lang: string): string {
+  switch (lang.trim().toLowerCase()) {
+    case "a":
+      return "en-us";
+    case "b":
+      return "en-gb";
+    default:
+      return lang || "en-us";
+  }
+}
+
+/** Lazy resolver: caller override → npm `phonemizer` → bundled fallback. */
 export async function resolvePhonemizer(
   override?: KokoroPhonemizer,
 ): Promise<KokoroPhonemizer> {

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -77,7 +77,8 @@
 	"dependencies": {
 		"@elizaos/core": "workspace:*",
 		"@elizaos/shared": "workspace:*",
-		"@elizaos/plugin-capacitor-bridge": "workspace:*"
+		"@elizaos/plugin-capacitor-bridge": "workspace:*",
+		"phonemizer": "^1.2.1"
 	},
 	"optionalDependencies": {
 		"node-llama-cpp": "3.18.1",

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { FallbackG2PPhonemizer, KOKORO_PAD_ID } from "../phonemizer";
+import {
+	FallbackG2PPhonemizer,
+	KOKORO_PAD_ID,
+	kokoroLangToPhonemizerLanguage,
+	NpmPhonemizePhonemizer,
+} from "../phonemizer";
 
 describe("FallbackG2PPhonemizer", () => {
 	it("uses Kokoro tokenizer boundary ids and IPA for common smoke phrases", async () => {
@@ -24,5 +29,25 @@ describe("FallbackG2PPhonemizer", () => {
 			4,
 			KOKORO_PAD_ID,
 		]);
+	});
+
+	it("maps Kokoro voice language ids to phonemizer locales", () => {
+		expect(kokoroLangToPhonemizerLanguage("a")).toBe("en-us");
+		expect(kokoroLangToPhonemizerLanguage("b")).toBe("en-gb");
+		expect(kokoroLangToPhonemizerLanguage("en-us")).toBe("en-us");
+	});
+
+	it("loads the bundled phonemizer package before falling back to pseudo phonemes", async () => {
+		const phonemizer = await NpmPhonemizePhonemizer.tryLoad();
+		expect(phonemizer?.id).toBe("phonemizer");
+		if (!phonemizer) {
+			throw new Error("phonemizer package did not load");
+		}
+
+		const seq = await phonemizer.phonemize("Hello there.", "a");
+
+		expect(seq.phonemes).not.toBe("hɛloʊ ðɛɹ.");
+		expect(seq.phonemes).toContain("h");
+		expect(Array.from(seq.ids)).toContain(156);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts
@@ -202,6 +202,7 @@ export class KokoroTtsBackend implements OmniVoiceBackend, StreamingTtsBackend {
 	private async ensurePhonemizer(): Promise<KokoroPhonemizer> {
 		if (this.phonemizer) return this.phonemizer;
 		this.phonemizer = await resolvePhonemizer(this.phonemizerOverride);
+		console.info(`[kokoro] using phonemizer=${this.phonemizer.id}`);
 		return this.phonemizer;
 	}
 }

--- a/plugins/plugin-local-inference/src/services/voice/kokoro/phonemizer.ts
+++ b/plugins/plugin-local-inference/src/services/voice/kokoro/phonemizer.ts
@@ -3,14 +3,14 @@
  *
  * Kokoro is trained against espeak-ng IPA tokens with a small fixed vocab
  * (~178 entries: IPA symbols + stress/punct markers + special <s>/<pad>).
- * Production deployments should bring real espeak-ng (`phonemize` npm
- * package wraps the C library); the bundled fallback here is a
+ * Production deployments should bring real espeak-ng phonemization
+ * (`phonemizer` is the pure-JS eSpeak NG package); the bundled fallback here is a
  * deterministic letter-to-pseudo-phoneme adapter that produces audible
  * speech for ASCII English text but loses prosodic accuracy.
  *
  * Resolution order:
  *   1. Caller-provided `KokoroPhonemizer` (preferred — bring your own).
- *   2. Dynamically-imported `phonemize` npm package, if installed.
+ *   2. Dynamically-imported `phonemizer`/`phonemize` npm package, if installed.
  *   3. Bundled `FallbackG2PPhonemizer` (degrades gracefully, never throws on
  *      ASCII input).
  *
@@ -223,7 +223,7 @@ export class FallbackG2PPhonemizer implements KokoroPhonemizer {
 			// surface non-English text rather than emit silence.
 			if (cp > 127) {
 				throw new KokoroPhonemizerError(
-					`[kokoro] fallback phonemizer cannot handle non-ASCII character '${ch}' (U+${cp.toString(16).padStart(4, "0")}). Install the 'phonemize' npm package or pass a custom KokoroPhonemizer for full Unicode coverage.`,
+					`[kokoro] fallback phonemizer cannot handle non-ASCII character '${ch}' (U+${cp.toString(16).padStart(4, "0")}). Install the 'phonemizer' npm package or pass a custom KokoroPhonemizer for full Unicode coverage.`,
 				);
 			}
 		}
@@ -244,29 +244,48 @@ export class FallbackG2PPhonemizer implements KokoroPhonemizer {
 }
 
 interface PhonemizeMod {
-	// The `phonemize` npm package's typing varies between v1/v2; we treat it
-	// structurally so a minor version bump does not break our import.
-	phonemize?: (text: string, opts?: unknown) => string | Promise<string>;
+	// The `phonemizer` / legacy `phonemize` npm package typing varies between
+	// packages and versions; treat it structurally so minor updates do not break
+	// mobile TTS.
+	phonemize?: (
+		text: string,
+		langOrOpts?: unknown,
+	) => string | string[] | Promise<string | string[]>;
 	default?: { phonemize?: PhonemizeMod["phonemize"] };
 }
 
 /**
- * Wraps the npm `phonemize` package when present. It returns an IPA string
+ * Wraps the npm `phonemizer` package when present. It returns an IPA string
  * which we tokenise with the same VOCAB above. Real Kokoro inference should
  * use a proper espeak tokenizer — production deployments bring their own;
  * this is the "install npm and it works" middle ground.
  */
 export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
-	readonly id = "phonemize";
-	private constructor(private readonly mod: PhonemizeMod) {}
+	readonly id: string;
+	private constructor(
+		private readonly mod: PhonemizeMod,
+		id = "phonemizer",
+		private readonly callStyle: "language" | "options" = "language",
+	) {
+		this.id = id;
+	}
 
 	static async tryLoad(): Promise<NpmPhonemizePhonemizer | null> {
+		try {
+			const mod = (await import("phonemizer")) as PhonemizeMod;
+			const phon = mod.phonemize ?? mod.default?.phonemize;
+			if (typeof phon !== "function") return null;
+			return new NpmPhonemizePhonemizer(mod);
+		} catch {
+			// Older local installs used a package named `phonemize`. Keep it as a
+			// secondary, deliberately non-bundled fallback for developer machines.
+		}
 		try {
 			const spec = "phonemize";
 			const mod = (await import(/* @vite-ignore */ spec)) as PhonemizeMod;
 			const phon = mod.phonemize ?? mod.default?.phonemize;
 			if (typeof phon !== "function") return null;
-			return new NpmPhonemizePhonemizer(mod);
+			return new NpmPhonemizePhonemizer(mod, "phonemize", "options");
 		} catch {
 			return null;
 		}
@@ -279,8 +298,17 @@ export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
 				"[kokoro] 'phonemize' module loaded but does not export a phonemize() function",
 			);
 		}
-		const out = await phon(text, { lang });
-		const phonemes = typeof out === "string" ? out : String(out);
+		const out = await phon(
+			text,
+			this.callStyle === "language"
+				? kokoroLangToPhonemizerLanguage(lang)
+				: { lang },
+		);
+		const phonemes = Array.isArray(out)
+			? out.join(" ")
+			: typeof out === "string"
+				? out
+				: String(out);
 		const ids: number[] = [BOS];
 		for (const ch of phonemes.toLowerCase()) {
 			const id = VOCAB[ch];
@@ -291,7 +319,18 @@ export class NpmPhonemizePhonemizer implements KokoroPhonemizer {
 	}
 }
 
-/** Lazy resolver: caller override → npm `phonemize` → bundled fallback. */
+export function kokoroLangToPhonemizerLanguage(lang: string): string {
+	switch (lang.trim().toLowerCase()) {
+		case "a":
+			return "en-us";
+		case "b":
+			return "en-gb";
+		default:
+			return lang || "en-us";
+	}
+}
+
+/** Lazy resolver: caller override → npm `phonemizer` → bundled fallback. */
 export async function resolvePhonemizer(
 	override?: KokoroPhonemizer,
 ): Promise<KokoroPhonemizer> {


### PR DESCRIPTION
## Summary

This makes the Kokoro mobile TTS path use the real bundled `phonemizer` package before falling back to the deterministic ASCII G2P adapter. It also sets the stock Android APK default Kokoro voice to `af_bella` when the APK bundles the native local-inference libraries, while preserving AOSP/product override behavior through `ELIZA_KOKORO_DEFAULT_VOICE_ID`.

## Why

Pixel stock-APK validation showed Kokoro was producing audible WAV output, but quality was wrong/noisy when the fallback pseudo-phoneme path was used. The backend should prefer a real phonemizer when the dependency is available, and the Play Store-style APK needs a release-safe default voice rather than depending on a product/AOSP-only override.

## Pixel Evidence

Validated on Pixel 9a / Android 16 with the stock Android debug APK using the local Eliza runtime and Shaw's fork native local-inference libraries packaged in the APK.

Observed in device logs:

- `Kokoro TEXT_TO_SPEECH backend ready in 1ms (onnx, voice=af_bella)`
- `[kokoro] using phonemizer=phonemizer`
- `Kokoro ORT wasm numThreads=1`
- `Kokoro TEXT_TO_SPEECH completed chars=17 voice=af_bella backendReadyMs=1 synthMs=7661 encodeMs=3 pcmSamples=50400 wavBytes=100844`

Latest benchmark artifact from the Pixel run:

- WAV: `100844` bytes, `2.1s` audio
- HTTP 200/audio headers: `7750.4ms`
- TTS total: `7757.8ms`
- Report: `/home/nubs/Git/iqlabs/eliza-labs-data/analytics/pixel-9a-plan/runs/2026-05-17-pixel-apk-voice/VOICE-BENCHMARK-REPORT.md`

This PR improves phoneme quality and stock APK voice selection. It does not claim Kokoro is realtime yet; current stock APK TTS is still buffered through ORT wasm and remains the latency bottleneck.

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bunx @biomejs/biome check packages/shared/src/local-inference/kokoro/kokoro-backend.ts packages/shared/src/local-inference/kokoro/phonemizer.ts packages/shared/src/local-inference/kokoro/phonemizer.test.ts plugins/plugin-local-inference/src/services/voice/kokoro/kokoro-backend.ts plugins/plugin-local-inference/src/services/voice/kokoro/phonemizer.ts plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java`
- `git diff --check`
- `BUN_CONFIG_COVERAGE=false bun test packages/shared/src/local-inference/kokoro/phonemizer.test.ts plugins/plugin-local-inference/src/services/voice/kokoro/__tests__/phonemizer.test.ts --timeout 60000`
  - `6 pass`, `0 fail`, `18 expect() calls`
