### PR TITLE
fix(local-inference): activate native Android loader from routes

### DIFF
--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -90,6 +90,7 @@ type LocalInferenceServerApi = {
   handleLocalInferenceRoutes: (
     req: http.IncomingMessage,
     res: http.ServerResponse,
+    state?: { current: AgentRuntime | null },
   ) => Promise<boolean>;
   handleLocalInferenceTtsRoute?: (
     req: http.IncomingMessage,
@@ -1656,7 +1657,8 @@ async function handleRequest(
   }
 
   const { handleLocalInferenceRoutes } = await getLocalInferenceServerApi();
-  if (await handleLocalInferenceRoutes(req, res)) return;
+  if (await handleLocalInferenceRoutes(req, res, { current: state.runtime }))
+    return;
   const localInferenceServerApi = await getLocalInferenceServerApi();
   if (
     localInferenceServerApi.handleLocalInferenceTtsRoute &&

--- a/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
+++ b/plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts
@@ -71,6 +71,7 @@ const SERVICE_NAME = "localInferenceLoader";
 const PROVIDER = "eliza-aosp-llama";
 const registeredRuntimes = new WeakSet<AgentRuntime>();
 const AOSP_ACTIVE_MODEL_STATE_FILE = "aosp-active.json";
+let routeActivationLoader: AospLoader | null = null;
 
 /**
  * Same priority band as cloud / direct provider plugins. Routing-policy
@@ -147,7 +148,23 @@ function writeAospActiveModelState(
   }
 }
 
-interface AospLoadModelArgs {
+function clearAospActiveModelState(): void {
+  try {
+    const activeStatePath = path.join(
+      resolveStateDir(),
+      "local-inference",
+      AOSP_ACTIVE_MODEL_STATE_FILE,
+    );
+    if (existsSync(activeStatePath)) unlinkSync(activeStatePath);
+  } catch (err) {
+    logger.warn(
+      "[aosp-local-inference] Failed to clear active model state:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export interface AospLoadModelArgs {
   modelPath: string;
   contextSize?: number;
   maxThreads?: number;
@@ -161,6 +178,77 @@ interface AospLoadModelArgs {
     k?: "f16" | "tbq3_0" | "tbq4_0" | "qjl1_256" | "q4_polar";
     v?: "f16" | "tbq3_0" | "tbq4_0" | "qjl1_256" | "q4_polar";
   };
+}
+
+export interface AospRouteActivationSnapshot {
+  modelId: string | null;
+  loadedAt: string | null;
+  status: "idle" | "ready" | "error";
+  error?: string;
+  loadedContextSize?: number | null;
+  loadedCacheTypeK?: string | null;
+  loadedCacheTypeV?: string | null;
+  loadedGpuLayers?: number | null;
+}
+
+function activeSnapshotFromLoadArgs(
+  modelId: string,
+  loadedAt: string,
+  loadArgs: AospLoadModelArgs,
+): AospRouteActivationSnapshot {
+  return {
+    modelId,
+    loadedAt,
+    status: "ready",
+    loadedContextSize: loadArgs.contextSize ?? null,
+    loadedCacheTypeK: loadArgs.kvCacheType?.k ?? null,
+    loadedCacheTypeV: loadArgs.kvCacheType?.v ?? null,
+    loadedGpuLayers:
+      typeof loadArgs.gpuLayers === "number" ? loadArgs.gpuLayers : null,
+  };
+}
+
+export async function activateAospLocalInferenceModel(args: {
+  modelId: string;
+  modelPath: string;
+  loadArgs: AospLoadModelArgs;
+}): Promise<AospRouteActivationSnapshot> {
+  if (!routeActivationLoader) {
+    throw new Error(
+      "[aosp-local-inference] Native localInferenceLoader is not ready yet.",
+    );
+  }
+  try {
+    await routeActivationLoader.unloadModel();
+    await routeActivationLoader.loadModel(args.loadArgs);
+    const loadedAt = new Date().toISOString();
+    writeAospActiveModelState({
+      status: "ready",
+      role: "chat",
+      provider: PROVIDER,
+      path: args.modelPath,
+      loadedAt,
+    });
+    return activeSnapshotFromLoadArgs(args.modelId, loadedAt, args.loadArgs);
+  } catch (err) {
+    writeAospActiveModelState({
+      status: "error",
+      role: "chat",
+      provider: PROVIDER,
+      path: args.modelPath,
+      error: err instanceof Error ? err.message : String(err),
+      updatedAt: new Date().toISOString(),
+    });
+    throw err;
+  }
+}
+
+export async function clearAospLocalInferenceModel(): Promise<AospRouteActivationSnapshot> {
+  if (routeActivationLoader) {
+    await routeActivationLoader.unloadModel();
+  }
+  clearAospActiveModelState();
+  return { modelId: null, loadedAt: null, status: "idle" };
 }
 
 type GenerateTextHandler = (
@@ -1976,6 +2064,7 @@ export async function ensureAospLocalInferenceHandlers(
     );
     return false;
   }
+  routeActivationLoader = loader;
 
   const lifecycle = makeLoaderLifecycle(loader);
   // TEXT_EMBEDDING is wired unconditionally now that the adapter resets

--- a/plugins/plugin-aosp-local-inference/src/index.ts
+++ b/plugins/plugin-aosp-local-inference/src/index.ts
@@ -28,7 +28,12 @@ export {
   resolveThreads,
 } from "./aosp-llama-adapter.js";
 
-export { ensureAospLocalInferenceHandlers } from "./aosp-local-inference-bootstrap.js";
+export {
+  activateAospLocalInferenceModel,
+  buildAospLoadModelArgs,
+  clearAospLocalInferenceModel,
+  ensureAospLocalInferenceHandlers,
+} from "./aosp-local-inference-bootstrap.js";
 
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
@@ -45,7 +50,12 @@ import {
   resolveLlamaShimPath as _bs_7_resolveLlamaShimPath,
   resolveThreads as _bs_8_resolveThreads,
 } from "./aosp-llama-adapter.js";
-import { ensureAospLocalInferenceHandlers as _bs_10_ensureAospLocalInferenceHandlers } from "./aosp-local-inference-bootstrap.js";
+import {
+  activateAospLocalInferenceModel as _bs_10_activateAospLocalInferenceModel,
+  buildAospLoadModelArgs as _bs_11_buildAospLoadModelArgs,
+  clearAospLocalInferenceModel as _bs_12_clearAospLocalInferenceModel,
+  ensureAospLocalInferenceHandlers as _bs_13_ensureAospLocalInferenceHandlers,
+} from "./aosp-local-inference-bootstrap.js";
 
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name.
@@ -59,7 +69,10 @@ const __bundle_safety_PLUGINS_PLUGIN_AOSP_LOCAL_INFERENCE_SRC_INDEX__ = [
   _bs_6_resolveLibllamaPath,
   _bs_7_resolveLlamaShimPath,
   _bs_8_resolveThreads,
-  _bs_10_ensureAospLocalInferenceHandlers,
+  _bs_10_activateAospLocalInferenceModel,
+  _bs_11_buildAospLoadModelArgs,
+  _bs_12_clearAospLocalInferenceModel,
+  _bs_13_ensureAospLocalInferenceHandlers,
 ];
 const bundleSafetyGlobal = globalThis as typeof globalThis & {
   __bundle_safety_PLUGINS_PLUGIN_AOSP_LOCAL_INFERENCE_SRC_INDEX__?: typeof __bundle_safety_PLUGINS_PLUGIN_AOSP_LOCAL_INFERENCE_SRC_INDEX__;

--- a/plugins/plugin-local-inference/src/local-inference-routes.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.test.ts
@@ -1,10 +1,12 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const serviceMock = vi.hoisted(() => {
-	let active = {
+function freshActiveState() {
+	return {
 		modelId: null as string | null,
 		loadedAt: null as string | null,
 		status: "idle" as "idle" | "loading" | "ready" | "error",
@@ -13,53 +15,195 @@ const serviceMock = vi.hoisted(() => {
 		loadedCacheTypeV: null as string | null,
 		loadedGpuLayers: null as number | null,
 	};
+}
+
+function createRouteTestMocks() {
+	const state = { active: freshActiveState() };
 	return {
-		getActive: () => active,
-		setActive: (next: typeof active) => {
-			active = next;
+		bridgeMock: {
+			getMobileDeviceBridgeStatus: vi.fn(() => ({
+				enabled: false,
+				connected: false,
+				devices: [],
+			})),
+			loadMobileDeviceBridgeModel: vi.fn(),
+			unloadMobileDeviceBridgeModel: vi.fn(),
+		},
+		aospMock: {
+			buildAospLoadModelArgs: vi.fn((role: string, modelPath: string) => ({
+				modelPath,
+				contextSize: role === "chat" ? 4096 : 512,
+				draftModelPath: `${modelPath}.draft`,
+				kvCacheType: { k: "qjl1_256", v: "q4_polar" },
+			})),
+			activateAospLocalInferenceModel: vi.fn(
+				async (args: { modelId: string }) => ({
+					modelId: args.modelId,
+					loadedAt: "2026-05-17T06:17:00.000Z",
+					status: "ready",
+					loadedContextSize: 4096,
+					loadedCacheTypeK: "qjl1_256",
+					loadedCacheTypeV: "q4_polar",
+					loadedGpuLayers: 0,
+				}),
+			),
+			clearAospLocalInferenceModel: vi.fn(async () => ({
+				modelId: null,
+				loadedAt: null,
+				status: "idle",
+			})),
+		},
+		serviceMock: {
+			getActive: () => state.active,
+			setActiveState: (next: ReturnType<typeof freshActiveState>) => {
+				state.active = next;
+			},
+			setActive: vi.fn(async (_runtime: unknown, modelId: string) => {
+				state.active = {
+					modelId,
+					loadedAt: "2026-05-17T06:17:00.000Z",
+					status: "ready",
+					loadedContextSize: 4096,
+					loadedCacheTypeK: "qjl1_256",
+					loadedCacheTypeV: "q4_polar",
+					loadedGpuLayers: 0,
+				};
+				return state.active;
+			}),
+			clearActive: vi.fn(async () => {
+				state.active = freshActiveState();
+				return state.active;
+			}),
 		},
 	};
-});
+}
+
+function getRouteTestMocks(): ReturnType<typeof createRouteTestMocks> {
+	const globalWithMocks = globalThis as typeof globalThis & {
+		__localInferenceRoutesTestMocks?: ReturnType<typeof createRouteTestMocks>;
+	};
+	globalWithMocks.__localInferenceRoutesTestMocks ??= createRouteTestMocks();
+	return globalWithMocks.__localInferenceRoutesTestMocks;
+}
 
 vi.mock("./services/service.ts", () => ({
 	localInferenceService: {
-		getActive: serviceMock.getActive,
+		getActive: getRouteTestMocks().serviceMock.getActive,
+		setActive: getRouteTestMocks().serviceMock.setActive,
+		clearActive: getRouteTestMocks().serviceMock.clearActive,
 	},
 }));
 
 vi.mock("./services/service.js", () => ({
 	localInferenceService: {
-		getActive: serviceMock.getActive,
+		getActive: getRouteTestMocks().serviceMock.getActive,
+		setActive: getRouteTestMocks().serviceMock.setActive,
+		clearActive: getRouteTestMocks().serviceMock.clearActive,
 	},
 }));
 
 vi.mock("@elizaos/plugin-capacitor-bridge", () => ({
-	getMobileDeviceBridgeStatus: () => ({
-		enabled: false,
-		connected: false,
-		devices: [],
-	}),
-	loadMobileDeviceBridgeModel: vi.fn(),
-	unloadMobileDeviceBridgeModel: vi.fn(),
+	getMobileDeviceBridgeStatus:
+		getRouteTestMocks().bridgeMock.getMobileDeviceBridgeStatus,
+	loadMobileDeviceBridgeModel:
+		getRouteTestMocks().bridgeMock.loadMobileDeviceBridgeModel,
+	unloadMobileDeviceBridgeModel:
+		getRouteTestMocks().bridgeMock.unloadMobileDeviceBridgeModel,
+}));
+
+vi.mock("@elizaos/plugin-aosp-local-inference", () => ({
+	activateAospLocalInferenceModel:
+		getRouteTestMocks().aospMock.activateAospLocalInferenceModel,
+	buildAospLoadModelArgs: getRouteTestMocks().aospMock.buildAospLoadModelArgs,
+	clearAospLocalInferenceModel:
+		getRouteTestMocks().aospMock.clearAospLocalInferenceModel,
 }));
 
 import {
 	getLocalInferenceActiveModelId,
 	getLocalInferenceActiveSnapshot,
 	getLocalInferenceChatStatus,
+	handleLocalInferenceRoutes,
 } from "./local-inference-routes.js";
 
+const { aospMock, bridgeMock, serviceMock } = getRouteTestMocks();
 const originalStateDir = process.env.ELIZA_STATE_DIR;
+const originalLocalLlama = process.env.ELIZA_LOCAL_LLAMA;
 let tempStateDir: string | null = null;
+
+function makeJsonRequest(
+	method: string,
+	url: string,
+	body?: unknown,
+): http.IncomingMessage {
+	const req = new PassThrough() as http.IncomingMessage;
+	req.method = method;
+	req.url = url;
+	req.headers = { "content-type": "application/json" };
+	req.end(body === undefined ? undefined : JSON.stringify(body));
+	return req;
+}
+
+function makeJsonResponse(): http.ServerResponse & {
+	json: () => unknown;
+} {
+	let body = "";
+	const res = {
+		statusCode: 200,
+		setHeader: vi.fn(),
+		writeHead: vi.fn((statusCode: number) => {
+			res.statusCode = statusCode;
+			return res;
+		}),
+		end: vi.fn((chunk?: unknown) => {
+			if (chunk !== undefined) body += String(chunk);
+			return res;
+		}),
+		json: () => JSON.parse(body),
+	} as unknown as http.ServerResponse & { json: () => unknown };
+	return res;
+}
+
+function writeInstalledModel(id: string): string {
+	const root = path.join(tempStateDir ?? "", "local-inference");
+	const modelPath = path.join(
+		root,
+		"models",
+		`${id}.bundle`,
+		"text",
+		`${id}.gguf`,
+	);
+	mkdirSync(path.dirname(modelPath), { recursive: true });
+	writeFileSync(modelPath, "GGUF");
+	writeFileSync(
+		path.join(root, "registry.json"),
+		JSON.stringify({
+			version: 1,
+			models: [
+				{
+					id,
+					displayName: id,
+					path: modelPath,
+					source: "eliza-download",
+					runtimeRole: "chat",
+					sizeBytes: 4,
+					installedAt: "2026-05-17T06:17:00.000Z",
+				},
+			],
+		}),
+	);
+	return modelPath;
+}
 
 describe("local inference chat status", () => {
 	beforeEach(() => {
 		if (tempStateDir) {
 			rmSync(tempStateDir, { recursive: true, force: true });
 		}
+		vi.clearAllMocks();
 		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-local-routes-"));
 		process.env.ELIZA_STATE_DIR = tempStateDir;
-		serviceMock.setActive({
+		serviceMock.setActiveState({
 			modelId: null,
 			loadedAt: null,
 			status: "idle",
@@ -68,6 +212,7 @@ describe("local inference chat status", () => {
 			loadedCacheTypeV: null,
 			loadedGpuLayers: null,
 		});
+		delete process.env.ELIZA_LOCAL_LLAMA;
 	});
 
 	afterEach(() => {
@@ -80,10 +225,15 @@ describe("local inference chat status", () => {
 		} else {
 			process.env.ELIZA_STATE_DIR = originalStateDir;
 		}
+		if (originalLocalLlama === undefined) {
+			delete process.env.ELIZA_LOCAL_LLAMA;
+		} else {
+			process.env.ELIZA_LOCAL_LLAMA = originalLocalLlama;
+		}
 	});
 
 	it("uses the desktop active-model service state for chat status", async () => {
-		serviceMock.setActive({
+		serviceMock.setActiveState({
 			modelId: "eliza-1-0_8b",
 			loadedAt: "2026-05-16T02:22:23.512Z",
 			status: "ready",
@@ -154,6 +304,41 @@ describe("local inference chat status", () => {
 			modelId: "eliza-1-0_8b",
 			status: "ready",
 			loadedAt: "2026-05-16T02:09:05.833Z",
+		});
+	});
+
+	it("activates through the AOSP loader instead of Capacitor when ELIZA_LOCAL_LLAMA is enabled", async () => {
+		process.env.ELIZA_LOCAL_LLAMA = "1";
+		writeInstalledModel("eliza-1-2b");
+		const runtime = {
+			getService: vi.fn(() => null),
+		};
+		const req = makeJsonRequest("POST", "/api/local-inference/active", {
+			modelId: "eliza-1-2b",
+		});
+		const res = makeJsonResponse();
+
+		await expect(
+			handleLocalInferenceRoutes(req, res, { current: runtime as never }),
+		).resolves.toBe(true);
+
+		expect(serviceMock.setActive).not.toHaveBeenCalled();
+		expect(aospMock.activateAospLocalInferenceModel).toHaveBeenCalledWith(
+			expect.objectContaining({
+				modelId: "eliza-1-2b",
+				modelPath: expect.stringContaining("eliza-1-2b.gguf"),
+				loadArgs: expect.objectContaining({
+					modelPath: expect.stringContaining("eliza-1-2b.gguf"),
+				}),
+			}),
+		);
+		expect(bridgeMock.loadMobileDeviceBridgeModel).not.toHaveBeenCalled();
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toMatchObject({
+			modelId: "eliza-1-2b",
+			status: "ready",
+			loadedCacheTypeK: "qjl1_256",
+			loadedCacheTypeV: "q4_polar",
 		});
 	});
 });

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -7,6 +7,7 @@ import * as https from "node:https";
 import os from "node:os";
 import path from "node:path";
 import {
+	type AgentRuntime,
 	type ContentValue,
 	logger,
 	readJsonBody,
@@ -27,6 +28,7 @@ import {
 import {
 	assertManifestEvalsPassed,
 	CandidateModelActivationError,
+	resolveLocalInferenceLoadArgs,
 } from "./services/active-model.js";
 import { localInferenceService } from "./services/service.js";
 import { prewarmLocalVoiceStackForModel } from "./services/voice-prewarm.js";
@@ -53,6 +55,10 @@ type MobileDeviceBridgeStatus = {
 	connected?: boolean;
 	reason?: string;
 	devices: Array<{ loadedPath?: string | null }>;
+};
+
+export type LocalInferenceRouteState = {
+	current?: AgentRuntime | null;
 };
 
 let mobileDeviceBridgeApiPromise: Promise<MobileDeviceBridgeApi> | null = null;
@@ -968,6 +974,7 @@ async function setRoutingForChat(provider: string): Promise<void> {
 }
 
 async function getConnectedMobileDeviceBridgeApi(): Promise<MobileDeviceBridgeApi | null> {
+	if (prefersInProcessLocalLlama()) return null;
 	try {
 		const api = await getMobileDeviceBridgeApi();
 		const status = api.getMobileDeviceBridgeStatus();
@@ -977,9 +984,14 @@ async function getConnectedMobileDeviceBridgeApi(): Promise<MobileDeviceBridgeAp
 	}
 }
 
+function prefersInProcessLocalLlama(): boolean {
+	return process.env.ELIZA_LOCAL_LLAMA?.trim() === "1";
+}
+
 function providerForActiveSnapshot(
 	active: LocalInferenceActiveSnapshot,
 ): string {
+	if (prefersInProcessLocalLlama()) return LOCAL_INFERENCE_PROVIDER_ID;
 	const desktopActive = getDesktopActiveSnapshot();
 	if (
 		desktopActive?.status === "ready" &&
@@ -991,8 +1003,74 @@ function providerForActiveSnapshot(
 	return "capacitor-llama";
 }
 
+async function activateWithAospLocalInference(
+	installed: InstalledModel,
+): Promise<LocalInferenceActiveSnapshot> {
+	const mod = await import("@elizaos/plugin-aosp-local-inference");
+	if (typeof mod.activateAospLocalInferenceModel !== "function") {
+		throw new Error(
+			"@elizaos/plugin-aosp-local-inference does not expose activateAospLocalInferenceModel.",
+		);
+	}
+	const loadArgs =
+		typeof mod.buildAospLoadModelArgs === "function"
+			? mod.buildAospLoadModelArgs("chat", installed.path)
+			: await resolveLocalInferenceLoadArgs(installed);
+	return mod.activateAospLocalInferenceModel({
+		modelId: installed.id,
+		modelPath: installed.path,
+		loadArgs: loadArgs as never,
+	}) as Promise<LocalInferenceActiveSnapshot>;
+}
+
+async function clearAospLocalInference(): Promise<LocalInferenceActiveSnapshot> {
+	const mod = await import("@elizaos/plugin-aosp-local-inference");
+	if (typeof mod.clearAospLocalInferenceModel !== "function") {
+		throw new Error(
+			"@elizaos/plugin-aosp-local-inference does not expose clearAospLocalInferenceModel.",
+		);
+	}
+	return mod.clearAospLocalInferenceModel() as Promise<LocalInferenceActiveSnapshot>;
+}
+
+async function activateInstalledModelWithRuntime(
+	installed: InstalledModel,
+	runtime: AgentRuntime | null | undefined,
+): Promise<{
+	active: LocalInferenceActiveSnapshot;
+	provider: string;
+}> {
+	if (prefersInProcessLocalLlama()) {
+		const active = await activateWithAospLocalInference(installed);
+		return { active, provider: LOCAL_INFERENCE_PROVIDER_ID };
+	}
+
+	const bridge = await getConnectedMobileDeviceBridgeApi();
+	if (bridge) {
+		await bridge.loadMobileDeviceBridgeModel(installed.path, installed.id);
+		return {
+			active: {
+				modelId: installed.id,
+				loadedAt: new Date().toISOString(),
+				status: "ready",
+			},
+			provider: "capacitor-llama",
+		};
+	}
+
+	const active = await localInferenceService.setActive(
+		runtime ?? null,
+		installed.id,
+	);
+	if (active.status === "error") {
+		throw new Error(active.error ?? "Failed to load model");
+	}
+	return { active, provider: LOCAL_INFERENCE_PROVIDER_ID };
+}
+
 async function activateInstalledModel(
 	installed: InstalledModel,
+	runtime?: AgentRuntime | null,
 ): Promise<LocalInferenceChatResult> {
 	activeModelState = {
 		modelId: installed.id,
@@ -1000,25 +1078,17 @@ async function activateInstalledModel(
 		status: "loading",
 	};
 	try {
-		const bridge = await getConnectedMobileDeviceBridgeApi();
-		let active: LocalInferenceActiveSnapshot;
-		if (bridge) {
-			await bridge.loadMobileDeviceBridgeModel(installed.path, installed.id);
-			active = {
-				modelId: installed.id,
-				loadedAt: new Date().toISOString(),
-				status: "ready",
-			};
-		} else {
-			active = await localInferenceService.setActive(null, installed.id);
-		}
+		const { active, provider } = await activateInstalledModelWithRuntime(
+			installed,
+			runtime ?? null,
+		);
 		activeModelState = active;
 		return buildLocalInferenceChatResult({
 			intent: "use_local",
 			status: "ready",
 			modelId: installed.id,
 			activeModelId: installed.id,
-			provider: bridge ? "capacitor-llama" : LOCAL_INFERENCE_PROVIDER_ID,
+			provider,
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -1240,6 +1310,7 @@ function writeSse(res: http.ServerResponse, payload: unknown): void {
 export async function handleLocalInferenceRoutes(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
+	state: LocalInferenceRouteState = {},
 ): Promise<boolean> {
 	const method = (req.method ?? "GET").toUpperCase();
 	const url = new URL(req.url ?? "/", "http://localhost");
@@ -1514,13 +1585,11 @@ export async function handleLocalInferenceRoutes(
 				loadedAt: null,
 				status: "loading",
 			};
-			const { loadMobileDeviceBridgeModel } = await getMobileDeviceBridgeApi();
-			await loadMobileDeviceBridgeModel(installed.path, installed.id);
-			activeModelState = {
-				modelId: installed.id,
-				loadedAt: new Date().toISOString(),
-				status: "ready",
-			};
+			const { active } = await activateInstalledModelWithRuntime(
+				installed,
+				state.current ?? null,
+			);
+			activeModelState = active;
 			sendJson(res, activeModelState);
 			void prewarmLocalVoiceStackForModel(installed.id);
 		} catch (error) {
@@ -1540,10 +1609,14 @@ export async function handleLocalInferenceRoutes(
 	}
 	if (method === "DELETE" && pathname === "/api/local-inference/active") {
 		try {
-			const { unloadMobileDeviceBridgeModel } =
-				await getMobileDeviceBridgeApi();
-			await unloadMobileDeviceBridgeModel();
-			activeModelState = { modelId: null, loadedAt: null, status: "idle" };
+			if (prefersInProcessLocalLlama()) {
+				activeModelState = await clearAospLocalInference();
+			} else {
+				const { unloadMobileDeviceBridgeModel } =
+					await getMobileDeviceBridgeApi();
+				await unloadMobileDeviceBridgeModel();
+				activeModelState = { modelId: null, loadedAt: null, status: "idle" };
+			}
 			sendJson(res, activeModelState);
 		} catch (error) {
 			sendJsonError(


### PR DESCRIPTION
## Summary

This fixes the stock Android APK local-inference activation path when `ELIZA_LOCAL_LLAMA=1` is enabled. `/api/local-inference/active` now activates the in-process Android native loader (`@elizaos/plugin-aosp-local-inference`) instead of trying the Capacitor bridge first, and `packages/agent` passes the live runtime into the local-inference route handler so non-Capacitor local activation can use the active runtime safely.

The AOSP local-inference bootstrap now exposes narrow activate/clear helpers around the already-registered `localInferenceLoader`, and the package barrel keeps those exports alive for the mobile bundle's tree-shaking rules.

## Why

The Pixel stock APK packages Shaw's fork llama.cpp libs and sets `ELIZA_LOCAL_LLAMA=1`. In that mode, the app should use the in-process bun:ffi loader, not the stock Capacitor llama bridge. The old route flow could still route model activation through the Capacitor bridge, which is the wrong loader for Eliza-1 Qwen35/QJL/Polar/TBQ GGUFs.

## Pixel Evidence

Validated on Pixel 9a / Android 16 with the stock Android debug APK path, not a full AOSP flash.

Latest packaged APK proof:

- `/api/health`: `ready:true`, runtime/database ok, `plugins.loaded=10`, `plugins.failed=0`
- `/api/local-inference/active`: `{"modelId":"eliza-1-0_8b","status":"ready"}`
- APK contains Shaw fork native assets under `assets/agent/arm64-v8a`: `libllama.so`, `libggml-cpu.so`, `libeliza-llama-shim.so`, `libeliza-llama-speculative-shim.so`, `llama-server`, `libelizainference.so`, `libomnivoice.so`
- Fork markers verified in APK/libs: `qwen35`, `qwen35moe`, `qwen3next`, `kokoro`, `qjl1_256`, `q4_polar`, `tbq3`, `tbq4`, `fused_attn_qjl_tbq`
- Screenshot shows the app mounted past the previous blank WebView: `/tmp/milady-packaged-apk-20260517T084510Z.png`
- Benchmark report: `/home/nubs/Git/iqlabs/eliza-labs-data/analytics/pixel-9a-plan/runs/2026-05-17-pixel-apk-voice/VOICE-BENCHMARK-REPORT.md`

Text benchmark from the same packaged APK run:

- response: `local voice ready.`
- TTFT: `2483.1ms`
- text total: `2483.5ms`
- prompt/completion: `81 / 5`
- provider/model observed by route: `mobile-local-direct-reply` / `aosp-local-llama`

Important caveats:

- This PR does not make DFlash a performance claim. The packaged `.8B` baseline loaded the speculative shim, but the current `.8B` drafter asset matches the target bytes, so that run remained target-only (`dflash=false`).
- A later integration APK run activated `eliza-1-2b` with `drafter-2b.gguf` and did use `generate:dflash:*` on the Pixel (`drafted=8`, `accepted=8`, `acceptRate=1.0`), but it was slower than target-only 2B for the measured short turn: DFlash `TTFT=11547.4ms`, `total=17124.4ms`; target-only 2B `TTFT=4705.3ms`, `total=6175.7ms`. That optimization/gating work is intentionally outside this PR.
- This PR does not claim NNAPI/Tensor/TPU acceleration.
- This PR does not change the Kokoro/OmniVoice TTS backend; that work is being split separately.

## Validation

- `node packages/shared/scripts/generate-keywords.mjs --target ts` for the local test worktree generated i18n files needed by route imports.
- `bun test plugins/plugin-local-inference/src/local-inference-routes.test.ts --timeout 60000 --coverage-reporter=lcov`
  - `3 pass`, `0 fail`, `12 expect() calls`
- `bunx @biomejs/biome format --write packages/agent/src/api/server.ts plugins/plugin-local-inference/src/local-inference-routes.ts plugins/plugin-local-inference/src/local-inference-routes.test.ts plugins/plugin-aosp-local-inference/src/aosp-local-inference-bootstrap.ts plugins/plugin-aosp-local-inference/src/index.ts`
- `git diff --check`
- `bunx @biomejs/biome ci ...` exited 0 for the touched files; it still reports pre-existing warnings in these files (`any`, `@ts-ignore`, unused suppression), but no formatter errors.
