### PR TITLE
feat(os): validate elizaOS live USB demo path

### DIFF
--- a/packages/os/linux/variants/milady-tails/docs/current-status.md
+++ b/packages/os/linux/variants/milady-tails/docs/current-status.md
@@ -7,33 +7,139 @@ enterprise release.
 
 ## Proven Evidence
 
-- A full elizaOS Live ISO was built and booted in QEMU.
-- QEMU evidence showed the branded greeter/desktop path and the elizaOS app
-  services active in the live session.
-- The guarded USB writer flashed that tested ISO to a removable SanDisk USB
-  device and verified the written bytes against the ISO.
-
-The validated ISO hash was:
+- A prior full elizaOS Live ISO was built, booted in QEMU, flashed to a
+  removable SanDisk USB device with the guarded writer, and verified by
+  readback. That earlier tested hash was:
 
 ```text
 6419dbee227317983ff2c6d02c3fd4bf97c6699ac1d26f0c98476f2ba58cfc10
 ```
 
+- The current HEAD source has now been rebuilt into a fresh canonical ISO at
+  `tails/binary.iso` / `out/binary.iso`. Do not use older named ISO copies in
+  `out/` for validation; they can be stale.
+
+```text
+2ff679a74464dd1ad37c0202b58fc56c5dd64b6e9ce047945d6ee60fcb139faa
+```
+
+- Normal QEMU boot of that exact current-HEAD artifact reached the elizaOS
+  greeter, started a normal GNOME desktop, and showed the elizaOS app window
+  on the desktop.
+
 ## Current HEAD Caveat
 
-After that successful QEMU/USB readback pass, the branch received additional
-source-only branding polish: official SVG icons, Persistent Storage icon
-replacement, EFI boot icon replacement, inherited visible-string cleanup, and
-docs updates.
+Current HEAD has QEMU visual evidence for boot, greeter, desktop, and app
+window startup. It has not yet been flashed/readback-tested to USB, booted on
+real hardware, or validated for real USB Persistent Storage create/unlock/delete
+behavior.
 
