### PR TITLE
feat(provisioning-worker): own the three SSH-bound cron paths instead of forwarding to control-plane

### DIFF
--- a/packages/cloud-shared/src/lib/cron/cloudflare-cron.ts
+++ b/packages/cloud-shared/src/lib/cron/cloudflare-cron.ts
@@ -32,9 +32,11 @@ export const CRON_FANOUT: Record<string, string[]> = {
     "/api/cron/sample-eliza-price",
     "/api/cron/process-redemptions",
     "/api/cron/cleanup-stuck-provisioning",
-    "/api/v1/cron/node-autoscale",
-    "/api/v1/cron/agent-hot-pool",
-    "/api/v1/cron/pool-drain-idle",
+    // node-autoscale, agent-hot-pool, pool-drain-idle moved to the
+    // provisioning-worker daemon's infra-maintenance cycle so the
+    // orchestrator host owns docker_nodes truth. The control-plane still
+    // serves these paths for compat but the CF cron no longer fans out
+    // to it — see packages/scripts/cloud/admin/daemons/provisioning-worker.ts.
   ],
   "*/2 * * * *": ["/api/v1/cron/pool-health-check"],
   "*/10 * * * *": ["/api/cron/cleanup-expired-crypto-payments", "/api/v1/cron/pool-image-rollout"],

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -26,11 +26,23 @@ type WorkerService =
   typeof import("@elizaos/cloud-shared/lib/services/provisioning-jobs").provisioningJobService;
 type WorkerNodeManager =
   typeof import("@elizaos/cloud-shared/lib/services/docker-node-manager").dockerNodeManager;
+type WorkerNodeAutoscaler =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/node-autoscaler").getNodeAutoscaler;
+type WorkerWarmPoolManager =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/warm-pool-manager").WarmPoolManager;
+type WorkerContainersEnv =
+  typeof import("@elizaos/cloud-shared/lib/config/containers-env").containersEnv;
+type WorkerWarmPoolCreator =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator").getHetznerPoolContainerCreator;
 
 interface WorkerDeps {
   logger: WorkerLogger;
   provisioningJobService: WorkerService;
   dockerNodeManager: WorkerNodeManager;
+  getNodeAutoscaler: WorkerNodeAutoscaler;
+  WarmPoolManager: WorkerWarmPoolManager;
+  getHetznerPoolContainerCreator: WorkerWarmPoolCreator;
+  containersEnv: WorkerContainersEnv;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -85,13 +97,46 @@ async function loadDeps(): Promise<WorkerDeps> {
       import("@elizaos/cloud-shared/lib/services/provisioning-jobs"),
       import("@elizaos/cloud-shared/lib/utils/logger"),
       import("@elizaos/cloud-shared/lib/services/docker-node-manager"),
-    ]).then(([jobsModule, loggerModule, nodeMgrModule]) => ({
-      provisioningJobService: jobsModule.provisioningJobService,
-      logger: loggerModule.logger,
-      dockerNodeManager: nodeMgrModule.dockerNodeManager,
-    }));
+      import("@elizaos/cloud-shared/lib/services/containers/node-autoscaler"),
+      import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool"),
+      import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator"),
+      import("@elizaos/cloud-shared/lib/config/containers-env"),
+    ]).then(
+      ([
+        jobsModule,
+        loggerModule,
+        nodeMgrModule,
+        autoscalerModule,
+        warmPoolModule,
+        warmPoolCreatorModule,
+        containersEnvModule,
+      ]) => ({
+        provisioningJobService: jobsModule.provisioningJobService,
+        logger: loggerModule.logger,
+        dockerNodeManager: nodeMgrModule.dockerNodeManager,
+        getNodeAutoscaler: autoscalerModule.getNodeAutoscaler,
+        WarmPoolManager: warmPoolModule.WarmPoolManager,
+        getHetznerPoolContainerCreator:
+          warmPoolCreatorModule.getHetznerPoolContainerCreator,
+        containersEnv: containersEnvModule.containersEnv,
+      }),
+    );
   }
   return depsPromise;
