### PR TITLE
ci(linux): enable snap arm64 experimental matrix + flatpak offline-mode prep

### DIFF
--- a/.github/workflows/snap-build-test.yml
+++ b/.github/workflows/snap-build-test.yml
@@ -25,9 +25,15 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
-          # arm64 builds can be enabled when arm runners are available
-          # - arch: arm64
-          #   runner: ubuntu-24.04-arm
+            experimental: false
+          # Linux arm64 hosted runners are in public preview for public
+          # repositories (free, but queue-prone). Mark this matrix entry
+          # experimental so a flaky ARM run doesn't block amd64 PRs.
+          # Promote `experimental: false` once ARM is GA and stable.
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            experimental: true
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Free disk space on runner

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -34,6 +34,30 @@ jobs:
       - name: Validate desktop entry
         run: desktop-file-validate packages/app-core/packaging/flatpak/ai.elizaos.App.desktop
 
+      # Offline-mode prep: generate node-sources.json on every PR so we
+      # catch regressions in the generator pipeline before they show up
+      # in a Flathub submission. Non-fatal for now — the manifest still
+      # uses `npm install -g` over the build-time network share.
+      - name: Install flatpak-node-generator
+        run: pipx install flatpak-node-generator || pip install --user flatpak-node-generator
+
+      - name: Generate offline node sources
+        id: gen-sources
+        continue-on-error: true
+        working-directory: packages/app-core/packaging/flatpak
+        run: |
+          chmod +x generate-sources.sh
+          ./generate-sources.sh
+          test -s node-sources.json
+
+      - name: Upload node-sources.json
+        if: steps.gen-sources.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: flatpak-node-sources
+          path: packages/app-core/packaging/flatpak/node-sources.json
+          retention-days: 30
+
       - name: Build Flatpak
         working-directory: packages/app-core/packaging/flatpak
         run: |

--- a/.github/workflows/test-flatpak.yml
+++ b/.github/workflows/test-flatpak.yml
@@ -39,9 +39,12 @@ jobs:
       # in a Flathub submission. Non-fatal for now — the manifest still
       # uses `npm install -g` over the build-time network share.
       - name: Install flatpak-node-generator
+        id: install-fng
+        continue-on-error: true
         run: pipx install flatpak-node-generator || pip install --user flatpak-node-generator
 
       - name: Generate offline node sources
+        if: steps.install-fng.outcome == 'success'
         id: gen-sources
         continue-on-error: true
         working-directory: packages/app-core/packaging/flatpak

--- a/packages/app-core/packaging/flatpak/ai.elizaos.App.yml
+++ b/packages/app-core/packaging/flatpak/ai.elizaos.App.yml
@@ -93,14 +93,28 @@ modules:
 
   # ── elizaOS App CLI ──────────────────────────────────────────────────
   # NOTE: For Flathub submission, replace the npm-install build with an
-  # offline approach using flatpak-node-generator or a vendored tarball.
-  # The current approach (npm install -g) requires network at build time
-  # and works for self-hosted builds and CI bundles, but Flathub's build
-  # infrastructure does not allow network access during the build phase.
+  # offline approach using flatpak-node-generator. The current approach
+  # (npm install -g) requires network at build time and works for
+  # self-hosted builds and CI bundles, but Flathub's build infrastructure
+  # does not allow network access during the build phase.
   #
-  # To generate offline sources for Flathub:
-  #   flatpak-node-generator npm package-lock.json -o npm-sources.json
-  # Then add: sources: [type: file, path: npm-sources.json]
+  # Offline-mode prep (Flathub submission path):
+  #   1. Run `./generate-sources.sh` from this directory on Linux. It
+  #      resolves the latest published `elizaos` CLI dependency graph and
+  #      writes `node-sources.json` next to this manifest.
+  #   2. Add the generated file to the `sources:` block below:
+  #          - type: file
+  #            path: node-sources.json
+  #   3. Replace the `npm install -g elizaos` build command with
+  #      `npm install -g --offline --prefix=/app elizaos` and drop the
+  #      `--share=network` build-arg above. The CI workflow
+  #      `.github/workflows/test-flatpak.yml` regenerates
+  #      node-sources.json on every run so the offline manifest stays in
+  #      sync with the published CLI.
+  #
+  # Until node-sources.json is committed AND the build command flipped
+  # to --offline, this manifest remains self-hosted/CI-only and is not
+  # Flathub-submittable.
   - name: elizaos-app
     buildsystem: simple
     build-options:

--- a/packages/app-core/packaging/flatpak/generate-sources.sh
+++ b/packages/app-core/packaging/flatpak/generate-sources.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Generate offline node sources for the elizaOS App Flatpak.
+#
+# Flathub's build infrastructure forbids network access during the build
+# phase. This script invokes `flatpak-node-generator` to produce a
+# `node-sources.json` manifest that lists every npm tarball + hash the
+# `elizaos` CLI install needs, so the Flathub build can populate
+# /app via vendored sources instead of `npm install -g elizaos`.
+#
+# Prerequisites (Linux only — flatpak-builder is Linux-only):
+#   - python3
+#   - pipx (recommended) OR pip
+#   - network access (this script is the one place we DO need it)
+#
+# Usage:
+#   ./generate-sources.sh            # writes node-sources.json next to the manifest
+#   ./generate-sources.sh /tmp/out   # writes /tmp/out/node-sources.json
+#
+# After running, commit node-sources.json alongside the manifest so the
+# Flathub build can reproduce the install offline.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${1:-$SCRIPT_DIR}"
+OUT_FILE="$OUT_DIR/node-sources.json"
+
+if ! command -v flatpak-node-generator >/dev/null 2>&1; then
+  echo "flatpak-node-generator not found on PATH." >&2
+  echo "Install it with one of:" >&2
+  echo "  pipx install flatpak-node-generator" >&2
+  echo "  pip install --user flatpak-node-generator" >&2
+  echo "Source: https://github.com/flatpak/flatpak-builder-tools/tree/master/node" >&2
+  exit 1
+fi
+
+# flatpak-node-generator needs a package-lock.json or yarn.lock to derive
+# the exact dependency closure. We don't ship a lockfile inside the flatpak
+# packaging dir, so synthesize one from a fresh install of the latest
+# published `elizaos` CLI in a temp dir.
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "[generate-sources] Resolving elizaos dependency closure in $WORK_DIR" >&2
+(
+  cd "$WORK_DIR"
+  # `npm install --package-lock-only` writes the lockfile without
+  # actually fetching/extracting tarballs into node_modules. We just
+  # need the resolved graph for flatpak-node-generator.
+  npm install --package-lock-only --ignore-scripts elizaos@latest
+)
+
+echo "[generate-sources] Generating $OUT_FILE" >&2
+flatpak-node-generator npm \
+  --recursive \
+  -o "$OUT_FILE" \
+  "$WORK_DIR/package-lock.json"
+
+echo "[generate-sources] Wrote $OUT_FILE" >&2
+echo "[generate-sources] Add the following to ai.elizaos.App.yml under the elizaos-app module sources:" >&2
+echo "      - type: file" >&2
+echo "        path: node-sources.json" >&2


### PR DESCRIPTION
## What

Two small linux-packaging polish items: enable arm64 in the snap CI matrix as an experimental leg, and prep the Flatpak manifest + CI for Flathub's offline-only build environment.

### Item A — Snap arm64 (experimental matrix entry)

`.github/workflows/snap-build-test.yml`:
- Adds an `arm64` matrix entry on `ubuntu-24.04-arm` with `experimental: true`.
- Adds `continue-on-error: ${{ matrix.experimental }}` at the job level so an arm64 flake never blocks an amd64 PR.
- Sets `experimental: false` on amd64 so it remains the gating leg.

`packages/app-core/packaging/snap/snapcraft.yaml` is **not** touched — it already lists `arm64` in `architectures:` (the previous "commented out" note in the manifest was already cleaned up by an earlier commit). This PR just lights up the CI leg.

Reason `continue-on-error` is on: GitHub's `ubuntu-24.04-arm` runners are in public preview for public repos — free but queue-prone. Promote `experimental: false` once ARM goes GA.

### Item B — Flatpak offline-mode prep (Flathub readiness)

The current `ai.elizaos.App.yml` build invokes `npm install -g elizaos` and relies on `--share=network` build-args. Flathub's submission infrastructure forbids network during build. This PR ships the **prep** path — script + CI generator + manifest playbook — without flipping the manifest to offline (that flip wants `node-sources.json` committed first, which we want to land in a follow-up after one green generator run).

- `packages/app-core/packaging/flatpak/generate-sources.sh` (new, executable) — wraps `flatpak-node-generator npm --recursive`. Spins up a tempdir, runs `npm install --package-lock-only --ignore-scripts elizaos@latest` to resolve the published-CLI dependency graph, then writes `node-sources.json` next to the manifest. Self-contained, with prereq checks + helpful error output.
- `.github/workflows/test-flatpak.yml` — runs the generator on every PR (3 new steps: pipx install, generate, upload-artifact). `continue-on-error: true` on the generate step so a flatpak-node-generator regression doesn't break the currently-green build.
- `ai.elizaos.App.yml` — replaces the short offline-mode note (lines 95–103 upstream) with a concrete 3-step Flathub-prep playbook referencing the new script and CI step. **No build-command changes**, so the green build stays green.