-Those changes are correct in source and covered by smoke checks, but they are
-not on the already-flashed USB until a fresh ISO is rebuilt and flashed again.
+## Fixed Tonight
+
+The latest boot blocker was not branding or the app runtime. Debug boots showed
+that the live root filesystem could be left mode `0700`, preventing non-root
+system services from traversing `/` and causing D-Bus, polkit, GDM, and
+Persistent Storage startup failures.
+
+The current artifact contains the fix:
+
+- `run-nosymfollow.mount.d/elizaos-root-mode.conf` documents the intended
+  `0755` directory mode for the inherited nosymfollow bind mount.
+- `elizaos-root-mode.service` runs after `run-nosymfollow.mount` and
+  `systemd-tmpfiles-setup.service`, then restores `/` plus
+  `/run/nosymfollow` to `0755`.
+- The earlier D-Bus and polkit working-directory drop-ins were removed because
+  they were symptom workarounds, not the root cause.
+- `milady.path` no longer participates in an ordering cycle with
+  `elizaos-update-verify.service`; the path unit can arm normally while
+  `milady.service` waits for verifier setup.
+
+## Tonight Validation Plan
+
+Completed so far:
+
+1. Synced the root-mode and ordering-cycle fixes into the existing build
+   chroot.
+2. Repacked the fixed chroot into a fresh `tails/binary.iso`.
+3. Pointed `out/binary.iso` at that exact artifact.
+4. Verified the built squashfs contains the root-mode drop-in,
+   `elizaos-root-mode.service`, update verifier, and health-check fixes.
+5. Booted the exact artifact in QEMU and visually confirmed greeter, desktop,
+   and app window startup.
+
+Still required before claiming a final USB demo:
+
+1. Repeat guarded USB flash/readback for the `2ff679a7...` artifact.
+2. Boot that USB on real hardware.
+3. Validate real USB Persistent Storage create/unlock/delete behavior.
+4. Validate privacy/direct networking behavior for the app, renderer, and any
+   external web/OAuth surfaces.
+
+Product ideas and production hardening are tracked in
+[`production-readiness.md`](./production-readiness.md) and
+[`distribution-and-updates.md`](./distribution-and-updates.md); they should not
+delay tonight's demo proof unless they affect boot, app launch, persistence,
+privacy, or USB safety.
+
+## Latest Source Audit Addendum
+
+The latest source audit does not add a new blocker for tonight's QEMU proof,
+but it does set the honest product boundary:
+
+- Clean source checkouts do not contain the generated staged app payload.
+  Build or CI must run `just milady-app` before a full ISO build.
+- The current baked runtime is good demo substrate, but the long-term
+  production package should be a deterministic signed app/runtime artifact
+  rather than a huge copied development tree.
+- The signed app/runtime updater foundation exists, but production still
+  needs downloader UX, revocation metadata, a production keyring, rollback
+  health policy, and no-follow/root-owned update materialization hardening.
+- Privacy Mode is not production-claimable for embedded browser, WebView,
+  OAuth, or arbitrary external web surfaces until explicit proxy behavior is
+  proven.
+- Residual visible Tails help/support/update links remain in lower-frequency
+  surfaces such as Tor Connection Assistant, USB Cloner help, WhisperBack,
+  low-RAM/UEFI/error notifications, and inherited updater/security messages.
+  Internal Tails module names and paths should stay unless doing a deeper
+  upstream fork.
+- Phase 9 customization actions must use the capability broker and approval
+  policy. Passwordless `apt-get`, broad sudoers, or free-form root shell
+  actions are rejected for this product.
+
+## Product Architecture Notes
+
+The intended product claim is **elizaOS Live: a Tails-derived live USB Linux
+distribution with the elizaOS app/runtime as the home AI surface**. The normal
+desktop stays available, and Tails internals stay intact where renaming would
+break upstream contracts.
+
+The app is already baked into the ISO as a factory fallback. The production
+path is not to give the app unrestricted root; it is to keep the app/UI under
+the `amnesia` user, keep root-owned supervision and launch policy in systemd,
+and expose privileged actions through a named capability broker with approval,
+argument allowlists, and audit evidence.
+
+Fast Milady/eliza app updates should not require a full ISO every time. The
+right architecture is signed app/runtime bundles in encrypted Persistent
+Storage, verified into a root-owned runtime store, with rollback to the baked
+factory runtime. Base OS updates remain separate: signed full ISO first, then
+signed OS deltas or a Tails-style incremental update path once release
+infrastructure exists.
+
+Large models should not be baked into every USB by default. The ISO should
+ship runtime support plus a signed model catalog. Onboarding can offer cloud
+sign-in, local-only mode, signed Eliza-1/local model download, or enterprise
+managed mirrors. Downloaded models belong in encrypted Persistent Storage; in
+amnesia mode they must disappear at shutdown.
+
+The clean production gates remain: deterministic signed app artifacts, no
+hidden dev workspace resolution, release keyring and revocation metadata,
+SBOM/license/provenance, formal sudoers/capability-broker review, privacy
+proof for embedded browser/OAuth paths, and real USB persistence validation.
 
 ## Still Pending
 
-- Rebuild the current HEAD ISO.
-- Run QEMU on that exact rebuilt artifact.
-- Repeat guarded USB flash/readback for that exact artifact.
+- Repeat guarded USB flash/readback for the current `2ff679a7...` artifact.
 - Boot the USB on real hardware.
 - Validate real USB Persistent Storage create/unlock/delete behavior.
 - Validate privacy/direct networking behavior for the app, renderer, and any

--- a/packages/os/linux/variants/milady-tails/docs/production-readiness.md
+++ b/packages/os/linux/variants/milady-tails/docs/production-readiness.md
@@ -68,6 +68,15 @@ must stay visible:
   release blockers in strict security smoke
 - generated optional-plugin stubs and live embedding fallback are demo
   compatibility glue, not final production packaging
