### PR TITLE
fix(image.yaml): pre-build packages/agent/dist before Docker build

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -40,6 +40,34 @@ jobs:
           sudo docker image prune -a -f
           echo "=== After cleanup ==="
           df -h
+
+      # Dockerfile.ci is a pruner-style image that expects pre-built artifacts
+      # in `packages/agent/dist/` already produced by the host (see the comment
+      # in the Dockerfile itself: "Pre-built artifacts come from GHA"). Without
+      # this step the very first RUN inside the Docker build fails with
+      # `Missing compiled package manifest for @elizaos/agent`. We only run
+      # the minimum needed to produce `packages/agent/dist/package.json` —
+      # the more elaborate docker-ci-smoke.sh path is reserved for the smoke
+      # workflow.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Cache Bun install
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-ubuntu-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-ubuntu-
+
+      - name: Install workspace deps
+        run: bun install --frozen-lockfile
+
+      - name: Pre-build packages/agent dist (required by Dockerfile.ci)
+        run: bun run --cwd packages/agent build:docker-dist
+
       # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v4


### PR DESCRIPTION
## Why

Manually triggering the **Create and publish a Docker image** workflow (\`image.yaml\`) on \`develop\` today fails at the very first RUN inside the Docker build:

\`\`\`
#13 0.536     throw new Error(
#13 0.536 Error: Missing compiled package manifest for @elizaos/agent:
          packages/agent/dist/package.json
#13 ERROR: process "/bin/sh -c node ${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs @elizaos/agent"
          did not complete successfully: exit code: 1
\`\`\`

[Run 25990638222](https://github.com/elizaOS/eliza/actions/runs/25990638222).

\`Dockerfile.ci\` is a *pruner* image — its [first line](https://github.com/elizaOS/eliza/blob/develop/packages/app-core/deploy/Dockerfile.ci#L3) literally says *"Pre-built artifacts come from GHA (bun install + tsdown + vite build done before docker)"* — and the second RUN attempts \`relink-workspace-packages-to-dist.mjs @elizaos/agent\`, which reads \`packages/agent/dist/package.json\` to wire the symlinks. The image.yaml workflow has always been missing that pre-build; the path simply hasn't been exercised because manual dispatches were rare and the historical release flow shipped a pre-built tree.

Today we needed to re-publish \`:stable\` to propagate recent fixes (DATABASE_URL → POSTGRES_URL bridge in app-core/entry.ts, the new sandbox self-registration, and the agent_delete queue path) to the Hetzner sandboxes. Without an image rebuild those sandboxes stay on the old \`:stable\` from May 13 and crash-loop on PGLite.

## What this PR does

Three steps before the Buildx step:

1. \`oven-sh/setup-bun@v2\` pinned to **1.3.13** (the version this repo standardizes on)
2. \`bun install --frozen-lockfile\` with a workspace-aware install cache
3. \`bun run --cwd packages/agent build:docker-dist\`
   - \`rm -rf dist\`
   - \`tsc --noCheck -p tsconfig.build.json\`
   - \`node ../scripts/prepare-package-dist.mjs packages/agent\` — this is what writes \`packages/agent/dist/package.json\` that the Dockerfile expects

## What this PR deliberately does NOT do

It does **not** replicate the full \`docker-ci-smoke.sh\` pre-build chain (\`build:client\`, \`build:web\`, root \`tsdown\`). Dockerfile.ci's first RUN only needs the agent dist for the workspace-relink step; the web bundle and the rest are produced inside later Docker stages. Keeping the host-side pre-build minimal is intentional — fewer moving pieces, faster build, less surface to drift.

## Verification

- [x] Workflow YAML parses (would-be drift caught by actionlint on CI)
- [ ] Trigger \`gh workflow run image.yaml --ref fix/image-yaml-prebuild\` against this branch — verify the new pre-build step produces \`packages/agent/dist/package.json\` and the subsequent Buildx step proceeds past the relink RUN

## Rollback

Single revert. The added steps are no-op for cached scenarios (Bun cache hit + idempotent build), so reverting puts us back to where we are today (workflow broken on manual dispatch) without any side effects on other jobs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three pre-build steps to `image.yaml` (Bun setup, `bun install --frozen-lockfile`, and `bun run --cwd packages/agent build:docker-dist`) so that `packages/agent/dist/package.json` exists in the Docker build context before the `relink-workspace-packages-to-dist.mjs` step runs.

- The root `.dockerignore` was recently updated to explicitly un-ignore `packages/agent/dist/**`, so the host-built artifact does reach the Docker build context.
- However, `Dockerfile.ci` line 28 (`RUN cd \"${AGENT_DIR}\" && npm run build:docker-dist`) starts with `rm -rf dist`, immediately deleting the pre-built directory; it then attempts `tsc`, which is not available because `**/node_modules` is excluded from the Docker context. The build still fails — just one step earlier than before.

<h3>Confidence Score: 2/5</h3>

The workflow change does not fully resolve the Docker build failure because Dockerfile.ci line 28 deletes the pre-built dist and then cannot rebuild it without node_modules.

The host pre-build produces packages/agent/dist/package.json and the .dockerignore correctly preserves it, but Dockerfile.ci line 28 immediately runs rm -rf dist then attempts tsc which is not resolvable because node_modules is excluded from the Docker build context. The Docker build fails at that RUN step and the relink step is never reached.

packages/app-core/deploy/Dockerfile.ci line 28 needs to be removed or guarded so the host-pre-built dist/ is not deleted before the relink step runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/image.yaml | Adds Bun setup, cache, install, and agent pre-build steps before Buildx; the pre-built dist/ is deleted by Dockerfile.ci line 28 (rm -rf dist at the start of build:docker-dist), and tsc then fails because node_modules is excluded from the Docker build context, so the Docker build still fails. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GHA Runner (host)
    participant Docker as Docker Build (Dockerfile.ci)

    GHA->>GHA: "oven-sh/setup-bun@v2 (1.3.13)"
    GHA->>GHA: bun install --frozen-lockfile
    Note over GHA: node_modules created (excluded from Docker context)
    GHA->>GHA: bun run --cwd packages/agent build:docker-dist
    Note over GHA: packages/agent/dist/package.json created
    GHA->>Docker: docker buildx build (context: .)
    Note over Docker: COPY . . node_modules EXCLUDED, packages/agent/dist/ INCLUDED
    Docker->>Docker: RUN cd packages/agent and npm run build:docker-dist
    Note over Docker: rm -rf dist wipes pre-built dist/, tsc not found (no node_modules)
    Docker--xGHA: Build fails at this RUN step
    Note over Docker: relink-workspace-packages-to-dist.mjs never reached
```

<sub>Reviews (1): Last reviewed commit: ["fix(image.yaml): pre-build packages/agen..."](https://github.com/elizaos/eliza/commit/b0574dc9cf13e5d66946c0b386d45c5ba8c39319) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32505395)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->