### PR TITLE
fix(android): keep DFlash opt-in for stock APK

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1046,6 +1046,7 @@ public class ElizaAgentService extends Service {
             File abiLlamaShim = new File(abiDir, "libeliza-llama-shim.so");
             File abiSpeculativeShim = new File(abiDir, "libeliza-llama-speculative-shim.so");
             boolean nativeLlamaBundled = abiLibllama.isFile() && abiLlamaShim.isFile();
+            boolean brandedAospBuild = BuildConfig.AOSP_BUILD && isBrandedDevice();
             if (nativeLlamaBundled && !env.containsKey("ELIZA_LOCAL_LLAMA")) {
                 agentEnv.put("ELIZA_LOCAL_LLAMA", "1");
                 Log.i(TAG, "agent/" + abiDir.getName()
@@ -1066,12 +1067,21 @@ public class ElizaAgentService extends Service {
                     // cache priming.
                     agentEnv.put("ELIZA_KOKORO_PREWARM_DELAY_MS", "60000");
                 }
-                if (abiSpeculativeShim.isFile() && !env.containsKey("ELIZA_DFLASH")) {
+                if (abiSpeculativeShim.isFile() && brandedAospBuild && !env.containsKey("ELIZA_DFLASH")) {
                     agentEnv.put("ELIZA_DFLASH", "1");
                     Log.i(TAG, "agent/" + abiDir.getName()
-                        + "/libeliza-llama-speculative-shim.so present; enabling in-process DFlash (ELIZA_DFLASH=1)");
+                        + "/libeliza-llama-speculative-shim.so present on branded AOSP build; enabling in-process DFlash (ELIZA_DFLASH=1)");
+                } else if (abiSpeculativeShim.isFile() && !brandedAospBuild) {
+                    // Ship the speculative shim in stock APKs so explicit
+                    // ELIZA_DFLASH diagnostics still work, but do not make
+                    // DFlash the default merely because the .so is present.
+                    // Pixel APK validation showed the current 2B drafter path
+                    // is functional but slower than target-only decode for
+                    // short chat turns, so stock Android stays target-only
+                    // until benchmark gating or a faster drafter path lands.
+                    Log.i(TAG, "agent/" + abiDir.getName()
+                        + "/libeliza-llama-speculative-shim.so present; leaving DFlash opt-in for stock APK");
                 }
-                boolean brandedAospBuild = BuildConfig.AOSP_BUILD && isBrandedDevice();
                 if (BuildConfig.DEBUG && !env.containsKey("ELIZA_AOSP_LLAMA_DEBUG_LOG")) {
                     File debugLog = new File(agentStateDir(), "aosp-llama-debug.log");
                     agentEnv.put("ELIZA_AOSP_LLAMA_DEBUG_LOG", debugLog.getAbsolutePath());


### PR DESCRIPTION
## Summary

Stock Android APK builds can package `libeliza-llama-speculative-shim.so` for diagnostics, but should not automatically enable in-process DFlash solely because the shim is present.

This keeps DFlash auto-enable scoped to branded AOSP builds and leaves stock APKs target-only unless `ELIZA_DFLASH` is explicitly provided. The AOSP path still gets the same behavior as before, and explicit env overrides still work.

## Why

Pixel APK validation showed the current 2B speculative path is functional, but slower than target-only decode for short interactive chat turns:

- `eliza-1-2b` with DFlash: TTFT `11547.4ms`, text total `17124.4ms`, drafted/accepted `8/8`, accept rate `1.0`.
- `eliza-1-2b` target-only: TTFT `4705.3ms`, text total `6175.7ms`.
- Rebuilt stock APK after this gate: env has no `ELIZA_DFLASH`, logcat prints `leaving DFlash opt-in for stock APK`, and `eliza-1-2b` target-only measured TTFT `4689.5ms`, text total `6336.3ms`.
- Final `eliza-1-0_8b` stock APK baseline after the gate: TTFT `2359.5ms`, text total `2359.8ms`; local Kokoro TTS returned `audio/wav`, `100844` bytes, `2.1s` audio in `6040.1ms`.

That means stock Android should not silently choose DFlash until benchmark gating or a faster drafter path lands. Branded AOSP can continue enabling it by default for device-image experiments.

## Validation

- `git diff --check` passed.
- Full local-source Android APK build passed in the integration tree with this Java behavior included.
- Installed rebuilt APK on Pixel 9a (`ai.milady.milady`) and verified:
  - `/api/health` returned `ready:true`, runtime/database ok, `10` plugins loaded, `0` failed.
  - Bun env included `ELIZA_LOCAL_LLAMA=1` and mobile llama caps, but no `ELIZA_DFLASH`.
  - logcat confirmed the stock APK branch: `libeliza-llama-speculative-shim.so present; leaving DFlash opt-in for stock APK`.
  - `eliza-1-0_8b` activation and direct local generation succeeded.

A scoped Gradle Java compile from this clean source-only worktree was blocked before compilation because the checked-out platform project references `packages/native-plugins/gateway/android`, which is not present until the generated/local mobile project alignment step runs. The full APK build path did compile and package the same Java service code.