+- residual visible upstream help/support/update links still exist in
+  low-frequency inherited surfaces, including Tor Connection Assistant, USB
+  Cloner help, WhisperBack, low-RAM/UEFI/error notifications, and inherited
+  updater/security messages. These should be rebranded or routed to elizaOS
+  support/update infrastructure before a polished public release.
+- Phase 9's earlier passwordless apt/sudoers direction is superseded by the
+  capability-broker security model. Privileged package, service, network,
+  and device actions need exact broker schemas, user approval or enterprise
+  policy, and audit events.
 
 ## AI OS Product Direction
 

--- a/packages/os/linux/variants/milady-tails/scripts/static-smoke.sh
+++ b/packages/os/linux/variants/milady-tails/scripts/static-smoke.sh
@@ -680,6 +680,8 @@ grep -q 'systemctl --global enable elizaos-renderer.service' \
     tails/config/chroot_local-hooks/52-update-systemd-units
 grep -q 'systemctl enable elizaos-update-verify.service' \
     tails/config/chroot_local-hooks/52-update-systemd-units
+grep -q 'systemctl enable elizaos-root-mode.service' \
+    tails/config/chroot_local-hooks/52-update-systemd-units
 grep -q 'Wants=.*elizaos-update-verify.service' \
     tails/config/chroot_local-includes/etc/systemd/system/milady.service
 grep -q 'Wants=.*elizaos-update-health-check.service' \
@@ -688,6 +690,12 @@ grep -q 'After=display-manager.service elizaos-update-verify.service' \
     tails/config/chroot_local-includes/etc/systemd/system/milady.service
 grep -q 'DirectoryMode=0755' \
     tails/config/chroot_local-includes/usr/lib/systemd/system/run-nosymfollow.mount.d/elizaos-root-mode.conf
+grep -q 'After=run-nosymfollow.mount' \
+    tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
+grep -q 'Before=sysinit.target basic.target dbus.service polkit.service gdm.service tails-persistent-storage.service' \
+    tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
+grep -q 'ExecStart=/bin/chmod 0755 / /run/nosymfollow' \
+    tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
 grep -q 'ExecStart=/usr/local/lib/elizaos/update-health-check' \
     tails/config/chroot_local-includes/etc/systemd/system/elizaos-update-health-check.service
 grep -q 'ELIZAOS_UPDATE_HEALTH_MARK_BAD_ON_TIMEOUT' \

--- a/packages/os/linux/variants/milady-tails/scripts/static-smoke.sh
+++ b/packages/os/linux/variants/milady-tails/scripts/static-smoke.sh
@@ -690,7 +690,7 @@ grep -q 'After=display-manager.service elizaos-update-verify.service' \
     tails/config/chroot_local-includes/etc/systemd/system/milady.service
 grep -q 'DirectoryMode=0755' \
     tails/config/chroot_local-includes/usr/lib/systemd/system/run-nosymfollow.mount.d/elizaos-root-mode.conf
-grep -q 'After=run-nosymfollow.mount' \
+grep -q 'After=run-nosymfollow.mount systemd-tmpfiles-setup.service' \
     tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
 grep -q 'Before=sysinit.target basic.target dbus.service polkit.service gdm.service tails-persistent-storage.service' \
     tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service

--- a/packages/os/linux/variants/milady-tails/tails/config/chroot_local-hooks/52-update-systemd-units
+++ b/packages/os/linux/variants/milady-tails/tails/config/chroot_local-hooks/52-update-systemd-units
@@ -10,6 +10,7 @@ set -u
 for path in \
     /etc/systemd/system/milady.path \
     /etc/systemd/system/milady.service \
+    /etc/systemd/system/elizaos-root-mode.service \
     /etc/systemd/system/elizaos-update-health-check.service \
     /etc/systemd/system/elizaos-update-verify.service \
     /etc/systemd/user/elizaos-agent.service \
