### PR TITLE
feat(swe-bench): elizaOS vs opencode head-to-head comparison harness

### DIFF
--- a/packages/benchmarks/swe_bench/README.md
+++ b/packages/benchmarks/swe_bench/README.md
@@ -1,0 +1,82 @@
+# SWE-bench
+
+elizaOS's SWE-bench Lite harness. The canonical single-shot flow lives in
+`cli.py` (entry: `python -m benchmarks.swe_bench …`). See `RESEARCH.md`
+for design notes and historical results.
+
+## Head-to-head comparison: elizaOS vs opencode
+
+`harness/comparison.py` runs the same N SWE-bench Lite instances through
+two paths and emits a side-by-side JSON report:
+
+- **Path A — elizaOS** uses the existing canonical bridge (`cli._run_instance`):
+  prompt the TS bench server, extract a unified diff, grade with
+  `SWEBenchEvaluator`.
+- **Path B — opencode** clones the target repo at `base_commit` into a
+  per-instance sandbox, invokes `opencode run "<task>"` in that workdir,
+  then captures the working-tree diff via `git diff` and grades it with
+  the same `SWEBenchEvaluator`. If `opencode` is not on `PATH`, each
+  Path B record is marked `status="skipped_opencode_missing"` and the
+  run continues.
+
+Both paths share dataset loading, sandboxing, and grading so the only
+honest delta is the patch producer.
+
+### Run it
+
+```bash
+# Stub-only — emits the report schema with placeholder entries, no Docker,
+# no eliza bridge, no opencode call. Use this to inspect the JSON shape.
+python -m benchmarks.swe_bench.harness.comparison --n 2 --stub
+
+# Real smoke (requires: docker, the eliza TS bench bridge, and opencode on PATH)
+python -m benchmarks.swe_bench.harness.comparison --n 2
+
+# Pin specific Lite instances
+python -m benchmarks.swe_bench.harness.comparison \
+  --instances django__django-11099 sympy__sympy-20590
+```
+
+### Output schema
+
+`comparison_<timestamp>.json` (or `comparison_smoke.json` for `--stub`):
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_at": "<ISO-8601 UTC>",
+  "totals": {
+    "instances": 2,
+    "elizaos_resolved": 0,
+    "opencode_resolved": 0,
+    "elizaos_wins": 0,
+    "opencode_wins": 0,
+    "ties_resolved": 0,
+    "ties_failed": 2
+  },
+  "records": [
+    {
+      "instance_id": "django__django-11099",
+      "repo": "django/django",
+      "base_commit": "<sha>",
+      "path_a": {
+        "path": "elizaos",
+        "status": "resolved | failed | no_patch | error | not_run_yet",
+        "patch": "<unified diff>",
+        "resolved": false,
+        "time_s": 0.0,
+        "patch_status": "tests_passed | tests_failed | apply_failed | …",
+        "tests_passed": [],
+        "tests_failed": [],
+        "error": null
+      },
+      "path_b": { "path": "opencode", "...": "(same shape, plus status=skipped_opencode_missing)" },
+      "winner": "elizaos | opencode | tie_resolved | tie_failed"
+    }
+  ]
+}
+```
+
+A pre-generated placeholder report lives at
+`harness/fixtures/comparison_smoke.json` for downstream tooling that
+wants to lock in the schema before the first real run.

--- a/packages/benchmarks/swe_bench/harness/__init__.py
+++ b/packages/benchmarks/swe_bench/harness/__init__.py
@@ -1,0 +1,1 @@
+"""Harness subpackage for SWE-bench comparison runners."""

--- a/packages/benchmarks/swe_bench/harness/comparison.py
+++ b/packages/benchmarks/swe_bench/harness/comparison.py
@@ -1,0 +1,400 @@
+"""Head-to-head comparison harness: elizaOS internal agent vs opencode.
+
+Runs the same N SWE-bench instances through two paths and emits a
+side-by-side JSON report.
+
+  Path A — elizaOS canonical SWE-bench flow (existing single-shot bridge
+  in ``swe_bench.cli``: prompt the TS bench server, extract a unified
+  diff, grade with ``SWEBenchEvaluator``).
+
+  Path B — opencode CLI as the patch producer. We clone the target repo
+  at ``base_commit`` into a sandbox, invoke ``opencode run "<task>"`` in
+  that workdir, then ``git diff`` the working tree to produce a unified
+  diff that goes through the same ``SWEBenchEvaluator``.
+
+The two paths share dataset loading, evaluator, and the result schema,
+so the only honest delta in the report is the patch producer.
+
+Usage::
+
+    python -m benchmarks.swe_bench.harness.comparison --n 2
+
+If ``opencode`` is not on ``PATH`` the Path B record for each instance
+is marked ``status="skipped_opencode_missing"`` and the run continues.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# Ensure the eliza-adapter package is importable for Path A.
+_ELIZA_ADAPTER_PKG = Path(__file__).resolve().parents[2] / "eliza-adapter"
+if _ELIZA_ADAPTER_PKG.exists() and str(_ELIZA_ADAPTER_PKG) not in sys.path:
+    sys.path.insert(0, str(_ELIZA_ADAPTER_PKG))
+
+from ..cli import _run_instance as run_path_a_instance  # noqa: E402
+from ..dataset import SWEBenchDataset  # noqa: E402
+from ..evaluator import SWEBenchEvaluator  # noqa: E402
+from ..types import PatchStatus, SWEBenchInstance, SWEBenchVariant  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Default cheap-ish Lite instances to keep smoke runs short. These are
+# stable, frequently-cited instances; the runner falls back to whatever
+# the dataset returns if any are absent.
+DEFAULT_INSTANCES: tuple[str, ...] = (
+    "django__django-11099",
+    "sympy__sympy-20590",
+)
+
+
+@dataclass
+class PathResult:
+    """Outcome of running a single instance through one path."""
+
+    path: str  # "elizaos" | "opencode"
+    status: str  # "resolved" | "failed" | "no_patch" | "skipped_opencode_missing" | "error" | "not_run_yet"
+    patch: str = ""
+    resolved: bool = False
+    time_s: float = 0.0
+    error: str | None = None
+    patch_status: str | None = None
+    tests_passed: list[str] = field(default_factory=list)
+    tests_failed: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ComparisonRecord:
+    instance_id: str
+    repo: str
+    base_commit: str
+    path_a: PathResult
+    path_b: PathResult
+    winner: str  # "elizaos" | "opencode" | "tie_resolved" | "tie_failed"
+
+
+def _decide_winner(a: PathResult, b: PathResult) -> str:
+    if a.resolved and b.resolved:
+        return "tie_resolved"
+    if a.resolved:
+        return "elizaos"
+    if b.resolved:
+        return "opencode"
+    return "tie_failed"
+
+
+def _opencode_available() -> bool:
+    return shutil.which("opencode") is not None
+
+
+def _build_opencode_task(instance: SWEBenchInstance) -> str:
+    """Render the SWE-bench problem statement into an opencode task prompt."""
+    hint = (
+        f"\n\nHints from the issue:\n{instance.hints_text}"
+        if instance.hints_text
+        else ""
+    )
+    return (
+        "You are fixing a bug in this repository checkout.\n\n"
+        f"Problem statement:\n{instance.problem_statement}{hint}\n\n"
+        "Edit files in place to resolve the issue. Do NOT create new commits — "
+        "leave the fix as unstaged working-tree changes so the harness can "
+        "capture it via `git diff`. Do not modify test files."
+    )
+
+
+async def _git(*args: str, cwd: str | None = None, timeout: int = 120) -> tuple[int, str, str]:
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    return proc.returncode or 0, stdout.decode("utf-8", "replace"), stderr.decode("utf-8", "replace")
+
+
+async def _checkout_instance(
+    instance: SWEBenchInstance, sandbox_root: Path
+) -> Path:
+    """Clone <repo> at <base_commit> into a fresh sandbox directory."""
+    workdir = sandbox_root / instance.instance_id
+    if workdir.exists():
+        shutil.rmtree(workdir, ignore_errors=True)
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    url = f"https://github.com/{instance.repo}.git"
+    rc, _, err = await _git("clone", "--quiet", url, str(workdir), timeout=600)
+    if rc != 0:
+        raise RuntimeError(f"git clone failed: {err.strip()}")
+    rc, _, err = await _git("checkout", "--quiet", instance.base_commit, cwd=str(workdir))
+    if rc != 0:
+        raise RuntimeError(f"git checkout {instance.base_commit} failed: {err.strip()}")
+    return workdir
+
+
+async def _run_path_b_instance(
+    instance: SWEBenchInstance,
+    evaluator: SWEBenchEvaluator,
+    sandbox_root: Path,
+    opencode_timeout_s: int,
+) -> PathResult:
+    """Run one instance through opencode and grade the resulting diff."""
+    started = time.time()
+    if not _opencode_available():
+        return PathResult(
+            path="opencode",
+            status="skipped_opencode_missing",
+            error="opencode binary not found on PATH",
+            time_s=time.time() - started,
+        )
+
+    try:
+        workdir = await _checkout_instance(instance, sandbox_root)
+    except Exception as exc:  # noqa: BLE001 — surface clone/checkout failure
+        return PathResult(
+            path="opencode",
+            status="error",
+            error=f"sandbox setup: {exc}",
+            time_s=time.time() - started,
+        )
+
+    task = _build_opencode_task(instance)
+    proc = await asyncio.create_subprocess_exec(
+        "opencode",
+        "run",
+        task,
+        cwd=str(workdir),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={**os.environ, "OPENCODE_DISABLE_AUTOUPDATE": "1"},
+    )
+    try:
+        await asyncio.wait_for(proc.communicate(), timeout=opencode_timeout_s)
+    except asyncio.TimeoutError:
+        proc.kill()
+        return PathResult(
+            path="opencode",
+            status="error",
+            error=f"opencode timed out after {opencode_timeout_s}s",
+            time_s=time.time() - started,
+        )
+
+    rc, diff, err = await _git("diff", "--no-color", cwd=str(workdir))
+    if rc != 0:
+        return PathResult(
+            path="opencode",
+            status="error",
+            error=f"git diff failed: {err.strip()}",
+            time_s=time.time() - started,
+        )
+
+    if not diff.strip():
+        return PathResult(
+            path="opencode",
+            status="no_patch",
+            time_s=time.time() - started,
+        )
+
+    graded = await evaluator.evaluate_patch(instance, diff)
+    return PathResult(
+        path="opencode",
+        status="resolved" if graded.success else "failed",
+        patch=diff,
+        resolved=graded.success,
+        time_s=time.time() - started,
+        patch_status=graded.patch_status.value,
+        tests_passed=list(graded.tests_passed),
+        tests_failed=list(graded.tests_failed),
+        error=graded.error,
+    )
+
+
+async def _run_path_a(
+    instance: SWEBenchInstance,
+    evaluator: SWEBenchEvaluator,
+    client: object,
+) -> PathResult:
+    started = time.time()
+    result = await run_path_a_instance(client, instance, evaluator, provider_label="elizaos")
+    return PathResult(
+        path="elizaos",
+        status="resolved" if result.success else ("no_patch" if result.patch_status == PatchStatus.NOT_GENERATED else "failed"),
+        patch=result.generated_patch,
+        resolved=result.success,
+        time_s=time.time() - started,
+        patch_status=result.patch_status.value,
+        tests_passed=list(result.tests_passed),
+        tests_failed=list(result.tests_failed),
+        error=result.error,
+    )
+
+
+def _stub_record(instance_id: str) -> ComparisonRecord:
+    return ComparisonRecord(
+        instance_id=instance_id,
+        repo="",
+        base_commit="",
+        path_a=PathResult(path="elizaos", status="not_run_yet"),
+        path_b=PathResult(path="opencode", status="not_run_yet"),
+        winner="tie_failed",
+    )
+
+
+def _to_payload(records: list[ComparisonRecord]) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "totals": {
+            "instances": len(records),
+            "elizaos_resolved": sum(1 for r in records if r.path_a.resolved),
+            "opencode_resolved": sum(1 for r in records if r.path_b.resolved),
+            "elizaos_wins": sum(1 for r in records if r.winner == "elizaos"),
+            "opencode_wins": sum(1 for r in records if r.winner == "opencode"),
+            "ties_resolved": sum(1 for r in records if r.winner == "tie_resolved"),
+            "ties_failed": sum(1 for r in records if r.winner == "tie_failed"),
+        },
+        "records": [asdict(r) for r in records],
+    }
+
+
+async def _run(args: argparse.Namespace) -> int:
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    sandbox_root = Path(args.sandbox)
+    sandbox_root.mkdir(parents=True, exist_ok=True)
+
+    if args.stub:
+        ids = list(args.instances) if args.instances else list(DEFAULT_INSTANCES[: args.n])
+        payload = _to_payload([_stub_record(i) for i in ids])
+        out_path = out_dir / "comparison_smoke.json"
+        out_path.write_text(json.dumps(payload, indent=2))
+        print(json.dumps(payload["totals"], indent=2))
+        print(f"\nStub report: {out_path}")
+        return 0
+
+    dataset = SWEBenchDataset(variant=SWEBenchVariant.LITE)
+    await dataset.load()
+    requested = list(args.instances) if args.instances else list(DEFAULT_INSTANCES[: args.n])
+    all_instances = list(dataset.get_instances(limit=None))
+    by_id = {i.instance_id: i for i in all_instances}
+    instances = [by_id[i] for i in requested if i in by_id][: args.n]
+    if not instances:
+        instances = all_instances[: args.n]
+    if not instances:
+        print("No instances available; aborting.", file=sys.stderr)
+        return 2
+
+    evaluator = SWEBenchEvaluator(
+        workspace_dir=str(sandbox_root / "_eval"),
+        timeout_seconds=args.timeout,
+        use_docker=not args.no_docker,
+    )
+
+    # Path A needs the eliza TS bridge; defer the import so --stub works
+    # without the adapter package present.
+    from eliza_adapter import ElizaServerManager  # type: ignore[import-not-found]
+
+    eliza_server = ElizaServerManager()
+    eliza_server.start()
+    client = eliza_server.client
+    try:
+        records: list[ComparisonRecord] = []
+        for idx, inst in enumerate(instances):
+            logger.info("[comparison] %d/%d %s", idx + 1, len(instances), inst.instance_id)
+            a = await _run_path_a(inst, evaluator, client)
+            b = await _run_path_b_instance(
+                inst, evaluator, sandbox_root, opencode_timeout_s=args.opencode_timeout
+            )
+            records.append(
+                ComparisonRecord(
+                    instance_id=inst.instance_id,
+                    repo=inst.repo,
+                    base_commit=inst.base_commit,
+                    path_a=a,
+                    path_b=b,
+                    winner=_decide_winner(a, b),
+                )
+            )
+    finally:
+        eliza_server.stop()
+
+    payload = _to_payload(records)
+    timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"comparison_{timestamp}.json"
+    out_path.write_text(json.dumps(payload, indent=2))
+    print(json.dumps(payload["totals"], indent=2))
+    print(f"\nReport: {out_path}")
+    return 0
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="benchmarks.swe_bench.harness.comparison",
+        description="Head-to-head: elizaOS internal agent vs opencode on SWE-bench Lite.",
+    )
+    p.add_argument("--n", type=int, default=2, help="Number of instances to run (default: 2)")
+    p.add_argument(
+        "--instances",
+        nargs="+",
+        default=None,
+        help="Explicit SWE-bench Lite instance IDs (overrides --n selection)",
+    )
+    p.add_argument(
+        "--output",
+        default="./benchmark_results/swe-bench-comparison",
+        help="Output directory for the comparison JSON",
+    )
+    p.add_argument(
+        "--sandbox",
+        default="./swe-bench-comparison-sandbox",
+        help="Scratch directory for per-instance opencode clones",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Evaluator (per-instance grading) timeout in seconds",
+    )
+    p.add_argument(
+        "--opencode-timeout",
+        type=int,
+        default=900,
+        help="Per-instance budget for the opencode subprocess in seconds",
+    )
+    p.add_argument(
+        "--no-docker",
+        action="store_true",
+        help="Skip Docker grading (use basic validator — useful for local smokes)",
+    )
+    p.add_argument(
+        "--stub",
+        action="store_true",
+        help="Emit a placeholder comparison_smoke.json without executing either path",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=os.environ.get("SWE_BENCH_LOG_LEVEL", "INFO"),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    return asyncio.run(_run(_parse_args(argv)))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/benchmarks/swe_bench/harness/comparison.py
+++ b/packages/benchmarks/swe_bench/harness/comparison.py
@@ -31,7 +31,6 @@ import json
 import logging
 import os
 import shutil
-import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -123,7 +122,12 @@ async def _git(*args: str, cwd: str | None = None, timeout: int = 120) -> tuple[
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise
     return proc.returncode or 0, stdout.decode("utf-8", "replace"), stderr.decode("utf-8", "replace")
 
 
@@ -186,6 +190,7 @@ async def _run_path_b_instance(
         await asyncio.wait_for(proc.communicate(), timeout=opencode_timeout_s)
     except asyncio.TimeoutError:
         proc.kill()
+        await proc.wait()
         return PathResult(
             path="opencode",
             status="error",

--- a/packages/benchmarks/swe_bench/harness/fixtures/comparison_smoke.json
+++ b/packages/benchmarks/swe_bench/harness/fixtures/comparison_smoke.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-18T00:00:00+00:00",
+  "totals": {
+    "instances": 2,
+    "elizaos_resolved": 0,
+    "opencode_resolved": 0,
+    "elizaos_wins": 0,
+    "opencode_wins": 0,
+    "ties_resolved": 0,
+    "ties_failed": 2
+  },
+  "records": [
+    {
+      "instance_id": "django__django-11099",
+      "repo": "",
+      "base_commit": "",
+      "path_a": {
+        "path": "elizaos",
+        "status": "not_run_yet",
+        "patch": "",
+        "resolved": false,
+        "time_s": 0.0,
+        "error": null,
+        "patch_status": null,
+        "tests_passed": [],
+        "tests_failed": []
+      },
+      "path_b": {
+        "path": "opencode",
+        "status": "not_run_yet",
+        "patch": "",
+        "resolved": false,
+        "time_s": 0.0,
+        "error": null,
+        "patch_status": null,
+        "tests_passed": [],
+        "tests_failed": []
+      },
+      "winner": "tie_failed"
+    },
+    {
+      "instance_id": "sympy__sympy-20590",
+      "repo": "",
+      "base_commit": "",
+      "path_a": {
+        "path": "elizaos",
+        "status": "not_run_yet",
+        "patch": "",
+        "resolved": false,
+        "time_s": 0.0,
+        "error": null,
+        "patch_status": null,
+        "tests_passed": [],
+        "tests_failed": []
+      },
+      "path_b": {
+        "path": "opencode",
+        "status": "not_run_yet",
+        "patch": "",
+        "resolved": false,
+        "time_s": 0.0,
+        "error": null,
+        "patch_status": null,
+        "tests_passed": [],
+        "tests_failed": []
+      },
+      "winner": "tie_failed"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `packages/benchmarks/swe_bench/harness/comparison.py` — a side-by-side comparison runner that grades the **same** SWE-bench Lite instance through two paths and produces a single JSON report with per-instance patches, resolve status, time, and a winner field.

- **Path A (elizaOS)**: reuses `swe_bench.cli._run_instance` — same TS bridge, same prompt, same diff extractor. Number changes there carry over automatically.
- **Path B (opencode)**: clones `<repo>.git`, `git checkout <base_commit>`, runs `opencode run "<task>"` in the workdir, captures `git diff`. Both paths feed the same `SWEBenchEvaluator.evaluate_patch` so grading is identical.

## Why

Closes the "is elizaOS on par at coding with opencode?" question with measurable apples-to-apples. The orchestrator's `buildOpencodeSpawnConfig` only adds routing wiring, so Path B bypasses the orchestrator to keep variance attributable to opencode itself (not routing).

## Schema (`comparison_<ts>.json`)

```jsonc
{
  "schema_version": 1,
  "totals": { "instances", "elizaos_resolved", "opencode_resolved",
              "elizaos_wins", "opencode_wins", "ties_resolved", "ties_failed" },
  "records": [{
    "instance_id", "repo", "base_commit",
    "path_a": { "path": "elizaos", "status", "patch", "resolved", "time_s",
                "patch_status", "tests_passed", "tests_failed", "error" },
    "path_b": { "path": "opencode", ... same shape ... },
    "winner": "elizaos | opencode | tie_resolved | tie_failed"
  }]
}
```

`status` ∈ `resolved | failed | no_patch | error | skipped_opencode_missing | not_run_yet`.

## Run

```bash
# schema check, zero deps
python -m benchmarks.swe_bench.harness.comparison --n 2 --stub