## Risk

- Snap arm64 leg depends on GH provisioning `ubuntu-24.04-arm`. Mitigated by `continue-on-error`. Worst case: arm64 leg shows yellow check on PRs.
- `flatpak-node-generator` requires pipx + network. `pip install --user` fallback present. Step is `continue-on-error: true`. Worst case: artifact missing one run.
- Generator pins to `elizaos@latest`, not the in-tree workspace. Acceptable for Flathub (which ships published CLI). Document this when flipping to offline.

## Verification

- All 4 touched YAML files parse with `yaml.safe_load` (Python).
- `generate-sources.sh` is shellcheck-clean.
- No edits to `agent-release.yml` / scoring / trust gate — no trust impact.

## Followup PR

Once we have one green generator run + a reviewed `node-sources.json`:

1. Commit `node-sources.json` next to the manifest.
2. Add `- type: file / path: node-sources.json` to the `elizaos-app` module `sources:` block.
3. Replace `npm install -g elizaos` with `npm install -g --offline --prefix=/app elizaos`.
4. Drop `--share=network` from the module's `build-options.build-args`.
5. Then we're Flathub-submittable.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an experimental arm64 CI leg to the snap build matrix and lays the groundwork for Flathub-compatible offline Flatpak builds, without changing any application logic or the currently-passing manifest build command.

- **Snap arm64**: Adds `ubuntu-24.04-arm` to the snap matrix with `experimental: true` and `continue-on-error: ${{ matrix.experimental }}`; `fail-fast: false` was already set, so a flaky ARM runner cannot block the gating amd64 job.
- **Flatpak offline prep**: Introduces `generate-sources.sh` (a self-contained `flatpak-node-generator` wrapper) and three new non-fatal CI steps (install → generate → upload-artifact); both the install and generate steps carry `continue-on-error: true` with correct `outcome == 'success'` guards on downstream steps.
- **Manifest comments**: Updates the `ai.elizaos.App.yml` comment block with a concrete 3-step Flathub submission playbook; no executable manifest lines are touched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are CI-only; no application code or manifest build commands are modified, and every new step is guarded against failure.

All four changed files are CI workflows or packaging scripts. The snap matrix change is isolated by `continue-on-error` and `fail-fast: false`. The flatpak generator steps are non-fatal by design and properly wired with `outcome`-based conditionals. The manifest change is comment-only. The only nit is a missing `mkdir -p` in the shell script for non-default output directories, which would not affect CI (the default path always exists).

No files require special attention; the `generate-sources.sh` script has a minor edge case with custom output directories but it does not affect CI operation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/snap-build-test.yml | Adds arm64 experimental matrix entry with `continue-on-error: ${{ matrix.experimental }}`; `fail-fast: false` is already set; placement and boolean propagation are correct. |
| .github/workflows/test-flatpak.yml | Adds three non-fatal steps (install, generate, upload) with proper `continue-on-error: true` on both the install and generate steps, and correct `outcome == 'success'` guards on dependent steps. |
| packages/app-core/packaging/flatpak/generate-sources.sh | New shell script for generating Flatpak offline sources; shellcheck-clean overall, but does not `mkdir -p` the custom `OUT_DIR` before writing to it, which would fail if a non-existent directory is passed as the first argument. |
| packages/app-core/packaging/flatpak/ai.elizaos.App.yml | Comment-only update expanding the offline-mode prep playbook; no build-command or manifest logic changes, so the currently-green build is unaffected. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install flatpak-node-generator\ncontinue-on-error: true] -->|outcome == success| B[Generate offline node sources\ncontinue-on-error: true]
    A -->|outcome == failure| D[Skip generate + upload]
    B -->|outcome == success| C[Upload node-sources.json artifact]
    B -->|outcome == failure| E[Skip upload]
    C --> F[Build Flatpak\nnpm install -g over network\ncurrently green]
    D --> F
    E --> F
```

<sub>Reviews (2): Last reviewed commit: ["ci(linux): tolerate flatpak-node-generat..."](https://github.com/elizaos/eliza/commit/fa9d3395869e099faa64e1103b1f50b90b190fee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32696211)</sub>

<!-- /greptile_comment -->