### PR TITLE
feat(provisioning-worker): fold node health checks into the orchestrator daemon

### DIFF
--- a/packages/cloud-services/container-control-plane/src/index.ts
+++ b/packages/cloud-services/container-control-plane/src/index.ts
@@ -564,7 +564,12 @@ app.post("/api/v1/cron/deployment-monitor", deploymentMonitorResponse);
 
 function agentHotPoolResponse(c: Context) {
   return handleInternal(c, async () => {
-    const healthChecks = await dockerNodeManager.healthCheckAll();
+    // Node health checks moved to the provisioning-worker daemon — see
+    // `packages/scripts/cloud/admin/daemons/provisioning-worker.ts:processNodeHealthCheckCycle`.
+    // The orchestrator host runs them now because it's the one with a valid
+    // CONTAINERS_SSH_KEY against the cores; leaving the call here too would
+    // race with the daemon and flip status every 5 min depending on which
+    // writer landed last.
     const syncChanges = await dockerNodeManager.syncAllocatedCounts();
     const image = containersEnv.defaultAgentImage();
     const prePullEnabled = process.env.ELIZA_AGENT_HOT_POOL_PREPULL !== "false";
@@ -591,7 +596,6 @@ function agentHotPoolResponse(c: Context) {
         data: {
           image,
           prePullEnabled,
-          healthChecks: Object.fromEntries(healthChecks),
           syncedAllocatedCounts: Object.fromEntries(syncChanges),
           capacity,
           nodes,

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -24,20 +24,34 @@ type WorkerLogger =
   typeof import("@elizaos/cloud-shared/lib/utils/logger").logger;
 type WorkerService =
   typeof import("@elizaos/cloud-shared/lib/services/provisioning-jobs").provisioningJobService;
+type WorkerNodeManager =
+  typeof import("@elizaos/cloud-shared/lib/services/docker-node-manager").dockerNodeManager;
 
 interface WorkerDeps {
   logger: WorkerLogger;
   provisioningJobService: WorkerService;
+  dockerNodeManager: WorkerNodeManager;
 }
 
 export interface ProvisioningWorkerConfig {
   pollIntervalMs: number;
   batchSize: number;
   runOnce: boolean;
+  nodeHealthIntervalMs: number;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_BATCH_SIZE = 3;
+
+/**
+ * Node health-check cadence. The same daemon now owns this responsibility
+ * (previously container-control-plane forwarded from a CF Worker cron, which
+ * left the orchestrator host blind to its own nodes when the control-plane
+ * was offline or missed its SSH key). 5 minutes mirrors the legacy CRON_FANOUT
+ * schedule for `agent-hot-pool`. SSH for the check itself uses the
+ * `CONTAINERS_SSH_KEY` env var that already powers provision/stop on this host.
+ */
+const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -60,6 +74,10 @@ export function readWorkerConfig(
     ),
     batchSize: parsePositiveInt(env.WORKER_BATCH_SIZE, DEFAULT_BATCH_SIZE),
     runOnce: env.WORKER_RUN_ONCE === "1" || hasFlag(argv, "--once"),
+    nodeHealthIntervalMs: parsePositiveInt(
+      env.WORKER_NODE_HEALTH_INTERVAL,
+      DEFAULT_NODE_HEALTH_INTERVAL_MS,
+    ),
   };
 }
 
@@ -70,9 +88,11 @@ async function loadDeps(): Promise<WorkerDeps> {
     depsPromise = Promise.all([
       import("@elizaos/cloud-shared/lib/services/provisioning-jobs"),
       import("@elizaos/cloud-shared/lib/utils/logger"),
-    ]).then(([jobsModule, loggerModule]) => ({
+      import("@elizaos/cloud-shared/lib/services/docker-node-manager"),
+    ]).then(([jobsModule, loggerModule, nodeMgrModule]) => ({
       provisioningJobService: jobsModule.provisioningJobService,
       logger: loggerModule.logger,
+      dockerNodeManager: nodeMgrModule.dockerNodeManager,
     }));
   }
   return depsPromise;
@@ -101,7 +121,38 @@ export async function processHeartbeatCycle(
   return provisioningJobService.processRunningHeartbeats(concurrency);
 }
 
+export interface NodeHealthSummary {
+  total: number;
+  healthy: number;
+  unhealthy: number;
+}
+
+/**
+ * Health-checks every enabled `docker_nodes` row (SSH + `docker info`) and
+ * persists the resulting status. Previously owned by the CF-cron-forwarded
+ * container-control-plane service; folded into this daemon so the orchestrator
+ * host that already has SSH access keeps the truth, instead of relying on a
+ * second moving piece that can be missing its key (verified in prod
+ * 2026-05-17: cores were stuck `offline` because the control-plane host
+ * lacked CONTAINERS_SSH_KEY, despite the keys being valid here).
+ */
+export async function processNodeHealthCheckCycle(): Promise<NodeHealthSummary> {
+  const { dockerNodeManager } = await loadDeps();
+  const result = await dockerNodeManager.healthCheckAll();
+  let healthy = 0;
+  let unhealthy = 0;
+  for (const status of result.values()) {
+    if (status === "healthy") {
+      healthy += 1;
+    } else {
+      unhealthy += 1;
+    }
+  }
+  return { total: result.size, healthy, unhealthy };
+}
+
 let running = true;
+let lastNodeHealthCheckAt = 0;
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -139,6 +190,27 @@ async function pollCycle(
       error: error instanceof Error ? error.message : String(error),
     });
   }
+
+  // Node health checks ride on a longer interval than the heartbeat cycle:
+  // SSH + `docker info` per node is expensive (~MAX_RETRIES * 10s timeout
+  // worst-case per offline node) and the data only feeds capacity decisions
+  // that don't need sub-minute freshness. Skip when not yet due.
+  const now = Date.now();
+  if (now - lastNodeHealthCheckAt >= config.nodeHealthIntervalMs) {
+    lastNodeHealthCheckAt = now;
+    try {
+      const summary = await processNodeHealthCheckCycle();
+      logger.info("[provisioning-worker] node health check cycle complete", {
+        total: summary.total,
+        healthy: summary.healthy,
+        unhealthy: summary.unhealthy,
+      });
+    } catch (error) {
+      logger.error("[provisioning-worker] node health check cycle failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 }
 
 async function main(): Promise<void> {
@@ -151,6 +223,7 @@ async function main(): Promise<void> {
     pollIntervalMs: config.pollIntervalMs,
     batchSize: config.batchSize,
     runOnce: config.runOnce,
+    nodeHealthIntervalMs: config.nodeHealthIntervalMs,
   });
 
   if (config.runOnce) {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -103,21 +103,21 @@ function resultContext(result: ProcessingResult): Record<string, unknown> {
   };
 }
 
-export async function processProvisioningWorkerCycle(
+async function processProvisioningWorkerCycle(
   batchSize = readWorkerConfig().batchSize,
 ): Promise<ProcessingResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processPendingJobs(batchSize);
 }
 
-export async function processHeartbeatCycle(
+async function processHeartbeatCycle(
   concurrency = 5,
 ): Promise<HeartbeatResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processRunningHeartbeats(concurrency);
 }
 
-export interface NodeHealthSummary {
+interface NodeHealthSummary {
   total: number;
   healthy: number;
   unhealthy: number;
@@ -129,7 +129,7 @@ export interface NodeHealthSummary {
  * holds `CONTAINERS_SSH_KEY`, so the node-status truth lives next to the
  * provisioner that acts on it.
  */
-export async function processNodeHealthCheckCycle(): Promise<NodeHealthSummary> {
+async function processNodeHealthCheckCycle(): Promise<NodeHealthSummary> {
   const { dockerNodeManager } = await loadDeps();
   const result = await dockerNodeManager.healthCheckAll();
   let healthy = 0;
@@ -187,6 +187,8 @@ async function pollCycle(
   // Node health checks run on a longer interval than the heartbeat cycle:
   // SSH + `docker info` per node is expensive (~MAX_RETRIES * 10s per offline
   // node) and only feeds capacity decisions that tolerate stale data.
+  // `lastNodeHealthCheckAt` initializes to 0 so the first poll always runs
+  // a check — we want a fresh node-status snapshot at worker startup.
   const now = Date.now();
   if (now - lastNodeHealthCheckAt >= config.nodeHealthIntervalMs) {
     lastNodeHealthCheckAt = now;

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -44,12 +44,8 @@ const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_BATCH_SIZE = 3;
 
 /**
- * Node health-check cadence. The same daemon now owns this responsibility
- * (previously container-control-plane forwarded from a CF Worker cron, which
- * left the orchestrator host blind to its own nodes when the control-plane
- * was offline or missed its SSH key). 5 minutes mirrors the legacy CRON_FANOUT
- * schedule for `agent-hot-pool`. SSH for the check itself uses the
- * `CONTAINERS_SSH_KEY` env var that already powers provision/stop on this host.
+ * Node health-check cadence. 5 minutes matches the `agent-hot-pool`
+ * CRON_FANOUT schedule. SSH uses `CONTAINERS_SSH_KEY` from this host.
  */
 const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
 
@@ -129,12 +125,9 @@ export interface NodeHealthSummary {
 
 /**
  * Health-checks every enabled `docker_nodes` row (SSH + `docker info`) and
- * persists the resulting status. Previously owned by the CF-cron-forwarded
- * container-control-plane service; folded into this daemon so the orchestrator
- * host that already has SSH access keeps the truth, instead of relying on a
- * second moving piece that can be missing its key (verified in prod
- * 2026-05-17: cores were stuck `offline` because the control-plane host
- * lacked CONTAINERS_SSH_KEY, despite the keys being valid here).
+ * persists the resulting status. Runs on the orchestrator host that already
+ * holds `CONTAINERS_SSH_KEY`, so the node-status truth lives next to the
+ * provisioner that acts on it.
  */
 export async function processNodeHealthCheckCycle(): Promise<NodeHealthSummary> {
   const { dockerNodeManager } = await loadDeps();
@@ -191,10 +184,9 @@ async function pollCycle(
     });
   }
 
-  // Node health checks ride on a longer interval than the heartbeat cycle:
-  // SSH + `docker info` per node is expensive (~MAX_RETRIES * 10s timeout
-  // worst-case per offline node) and the data only feeds capacity decisions
-  // that don't need sub-minute freshness. Skip when not yet due.
+  // Node health checks run on a longer interval than the heartbeat cycle:
+  // SSH + `docker info` per node is expensive (~MAX_RETRIES * 10s per offline
+  // node) and only feeds capacity decisions that tolerate stale data.
   const now = Date.now();
   if (now - lastNodeHealthCheckAt >= config.nodeHealthIntervalMs) {
     lastNodeHealthCheckAt = now;


### PR DESCRIPTION
## Why

\`docker_nodes.status\` is currently driven by a separate \`container-control-plane\` Node service that the CF Worker cron \`agent-hot-pool\` forwards to every 5 minutes. In prod today that service runs on a host we no longer reliably track, and (verified 2026-05-17) it can't SSH the cores — its \`CONTAINERS_SSH_KEY\` is empty.

Result: all six \`milady-core-*\` nodes have been stuck in \`offline\` for days even though SSH + \`docker info\` succeed instantly from the orchestrator (provisioning-worker daemon) host using the key we set up there last night for provision/stop.

Concretely from the orchestrator VM:

\`\`\`
$ for ip in 88.99.66.168 178.63.251.122 138.201.80.125 \\
            85.10.193.52  136.243.47.243 195.201.57.227; do
    ssh -i ~/.ssh/clawdnet_nodes root@\$ip \\
      "docker info --format '{{.ID}}'"
  done
3378395a-...
5e0b07c7-...
aab68679-...
ed32c4bb-...
13241c37-...
d51175ba-...
\`\`\`

All six respond. Yet \`SELECT node_id, status FROM docker_nodes\` returns \`offline\` for all of them. The check itself is fine; the host that runs it is the wrong one.

## What this PR does

Folds the loop into the daemon that already has everything it needs:

- the \`CONTAINERS_SSH_KEY\` load-bearing for provision and stop (PR #7746),
- direct Neon write access via \`DATABASE_URL\`,
- a 30s poll cycle that's a perfect carrier for a 5-min cadence.

\`pollCycle\` now calls \`dockerNodeManager.healthCheckAll()\` gated by \`lastNodeHealthCheckAt + nodeHealthIntervalMs <= now\`, and logs a summary line per tick (\`total/healthy/unhealthy\`) so ops can spot regressions without grepping CF tail.

The legacy CF Worker cron route is left in place — it returns 503 when no \`CONTAINER_CONTROL_PLANE_URL\` is configured, which is harmless. A follow-up can remove the forward + the unused \`container-control-plane\` package once the daemon has been proven in prod for a week.

## Env knobs

- \`WORKER_NODE_HEALTH_INTERVAL\` (ms) — defaults to **5 minutes**, mirroring the legacy CRON_FANOUT cadence for \`agent-hot-pool\`. Set to a smaller value during the initial rollout if you want faster recovery, or a larger one once steady-state.

## Files touched

- \`packages/scripts/cloud/admin/daemons/provisioning-worker.ts\` — adds \`dockerNodeManager\` to \`loadDeps\`, a \`processNodeHealthCheckCycle\` helper, and the gated invocation in \`pollCycle\`. ~75 lines net.

## Behavior under load

\`dockerNodeManager.healthCheckAll()\` already iterates with \`Promise.allSettled\` and the per-node \`healthCheckNode\` has its own \`MAX_RETRIES * SSH_TIMEOUT\` budget (~40s worst case for a fully offline node). So even with all six cores unreachable the worst-case node health tick stays well under one minute and the heartbeat / job pickup cycles aren't starved.

## Test plan

- [x] Daemon parses + cloud-shared typecheck clean on touched paths
- [ ] Roll to staging orchestrator → tail journal, verify a \`node health check cycle complete\` log fires once at boot and then every 5 minutes
- [ ] After 5–10 min, query Neon: every reachable milady-core flips to \`healthy\` with a fresh \`last_health_check\` (this is the load-bearing observation)
- [ ] Provision a fresh agent on staging — \`getAvailableNode\` should now pick a milady-core (since they're healthy with 50 capacity each)
- [ ] Roll to prod orchestrator (\`systemctl restart eliza-provisioning-worker\`) and repeat the observation

## Rollback

Single revert. The legacy CF Worker cron path is unchanged and still gets ticked every 5 min — it just no-ops when the control-plane URL is unset. Reverting this PR puts us back to where we are today (daemon doesn't health-check, control-plane is missing) without any data migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves Docker node health-checking from a broken `container-control-plane` service (whose SSH key is empty) into the provisioning-worker daemon that already holds a working `CONTAINERS_SSH_KEY`. The `agentHotPoolResponse` in `container-control-plane` no longer calls `healthCheckAll()`, preventing a write race between the two processes; the legacy CF Worker cron still fires but returns 503 from the CF layer when `CONTAINER_CONTROL_PLANE_URL` is unset.

- **provisioning-worker.ts**: Adds `dockerNodeManager` to the lazy-loaded dep singleton, implements `processNodeHealthCheckCycle` (iterates `healthCheckAll` results into a `{ total, healthy, unhealthy }` summary), and gates invocation in `pollCycle` with `lastNodeHealthCheckAt` — initialized to 0 so the first tick always runs a check. A new `WORKER_NODE_HEALTH_INTERVAL` env knob (default 5 min) controls cadence.
- **container-control-plane/src/index.ts**: Removes the `healthCheckAll()` call and the `healthChecks` field from the `agentHotPoolResponse` JSON, shrinking the response payload but not breaking the hot-pool pre-pull or capacity-report paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted relocation of an existing operation to a host that already has the required SSH credentials, with no data migration and a clean rollback path.

The provisioning cycle, heartbeat cycle, and node health check each run in independent try/catch blocks, so a failure in one cannot stall the others. The `lastNodeHealthCheckAt = 0` initialization guarantees a fresh status snapshot at startup. Removing `healthCheckAll()` from the CF cron handler eliminates the write race without affecting the pre-pull or capacity-report paths. No callers import the now-unexported `processProvisioningWorkerCycle`/`processHeartbeatCycle` functions. The legacy CF cron path is unchanged and harmlessly no-ops when the control-plane URL is unset.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/scripts/cloud/admin/daemons/provisioning-worker.ts | Adds `dockerNodeManager` to the lazy-loaded deps, introduces `processNodeHealthCheckCycle`, and gates health checks via `lastNodeHealthCheckAt` in `pollCycle`. Logic is straightforward; previously exported cycle functions are correctly unexported since they have no external callers. |
| packages/cloud-services/container-control-plane/src/index.ts | Removes the `healthCheckAll()` call and its `healthChecks` field from `agentHotPoolResponse`, eliminating the write race with the daemon and leaving `syncAllocatedCounts`/pre-pull/capacity reporting intact. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CronTimer as CF Worker Cron (*/5 min)
    participant CFWorker as CF Worker<br/>/api/v1/cron/agent-hot-pool
    participant CCP as container-control-plane
    participant Daemon as provisioning-worker<br/>(daemon loop)
    participant DB as Neon DB<br/>(docker_nodes)
    participant Nodes as milady-core-* nodes<br/>(SSH)

    Note over Daemon: lastNodeHealthCheckAt = 0 at startup

    loop Every 30s poll cycle
        Daemon->>Daemon: processProvisioningWorkerCycle()
        Daemon->>Daemon: processHeartbeatCycle()
        Daemon->>Daemon: "now - lastNodeHealthCheckAt >= 5min?"
        alt Interval elapsed
            Daemon->>Nodes: SSH + docker info (Promise.allSettled)
            Nodes-->>Daemon: healthy / offline / degraded
            Daemon->>DB: updateStatus() per node
            Daemon->>Daemon: "log { total, healthy, unhealthy }"
            Daemon->>Daemon: "lastNodeHealthCheckAt = now"
        end
    end

    CronTimer->>CFWorker: POST /api/v1/cron/agent-hot-pool
    CFWorker->>CCP: forward (if CONTAINER_CONTROL_PLANE_URL set)
    Note over CCP: healthCheckAll() REMOVED
    CCP->>DB: syncAllocatedCounts()
    CCP->>Nodes: prePullAgentImageOnAvailableNodes()
    CCP->>DB: getCapacityReport()
    CCP-->>CFWorker: "{ syncedAllocatedCounts, capacity, nodes }"
    CFWorker-->>CronTimer: 200 OK
```

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;develop&#39; into feat/consoli..."](https://github.com/elizaos/eliza/commit/63dc1196d38c25c7972b7ddb5eeac69100255938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32503846)</sub>

<!-- /greptile_comment -->