### PR TITLE
Add iOS Bun engine artifact

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.patch whitespace=-blank-at-eol
+packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -725,3 +725,8 @@ storybook-static
 .wrangler
 .wrangler-dry-run
 swe-bench-workspace-opencode/
+
+# iOS Bun engine artifact
+!packages/bun-ios-runtime/artifacts/
+!packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/
+!packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/**

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/Info.plist
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/Info.plist
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfc2615402b1c68f19f31582948468da3987430e69f7d3cb3b083aee60bb7e17
+size 1191

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/ElizaBunEngine
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/ElizaBunEngine
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78b120cf8f538333772996df48ec9f71a9f145f07e80589cf0a1b0031c460a22
+size 72519216

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Headers/ElizaBunEngine.h
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Headers/ElizaBunEngine.h
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88118cf08f550057e755492c2bf1893904ddce51bb930da7609c7f43b2cdd458
+size 1166

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Info.plist
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Info.plist
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4403372f8e3058c24712e46ddbd4432499508f4e01c95eba0850fc8b9859d8
+size 891

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Modules/module.modulemap
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b39e62b613d8bd2be2e4edec03bb016b0188a90b79d5af02e1dfd3f7a0a4390
+size 108

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/ElizaBunEngine
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/ElizaBunEngine
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24509ac2696fd346716ddadfc6ecc887e2bd2999efcb1c5d69fa5ca6c921e0c9
+size 63961560

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Headers/ElizaBunEngine.h
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Headers/ElizaBunEngine.h
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88118cf08f550057e755492c2bf1893904ddce51bb930da7609c7f43b2cdd458
+size 1166

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Info.plist
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Info.plist
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4403372f8e3058c24712e46ddbd4432499508f4e01c95eba0850fc8b9859d8
+size 891

--- a/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Modules/module.modulemap
+++ b/packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b39e62b613d8bd2be2e4edec03bb016b0188a90b79d5af02e1dfd3f7a0a4390
+size 108

--- a/packages/native/bun-runtime/.gitignore
+++ b/packages/native/bun-runtime/.gitignore
@@ -1,3 +1,5 @@
-artifacts/
+artifacts/*
+!artifacts/ElizaBunEngine.xcframework/
+!artifacts/ElizaBunEngine.xcframework/**
 build/
 vendor/


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces `packages/bun-ios-runtime/` as a new Git LFS home for a pre-built `ElizaBunEngine.xcframework` — an iOS-targeted Bun engine for device (arm64) and Apple Silicon simulator (arm64-simulator) builds. The PR wires up `.gitattributes` LFS tracking and updates `.gitignore` rules accordingly.

- The LFS attribute in `.gitattributes` correctly guards the `packages/bun-ios-runtime/artifacts/**` path, and the root `.gitignore` negation rules are ordered correctly to override the global `artifacts/` catch-all.
- `packages/native/bun-runtime/.gitignore` is updated to allow `artifacts/ElizaBunEngine.xcframework/` to be committed, but no LFS attribute covers that path — if the xcframework is built locally and staged there, the 60–70 MB binaries would enter git history as raw objects, not LFS pointers.
- The xcframework omits an `ios-x86_64-simulator` (or universal fat simulator) slice, meaning the framework will fail to link on Intel Mac simulators.
</details>

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: the gitignore change for packages/native/bun-runtime opens a path for 60-70 MB framework binaries to be committed without LFS protection.

The change to packages/native/bun-runtime/.gitignore allows ElizaBunEngine.xcframework to be tracked by git at that path, but the .gitattributes LFS filter only covers packages/bun-ios-runtime/artifacts/**. Any developer who builds the xcframework locally and runs git add would silently commit ~135 MB of raw binary objects, permanently bloating the repository history. The xcframework also lacks an x86_64 simulator slice, which would silently break builds for developers on Intel Macs.

packages/native/bun-runtime/.gitignore and .gitattributes need to be reconciled: either extend the LFS rule to cover packages/native/bun-runtime/artifacts/ElizaBunEngine.xcframework/**, or revert the .gitignore change and keep that build output fully ignored.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .gitattributes | Adds LFS tracking for packages/bun-ios-runtime/artifacts/** — correct scope for the new LFS artifact copy, but does not cover the parallel packages/native/bun-runtime/artifacts/ path that the .gitignore change enables. |
| .gitignore | Adds negation rules to override the global artifacts/ ignore for the new bun-ios-runtime package; ordering is correct (negations come after the catch-all). |
| packages/native/bun-runtime/.gitignore | Switches from ignoring the entire artifacts/ directory to selectively allowing ElizaBunEngine.xcframework/, but no LFS attribute covers this path — raw binaries could be committed here without LFS. |
| packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/Info.plist | Root xcframework Info.plist stored as LFS pointer; missing ios-x86_64-simulator slice means Intel Mac simulator builds will fail. |
| packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64/ElizaBunEngine.framework/ElizaBunEngine | Device arm64 framework binary (~64 MB) correctly stored as LFS pointer. |
| packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework/ios-arm64-simulator/ElizaBunEngine.framework/ElizaBunEngine | Apple Silicon simulator framework binary (~73 MB) correctly stored as LFS pointer. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[packages/bun-ios-runtime/artifacts/ElizaBunEngine.xcframework] -->|stored as LFS pointer - .gitattributes covers this| B[Git LFS storage]
    C[packages/native/bun-runtime/artifacts/ElizaBunEngine.xcframework] -->|.gitignore now ALLOWS commit but NO LFS rule covers this path| D[Raw binary in git history]
    E[Build script / podspec] -->|writes xcframework here per ElizaBunEngine.podspec| C
    F[ELIZA_IOS_BUN_ENGINE_XCFRAMEWORK] -->|optional override| E
    A -.->|expected source| F
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnative%2Fbun-runtime%2F.gitignore%3A2-3%0A**LFS%20rule%20does%20not%20cover%20this%20path%20%E2%80%94%20raw%20binaries%20could%20enter%20git%20history**%0A%0AThe%20%60.gitattributes%60%20LFS%20filter%20is%20scoped%20only%20to%20%60packages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60.%20The%20%60.gitignore%60%20here%20now%20allows%20%60artifacts%2FElizaBunEngine.xcframework%2F%60%20and%20its%20contents%20to%20be%20tracked%20at%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2F%60%2C%20but%20that%20path%20has%20no%20corresponding%20LFS%20attribute.%20If%20a%20developer%20builds%20the%20xcframework%20locally%20%28the%20build%20script%20writes%20it%20to%20this%20directory%20per%20the%20podspec%20and%20README%29%20and%20stages%20it%20with%20%60git%20add%60%2C%20the%2060%E2%80%9370%20MB%20arm64%20and%20simulator%20binaries%20would%20be%20committed%20as%20raw%20objects%20with%20no%20LFS%20pointer%2C%20permanently%20bloating%20git%20history.%20Either%20extend%20%60.gitattributes%60%20to%20also%20cover%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60%20with%20the%20same%20LFS%20filters%2C%20or%20keep%20%60artifacts%2F%60%20fully%20ignored%20here%20and%20rely%20exclusively%20on%20the%20%60packages%2Fbun-ios-runtime%2F%60%20LFS%20copy.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2FInfo.plist%3A1-3%0A**xcframework%20missing%20%60ios-x86_64-simulator%60%20slice**%0A%0AThe%20xcframework%20contains%20only%20an%20%60ios-arm64%60%20%28device%29%20slice%20and%20an%20%60ios-arm64-simulator%60%20slice.%20Developers%20using%20Intel%20Macs%20will%20get%20a%20link%20error%20%28%22building%20for%20iOS%20Simulator%2C%20but%20linking%20in%20object%20file%20built%20for%20iOS%22%29%20when%20attempting%20to%20run%20in%20the%20simulator%2C%20because%20the%20fat%2Funiversal%20simulator%20slice%20%28%60ios-arm64_x86_64-simulator%60%29%20or%20an%20%60ios-x86_64-simulator%60%20slice%20is%20absent.%20If%20Intel%20simulator%20support%20is%20intentionally%20deferred%2C%20this%20limitation%20should%20be%20documented%20in%20the%20README%20so%20teams%20with%20mixed%20hardware%20are%20not%20surprised.%0A%0A&repo=elizaos%2Feliza&pr=7809&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22codex%2Fios-bun-engine-artifact%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fios-bun-engine-artifact%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnative%2Fbun-runtime%2F.gitignore%3A2-3%0A**LFS%20rule%20does%20not%20cover%20this%20path%20%E2%80%94%20raw%20binaries%20could%20enter%20git%20history**%0A%0AThe%20%60.gitattributes%60%20LFS%20filter%20is%20scoped%20only%20to%20%60packages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60.%20The%20%60.gitignore%60%20here%20now%20allows%20%60artifacts%2FElizaBunEngine.xcframework%2F%60%20and%20its%20contents%20to%20be%20tracked%20at%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2F%60%2C%20but%20that%20path%20has%20no%20corresponding%20LFS%20attribute.%20If%20a%20developer%20builds%20the%20xcframework%20locally%20%28the%20build%20script%20writes%20it%20to%20this%20directory%20per%20the%20podspec%20and%20README%29%20and%20stages%20it%20with%20%60git%20add%60%2C%20the%2060%E2%80%9370%20MB%20arm64%20and%20simulator%20binaries%20would%20be%20committed%20as%20raw%20objects%20with%20no%20LFS%20pointer%2C%20permanently%20bloating%20git%20history.%20Either%20extend%20%60.gitattributes%60%20to%20also%20cover%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60%20with%20the%20same%20LFS%20filters%2C%20or%20keep%20%60artifacts%2F%60%20fully%20ignored%20here%20and%20rely%20exclusively%20on%20the%20%60packages%2Fbun-ios-runtime%2F%60%20LFS%20copy.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2FInfo.plist%3A1-3%0A**xcframework%20missing%20%60ios-x86_64-simulator%60%20slice**%0A%0AThe%20xcframework%20contains%20only%20an%20%60ios-arm64%60%20%28device%29%20slice%20and%20an%20%60ios-arm64-simulator%60%20slice.%20Developers%20using%20Intel%20Macs%20will%20get%20a%20link%20error%20%28%22building%20for%20iOS%20Simulator%2C%20but%20linking%20in%20object%20file%20built%20for%20iOS%22%29%20when%20attempting%20to%20run%20in%20the%20simulator%2C%20because%20the%20fat%2Funiversal%20simulator%20slice%20%28%60ios-arm64_x86_64-simulator%60%29%20or%20an%20%60ios-x86_64-simulator%60%20slice%20is%20absent.%20If%20Intel%20simulator%20support%20is%20intentionally%20deferred%2C%20this%20limitation%20should%20be%20documented%20in%20the%20README%20so%20teams%20with%20mixed%20hardware%20are%20not%20surprised.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fnative%2Fbun-runtime%2F.gitignore%3A2-3%0A**LFS%20rule%20does%20not%20cover%20this%20path%20%E2%80%94%20raw%20binaries%20could%20enter%20git%20history**%0A%0AThe%20%60.gitattributes%60%20LFS%20filter%20is%20scoped%20only%20to%20%60packages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60.%20The%20%60.gitignore%60%20here%20now%20allows%20%60artifacts%2FElizaBunEngine.xcframework%2F%60%20and%20its%20contents%20to%20be%20tracked%20at%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2F%60%2C%20but%20that%20path%20has%20no%20corresponding%20LFS%20attribute.%20If%20a%20developer%20builds%20the%20xcframework%20locally%20%28the%20build%20script%20writes%20it%20to%20this%20directory%20per%20the%20podspec%20and%20README%29%20and%20stages%20it%20with%20%60git%20add%60%2C%20the%2060%E2%80%9370%20MB%20arm64%20and%20simulator%20binaries%20would%20be%20committed%20as%20raw%20objects%20with%20no%20LFS%20pointer%2C%20permanently%20bloating%20git%20history.%20Either%20extend%20%60.gitattributes%60%20to%20also%20cover%20%60packages%2Fnative%2Fbun-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2F**%60%20with%20the%20same%20LFS%20filters%2C%20or%20keep%20%60artifacts%2F%60%20fully%20ignored%20here%20and%20rely%20exclusively%20on%20the%20%60packages%2Fbun-ios-runtime%2F%60%20LFS%20copy.%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fbun-ios-runtime%2Fartifacts%2FElizaBunEngine.xcframework%2FInfo.plist%3A1-3%0A**xcframework%20missing%20%60ios-x86_64-simulator%60%20slice**%0A%0AThe%20xcframework%20contains%20only%20an%20%60ios-arm64%60%20%28device%29%20slice%20and%20an%20%60ios-arm64-simulator%60%20slice.%20Developers%20using%20Intel%20Macs%20will%20get%20a%20link%20error%20%28%22building%20for%20iOS%20Simulator%2C%20but%20linking%20in%20object%20file%20built%20for%20iOS%22%29%20when%20attempting%20to%20run%20in%20the%20simulator%2C%20because%20the%20fat%2Funiversal%20simulator%20slice%20%28%60ios-arm64_x86_64-simulator%60%29%20or%20an%20%60ios-x86_64-simulator%60%20slice%20is%20absent.%20If%20Intel%20simulator%20support%20is%20intentionally%20deferred%2C%20this%20limitation%20should%20be%20documented%20in%20the%20README%20so%20teams%20with%20mixed%20hardware%20are%20not%20surprised.%0A%0A&pr=7809&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add iOS Bun engine artifact"](https://github.com/elizaos/eliza/commit/ae9b76350938083af64c0602dc372e3f61730ced) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32843335)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->