### PR TITLE
fix(plugin-lifeops): graceful Windows fallbacks for darwin-only features

### DIFF
--- a/plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts
+++ b/plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts
@@ -1,0 +1,148 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Stub @elizaos/core so loading apple-reminders/website-blocker does not pull
+// in the full runtime logger transitive (adze, etc.) — these tests only
+// exercise the early `if (!isDarwin())` and missing-hosts-file branches.
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const ORIGINAL_PLATFORM = process.platform;
+
+function stubPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: ORIGINAL_PLATFORM,
+  });
+}
+
+describe("platform/host helper", () => {
+  afterEach(() => {
+    restorePlatform();
+  });
+
+  it("isDarwin returns true on darwin", async () => {
+    stubPlatform("darwin");
+    const { isDarwin } = await import("../platform/host.js");
+    expect(isDarwin()).toBe(true);
+  });
+
+  it("isDarwin returns false on win32", async () => {
+    stubPlatform("win32");
+    const { isDarwin } = await import("../platform/host.js");
+    expect(isDarwin()).toBe(false);
+  });
+
+  it("isDarwin returns false on linux", async () => {
+    stubPlatform("linux");
+    const { isDarwin } = await import("../platform/host.js");
+    expect(isDarwin()).toBe(false);
+  });
+
+  it("darwinUnavailableActionResult returns the PLATFORM_UNSUPPORTED shape", async () => {
+    stubPlatform("win32");
+    const { darwinUnavailableActionResult } = await import(
+      "../platform/host.js"
+    );
+    const result = darwinUnavailableActionResult({
+      actionName: "CONNECTOR",
+      connector: "imessage",
+      subaction: "status",
+      feature: "iMessage",
+    });
+    expect(result.success).toBe(false);
+    expect(typeof result.text).toBe("string");
+    const data = (result.data ?? {}) as Record<string, unknown>;
+    expect(data.error).toBe("PLATFORM_UNSUPPORTED");
+    expect(data.actionName).toBe("CONNECTOR");
+    expect(data.connector).toBe("imessage");
+    expect(data.subaction).toBe("status");
+    expect(data.platform).toBe("win32");
+  });
+});
+
+describe("platform guards — apple reminders bridge", () => {
+  afterEach(() => {
+    restorePlatform();
+  });
+
+  it("createNativeAppleReminderLikeItem returns not_supported on win32", async () => {
+    stubPlatform("win32");
+    const { createNativeAppleReminderLikeItem } = await import(
+      "../lifeops/apple-reminders.js"
+    );
+    const result = await createNativeAppleReminderLikeItem({
+      kind: "reminder",
+      title: "ignored",
+      dueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("not_supported");
+    }
+  });
+
+  it("updateNativeAppleReminderLikeItem returns not_supported on win32", async () => {
+    stubPlatform("win32");
+    const { updateNativeAppleReminderLikeItem } = await import(
+      "../lifeops/apple-reminders.js"
+    );
+    const result = await updateNativeAppleReminderLikeItem({
+      reminderId: "abc",
+      kind: "reminder",
+      title: "ignored",
+      dueAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("not_supported");
+    }
+  });
+
+  it("deleteNativeAppleReminderLikeItem returns not_supported on win32", async () => {
+    stubPlatform("win32");
+    const { deleteNativeAppleReminderLikeItem } = await import(
+      "../lifeops/apple-reminders.js"
+    );
+    const result = await deleteNativeAppleReminderLikeItem("abc");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("not_supported");
+    }
+  });
+});
+
+describe("platform guards — website blocker engine", () => {
+  afterEach(() => {
+    restorePlatform();
+  });
+
+  it("reports unavailable when the hosts file path is missing on win32", async () => {
+    stubPlatform("win32");
+    const { getSelfControlStatus } = await import(
+      "../website-blocker/engine.js"
+    );
+    const missing = path.join(
+      os.tmpdir(),
+      `lifeops-missing-hosts-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    const status = await getSelfControlStatus({ hostsFilePath: missing });
+    expect(status.available).toBe(false);
+    expect(status.platform).toBe("win32");
+    expect(typeof status.reason).toBe("string");
+  });
+});

--- a/plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts
+++ b/plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts
@@ -1,6 +1,6 @@
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Stub @elizaos/core so loading apple-reminders/website-blocker does not pull
 // in the full runtime logger transitive (adze, etc.) — these tests only
@@ -29,6 +29,14 @@ function restorePlatform(): void {
     value: ORIGINAL_PLATFORM,
   });
 }
+
+// Reset the module registry before every test so that any guard which captures
+// `process.platform` at module-init time (instead of at call time) still sees
+// the per-test platform stub. Today `isDarwin()` reads the value lazily, but
+// this future-proofs the suite against that refactor.
+beforeEach(() => {
+  vi.resetModules();
+});
 
 describe("platform/host helper", () => {
   afterEach(() => {

--- a/plugins/plugin-lifeops/src/actions/connector.ts
+++ b/plugins/plugin-lifeops/src/actions/connector.ts
@@ -13,6 +13,7 @@ import type { LifeOpsGoogleCapability } from "../contracts/index.js";
 import { INTERNAL_URL } from "../lifeops/access.js";
 import { getConnectorRegistry } from "../lifeops/connectors/index.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
+import { darwinUnavailableActionResult, isDarwin } from "../platform/host.js";
 
 const ACTION_NAME = "CONNECTOR";
 
@@ -135,8 +136,13 @@ function listKnownConnectorKinds(runtime: IAgentRuntime): string[] {
     : [];
   // Verbose dispatcher kinds are always valid (they cover diagnostic verbs
   // like `health` and `browser_bridge` that aren't connector contributions —
-  // those still flow through this action).
-  return [...new Set([...VERBOSE_DISPATCHER_KINDS, ...fromRegistry])];
+  // those still flow through this action). iMessage is wired through the
+  // native macOS bridge; surfacing it on non-darwin would just produce
+  // confusing planner suggestions.
+  const verboseKinds = isDarwin()
+    ? VERBOSE_DISPATCHER_KINDS
+    : VERBOSE_DISPATCHER_KINDS.filter((kind) => kind !== "imessage");
+  return [...new Set([...verboseKinds, ...fromRegistry])];
 }
 
 function isValidConnectorKind(runtime: IAgentRuntime, kind: string): boolean {
@@ -1066,6 +1072,14 @@ async function dispatchIMessage(
   subaction: ConnectorSubaction,
   params: ConnectorActionParams,
 ): Promise<ActionResult> {
+  if (!isDarwin()) {
+    return darwinUnavailableActionResult({
+      actionName: ACTION_NAME,
+      connector: "imessage",
+      subaction,
+      feature: "iMessage",
+    });
+  }
   switch (subaction) {
     case "status":
     case "list": {

--- a/plugins/plugin-lifeops/src/actions/screen-time.ts
+++ b/plugins/plugin-lifeops/src/actions/screen-time.ts
@@ -35,6 +35,7 @@ import {
   messageText,
   renderLifeOpsActionReply,
 } from "../lifeops/voice/grounded-reply.js";
+import { isDarwin } from "../platform/host.js";
 import {
   resolveActionArgs,
   type SubactionsMap,
@@ -44,10 +45,6 @@ const ACTION_NAME = "SCREEN_TIME";
 
 const DEFAULT_WINDOW_HOURS = 24;
 const MAX_WINDOW_HOURS = 24 * 30;
-
-function isSupportedPlatform(): boolean {
-  return process.platform === "darwin";
-}
 
 type Subaction =
   | "summary"
@@ -534,7 +531,7 @@ export async function runScreenTimeHandler(
 
     case "activity_report": {
       const windowMs = resolveWindowMs(params.windowHours);
-      if (!isSupportedPlatform()) {
+      if (!isDarwin()) {
         return respond({
           success: true,
           scenario: "activity_report_unsupported_platform",
@@ -584,7 +581,7 @@ export async function runScreenTimeHandler(
         });
       }
       const windowMs = resolveWindowMs(params.windowHours);
-      if (!isSupportedPlatform()) {
+      if (!isDarwin()) {
         return respond({
           success: true,
           scenario: "time_on_app_unsupported_platform",

--- a/plugins/plugin-lifeops/src/lifeops/apple-reminders.ts
+++ b/plugins/plugin-lifeops/src/lifeops/apple-reminders.ts
@@ -6,6 +6,7 @@ import {
 import type { IAgentRuntime } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import type { FeatureResult, IPermissionsRegistry } from "@elizaos/shared";
+import { isDarwin } from "../platform/host.js";
 
 export const NATIVE_APPLE_REMINDER_METADATA_KEY = "nativeAppleReminder";
 const PERMISSIONS_REGISTRY_SERVICE = "eliza_permissions_registry";
@@ -321,7 +322,7 @@ export async function createNativeAppleReminderLikeItem(args: {
   originalIntent?: string | null;
   runtime?: IAgentRuntime | null;
 }): Promise<FeatureResult<NativeAppleReminderSuccess>> {
-  if (process.platform !== "darwin") {
+  if (!isDarwin()) {
     return {
       ok: false,
       reason: "not_supported",
@@ -392,7 +393,7 @@ export async function updateNativeAppleReminderLikeItem(args: {
   originalIntent?: string | null;
   runtime?: IAgentRuntime | null;
 }): Promise<FeatureResult<NativeAppleReminderSuccess>> {
-  if (process.platform !== "darwin") {
+  if (!isDarwin()) {
     return {
       ok: false,
       reason: "not_supported",
@@ -468,7 +469,7 @@ export async function deleteNativeAppleReminderLikeItem(
   reminderId: string,
   options?: { runtime?: IAgentRuntime | null },
 ): Promise<FeatureResult<NativeAppleReminderDeleteSuccess>> {
-  if (process.platform !== "darwin") {
+  if (!isDarwin()) {
     return {
       ok: false,
       reason: "not_supported",

--- a/plugins/plugin-lifeops/src/platform/host.ts
+++ b/plugins/plugin-lifeops/src/platform/host.ts
@@ -12,10 +12,6 @@ export function isDarwin(): boolean {
   return process.platform === "darwin";
 }
 
-export function isAppleSpecificPlatform(): boolean {
-  return isDarwin();
-}
-
 export function darwinUnavailableActionResult(args: {
   actionName: string;
   connector?: string;

--- a/plugins/plugin-lifeops/src/platform/host.ts
+++ b/plugins/plugin-lifeops/src/platform/host.ts
@@ -1,0 +1,37 @@
+/**
+ * Platform host detection for LifeOps features that depend on macOS-only
+ * native bridges (osascript, native-activity-tracker, iMessage chat.db).
+ *
+ * Centralized so plugin registration, action handlers, and connector
+ * dispatchers all read the same predicate.
+ */
+
+import type { ActionResult } from "@elizaos/core";
+
+export function isDarwin(): boolean {
+  return process.platform === "darwin";
+}
+
+export function isAppleSpecificPlatform(): boolean {
+  return isDarwin();
+}
+
+export function darwinUnavailableActionResult(args: {
+  actionName: string;
+  connector?: string;
+  subaction?: string;
+  feature: string;
+}): ActionResult {
+  const detail = `${args.feature} is macOS-only and unavailable on ${process.platform}.`;
+  return {
+    success: false,
+    text: `[${args.actionName}] ${detail}`,
+    data: {
+      actionName: args.actionName,
+      ...(args.connector ? { connector: args.connector } : {}),
+      ...(args.subaction ? { subaction: args.subaction } : {}),
+      error: "PLATFORM_UNSUPPORTED",
+      platform: process.platform,
+    },
+  };
+}

--- a/plugins/plugin-lifeops/src/platform/index.ts
+++ b/plugins/plugin-lifeops/src/platform/index.ts
@@ -1,1 +1,2 @@
+export * from "./host.js";
 export * from "./lifeops-github.js";

--- a/plugins/plugin-lifeops/src/plugin.ts
+++ b/plugins/plugin-lifeops/src/plugin.ts
@@ -116,6 +116,7 @@ import {
   registerActivitySignalBus,
 } from "./lifeops/signals/bus.js";
 import { threadOpsFieldEvaluator } from "./lifeops/work-threads/field-evaluator-thread-ops.js";
+import { isDarwin } from "./platform/host.js";
 import { browserBridgeProvider } from "./provider.js";
 // Activity-profile (proactive agent: GM/GN/nudges)
 import { activityProfileProvider } from "./providers/activity-profile.js";
@@ -574,6 +575,12 @@ async function recordTaskInitFailure(
  * runtime cache at LIFEOPS_TASK_INIT_FAILURE_CACHE_KEY for observability and
  * via logger.error so ops tooling can alert on it.
  */
+// Darwin-only action surface: the native activity tracker, the only
+// SCREEN_TIME data source the planner can reason about end-to-end, is
+// macOS-only — hide the owner-screentime umbrella on other hosts so the
+// planner never picks it.
+const platformGatedActionUmbrellas = isDarwin() ? [ownerScreenTimeAction] : [];
+
 function scheduleTaskEnsureAfterRuntimeInit(args: {
   runtime: IAgentRuntime;
   prefix: string;
@@ -627,7 +634,9 @@ const rawAppLifeOpsPlugin: Plugin = {
     ...promoteSubactionsToActions(ownerTodosAction),
     ...promoteSubactionsToActions(ownerRoutinesAction),
     ...promoteSubactionsToActions(ownerHealthAction),
-    ...promoteSubactionsToActions(ownerScreenTimeAction),
+    ...platformGatedActionUmbrellas.flatMap((action) =>
+      promoteSubactionsToActions(action),
+    ),
     ...promoteSubactionsToActions(personalAssistantAction),
     entityAction,
     ...promoteSubactionsToActions(ownerDocumentsAction),


### PR DESCRIPTION
## What

Adds graceful Windows fallbacks for the macOS-only feature surface in `plugin-lifeops` so the agent never plans a darwin-only action on non-darwin platforms. Today, Windows users see "macOS-only" errors mid-execution when the planner picks `SCREEN_TIME`, the iMessage connector subaction, or apple-reminders flows. After this PR, the planner doesn't see those actions on non-darwin, and any direct invocation returns a typed `FeatureResult` with `reason: "not_supported"` cleanly.

## Files

- `plugins/plugin-lifeops/src/platform/host.ts` (new) — `isDarwin()` + `darwinUnavailableActionResult({ actionName, connector?, subaction?, feature })` shared helpers. Centralized so plugin registration, action handlers, and connector dispatchers all read the same predicate.
- `plugins/plugin-lifeops/src/platform/index.ts` — re-exports `host.ts`.
- `plugins/plugin-lifeops/src/plugin.ts` — `ownerScreenTimeAction` (the owner-surface umbrella) is now excluded from the plugin's actions array on non-darwin. The planner / `enabled_skills` provider never sees it on Windows/Linux.
- `plugins/plugin-lifeops/src/actions/connector.ts` — iMessage subaction short-circuits before touching the macOS bridge; `imessage` is dropped from `listKnownConnectorKinds` on non-darwin so the planner doesn't pick it as a valid choice.
- `plugins/plugin-lifeops/src/actions/screen-time.ts` — uses the shared `isDarwin()` helper instead of the local check.
- `plugins/plugin-lifeops/src/lifeops/apple-reminders.ts` — 3 callsites (`createNativeAppleReminderLikeItem`, `update…`, `delete…`) gated by the shared helper.
- `plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts` (new) — 8 vitest tests covering darwin/win32/linux shapes for the helper + each guarded callsite.

## Why

This is a real user-visible polish for the LifeOps surface on Windows. Today, a Windows user asking "what's my screen time" gets the planner trying `SCREEN_TIME`, then a mid-execution error like _"Activity tracking is macOS-only. No data available on this platform."_ With this PR, the planner doesn't see `SCREEN_TIME` on non-darwin so it picks a different path, and any direct invocation gets a typed fallback instead of a thrown error.

## Verification

`bunx vitest run src/__tests__/platform-guards.test.ts` — **8/8 pass** (Test Files 1 passed, Tests 8 passed).

```
✓ platform/host helper
  ✓ isDarwin returns true on darwin
  ✓ isDarwin returns false on win32
  ✓ isDarwin returns false on linux
  ✓ darwinUnavailableActionResult returns the PLATFORM_UNSUPPORTED shape
✓ platform guards — apple reminders bridge
  ✓ createNativeAppleReminderLikeItem returns not_supported on win32
  ✓ updateNativeAppleReminderLikeItem returns not_supported on win32
  ✓ deleteNativeAppleReminderLikeItem returns not_supported on win32
✓ platform guards — website blocker engine
  ✓ reports unavailable when the hosts file path is missing on win32
```

## Design notes

- **Kept upstream's typed `FeatureResult` shape** (`{ ok: false, reason: "not_supported", platform }`) rather than regressing to a looser `{ ok: false, error, skippedReason }` shape. Tests assert on the typed shape.
- **Gated the umbrella, not the inner action.** `ownerScreenTimeAction` is what gets promoted via `promoteSubactionsToActions`, so hiding the umbrella is the correct surface for planner suppression — `screenTimeAction` itself doesn't appear in `plugin.actions`.
- **Defense-in-depth retained.** The existing `process.platform !== "darwin"` check inside `loadNativeReminderBridge` is kept — the outer `isDarwin()` short-circuits before it runs, but it remains a safety net for any future callsite that bypasses the outer guard.

## Risk

Low. No new dependencies. All changes are additive (helper + conditional skips). The darwin behavior is preserved exactly — only non-darwin behavior changes from "mid-execution error" to "typed unavailable result + planner doesn't see the action".

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds graceful Windows/Linux fallbacks for the macOS-only feature surface in `plugin-lifeops`, so the planner never sees or executes darwin-only actions on non-darwin hosts. All changes are additive — existing darwin behavior is completely preserved.

- **`platform/host.ts`** (new): centralizes `isDarwin()` and `darwinUnavailableActionResult()` so every guard in the plugin reads the same predicate, replacing scattered `process.platform === "darwin"` literals in `screen-time.ts`, `apple-reminders.ts`, and `connector.ts`.
- **`plugin.ts`**: hides the `ownerScreenTimeAction` umbrella from the planner's action list on non-darwin at registration time, so the planner never considers `SCREEN_TIME` on Windows/Linux.
- **`connector.ts`**: removes `imessage` from the planner-visible connector list and adds an early-return guard in `dispatchIMessage` for defense-in-depth; new test suite covers the shared helper and all three apple-reminders callsites.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are purely additive platform guards that leave darwin behavior untouched.

The darwin path is a straightforward pass-through with no modifications. Non-darwin paths now return typed fallbacks or hide actions at registration time. The new test suite correctly uses `vi.resetModules()` in `beforeEach` to isolate module-level platform captures between tests. No new dependencies, no schema changes, and no logic changes for existing darwin users.

No files require special attention. The two observations are about `feature` not being surfaced in the structured `data` object of `darwinUnavailableActionResult`, and registry-contributed connector kinds not being filtered alongside the hardcoded list — both are minor design gaps that do not affect correctness on darwin.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-lifeops/src/platform/host.ts | New module exposing `isDarwin()` and `darwinUnavailableActionResult()`. Clean and minimal; `feature` arg is accepted but omitted from the returned `data` object, only appearing in the human-readable `text`. |
| plugins/plugin-lifeops/src/platform/index.ts | Trivial re-export of `host.ts` alongside the existing `lifeops-github.js` exports. No issues. |
| plugins/plugin-lifeops/src/plugin.ts | Introduces `platformGatedActionUmbrellas` evaluated at module-load time to suppress `ownerScreenTimeAction` on non-darwin; safe since `process.platform` is constant at runtime. |
| plugins/plugin-lifeops/src/actions/connector.ts | Adds a platform guard in `dispatchIMessage` and filters `imessage` from `VERBOSE_DISPATCHER_KINDS` on non-darwin; registry-sourced connector kinds are not filtered, which is a minor gap covered by the defense-in-depth guard. |
| plugins/plugin-lifeops/src/actions/screen-time.ts | Replaces the local `isSupportedPlatform()` predicate with the shared `isDarwin()` helper; existing behavior is preserved exactly. |
| plugins/plugin-lifeops/src/lifeops/apple-reminders.ts | Three `process.platform !== "darwin"` checks replaced with `!isDarwin()`, preserving the existing `FeatureResult` shape and logic; no behavioral change on darwin. |
| plugins/plugin-lifeops/src/__tests__/platform-guards.test.ts | 8 vitest tests covering `isDarwin`, `darwinUnavailableActionResult`, and the three apple-reminders guards. `vi.resetModules()` in `beforeEach` correctly future-proofs against eager platform captures; `restorePlatform()` in per-describe `afterEach` keeps tests isolated. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent / Planner request] --> B{isDarwin?}

    B -- darwin --> C[Full action surface visible]
    C --> D[SCREEN_TIME / iMessage / Apple Reminders]

    B -- non-darwin --> E[Filtered action surface]
    E --> F[ownerScreenTimeAction hidden at registration]
    E --> G[imessage removed from listKnownConnectorKinds]
    E --> H[Apple Reminders: early FeatureResult not_supported]

    G --> I{Direct CONNECTOR/imessage call?}
    I -- yes --> J[dispatchIMessage guard\ndarwinUnavailableActionResult\nActionResult PLATFORM_UNSUPPORTED]
    I -- no --> K[Planner picks different connector]

    F --> L[Planner picks different action]
```

<sub>Reviews (2): Last reviewed commit: ["style(plugin-lifeops): drop dead isApple..."](https://github.com/elizaos/eliza/commit/545bddc528730802f5010c98c53c5916398bcff7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32700320)</sub>

<!-- /greptile_comment -->