@@ -30,6 +31,7 @@ if [ -d /usr/local/lib/elizaos ]; then
     chmod 755 /usr/local/lib/elizaos/* 2>/dev/null || true
 fi
 chmod 644 /etc/systemd/system/milady.path /etc/systemd/system/milady.service \
+    /etc/systemd/system/elizaos-root-mode.service \
     /etc/systemd/system/elizaos-update-health-check.service \
     /etc/systemd/system/elizaos-update-verify.service \
     /etc/systemd/user/elizaos-agent.service /etc/systemd/user/elizaos-renderer.service \
@@ -62,6 +64,7 @@ systemctl enable tails-tor-has-bootstrapped-flag-file.service
 systemctl enable tca-portal.socket
 systemctl enable run-initramfs.mount
 systemctl enable var-tmp.mount
+systemctl enable elizaos-root-mode.service
 systemctl enable elizaos-update-verify.service
 systemctl enable milady.path
 

--- a/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
+++ b/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
@@ -2,7 +2,7 @@
 Description=Restore traversable elizaOS live root permissions
 DefaultDependencies=no
 Requires=run-nosymfollow.mount
-After=run-nosymfollow.mount
+After=run-nosymfollow.mount systemd-tmpfiles-setup.service
 Before=sysinit.target basic.target dbus.service polkit.service gdm.service tails-persistent-storage.service
 ConditionPathIsMountPoint=/run/nosymfollow
 

--- a/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
+++ b/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-root-mode.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Restore traversable elizaOS live root permissions
+DefaultDependencies=no
+Requires=run-nosymfollow.mount
+After=run-nosymfollow.mount
+Before=sysinit.target basic.target dbus.service polkit.service gdm.service tails-persistent-storage.service
+ConditionPathIsMountPoint=/run/nosymfollow
+
+[Service]
+Type=oneshot
+ExecStart=/bin/chmod 0755 / /run/nosymfollow
+RemainAfterExit=yes
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-update-health-check.service
+++ b/packages/os/linux/variants/milady-tails/tails/config/chroot_local-includes/etc/systemd/system/elizaos-update-health-check.service
@@ -12,5 +12,4 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectHome=read-only
 ProtectSystem=strict
-ReadWritePaths=/run/elizaos /live/persistence/TailsData_unlocked/elizaos-system
-
+ReadWritePaths=/run/elizaos -/live/persistence/TailsData_unlocked/elizaos-system


### PR DESCRIPTION
## Summary

This PR carries the current elizaOS Live Linux/Tails-derived USB work on the clean `nubs/messylinux` branch.

It includes:
- elizaOS Live branding and desktop/app integration
- root-mode boot fix for `/` and `/run/nosymfollow` after `systemd-tmpfiles-setup.service`
- removal of the temporary D-Bus/polkit working-directory workaround path
- update verifier/health-check pre-persistence path hardening
- source smoke/security checks for the root-mode, updater, persistence, privacy, and capability boundaries
- docs for current validation state, production gaps, signed app/runtime updates, model catalog, and distribution/update strategy

## Validation

Latest current-HEAD ISO artifact tested locally:

```text
2ff679a74464dd1ad37c0202b58fc56c5dd64b6e9ce047945d6ee60fcb139faa
```

QEMU normal boot of that artifact reached:
- elizaOS greeter
- normal GNOME desktop
- elizaOS app window on the desktop

Post-rebase checks:
- `ELIZAOS_STATIC_SOURCE_ONLY=1 ./scripts/static-smoke.sh` passed
- `./scripts/security-smoke.sh` passed with 2 expected production warnings: missing production update keyring and missing SBOM/provenance artifacts

## Still Not Claimed

This is demo/productization work, not a final enterprise release. Remaining proof before calling the USB demo final:
- repeat guarded USB flash/readback for the `2ff679a7...` artifact
- boot the USB on real hardware
- validate real USB Persistent Storage create/unlock/delete behavior
- validate privacy/direct networking behavior for app, renderer, embedded browser, and OAuth/external web surfaces
- add production release keyring, SBOM, provenance, downloader, revocation, and rollback promotion policy before production claims