+}
+
+let cachedWarmPoolManagerInstance:
+  | InstanceType<WorkerWarmPoolManager>
+  | null = null;
+async function getWarmPoolManager(): Promise<
+  InstanceType<WorkerWarmPoolManager>
+> {
+  if (cachedWarmPoolManagerInstance) return cachedWarmPoolManagerInstance;
+  const { WarmPoolManager, getHetznerPoolContainerCreator } = await loadDeps();
+  cachedWarmPoolManagerInstance = new WarmPoolManager(
+    getHetznerPoolContainerCreator(),
+  );
+  return cachedWarmPoolManagerInstance;
 }
 
 function resultContext(result: ProcessingResult): Record<string, unknown> {
@@ -123,6 +168,20 @@ interface NodeHealthSummary {
   unhealthy: number;
 }
 
+interface PrePullImagesSummary {
+  attempted: number;
+  failed: number;
+}
+
+interface NodeAutoscaleSummary {
+  action: "noop" | "scale_up" | "scale_down" | "scale_up_skipped" | "scale_up_failed" | "drain_failed";
+  detail?: string;
+}
+
+interface PoolDrainSummary {
+  drained: number;
+}
+
 /**
  * Health-checks every enabled `docker_nodes` row (SSH + `docker info`) and
  * persists the resulting status. Runs on the orchestrator host that already
@@ -144,8 +203,107 @@ async function processNodeHealthCheckCycle(): Promise<NodeHealthSummary> {
   return { total: result.size, healthy, unhealthy };
 }
 
+/**
+ * Reconcile the `allocated_count` column on each `docker_nodes` row against
+ * the real number of provisioned sandboxes referencing the node. Previously
+ * fired by `agent-hot-pool` cron forwarded to the mystery control-plane
+ * host; folded here so the orchestrator owns the truth.
+ */
+async function processSyncAllocatedCountsCycle(): Promise<number> {
+  const { dockerNodeManager } = await loadDeps();
+  const changes = await dockerNodeManager.syncAllocatedCounts();
+  return changes.size;
+}
+
+/**
+ * Pre-pull the current agent image on every healthy node with spare
+ * capacity. Keeps the warm pool / cold-start path fast. Gated by
+ * `ELIZA_AGENT_HOT_POOL_PREPULL` (default on).
+ */
+async function processPrePullImagesCycle(): Promise<PrePullImagesSummary | null> {
+  if (process.env.ELIZA_AGENT_HOT_POOL_PREPULL === "false") return null;
+  const { dockerNodeManager, containersEnv } = await loadDeps();
+  const image = containersEnv.defaultAgentImage();
+  const result = await dockerNodeManager.prePullAgentImageOnAvailableNodes(image);
+  const failed = result.filter((n) => n.status === "failed").length;
+  return { attempted: result.length, failed };
+}
+
+/**
+ * Evaluate capacity and scale Hetzner-cloud autoscaled nodes up or down.
+ * Was forwarded to control-plane via `node-autoscale` cron; folded here.
+ *
+ * Requires `HCLOUD_TOKEN` + `CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY` on the
+ * daemon host for scale-up to succeed. Without those, the cycle still
+ * runs (decision + drain) but reports `scale_up_skipped`.
+ */
+async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
+  const { getNodeAutoscaler } = await loadDeps();
+  const autoscaler = getNodeAutoscaler();
+  const decision = await autoscaler.evaluateCapacity();
+
+  if (!decision.shouldScaleUp && decision.shouldScaleDownNodeIds.length === 0) {
+    return { action: "noop" };
+  }
+
+  if (decision.shouldScaleUp) {
+    const publicKey = process.env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
+    if (!publicKey) {
+      return {
+        action: "scale_up_skipped",
+        detail: "CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY not set on daemon host",
+      };
+    }
+    try {
+      const provisioned = await autoscaler.provisionNode(
+        {},
+        {
+          controlPlanePublicKey: publicKey,
+          registrationUrl: process.env.CONTAINERS_BOOTSTRAP_CALLBACK_URL,
+          registrationSecret: process.env.CONTAINERS_BOOTSTRAP_SECRET,
+        },
+      );
+      return {
+        action: "scale_up",
+        detail: `${provisioned.nodeId} (${provisioned.hostname})`,
+      };
+    } catch (error) {
+      return {
+        action: "scale_up_failed",
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // Scale down path. Drain only the first candidate per cycle to avoid
+  // draining the whole pool on a single cron tick if multiple nodes show
+  // up as idle simultaneously.
+  const target = decision.shouldScaleDownNodeIds[0]!;
+  try {
+    await autoscaler.drainNode(target, { deprovision: true });
+    return { action: "scale_down", detail: target };
+  } catch (error) {
+    return {
+      action: "drain_failed",
+      detail: `${target}: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+}
+
+/**
+ * Drain warm-pool sandboxes that have been idle past their TTL. Replaces the
+ * `pool-drain-idle` cron path.
+ */
+async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
+  const { containersEnv } = await loadDeps();
+  const image = containersEnv.defaultAgentImage();
+  const pool = await getWarmPoolManager();
+  const result = await pool.drainIdle(image);
+  return { drained: result.drained.length };
+}
+
 let running = true;
-let lastNodeHealthCheckAt = 0;
+let lastInfraMaintenanceAt = 0;
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -184,26 +342,92 @@ async function pollCycle(
     });
   }
 
-  // Node health checks run on a longer interval than the heartbeat cycle:
-  // SSH + `docker info` per node is expensive (~MAX_RETRIES * 10s per offline
-  // node) and only feeds capacity decisions that tolerate stale data.
-  // `lastNodeHealthCheckAt` initializes to 0 so the first poll always runs
-  // a check — we want a fresh node-status snapshot at worker startup.
+  // Infra maintenance cycle runs on a longer interval than the heartbeat
+  // (SSH + Docker probes per node are expensive). Bundles every job that
+  // used to be forwarded from CF crons to the now-deprecated control-plane:
+  //   - node health check  (was: /api/v1/cron/agent-hot-pool — healthCheckAll)
+  //   - alloc reconciliation (was: agent-hot-pool — syncAllocatedCounts)
+  //   - pre-pull warm image (was: agent-hot-pool — prePullAgentImageOnAvailableNodes)
+  //   - node autoscale     (was: /api/v1/cron/node-autoscale)
+  //   - warm pool drain    (was: /api/v1/cron/pool-drain-idle)
+  // Folding them together avoids 3 parallel writers fighting over the same
+  // docker_nodes rows and means there's exactly one host that owns the
+  // truth: the orchestrator (this daemon). `lastInfraMaintenanceAt`
+  // initializes to 0 so the first poll always runs — we want a fresh
+  // node-status snapshot at worker startup.
   const now = Date.now();
-  if (now - lastNodeHealthCheckAt >= config.nodeHealthIntervalMs) {
-    lastNodeHealthCheckAt = now;
-    try {
-      const summary = await processNodeHealthCheckCycle();
-      logger.info("[provisioning-worker] node health check cycle complete", {
-        total: summary.total,
-        healthy: summary.healthy,
-        unhealthy: summary.unhealthy,
-      });
-    } catch (error) {
-      logger.error("[provisioning-worker] node health check cycle failed", {
-        error: error instanceof Error ? error.message : String(error),
+  if (now - lastInfraMaintenanceAt >= config.nodeHealthIntervalMs) {
+    lastInfraMaintenanceAt = now;
+    await runInfraMaintenanceCycle(logger);
+  }
+}
+
+async function runInfraMaintenanceCycle(logger: WorkerLogger): Promise<void> {
+  try {
+    const summary = await processNodeHealthCheckCycle();
+    logger.info("[provisioning-worker] node health check cycle complete", {
+      total: summary.total,
+      healthy: summary.healthy,
+      unhealthy: summary.unhealthy,
+    });
+  } catch (error) {
+    logger.error("[provisioning-worker] node health check cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const changes = await processSyncAllocatedCountsCycle();
+    if (changes > 0) {
+      logger.info("[provisioning-worker] alloc reconcile cycle complete", {
+        changed: changes,
       });
     }
+  } catch (error) {
+    logger.error("[provisioning-worker] alloc reconcile cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const summary = await processPrePullImagesCycle();
+    if (summary) {
+      logger.info("[provisioning-worker] pre-pull images cycle complete", {
+        attempted: summary.attempted,
+        failed: summary.failed,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] pre-pull images cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const decision = await processNodeAutoscaleCycle();
+    if (decision.action !== "noop") {
+      logger.info("[provisioning-worker] node autoscale cycle complete", {
+        action: decision.action,
+        detail: decision.detail,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] node autoscale cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const result = await processPoolDrainIdleCycle();
+    if (result.drained > 0) {
+      logger.info("[provisioning-worker] warm pool drain cycle complete", {
+        drained: result.drained,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] warm pool drain cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 


### PR DESCRIPTION
## Context

After PR #7775 folded node health checks into the provisioning-worker daemon, three more cron paths in `CRON_FANOUT` still forwarded from CF Workers to the container-control-plane Node service for SSH-bound work:

- `/api/v1/cron/agent-hot-pool` — `syncAllocatedCounts` + `prePullAgentImageOnAvailableNodes`
- `/api/v1/cron/node-autoscale` — `evaluateCapacity` + `provisionNode` / `drainNode`
- `/api/v1/cron/pool-drain-idle` — `WarmPoolManager.drainIdle`

The control-plane host runs in a place we no longer reliably track and, verified in prod on 2026-05-17, lacks a valid `CONTAINERS_SSH_KEY`. Result: it flips every `milady-core-*` from `healthy` back to `offline` five minutes after PR #7775's daemon writes them `healthy`. The race is determined by who runs last, and right now that's the control-plane.

## Fix

Same lever as PR #7775: rapatrier the cycles into the orchestrator host that already has the SSH key + Neon access, and stop fanning out to a service that drifts.

| Function | Before | After |
|---|---|---|
| `healthCheckAll` | control-plane | **daemon** (PR #7775) |
| `syncAllocatedCounts` | control-plane | **daemon** (this PR) |
| `prePullAgentImageOnAvailableNodes` | control-plane | **daemon** (this PR) |
| `evaluateCapacity` + `provisionNode` / `drainNode` | control-plane | **daemon** (this PR) |
| `WarmPoolManager.drainIdle` | control-plane | **daemon** (this PR) |

All five cycles run on the same `nodeHealthIntervalMs` cadence (default 5 min) inside a new `runInfraMaintenanceCycle` helper. Each cycle has its own `try/catch` so a missing optional secret (e.g. `HCLOUD_TOKEN` for scale-up) doesn't starve the others.

## Removed from CRON_FANOUT

```diff
   "*/5 * * * *": [
     "/api/cron/social-automation",
     "/api/cron/sample-eliza-price",
     "/api/cron/process-redemptions",
     "/api/cron/cleanup-stuck-provisioning",
-    "/api/v1/cron/node-autoscale",
-    "/api/v1/cron/agent-hot-pool",
-    "/api/v1/cron/pool-drain-idle",
   ],
```

The control-plane keeps the corresponding route handlers wired for backwards compatibility (and direct admin invocation), but the CF Worker no longer hands them off automatically. Daemon is the only writer.

## What stays in the control-plane (for now)

Out of scope for this PR — moved in a follow-up that adds an HTTP server to the daemon so CF Workers can forward user-facing routes the same way they forward crons:

- `/api/v1/containers/*` user CRUD (create, get, delete, patch, logs, metrics, workspace-sync)
- `/api/v1/eliza/agents/:id/bridge` + `/stream`
- `DELETE /api/compat/agents/:id`
- The remaining warm-pool / pool-health-check / deployment-monitor crons that don't write `docker_nodes` and don't contest the daemon

## Ops note

`provisionNode` (scale-up) only succeeds when both `HCLOUD_TOKEN` and `CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY` are present on the daemon host. Today the orchestrator VM at `89.167.63.246` doesn't have them, so scale-up reports `scale_up_skipped` until they're added — same posture as the control-plane was in. Adding them to `/opt/eliza/cloud/.env.local` unlocks autoscale without any further code change.

## Test plan

- [x] Compiles clean (`bun run --cwd packages/cloud-shared typecheck` filtered to the touched files — empty)
- [ ] Roll to staging orchestrator → tail journal, verify the new logs fire: `alloc reconcile cycle complete`, `pre-pull images cycle complete`, `node autoscale cycle complete` (will be `noop` until something is at capacity), `warm pool drain cycle complete`
- [ ] After 5-10 min, query Neon: `milady-core-*` rows show fresh `last_health_check` and `status = 'healthy'` written by the daemon, no more 5-min flap back to `offline`
- [ ] Provision a fresh agent — `getAvailableNode` picks a healthy milady-core, sandbox starts on the cached `:stable` image

## Rollback

Single revert. The legacy control-plane handlers stay in place; reverting puts the CRON_FANOUT back and the control-plane resumes serving these paths from CF Workers crons. No data migration to undo.

## Architecture context

```
Today (pre-PR):                            After this PR:

CF Workers cron        CF Workers cron
  ├─ agent-hot-pool ┐    (no fanout for these 3 paths)
  ├─ node-autoscale ┤
  └─ pool-drain-idle┘
        │
        ▼ HTTP forward
  control-plane (unknown host)
        │ SSH (broken — bad key)
        ▼
  docker_nodes ← writes 'offline' (race)
        ▲
        │
  daemon (PR #7775 wrote 'healthy')         daemon (this PR)
                                              ├─ healthCheckAll
                                              ├─ syncAllocatedCounts
                                              ├─ prePullImage
                                              ├─ nodeAutoscale
                                              └─ drainIdle
                                                  ▼
                                              docker_nodes ← single writer
```

This continues the pivot toward "the orchestrator host that runs the work also writes the truth," documented in `plan/onboarding-gateway/05-prod-audit-and-pivot-2026-05-16.md`. Next: move the user-facing endpoints off the control-plane so it can be decommissioned entirely.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates three SSH-bound cron paths (`agent-hot-pool`, `node-autoscale`, `pool-drain-idle`) out of the Cloudflare Worker fanout and into the provisioning-worker daemon, eliminating a race condition where the control-plane (running without a valid `CONTAINERS_SSH_KEY`) was overwriting healthy node statuses set by the daemon from PR #7775.

- **`cloudflare-cron.ts`**: Removes the three control-plane-forwarded paths from `CRON_FANOUT`; the routes remain wired in the control-plane for backwards compat but are no longer triggered by the CF scheduler.
- **`provisioning-worker.ts`**: Introduces `runInfraMaintenanceCycle` which sequences `syncAllocatedCounts`, `prePullAgentImageOnAvailableNodes`, `evaluateCapacity`/`provisionNode`/`drainNode`, and `drainIdle` — all guarded by individual `try/catch` blocks so one failing step doesn't block the others.

<h3>Confidence Score: 4/5</h3>

The change is a clean repatriation of work from a broken control-plane to the daemon that already holds the SSH key; the core logic is well-isolated and each sub-cycle is independently faulted.

The structural change is sound and the try/catch isolation means one failing sub-cycle cannot cascade. Two minor gaps are worth addressing: pre-pull node failures are silently absorbed into an info-level log entry, and a missing HCLOUD_TOKEN surfaces as scale_up_failed rather than scale_up_skipped — inconsistent with the explicit SSH key guard added right beside it.

Pay close attention to processNodeAutoscaleCycle in provisioning-worker.ts — the HCLOUD_TOKEN pre-check gap means the daemon journal on the current orchestrator VM will show scale_up_failed entries instead of the expected scale_up_skipped until credentials are added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/scripts/cloud/admin/daemons/provisioning-worker.ts | Adds four new infra-maintenance sub-cycles (alloc reconciliation, pre-pull images, node autoscale, warm-pool drain) bundled into a single sequential runInfraMaintenanceCycle; pre-pull failure logging uses info level regardless of failure count, and HCLOUD_TOKEN is not pre-checked before provisionNode unlike the parallel SSH key guard. |
| packages/cloud-shared/src/lib/cron/cloudflare-cron.ts | Removes three cron fanout paths forwarded to the control-plane and replaces them with an explanatory comment; no logic change, the daemon now owns these cycles. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CF as CF Workers Cron
    participant CP as control-plane (deprecated path)
    participant D as provisioning-worker daemon
    participant DB as docker_nodes (Neon)

    Note over CF,DB: Before this PR
    CF->>CP: POST /api/v1/cron/agent-hot-pool
    CP-->>DB: healthCheckAll / syncAllocatedCounts (bad SSH key writes offline)
    CF->>CP: POST /api/v1/cron/node-autoscale
    CP-->>DB: evaluateCapacity / provisionNode / drainNode
    CF->>CP: POST /api/v1/cron/pool-drain-idle
    CP-->>DB: drainIdle
    D-->>DB: healthCheckAll writes healthy - race with CP

    Note over CF,DB: After this PR
    CF->>CF: no fanout for agent-hot-pool / node-autoscale / pool-drain-idle
    D->>D: runInfraMaintenanceCycle every 5 min
    D->>DB: healthCheckAll
    D->>DB: syncAllocatedCounts
    D->>DB: prePullAgentImageOnAvailableNodes
    D->>DB: evaluateCapacity + provisionNode/drainNode
    D->>DB: drainIdle
    Note over D,DB: Single writer - no race
```

<sub>Reviews (1): Last reviewed commit: ["feat(provisioning-worker): own the three..."](https://github.com/elizaos/eliza/commit/a6d724efbdd902b63debe47153f2c5088cddfdec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32506825)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->