### PR TITLE
feat(elizaos): elizaos deploy keel command + design doc

### DIFF
--- a/packages/elizaos/src/cli.ts
+++ b/packages/elizaos/src/cli.ts
@@ -4,6 +4,7 @@ import * as clack from "@clack/prompts";
 import { Command } from "commander";
 import {
   create,
+  deploy,
   info,
   registerPluginsCommand,
   submitPluginToRegistry,
@@ -88,6 +89,17 @@ program
   .option("--dry-run", "Preview the upgrade without writing files")
   .option("--skip-upstream", "Skip updating the upstream eliza checkout")
   .action(upgrade);
+
+program
+  .command("deploy")
+  .description(
+    "Deploy the current elizaOS project to Eliza Cloud (experimental — keel only)",
+  )
+  .option("--app-id <id>", "Eliza Cloud app UUID to deploy")
+  .option("--domain <host>", "Custom domain to attach after deploy")
+  .option("--dry-run", "Print the planned deploy sequence without running it")
+  .option("--verbose", "Echo backend requests to stderr")
+  .action(deploy);
 
 registerPluginsCommand(program);
 

--- a/packages/elizaos/src/commands/DEPLOY_DESIGN.md
+++ b/packages/elizaos/src/commands/DEPLOY_DESIGN.md
@@ -1,0 +1,69 @@
+# `elizaos deploy` — Design Doc
+
+Status: **keel only** (this PR). Real deploy logic lands in a follow-up.
+
+## Goal
+
+Ship a single command that takes a generated elizaOS project (`template.json` present in cwd) and deploys it to Eliza Cloud, optionally bound to a custom domain. Surface enough flag plumbing now that the implementation PR has nothing to design — only fill in.
+
+## Command surface
+
+```
+elizaos deploy [--app-id <id>] [--domain <host>] [--dry-run] [--verbose]
+```
+
+- `--app-id <id>` — Eliza Cloud app UUID. If omitted, resolved from `.elizaos/template.json` (`values.appId`) or, failing that, by name match against `GET /api/v1/apps?owned=true`.
+- `--domain <host>` — Custom external domain to attach after the deploy goes `READY`. Must match the same regex enforced by `POST /api/v1/apps/[id]/domains`: `^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$`. Subdomain rule is enforced server-side.
+- `--dry-run` — Print the planned sequence and exit 0. No network calls. **Default for the keel PR.**
+- `--verbose` — Echo every backend request URL + status to stderr.
+
+## Auth flow
+
+Reuse whatever `create`/`upgrade` already established: `process.env.ELIZACLOUD_API_KEY` first, then `~/.elizaos/credentials.json` (same file the dashboard CLI writes). On first run with neither present, prompt with `@clack/prompts` for the API key and persist it. **The keel performs no auth read** — it only prints `auth check` as the first planned step.
+
+## Deploy sequence
+
+Each step is its own function in the implementation PR so the dry-run banner stays one source of truth.
+
+1. **auth check** — load credentials, ping `GET /api/v1/me`, abort on 401.
+2. **app lookup** — resolve `--app-id` (see above). If still missing, prompt to register a new app via `POST /api/v1/apps`.
+3. **build** — run `bun run build` in cwd (for `project` template). For `plugin` template, abort with a clear error: plugins ship to npm, not Vercel.
+4. **upload** — push the built artifact to the app's linked GitHub repo (`apps.github_repo` column). The Vercel project is wired to that repo, so push-to-deploy is the contract. If `github_repo` is null, call the existing app-builder route that provisions it.
+5. **register app deploy** — `POST /api/v1/apps/[id]/deploy` (route exists; see `cloud/apps/api/v1/apps/[id]/deploy/route.ts` if present, otherwise this is a follow-up endpoint). This sets `app_deployment_status` to `building`.
+6. **attach domain** (only when `--domain` set) — `POST /api/v1/apps/[id]/domains` with `{ domain }`. Server returns the verification TXT record + DNS instructions. CLI prints them and waits.
+7. **poll status** — `GET /api/v1/apps/[id]/deploy/status` every 5s with exponential backoff up to 10min. Terminal states: `deployed`, `failed`. On `deployed` print the final URL: `https://<subdomain>.apps.elizacloud.ai` plus the custom domain if attached + verified.
+8. **print URL** — final line, machine-readable: `URL: https://...`.
+
+## Vercel as the implementation target
+
+The CLI never talks to Vercel directly. It hits Eliza Cloud, which owns `VERCEL_TOKEN` and `VERCEL_TEAM_ID` (see `cloud/packages/lib/services/vercel-deployments.ts`). One Vercel project per app, subdomain on `apps.elizacloud.ai`, custom-domain attachment routed through Cloudflare. Keeping the CLI thin means no token leakage and no parallel auth surface.
+
+## Dry-run semantics
+
+`--dry-run` prints the eight steps above with the resolved inputs (app-id, domain, cwd) substituted in. No network, no fs writes, no shelling out. Exit code 0. Same output shape every time so it can be snapshot-tested.
+
+## Error modes the implementation must handle
+
+- **No `template.json` in cwd** — abort with `not an elizaOS project` (same wording as `upgrade`).
+- **`plugin` template** — refuse: "plugins deploy to npm, not Eliza Cloud. Run `bun publish`."
+- **Auth missing** — prompt; on cancel, exit 1 with a hint.
+- **App not found** — list owned apps and prompt to pick.
+- **Domain already attached to another app** — server returns 409; CLI prints the conflicting app and exits.
+- **Build failure** — surface the underlying `bun run build` exit code.
+- **Deploy timeout (>10min)** — exit 2 with the dashboard URL so the user can watch it finish.
+- **`failed` terminal state** — fetch `GET /api/v1/apps/[id]/deploy/logs` and tail the last 50 lines before exiting.
+
+## Deferred to follow-up PR
+
+- Steps 1, 3, 4, 5, 6, 7 — all the real network/fs work.
+- Credentials file shape + first-run prompt.
+- The `deploy` / `deploy/status` / `deploy/logs` endpoints if they don't exist yet.
+- Snapshot tests for the dry-run output.
+- `--watch` mode that re-deploys on file change.
+- Multi-environment (`--env preview|production`) support.
+
+## Open questions
+
+- Does `POST /api/v1/apps/[id]/deploy` exist today, or does the keel implicitly spec it? Recon turned up domain routes and the vercel-deployments service but no deploy-trigger route under `apps/[id]/`. Confirm before the implementation PR.
+- For projects with no `github_repo`, do we (a) create one on first deploy, or (b) require the user to run a separate `elizaos link` command first? (a) is more friendly, (b) is more predictable.
+- Should `--domain` accept a comma-separated list? `apps.app_domains` is 1:N — the schema supports it, but the UX gets noisy fast.

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -10,7 +10,7 @@
 import pc from "picocolors";
 import type { DeployOptions } from "../types.js";
 
-const DOMAIN_REGEX = /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i;
+const DOMAIN_REGEX = /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/;
 
 interface PlannedStep {
   label: string;
@@ -78,7 +78,7 @@ function printPlan(plan: PlannedStep[]): void {
   console.log();
   console.log(
     pc.dim(
-      "See packages/elizaos/src/commands/DEPLOY_DESIGN.md for the full design.",
+      "See https://github.com/elizaOS/eliza/blob/develop/packages/elizaos/src/commands/DEPLOY_DESIGN.md for the full design.",
     ),
   );
   console.log();
@@ -109,7 +109,7 @@ export function deploy(options: DeployOptions): void {
 
   console.error(
     pc.yellow(
-      "Real deploy not yet implemented — see DEPLOY_DESIGN.md. Pass --dry-run to preview.",
+      "Real deploy not yet implemented — see https://github.com/elizaOS/eliza/blob/develop/packages/elizaos/src/commands/DEPLOY_DESIGN.md. Pass --dry-run to preview.",
     ),
   );
   process.exit(1);

--- a/packages/elizaos/src/commands/deploy.ts
+++ b/packages/elizaos/src/commands/deploy.ts
@@ -1,0 +1,116 @@
+/**
+ * `elizaos deploy` — keel only.
+ *
+ * @experimental
+ * This command currently registers the flag surface and prints the planned
+ * deploy sequence in --dry-run mode. The real Vercel + custom-domain pipeline
+ * lands in a follow-up PR. See DEPLOY_DESIGN.md.
+ */
+
+import pc from "picocolors";
+import type { DeployOptions } from "../types.js";
+
+const DOMAIN_REGEX = /^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/i;
+
+interface PlannedStep {
+  label: string;
+  detail: string;
+  skipped?: boolean;
+}
+
+function buildPlan(options: DeployOptions, cwd: string): PlannedStep[] {
+  const appId = options.appId ?? "<resolved from .elizaos/template.json>";
+  const domain = options.domain;
+  return [
+    {
+      label: "auth check",
+      detail: "Load credentials, GET /api/v1/me, abort on 401.",
+    },
+    {
+      label: "app lookup",
+      detail: `Resolve app-id (${appId}).`,
+    },
+    {
+      label: "build",
+      detail: `Run 'bun run build' in ${cwd}.`,
+    },
+    {
+      label: "upload",
+      detail: "Push built artifact to the app's linked GitHub repo.",
+    },
+    {
+      label: "register app deploy",
+      detail: `POST /api/v1/apps/${appId}/deploy → status=building.`,
+    },
+    {
+      label: "attach domain",
+      detail: domain
+        ? `POST /api/v1/apps/${appId}/domains { domain: "${domain}" } and surface DNS TXT record.`
+        : "(no --domain provided — using default apps.elizacloud.ai subdomain).",
+      skipped: !domain,
+    },
+    {
+      label: "poll status",
+      detail: `GET /api/v1/apps/${appId}/deploy/status every 5s until deployed|failed (10min cap).`,
+    },
+    {
+      label: "print URL",
+      detail: domain
+        ? `URL: https://${domain}  (+ apps.elizacloud.ai subdomain).`
+        : "URL: https://<subdomain>.apps.elizacloud.ai",
+    },
+  ];
+}
+
+function printPlan(plan: PlannedStep[]): void {
+  console.log();
+  console.log(pc.bold(pc.cyan("elizaos deploy — dry run")));
+  console.log(pc.dim("Planned sequence (no network calls performed):"));
+  console.log();
+  plan.forEach((step, index) => {
+    const num = pc.dim(`${(index + 1).toString().padStart(2, " ")}.`);
+    const label = step.skipped
+      ? pc.dim(pc.strikethrough(step.label))
+      : pc.bold(step.label);
+    console.log(`  ${num} ${label}`);
+    console.log(`      ${pc.dim(step.detail)}`);
+  });
+  console.log();
+  console.log(
+    pc.dim(
+      "See packages/elizaos/src/commands/DEPLOY_DESIGN.md for the full design.",
+    ),
+  );
+  console.log();
+}
+
+export function deploy(options: DeployOptions): void {
+  if (options.domain && !DOMAIN_REGEX.test(options.domain)) {
+    console.error(
+      pc.red(
+        `Invalid --domain "${options.domain}". Expected a valid hostname (e.g. app.example.com).`,
+      ),
+    );
+    process.exit(1);
+  }
+
+  const cwd = process.cwd();
+  const plan = buildPlan(options, cwd);
+
+  if (options.verbose) {
+    console.error(pc.dim(`[deploy] cwd=${cwd}`));
+    console.error(pc.dim(`[deploy] options=${JSON.stringify(options)}`));
+  }
+
+  if (options.dryRun) {
+    printPlan(plan);
+    process.exit(0);
+  }
+
+  console.error(
+    pc.yellow(
+      "Real deploy not yet implemented — see DEPLOY_DESIGN.md. Pass --dry-run to preview.",
+    ),
+  );
+  process.exit(1);
+}

--- a/packages/elizaos/src/commands/index.ts
+++ b/packages/elizaos/src/commands/index.ts
@@ -1,4 +1,5 @@
 export { create } from "./create.js";
+export { deploy } from "./deploy.js";
 export { info } from "./info.js";
 export { registerPluginsCommand, submitPluginToRegistry } from "./plugins.js";
 export { upgrade } from "./upgrade.js";

--- a/packages/elizaos/src/types.ts
+++ b/packages/elizaos/src/types.ts
@@ -49,6 +49,13 @@ export interface UpgradeOptions {
   skipUpstream?: boolean;
 }
 
+export interface DeployOptions {
+  appId?: string;
+  domain?: string;
+  dryRun?: boolean;
+  verbose?: boolean;
+}
+
 export interface PluginTemplateValues extends Record<string, string> {
   displayName: string;
   elizaVersion: string;


### PR DESCRIPTION
## What

Lays the keel for `elizaos deploy` so creators wiring monetized apps to `.com` domains have a stable CLI surface + agreed design while the real implementation lands.

```bash
elizaos deploy --dry-run --domain test.example
```

Output:

```
elizaos deploy — dry run
Planned sequence (no network calls performed):

   1. auth check
       Load credentials, GET /api/v1/me, abort on 401.
   2. app lookup
       Resolve app-id (<resolved from .elizaos/template.json>).
   3. build
       Run 'bun run build' in <cwd>.
   4. upload
       Push built artifact to the app's linked GitHub repo.
   5. register app deploy
       POST /api/v1/apps/<id>/deploy → status=building.
   6. attach domain
       POST /api/v1/apps/<id>/domains { domain: "test.example" } and surface DNS TXT record.
   7. poll status
       GET /api/v1/apps/<id>/deploy/status every 5s until deployed|failed (10min cap).
   8. print URL
       URL: https://test.example  (+ apps.elizacloud.ai subdomain).
```

## Files

- `packages/elizaos/src/commands/deploy.ts` (new) — keel handler. Validates `--domain` against a hostname regex; in `--dry-run` prints the planned 8-step sequence + exit 0; bare invocation prints a stub message + exit 1 pointing to the design doc.
- `packages/elizaos/src/commands/DEPLOY_DESIGN.md` (new) — full design: command surface, auth, 8-step sequence, Vercel routing, error modes, deferrals, open questions.
- `packages/elizaos/src/cli.ts` — wires the deploy command into commander with `--app-id`, `--domain`, `--dry-run`, `--verbose`.
- `packages/elizaos/src/commands/index.ts` — re-exports `deploy`.
- `packages/elizaos/src/types.ts` — adds `DeployOptions`.

## What is intentionally NOT in this PR

- The real Vercel build/upload/poll loop. The backing service `cloud/packages/lib/services/vercel-deployments.ts` and the custom-domain attach API (`POST /api/v1/apps/[id]/domains`) already exist; what's still missing is `POST /api/v1/apps/[id]/deploy` + `…/deploy/status`. These land in the follow-up. See `DEPLOY_DESIGN.md` §Open questions.
- Credentials file shape. Assumed `~/.elizaos/credentials.json` for the design doc; not actually read or written by this keel. Pick canonical path before first-run prompt logic.
- 1:N domain support (one `--domain` per invocation today; `app_domains` is 1:N upstream).

## Verification

- `bunx tsc -p tsconfig.json --noEmit` clean on `packages/elizaos` (verified on the source branch before retargeting onto `develop`).
- Built `dist/cli.js` via tsc, then ran the 4 keel scenarios:
  - `node dist/cli.js deploy --dry-run --domain test.example` → 8-step plan, exit 0
  - `node dist/cli.js deploy` → stub message, exit 1
  - `node dist/cli.js deploy --dry-run --domain "not a domain"` → validation error, exit 1
  - `node dist/cli.js --help` → `deploy` appears alongside `create`/`upgrade`/`info`

## Why a keel and not the real thing

`elizaos deploy` is the difference between "creators can ship their monetized app to a `.com`" and "they can't". Locking the command surface + design first means the follow-up PR is mechanical and reviewable — and unblocks downstream design work (onboarding flow, dashboards) that needs to point at the right command today.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `elizaos deploy` command as a "keel" — registering the full flag surface (`--app-id`, `--domain`, `--dry-run`, `--verbose`) and printing a planned 8-step deploy sequence in `--dry-run` mode, while stubbing the real implementation with `exit 1` pending a follow-up PR.

- **`deploy.ts`**: validates `--domain` with a regex matching the server-side contract, renders the dry-run plan to stdout, and exits cleanly; non-dry-run path prints a link to the design doc and exits 1.
- **`DEPLOY_DESIGN.md`**: documents the full command surface, auth flow, Vercel integration strategy, error modes, and open questions for the follow-up implementation PR.
- **`cli.ts` / `index.ts` / `types.ts`**: standard wiring — Commander subcommand registration, re-export, and `DeployOptions` interface additions.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge; it adds no real network calls, no auth logic, and no filesystem writes — only flag registration and dry-run output printing.

The change is strictly additive: a new subcommand that either prints a plan and exits 0 (dry-run) or prints a stub message and exits 1 (bare invocation). No existing command paths are touched, no credentials are read or written, and the domain regex matches the documented server-side contract. The only nits are cosmetic (floating branch links).

No files require special attention — deploy.ts is the only substantive addition and its logic is trivially simple.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/elizaos/src/commands/deploy.ts | New keel handler for the deploy command; validates domain regex, prints 8-step dry-run plan, and stubs non-dry-run with exit 1. Floating develop-branch links are the main cosmetic concern. |
| packages/elizaos/src/cli.ts | Wires deploy subcommand into Commander with four options; straightforward registration consistent with existing commands. |
| packages/elizaos/src/types.ts | Adds DeployOptions interface; fields align exactly with the CLI option definitions. |
| packages/elizaos/src/commands/index.ts | Re-exports deploy alongside existing commands; no issues. |
| packages/elizaos/src/commands/DEPLOY_DESIGN.md | Design doc covering the 8-step deploy sequence, auth, Vercel integration, error modes, and open questions; internal documentation only. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([elizaos deploy]) --> B{--domain set?}
    B -->|Yes| C{Domain valid?}
    C -->|No| D[console.error invalid domain\nexit 1]
    C -->|Yes| E{--dry-run?}
    B -->|No| E
    E -->|Yes| F[buildPlan\nappId + domain + cwd]
    F --> G[printPlan\n8 steps to stdout]
    G --> H[exit 0]
    E -->|No| I[console.error stub msg\nexit 1]

    subgraph Planned Steps dry-run only
        S1[1. auth check]
        S2[2. app lookup]
        S3[3. build]
        S4[4. upload]
        S5[5. register deploy]
        S6[6. attach domain]
        S7[7. poll status]
        S8[8. print URL]
        S1 --> S2 --> S3 --> S4 --> S5 --> S6 --> S7 --> S8
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(elizaos): point deploy doc pointer a..."](https://github.com/elizaos/eliza/commit/0ba44fc7a3e2b6b6a69b6b40aeec6d70462133b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32695822)</sub>

<!-- /greptile_comment -->