# real N=2 smoke (needs docker + eliza-adapter + opencode on PATH)
python -m benchmarks.swe_bench.harness.comparison --n 2
```

## What is stubbed

`harness/fixtures/comparison_smoke.json` contains 2 placeholder records (`status: "not_run_yet"`) so the schema is validatable without docker. Real run output replaces it.

## Verification

- `python -c "import ast; ast.parse(open('harness/comparison.py').read())"` — clean.
- `json.load(open('harness/fixtures/comparison_smoke.json'))` — schema matches.

## Caveats

- For a fair head-to-head, the caller pins both sides to the same model before the real run. The harness sets only `OPENCODE_DISABLE_AUTOUPDATE=1`; the rest is the caller's opencode config.
- Sequential by instance — add `--parallel` later if cost allows.
- If `opencode` isn't on PATH, Path B emits `skipped_opencode_missing` instead of crashing.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `harness/comparison.py`, a new benchmarking runner that evaluates the same SWE-bench Lite instances through two code-generation paths (elizaOS and opencode) and emits a unified JSON report. It also adds a README, a package `__init__.py`, and a stub fixture for schema validation.

- **Path B (opencode)** clones each repo at `base_commit` into a sandbox, invokes `opencode run \"<task>\"`, and captures the working-tree diff; both paths share the same `SWEBenchEvaluator` so grading is consistent.
- **`_run_path_a` has no exception guard** unlike `_run_path_b_instance` — any uncaught error from the eliza bridge propagates to the main loop and aborts the run, discarding all previously collected records since the output file is written only after the loop completes.
- **Intermediate persistence is absent** — for long multi-instance runs a mid-run failure (network error, eliza server crash, `KeyboardInterrupt`) means total data loss; writing a partial report in the `finally` block would mitigate this.

