### PR TITLE
fix(docker): break circular symlink for app-core's jose / @node-rs/argon2 in pruner

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,7 +14,7 @@ This directory contains GitHub Actions workflows for the elizaOS project (v2.0.0
 | `claude-security-review.yml` | PR opened | Security-focused review |
 | `codeql.yml` | Push/PR to main, Weekly | Static security analysis |
 | `docs-ci.yml` | PR (docs paths), Manual | Documentation quality checks |
-| `image.yaml` | Release, Manual | Docker image builds |
+| `build-agent-image.yml` | Push develop/main, Release, Manual | Docker image builds (`:develop`, `:stable`, `:latest`, release tags) |
 | `tee-build-deploy.yml` | Push to main, Manual | TEE deployment to Phala Cloud |
 | `weekly-maintenance.yml` | Weekly, Manual | Dependency/security audits |
 | `jsdoc-automation.yml` | Manual | JSDoc generation |

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3171,8 +3171,13 @@ export async function startEliza(
   // routing layer, then write the resolved value into process.env so
   // the synchronous runtime.getSetting fast path picks it up. Idempotent;
   // safe to run multiple times. Opt-out via
-  // ELIZA_DISABLE_VAULT_PROFILE_RESOLVER=1.
-  if (process.env.ELIZA_DISABLE_VAULT_PROFILE_RESOLVER !== "1") {
+  // ELIZA_DISABLE_VAULT_PROFILE_RESOLVER=1. Auto-disabled in cloud containers
+  // (ELIZA_CLOUD_PROVISIONED=1) — vault PGlite init hangs in the slim Docker
+  // image; see the boot-time vault hydration block earlier in this function.
+  if (
+    process.env.ELIZA_DISABLE_VAULT_PROFILE_RESOLVER !== "1" &&
+    process.env.ELIZA_CLOUD_PROVISIONED !== "1"
+  ) {
     try {
       const { sharedVault } = await importAppCoreRuntime();
       const { applyVaultProfilesForAgent } = await import(
@@ -3191,7 +3196,12 @@ export async function startEliza(
   // the *user* wallet; per-agent wallets live inside the encrypted vault and
   // are surfaced separately in the in-app browser. Idempotent — existing
   // wallets are preserved. Opt-out via ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP=1.
-  if (process.env.ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP !== "1") {
+  // Auto-disabled in cloud containers (ELIZA_CLOUD_PROVISIONED=1) — same
+  // PGlite vault init hang as the earlier vault hydration block.
+  if (
+    process.env.ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP !== "1" &&
+    process.env.ELIZA_CLOUD_PROVISIONED !== "1"
+  ) {
     try {
       const { sharedVault } = await importAppCoreRuntime();
       const { ensureAgentWallets } = await import("./agent-wallets.ts");

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2861,19 +2861,25 @@ export async function startEliza(
   // Boot-time vault hydration: migrate plaintext sensitive values into the
   // OS-keychain vault and resolve vault://KEY sentinels in config.env.
   //
-  // Skipped on mobile. `hydrateWalletKeysFromNodePlatformSecureStore` and
-  // `runVaultBootstrap` both reach for the OS keychain through
-  // `defaultMasterKey().load()` (packages/vault/src/master-key.ts:217)
-  // and open a second PGlite worker at `<stateDir>/.vault-pglite/`. Neither
-  // is meaningful on Android: there is no D-Bus session for the libsecret
-  // backend (vault falls back to an ELIZA_VAULT_PASSPHRASE-derived key,
-  // which `ElizaAgentService` already sets per-install from ANDROID_ID),
-  // the spawned bun process has no sensitive secrets to migrate (those
-  // arrive through the service env — per-boot bearer token, llama config),
-  // and the second PGlite worker just doubles disk + RAM pressure on a
-  // 4 GB device. Mirrors the `if (!isMobilePlatform()) { ... }` guard at
-  // line ~2888 around the `applyCloudConfigToEnv` block.
-  if (!isMobilePlatform()) {
+  // Skipped on mobile AND in cloud-provisioned containers. The vault flow
+  // (`hydrateWalletKeysFromNodePlatformSecureStore` + `runVaultBootstrap`)
+  // reaches for the OS keychain through `defaultMasterKey().load()`
+  // (packages/vault/src/master-key.ts:217) and opens a second PGlite worker
+  // at `<stateDir>/.vault-pglite/`. Both target environments where it's
+  // pointless or actively harmful:
+  //   - Android: no D-Bus for libsecret (vault falls back to an
+  //     ELIZA_VAULT_PASSPHRASE-derived key, which `ElizaAgentService` already
+  //     sets per-install from ANDROID_ID), the spawned bun process has no
+  //     plaintext secrets to migrate (env arrives from the service), and the
+  //     second PGlite worker doubles disk + RAM pressure on a 4 GB device.
+  //   - Cloud sandbox (Docker, ELIZA_CLOUD_PROVISIONED=1): the daemon already
+  //     injects every secret as a real env var (ELIZA_API_TOKEN,
+  //     ELIZAOS_CLOUD_API_KEY, OPENAI_API_KEY, …), libsecret isn't installed
+  //     in the slim image, and the second PGlite worker has been observed to
+  //     hang vault-pglite init silently — blocking the HTTP listen and
+  //     tripping the 180s health check on every fresh provision.
+  const isCloudProvisioned = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+  if (!isMobilePlatform() && !isCloudProvisioned) {
     try {
       const { hydrateWalletKeysFromNodePlatformSecureStore } =
         await importAppCoreRuntime();

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3057,7 +3057,18 @@ export async function startEliza(
 
   // 2f. Install the multi-account pool shims and apply selected direct API
   //     accounts before plugin resolution snapshots process.env.
-  try {
+  //
+  // Skipped in cloud containers (ELIZA_CLOUD_PROVISIONED=1): the multi-account
+  // pool is a desktop feature for users juggling several accounts per provider
+  // (work / personal / throwaway). Cloud sandboxes get one set of credentials
+  // injected by the daemon as env vars, so there's nothing to multiplex. The
+  // dynamic `importAppCoreRuntime()` here also pulls in
+  // `app-core/services/account-pool`, which statically imports from
+  // `@elizaos/agent` — completing a circular import that deadlocks Node ESM
+  // module evaluation in the cloud Docker boot path. Manifests as a silent
+  // hang at this await call after the node:sqlite experimental warning; PID 1
+  // sits in `ep_poll`, no listen, 180s health timeout.
+  if (process.env.ELIZA_CLOUD_PROVISIONED !== "1") try {
     const accountPool = await importAppCoreRuntime();
     accountPool.getDefaultAccountPool();
     await accountPool.applyAccountPoolApiCredentials({

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -182,30 +182,39 @@ function removePath(filePath) {
 
 function resolveDependencyPackageDir(packageName, baseDirs = [repoRoot]) {
   const packageSegments = packageName.split("/");
-  for (const baseDir of baseDirs) {
-    const packageDir = path.join(
-      baseDir,
-      "node_modules",
-      ...packageSegments,
-    );
-    if (fs.existsSync(path.join(packageDir, "package.json"))) {
-      return packageDir;
+  // Always return the realpath: when a previous iteration of this loop has
+  // already linked the dep (e.g. app-core's per-package node_modules pointing
+  // at the root install), a later call must surface the real directory, not
+  // the symlink chain — otherwise `linkDependencyPackage`'s equality check
+  // can't detect that source and target refer to the same place, and we end
+  // up replacing the real npm-installed package with a circular symlink that
+  // points back at itself. This was the root cause of the prod `:develop`
+  // sandbox hang where `import 'jose'` from plugin-elizacloud failed with
+  // ERR_MODULE_NOT_FOUND because /app/node_modules/jose pointed to
+  // /app/packages/app-core/node_modules/jose pointed to /app/node_modules/jose.
+  const realIfExists = (dir) => {
+    if (!fs.existsSync(path.join(dir, "package.json"))) return null;
+    try {
+      return fs.realpathSync(dir);
+    } catch {
+      return dir;
     }
+  };
+  for (const baseDir of baseDirs) {
+    const real = realIfExists(
+      path.join(baseDir, "node_modules", ...packageSegments),
+    );
+    if (real) return real;
   }
 
   for (const baseDir of baseDirs) {
     const bunStoreDir = path.join(baseDir, "node_modules", ".bun");
     if (pathExists(bunStoreDir)) {
       for (const entry of fs.readdirSync(bunStoreDir).sort().reverse()) {
-        const candidate = path.join(
-          bunStoreDir,
-          entry,
-          "node_modules",
-          ...packageSegments,
+        const real = realIfExists(
+          path.join(bunStoreDir, entry, "node_modules", ...packageSegments),
         );
-        if (fs.existsSync(path.join(candidate, "package.json"))) {
-          return candidate;
-        }
+        if (real) return real;
       }
     }
   }

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -182,16 +182,9 @@ function removePath(filePath) {
 
 function resolveDependencyPackageDir(packageName, baseDirs = [repoRoot]) {
   const packageSegments = packageName.split("/");
-  // Always return the realpath: when a previous iteration of this loop has
-  // already linked the dep (e.g. app-core's per-package node_modules pointing
-  // at the root install), a later call must surface the real directory, not
-  // the symlink chain — otherwise `linkDependencyPackage`'s equality check
-  // can't detect that source and target refer to the same place, and we end
-  // up replacing the real npm-installed package with a circular symlink that
-  // points back at itself. This was the root cause of the prod `:develop`
-  // sandbox hang where `import 'jose'` from plugin-elizacloud failed with
-  // ERR_MODULE_NOT_FOUND because /app/node_modules/jose pointed to
-  // /app/packages/app-core/node_modules/jose pointed to /app/node_modules/jose.
+  // Return the realpath so `linkDependencyPackage`'s `packageDir === target`
+  // check works when a previous loop iteration already symlinked the dep
+  // (avoids circular symlinks like jose → app-core/jose → root jose).
   const realIfExists = (dir) => {
     if (!fs.existsSync(path.join(dir, "package.json"))) return null;
     try {


### PR DESCRIPTION
## Root cause

Fresh sandboxes provisioned with `:develop` consistently failed health check at 180s. The container started, Node ran, but never reached the HTTP listen.

Container logs:
```
[wallet][os-store] boot hydrate skipped: Cannot find package 'jose' imported from /app/plugins/plugin-elizacloud/dist/node/index.node.js
[eliza-autonomous] Failed to start: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'jose' ...
```

Inspecting the image:

```
/app/node_modules/jose -> /app/packages/app-core/node_modules/jose
/app/packages/app-core/node_modules/jose -> ../../../node_modules/jose
```

Two-hop circular symlink. Node's ESM resolver can't traverse it → import fails → process never finishes boot → container hangs in `ep_poll` until daemon kills it.

## How the loop was formed

`link-docker-local-app-packages.mjs` links app-core's owned root deps (`jose`, `@node-rs/argon2`) in two passes:
1. `packages/app-core/node_modules/<dep>` (for app-core's local resolution)
2. `/app/node_modules/<dep>` (for transitive imports from other plugins)

Each pass calls `resolveDependencyPackageDir` with `[packageDir, repoRoot]`. After the first pass linked `app-core/node_modules/jose → /app/node_modules/jose`, the second pass's resolver searched packageDir first, saw the freshly-created symlink's target had `package.json` (`fs.existsSync` follows symlinks), and returned the symlink path verbatim.

`linkDependencyPackage`'s equality check `path.resolve(packageDir) === path.resolve(target)` compared the symlink path against the target — different strings, so the function proceeded:
1. `removePath(target)` — **deleted the real npm-installed jose at `/app/node_modules/jose`**
2. symlinked target → packageDir (the now-broken intermediate symlink)

End state: circular symlink. Real npm install gone.

## Fix

`resolveDependencyPackageDir` now returns `fs.realpathSync(dir)` instead of the raw join path. The realpath collapses any prior symlink, so when the second-pass call resolves jose it returns `/app/node_modules/jose` (the actual install). `linkDependencyPackage`'s equality check then correctly detects `target === packageDir` and skips — preserving the real npm install at root.

## How this was missed

The first `:develop` builds without Shaw's `baseDirs` patch resolved only at root, so this couldn't happen. The bug was introduced in `06dc596` ("fix(docker): resolve app-core owned dependencies") which added `baseDirs: [packageDir, repoRoot]` so the resolver searches both. Once that landed, every subsequent `:develop` build had the circular symlink baked in.

## Test plan

- [ ] CI build-agent-image.yml succeeds on this branch
- [ ] In the resulting image, `ls -la /app/node_modules/jose` is a real directory (not a symlink)
- [ ] In the resulting image, `ls -la /app/packages/app-core/node_modules/jose` is a symlink → `/app/node_modules/jose` (one hop, not circular)
- [ ] Manual provision of a fresh sandbox via the dashboard transitions from `pending` → `running` (not stuck in health timeout)
- [ ] Existing PR #7780's consolidation + tsx fix still works (this branch contains all those commits)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related Docker container boot failures: a circular symlink for `jose` / `@node-rs/argon2` created by the pruner script, and vault/account-pool operations that hang indefinitely in slim cloud images. Both issues caused fresh sandbox containers to never reach HTTP listen, tripping the 180s health check.

- **Symlink fix**: `resolveDependencyPackageDir` now calls `fs.realpathSync` via a `realIfExists` helper before returning a candidate path, so the equality guard in `linkDependencyPackage` correctly detects the already-linked destination and skips overwriting it with a circular symlink.
- **Cloud boot fix**: Three vault/account-pool code paths in `startEliza` are now gated on `ELIZA_CLOUD_PROVISIONED !== \"1\"`, preventing the PGlite worker init and ESM circular-import deadlock that blocked the HTTP listen in Docker.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the symlink fix is targeted and correct; the catch fallback path that could theoretically re-introduce the circular symlink under a race condition was already flagged in a prior review thread.

The `realIfExists` catch block returns the raw (possibly symlinked) `dir` instead of `null`. Under a race where the path disappears between `existsSync` and `realpathSync`, or an `EPERM` traversing the chain, the function hands back an unresolved symlink path — recreating the circular symlink this PR is fixing. This was raised in the prior review thread and remains unaddressed in this commit.

packages/app-core/scripts/link-docker-local-app-packages.mjs — specifically the catch branch of `realIfExists` at line 193.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/link-docker-local-app-packages.mjs | Core fix: `resolveDependencyPackageDir` now uses `fs.realpathSync` to collapse symlinks before returning, preventing circular symlink formation; the catch fallback returns `dir` instead of `null` (already flagged in a prior thread). |
| packages/agent/src/runtime/eliza.ts | Adds `ELIZA_CLOUD_PROVISIONED=1` guards to skip vault hydration, account-pool init, vault profile resolver, and agent wallet bootstrap in cloud containers; guards are correct and comments are thorough. |
| .github/workflows/README.md | Documentation-only: updates the workflow filename from `image.yaml` to `build-agent-image.yml` with an expanded description of its trigger events. |

</details>

<sub>Reviews (7): Last reviewed commit: ["Merge branch &#39;develop&#39; into fix/image-ya..."](https://github.com/elizaos/eliza/commit/c3bd30de2b434ce55e0a14c292e347b3f1eccd3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32536457)</sub>

<!-- /greptile_comment -->