<h3>Confidence Score: 3/5</h3>

The harness is safe for short stub runs but will silently lose all collected data in any real multi-instance run that encounters an error mid-loop.

The main loop writes its output file only after completing without error. `_run_path_a` propagates exceptions instead of catching them (unlike the symmetrically structured `_run_path_b_instance`), so a single eliza-server failure mid-run aborts the loop and discards every record collected so far. These two issues compound each other for real N>2 runs.

packages/benchmarks/swe_bench/harness/comparison.py — specifically `_run_path_a` (no exception guard) and the post-loop output write in `_run()`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/benchmarks/swe_bench/harness/comparison.py | New comparison harness; `_run_path_a` lacks exception handling unlike its Path B counterpart, and the output file is only written after the full loop, meaning any mid-run failure causes complete data loss |
| packages/benchmarks/swe_bench/README.md | New README documenting the comparison harness; accurate and matches the implementation |
| packages/benchmarks/swe_bench/harness/__init__.py | Minimal package init for the harness subpackage; no issues |
| packages/benchmarks/swe_bench/harness/fixtures/comparison_smoke.json | Placeholder fixture with two stub records; schema matches the code's output format |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as comparison.py main()
    participant DS as SWEBenchDataset
    participant EA as ElizaServerManager
    participant PA as _run_path_a
    participant PB as _run_path_b_instance
    participant GH as GitHub (git clone)
    participant OC as opencode CLI
    participant EV as SWEBenchEvaluator

    CLI->>DS: load() SWE-bench Lite
    CLI->>EA: start() eliza bridge
    loop for each instance
        CLI->>PA: run instance (elizaOS path)
        PA->>EV: evaluate_patch(instance, diff)
        EV-->>PA: PathResult
        PA-->>CLI: PathResult (or exception - no guard)

        CLI->>PB: run instance (opencode path)
        PB->>GH: git clone + checkout base_commit
        GH-->>PB: workdir
        PB->>OC: opencode run task
        OC-->>PB: working-tree changes
        PB->>EV: git diff to evaluate_patch
        EV-->>PB: PathResult
        PB-->>CLI: PathResult (always, try/except)

        CLI->>CLI: _decide_winner(a, b)
    end
    CLI->>EA: stop()
    CLI->>CLI: write comparison_ts.json (only on success)
```

<sub>Reviews (2): Last reviewed commit: ["fix(swe-bench): reap git + opencode subp..."](https://github.com/elizaos/eliza/commit/f348026d0fb35c7d7da116c50728b2474e20d85f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32695163)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->